### PR TITLE
Add rootDir to VersionControlSpec

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/vcs/VersionControlSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/VersionControlSpec.java
@@ -35,4 +35,16 @@ public interface VersionControlSpec extends Describable {
      * Returns the name of the repository.
      */
     String getRepoName();
+
+    /**
+     * Returns the relative path to the root of the build within the repository.
+     */
+    String getRootDir();
+
+    /**
+     * Sets the relative path to the root of the build within the repository.
+     * <p>
+     * Defaults to an empty relative path, meaning the root of the repository.
+     */
+    void setRootDir(String rootDir);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/vcs/VersionControlSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/VersionControlSpec.java
@@ -38,6 +38,8 @@ public interface VersionControlSpec extends Describable {
 
     /**
      * Returns the relative path to the root of the build within the repository.
+     *
+     * @since 4.5
      */
     String getRootDir();
 
@@ -45,6 +47,8 @@ public interface VersionControlSpec extends Describable {
      * Sets the relative path to the root of the build within the repository.
      * <p>
      * Defaults to an empty relative path, meaning the root of the repository.
+     *
+     * @since 4.5
      */
     void setRootDir(String rootDir);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
@@ -255,7 +255,7 @@ For more information on how to apply the build scan plugin, please visit https:/
     void installVcsMappings() {
         def mapped = file('repo/mapped')
         settingsFile.text = """
-            import org.gradle.vcs.internal.DirectoryRepositorySpec
+            import org.gradle.vcs.internal.spec.DirectoryRepositorySpec
             sourceControl {
                 vcsMappings {
                     withModule('external-source:artifact') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.vcs.internal
 
+import org.gradle.vcs.internal.spec.DirectoryRepositorySpec
+
 class VcsMappingsIntegrationTest extends AbstractVcsIntegrationTest {
     def setup() {
         settingsFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
@@ -169,6 +169,26 @@ class VcsMappingsIntegrationTest extends AbstractVcsIntegrationTest {
         failureCauseContains("' must contain a settings file.")
     }
 
+    def 'can build from sub-directory of repository'() {
+        file('repoRoot').mkdir()
+        file('dep').renameTo(file('repoRoot/dep'))
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule('org.test:dep') {
+                        from vcs(DirectoryRepositorySpec) {
+                            sourceDir = file('repoRoot')
+                            rootDir = 'dep'
+                        }
+                    }
+                }
+            }
+        """
+        expect:
+        succeeds('assemble')
+        assertRepoCheckedOut('repoRoot')
+    }
+
     void assertRepoCheckedOut(String repoName="dep") {
         def checkout = checkoutDir(repoName, "fixed", "directory-repo:${file(repoName).absolutePath}")
         checkout.file("checkedout").assertIsFile()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -86,6 +86,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                     return;
                 }
                 File dependencyWorkingDir = populateWorkingDirectory(baseWorkingDir, spec, versionControlSystem, selectedVersion);
+                dependencyWorkingDir = new File(dependencyWorkingDir, spec.getRootDir());
 
                 //TODO: Allow user to provide settings script in VcsMapping
                 if (!(new File(dependencyWorkingDir, "settings.gradle").exists())

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.language.cpp
 
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
-import org.gradle.vcs.internal.DirectoryRepositorySpec
+import org.gradle.vcs.internal.spec.DirectoryRepositorySpec
 
 class CppDependenciesIntegrationTest extends AbstractCppInstalledToolChainIntegrationTest {
     def app = new CppAppWithLibraries()

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
@@ -18,7 +18,7 @@ package org.gradle.vcs.git.internal;
 
 import org.gradle.internal.UncheckedException;
 import org.gradle.vcs.git.GitVersionControlSpec;
-import org.gradle.vcs.internal.AbstractVersionControlSpec;
+import org.gradle.vcs.internal.spec.AbstractVersionControlSpec;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
@@ -18,11 +18,12 @@ package org.gradle.vcs.git.internal;
 
 import org.gradle.internal.UncheckedException;
 import org.gradle.vcs.git.GitVersionControlSpec;
+import org.gradle.vcs.internal.AbstractVersionControlSpec;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
-public class DefaultGitVersionControlSpec implements GitVersionControlSpec {
+public class DefaultGitVersionControlSpec extends AbstractVersionControlSpec implements GitVersionControlSpec {
     private URI url;
 
     @Override

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/AbstractVersionControlSpec.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/AbstractVersionControlSpec.java
@@ -18,32 +18,16 @@ package org.gradle.vcs.internal;
 
 import org.gradle.vcs.VersionControlSpec;
 
-import java.io.File;
-
-// TODO: Remove this when we have a real Vcs (like Git)
-public class DirectoryRepositorySpec extends AbstractVersionControlSpec implements VersionControlSpec {
-    private File sourceDir;
+public abstract class AbstractVersionControlSpec implements VersionControlSpec {
+    private String rootDir = "";
 
     @Override
-    public String getDisplayName() {
-        return "dir repo " + sourceDir;
-    }
-
-    public File getSourceDir() {
-        return sourceDir;
-    }
-
-    public void setSourceDir(File sourceDir) {
-        this.sourceDir = sourceDir;
+    public String getRootDir() {
+        return rootDir;
     }
 
     @Override
-    public String getUniqueId() {
-        return "directory-repo:" + sourceDir.getAbsolutePath();
-    }
-
-    @Override
-    public String getRepoName() {
-        return sourceDir.getName();
+    public void setRootDir(String rootDir) {
+        this.rootDir = rootDir;
     }
 }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
@@ -25,6 +25,7 @@ import org.gradle.vcs.VersionControlSpec;
 import org.gradle.vcs.VersionControlSystem;
 import org.gradle.vcs.VersionRef;
 import org.gradle.vcs.git.internal.GitVersionControlSystem;
+import org.gradle.vcs.internal.spec.DirectoryRepositorySpec;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
@@ -22,6 +22,7 @@ import org.gradle.util.GFileUtils;
 import org.gradle.vcs.VersionControlSpec;
 import org.gradle.vcs.VersionControlSystem;
 import org.gradle.vcs.VersionRef;
+import org.gradle.vcs.internal.spec.DirectoryRepositorySpec;
 
 import java.io.File;
 import java.io.IOException;

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlSpecFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlSpecFactory.java
@@ -21,6 +21,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.vcs.VersionControlSpec;
 import org.gradle.vcs.git.GitVersionControlSpec;
 import org.gradle.vcs.git.internal.DefaultGitVersionControlSpec;
+import org.gradle.vcs.internal.spec.DirectoryRepositorySpec;
 
 import javax.annotation.Nullable;
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/spec/AbstractVersionControlSpec.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/spec/AbstractVersionControlSpec.java
@@ -14,36 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.vcs.internal;
+package org.gradle.vcs.internal.spec;
 
 import org.gradle.vcs.VersionControlSpec;
 
-import java.io.File;
-
-// TODO: Remove this when we have a real Vcs (like Git)
-public class DirectoryRepositorySpec extends AbstractVersionControlSpec implements VersionControlSpec {
-    private File sourceDir;
+public abstract class AbstractVersionControlSpec implements VersionControlSpec {
+    private String rootDir = "";
 
     @Override
-    public String getDisplayName() {
-        return "dir repo " + sourceDir;
-    }
-
-    public File getSourceDir() {
-        return sourceDir;
-    }
-
-    public void setSourceDir(File sourceDir) {
-        this.sourceDir = sourceDir;
+    public String getRootDir() {
+        return rootDir;
     }
 
     @Override
-    public String getUniqueId() {
-        return "directory-repo:" + sourceDir.getAbsolutePath();
-    }
-
-    @Override
-    public String getRepoName() {
-        return sourceDir.getName();
+    public void setRootDir(String rootDir) {
+        this.rootDir = rootDir;
     }
 }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/spec/DirectoryRepositorySpec.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/spec/DirectoryRepositorySpec.java
@@ -14,20 +14,36 @@
  * limitations under the License.
  */
 
-package org.gradle.vcs.internal;
+package org.gradle.vcs.internal.spec;
 
 import org.gradle.vcs.VersionControlSpec;
 
-public abstract class AbstractVersionControlSpec implements VersionControlSpec {
-    private String rootDir = "";
+import java.io.File;
+
+// TODO: Remove this when we have a real Vcs (like Git)
+public class DirectoryRepositorySpec extends AbstractVersionControlSpec implements VersionControlSpec {
+    private File sourceDir;
 
     @Override
-    public String getRootDir() {
-        return rootDir;
+    public String getDisplayName() {
+        return "dir repo " + sourceDir;
+    }
+
+    public File getSourceDir() {
+        return sourceDir;
+    }
+
+    public void setSourceDir(File sourceDir) {
+        this.sourceDir = sourceDir;
     }
 
     @Override
-    public void setRootDir(String rootDir) {
-        this.rootDir = rootDir;
+    public String getUniqueId() {
+        return "directory-repo:" + sourceDir.getAbsolutePath();
+    }
+
+    @Override
+    public String getRepoName() {
+        return sourceDir.getName();
     }
 }


### PR DESCRIPTION
Users can now set a relative path from the root of the version control
repository where an external source dependency should be built. This
allows users to clone and use repositories where their target
dependency is actually built in a sub-directory of the repository.

Fixes gradle/gradle-native#191