### PR TITLE
Fix regression with Assembler and Windows Resource compiler

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/plugins/internal/AssembleTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/plugins/internal/AssembleTaskConfig.java
@@ -15,9 +15,13 @@
  */
 package org.gradle.language.assembler.plugins.internal;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.collections.MinimalFileSet;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.language.assembler.tasks.Assemble;
@@ -26,9 +30,15 @@ import org.gradle.language.base.internal.LanguageSourceSetInternal;
 import org.gradle.language.base.internal.SourceTransformTaskConfig;
 import org.gradle.nativeplatform.Tool;
 import org.gradle.nativeplatform.internal.NativeBinarySpecInternal;
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.nativeplatform.toolchain.internal.SystemIncludesAwarePlatformToolProvider;
 import org.gradle.platform.base.BinarySpec;
 
 import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class AssembleTaskConfig implements SourceTransformTaskConfig {
     @Override
@@ -53,6 +63,23 @@ public class AssembleTaskConfig implements SourceTransformTaskConfig {
         task.setTargetPlatform(binary.getTargetPlatform());
 
         task.source(sourceSet.getSource());
+
+        FileCollectionFactory fileCollectionFactory = ((ProjectInternal) task.getProject()).getServices().get(FileCollectionFactory.class);
+        task.includes(fileCollectionFactory.create(new MinimalFileSet() {
+            @Override
+            public Set<File> getFiles() {
+                PlatformToolProvider platformToolProvider = ((NativeToolChainInternal) binary.getToolChain()).select((NativePlatformInternal) binary.getTargetPlatform());
+                if (platformToolProvider instanceof SystemIncludesAwarePlatformToolProvider) {
+                    return new LinkedHashSet<File>(((SystemIncludesAwarePlatformToolProvider) platformToolProvider).getSystemIncludes());
+                }
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public String getDisplayName() {
+                return "System includes for " + binary.getToolChain().getDisplayName();
+            }
+        }));
 
         final Project project = task.getProject();
         task.setObjectFileDir(new File(binary.getNamingScheme().getOutputDirectory(project.getBuildDir(), "objs"), sourceSet.getProjectScopedName()));

--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
@@ -18,6 +18,7 @@ package org.gradle.language.assembler.tasks;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -50,6 +51,7 @@ import java.util.concurrent.Callable;
 @Incubating
 public class Assemble extends DefaultTask {
     private FileCollection source;
+    private ConfigurableFileCollection includes;
     private NativeToolChainInternal toolChain;
     private NativePlatformInternal targetPlatform;
     private File objectFileDir;
@@ -58,6 +60,7 @@ public class Assemble extends DefaultTask {
     @Inject
     public Assemble() {
         source = getProject().files();
+        includes = getProject().files();
         getInputs().property("outputType", new Callable<String>() {
             @Override
             public String call() throws Exception {
@@ -83,6 +86,7 @@ public class Assemble extends DefaultTask {
 
         spec.setObjectFileDir(getObjectFileDir());
         spec.source(getSource());
+        spec.include(getIncludes());
         spec.args(getAssemblerArgs());
         spec.setOperationLogger(operationLogger);
 
@@ -150,5 +154,24 @@ public class Assemble extends DefaultTask {
 
     public void setObjectFileDir(File objectFileDir) {
         this.objectFileDir = objectFileDir;
+    }
+
+    /**
+     * Returns the header directories to be used for compilation.
+     *
+     * @since 4.4
+     */
+    @InputFiles
+    public FileCollection getIncludes() {
+        return includes;
+    }
+
+    /**
+     * Add directories where the compiler should search for header files.
+     *
+     * @since 4.4
+     */
+    public void includes(Object includeRoots) {
+        includes.from(includeRoots);
     }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/MixedLanguageHelloWorldApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/MixedLanguageHelloWorldApp.groovy
@@ -110,10 +110,13 @@ class MixedLanguageHelloWorldApp extends HelloWorldApp {
         return i386GnuAsmSource
     }
 
+    // HACK: Ensure include root are correctly setup, use `INCLUDE <winbase.h>`
+    // See: https://github.com/gradle/gradle/issues/3662
     private static String windowsMasmSource = '''
 .386
 .model    flat
 
+INCLUDE <winbase.h>
 PUBLIC    _sumx
 _TEXT     SEGMENT
 _sumx    PROC

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/MixedLanguageHelloWorldApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/MixedLanguageHelloWorldApp.groovy
@@ -110,13 +110,13 @@ class MixedLanguageHelloWorldApp extends HelloWorldApp {
         return i386GnuAsmSource
     }
 
-    // HACK: Ensure include root are correctly setup, use `INCLUDE <winbase.h>`
+    // HACK: Ensure include root are correctly setup, use `INCLUDE <ks386.inc>`
     // See: https://github.com/gradle/gradle/issues/3662
     private static String windowsMasmSource = '''
 .386
 .model    flat
 
-INCLUDE <winbase.h>
+INCLUDE <ks386.inc>
 PUBLIC    _sumx
 _TEXT     SEGMENT
 _sumx    PROC

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/WindowsResourceHelloWorldApp.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/WindowsResourceHelloWorldApp.groovy
@@ -123,6 +123,10 @@ void DLL_FUNC hello() {
         sourceFile("rc", "resources.rc", """
 #include "hello.h"
 
+// HACK: Ensure include root are correctly setup
+// See: https://github.com/gradle/gradle/issues/3662
+#include "winres.h"
+
 STRINGTABLE
 {
     #ifdef FRENCH


### PR DESCRIPTION
Fixes #3662.

Looks like we forgot to add the system includes back to the `Assemble` and the `WindowsResourceCompile` task, since they do not extend `AbstractNativeCompileTask`.