### PR TITLE
Expose build path in CalculateTaskGraph

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -83,6 +83,38 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         operation().failure.contains("Task 'someNonExisting' not found in root project")
     }
 
+    def "build path for calculated task graph is exposed"() {
+        settingsFile << """
+            includeBuild "b"
+        """
+
+        buildFile << """
+            apply plugin:'java'
+            
+            dependencies {
+                compile "org.acme:b:1.0"            
+            }
+        """
+
+        file("b/build.gradle") << """
+            apply plugin:'java'
+            group = 'org.acme'
+            version = '1.0'
+        """
+        file('b/settings.gradle') << ""
+
+        when:
+        succeeds('build')
+
+        def taskGraphCalculations = buildOperations.all(CalculateTaskGraphBuildOperationType)
+        then:
+        taskGraphCalculations.size() == 2
+        taskGraphCalculations[0].details.buildPath == ":"
+        taskGraphCalculations[0].result.requestedTaskPaths == [":build"]
+        taskGraphCalculations[1].details.buildPath== ":b"
+        taskGraphCalculations[1].result.requestedTaskPaths == [":jar"]
+    }
+
     private BuildOperationRecord operation() {
         buildOperations.first(CalculateTaskGraphBuildOperationType)
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -102,7 +102,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         finished(ApplyScriptPluginBuildOperationType.Result, [:])
         finished(ConfigureProjectBuildOperationType.Result, [:])
 
-        started(CalculateTaskGraphBuildOperationType.Details, [:])
+        started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
         finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
         started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
         finished(ExecuteTaskBuildOperationType.Result, [actionable: false, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
@@ -124,7 +124,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notIncluded(ApplyPluginBuildOperationType)
         notIncluded(ConfigureProjectBuildOperationType)
 
-        started(CalculateTaskGraphBuildOperationType.Details, [:])
+        started(CalculateTaskGraphBuildOperationType.Details, [buildPath:':'])
         finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
         started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
         finished(ExecuteTaskBuildOperationType.Result, [actionable: false, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -26,11 +26,11 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.ExceptionAnalyser;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.configuration.BuildConfigurer;
 import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
 import org.gradle.execution.TaskGraphExecuter;
-import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -299,6 +299,10 @@ public class DefaultGradleLauncher implements GradleLauncher {
         public BuildOperationDescriptor.Builder description() {
             return BuildOperationDescriptor.displayName(contextualize("Calculate task graph"))
                 .details(new CalculateTaskGraphBuildOperationType.Details() {
+                    @Override
+                    public String getBuildPath() {
+                        return getGradle().getIdentityPath().getPath();
+                    }
                 }).parent(getGradle().getBuildOperation());
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -30,7 +30,11 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
 
     @UsedByScanPlugin
     public interface Details {
-
+        /**
+         * The build path the calculated task graph belongs too)
+         * @since 4.5
+         */
+        String getBuildPath();
     }
 
     @UsedByScanPlugin
@@ -49,7 +53,6 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
          * Never contains duplicates.
          */
         List<String> getExcludedTaskPaths();
-
     }
 
     private CalculateTaskGraphBuildOperationType() {


### PR DESCRIPTION
### Context
In composite builds different task graphs can be calculated, which can belong to root builds or included builds.
To distinguish these different task graph calculations in Gradle we need to know to which build path they belong.