### PR TITLE
Keep ResolutionResultsStore open for scope of the BuildTree

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -19,6 +19,11 @@ package org.gradle.integtests.resolve
 import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.operations.notify.BuildOperationFinishedNotification
+import org.gradle.internal.operations.notify.BuildOperationNotificationListener2
+import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar
+import org.gradle.internal.operations.notify.BuildOperationProgressNotification
+import org.gradle.internal.operations.notify.BuildOperationStartedNotification
 import spock.lang.Unroll
 
 class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -258,7 +263,79 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         "script plugin" | 'buildscript' | "scriptPlugin.gradle"
         "settings"      | 'buildscript' | 'settings.gradle'
         "init"          | 'initscript'  | 'init.gradle'
+    }
 
+    def "included build classpath configuration resolution result is exposed"() {
+        setup:
+        def m1 = mavenHttpRepo.module('org.foo', 'some-dep').publish()
+
+        file("projectB/settings.gradle") << """
+        rootProject.name = 'project-b'
+        include "sub1"
+        """
+
+        file("projectB/build.gradle") << """
+                buildscript {
+                    repositories {
+                        maven { url '${mavenHttpRepo.uri}' }
+                    }
+                    dependencies {
+                        classpath "org.foo:some-dep:1.0"
+                    }
+                }
+                allprojects {
+                    apply plugin: 'java'
+                    group "org.sample"
+                    version "1.0"
+                }
+                
+        """
+
+        settingsFile << """
+            includeBuild 'projectB'
+        """
+
+        buildFile << """
+            buildscript {
+                dependencies {
+                    classpath 'org.sample:sub1:1.0'
+                }
+            }    
+        
+            class OperationPlugin implements Plugin<Project> {
+                void apply(Project project){
+                    def listener = new $BuildOperationNotificationListener2.name() {
+                        void started($BuildOperationStartedNotification.name notification){
+                        } 
+                        void progress($BuildOperationProgressNotification.name notification){
+                        }
+                        void finished($BuildOperationFinishedNotification.name notification) {
+                            def result = notification.notificationOperationResult
+                            def details = notification.notificationOperationDetails
+                            if (result instanceof $ResolveConfigurationDependenciesBuildOperationType.Result.name) {
+                                result.rootComponent.dependencies.each {
+                                    println "configuration: "+ details.configurationName + ", buildPath: " + details.buildPath + ", id: "  + it.selected.id
+                                }
+                            }
+                        }
+                    }
+                
+                    def registrar = project.services.get($BuildOperationNotificationListenerRegistrar.name)            
+                    registrar.register(listener)
+                }
+            }
+            
+            apply plugin:OperationPlugin
+            task foo
+        """
+
+        m1.allowAll()
+        executer.requireIsolatedDaemons()
+        when:
+        run "foo"
+
+        then:
+        outputContains("configuration: classpath, buildPath: :project-b, id: org.foo:some-dep:1.0")
     }
 
     private void setupComposite() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -53,7 +53,6 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectLocalCo
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.ResolutionResultsStoreFactory;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultLocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenFileLocations;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvider;
@@ -307,10 +306,6 @@ class DependencyManagementBuildScopeServices {
             moduleExclusions,
             componentSelectorConverter,
             experimentalFeatures);
-    }
-
-    ResolutionResultsStoreFactory createResolutionResultsStoreFactory(TemporaryFileProvider temporaryFileProvider) {
-        return new ResolutionResultsStoreFactory(temporaryFileProvider);
     }
 
     ProjectPublicationRegistry createProjectPublicationRegistry() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.ResolutionResultsStoreFactory;
 import org.gradle.api.internal.artifacts.vcs.VcsWorkingDirectoryRoot;
+import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.initialization.layout.ProjectCacheDir;
 
 import java.io.File;
@@ -28,4 +30,9 @@ class DependencyManagementBuildTreeScopeServices {
     VcsWorkingDirectoryRoot createVcsWorkingDirectoryRoot(ProjectCacheDir projectCacheDir) {
         return new VcsWorkingDirectoryRoot(new File(projectCacheDir.getDir(), "vcsWorkingDirs"));
     }
+
+    ResolutionResultsStoreFactory createResolutionResultsStoreFactory(TemporaryFileProvider temporaryFileProvider) {
+        return new ResolutionResultsStoreFactory(temporaryFileProvider);
+    }
+
 }


### PR DESCRIPTION
### Context

The build scan plugin accesses `ResolveConfigurationDependenciesBuildOperationType.Result#getRootComponent().getDependencies()` after the included build has been run. This throws an exception as this is triggering to read the dependency resolution in BT from a persisted cache. With this change we keep the ResolutionResultsStore open for the whole BuildTree, which allows the access of the resolution result even though an included build in a composite has already finished.

I added an integration test that mimics what we see in the build scan plugin. Though I wasn't able to reproduce an integration test reproducing the error we see in an build scan integration test see at https://github.com/gradle/dotcom/blob/0b1445026d8ddb655a2a904cf3409163dd90cbf3/scans-plugin-test-func/src/test/groovy/com/gradle/scan/plugin/test/func/CompositeBuildPluginFuncTest.groovy#L100-L114
I don't understand what difference there is to the integ test I've added.
 
Verified fix works for build scan plugin.