### PR TITLE
Introduce `ArtifactResolutionQuery#forComponent(group, name, version)`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
@@ -62,15 +62,15 @@ public interface ArtifactResolutionQuery {
     ArtifactResolutionQuery forComponents(ComponentIdentifier... componentIds);
 
     /**
-     * Specifies a component to include in the result using GAV coordinates.
+     * Specifies a module component to include in the result using its GAV coordinates.
      *
-     * @param group Component group.
-     * @param name Component name.
-     * @param version Component version.
+     * @param group Module group.
+     * @param name Module name.
+     * @param version Module version.
      *
      * @since 4.5
      */
-    ArtifactResolutionQuery forComponent(String group, String name, String version);
+    ArtifactResolutionQuery forModule(String group, String name, String version);
 
     /**
      * Defines the type of component that is expected in the result, and the artifacts to retrieve for components of this type.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
@@ -62,6 +62,17 @@ public interface ArtifactResolutionQuery {
     ArtifactResolutionQuery forComponents(ComponentIdentifier... componentIds);
 
     /**
+     * Specifies a component to include in the result using GAV coordinates.
+     *
+     * @param group Component group.
+     * @param name Component name.
+     * @param version Component version.
+     *
+     * @since 4.5
+     */
+    ArtifactResolutionQuery forComponent(String group, String name, String version);
+
+    /**
      * Defines the type of component that is expected in the result, and the artifacts to retrieve for components of this type.
      *
      * Presently, only a single component type and set of artifacts is permitted.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -97,7 +97,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
         return this;
     }
 
-    public ArtifactResolutionQuery forComponent(@Nonnull String group, @Nonnull String name, @Nonnull String version) {
+    public ArtifactResolutionQuery forModule(@Nonnull String group, @Nonnull String name, @Nonnull String version) {
         componentIds.add(DefaultModuleComponentIdentifier.newId(group, name, version));
         return this;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -44,6 +44,7 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.internal.Factory;
 import org.gradle.internal.Transformers;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
@@ -57,6 +58,7 @@ import org.gradle.internal.resolve.result.DefaultBuildableArtifactSetResolveResu
 import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult;
 import org.gradle.util.CollectionUtils;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -92,6 +94,11 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
 
     public ArtifactResolutionQuery forComponents(ComponentIdentifier... componentIds) {
         CollectionUtils.addAll(this.componentIds, componentIds);
+        return this;
+    }
+
+    public ArtifactResolutionQuery forComponent(@Nonnull String group, @Nonnull String name, @Nonnull String version) {
+        componentIds.add(DefaultModuleComponentIdentifier.newId(group, name, version));
         return this;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
@@ -109,7 +109,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
         testComponentTypeRegistry  | TestComponent         | UnknownArtifact        | "Artifact type $UnknownArtifact.name is not registered for component type ${TestComponent.name}."
     }
 
-    def "forComponent is cumulative"() {
+    def "forModule is cumulative"() {
         withArtifactResolutionInteractions(2)
 
         given:
@@ -117,8 +117,8 @@ class DefaultArtifactResolutionQueryTest extends Specification {
 
         when:
         def result = query
-            .forComponent("g1", "n1", "v1")
-            .forComponent("g2", "n2", "v2")
+            .forModule("g1", "n1", "v1")
+            .forModule("g2", "n2", "v2")
             .withArtifacts(TestComponent, TestArtifact)
             .execute()
 


### PR DESCRIPTION
So it can be used by `kotlin-dsl` in place of the internal `DefaultModuleComponentIdentifier#newId`.