### PR TITLE
Prevent NPE in concurrent access by making precomputeCaches() synchronized

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/ImmutableModuleExclusionSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/ImmutableModuleExclusionSet.java
@@ -43,7 +43,7 @@ final class ImmutableModuleExclusionSet implements Set<AbstractModuleExclusion> 
         this.hashCode = delegate.hashCode();
     }
 
-    private void precomputeCaches() {
+    private synchronized void precomputeCaches() {
         if (excludedModules != null) {
             return;
         }


### PR DESCRIPTION
Fix for #3679.