### PR TITLE
Include kotlin-dsl script cache in integ test home dir script cache cleanup

### DIFF
--- a/gradle/distributionTesting.gradle
+++ b/gradle/distributionTesting.gradle
@@ -182,7 +182,7 @@ def removeCachedScripts(File cachesDir) {
     if (cachesDir.directory) {
         for (File cacheDir : cachesDir.listFiles()) {
             if(cacheDir.directory) {
-                ["scripts", "scripts-remapped"].each {
+                ["scripts", "scripts-remapped", "gradle-kotlin-dsl", "gradle-kotlin-dsl-accessors"].each {
                     File scriptsCacheDir = new File(cacheDir, it)
                     if(scriptsCacheDir.directory) {
                         println "Removing scripts cache directory : ${scriptsCacheDir}"


### PR DESCRIPTION
So the build of `gradle/gradle` behave the same for both Groovy and Kotlin build scripts.