### PR TITLE
Fix `WindowsResourcesUnsupportedIntegrationTest`

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.Ignore
 
 class WindowsResourcesUnsupportedIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
@@ -59,7 +58,6 @@ model {
         !executedTasks.contains(":compileMainExecutableMainRc")
     }
 
-    @Ignore
     @Requires(TestPrecondition.WINDOWS)
     @RequiresInstalledToolChain(ToolChainRequirement.GCC_COMPATIBLE)
     def "reasonable error message when attempting to compile resource files with unsupported tool chain"() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/DefaultGccPlatformToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/DefaultGccPlatformToolChain.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.nativeplatform.toolchain.internal.gcc;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.toolchain.GccPlatformToolChain;
 import org.gradle.nativeplatform.toolchain.internal.ToolType;
@@ -22,8 +23,15 @@ import org.gradle.nativeplatform.toolchain.internal.tools.DefaultGccCommandLineT
 import org.gradle.nativeplatform.toolchain.internal.tools.GccCommandLineToolConfigurationInternal;
 import org.gradle.nativeplatform.toolchain.internal.tools.ToolRegistry;
 
-import java.util.*;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+@NonNullApi
 public class DefaultGccPlatformToolChain implements GccPlatformToolChain, ToolRegistry {
     private final NativePlatform platform;
     private boolean canUseCommandFile = true;
@@ -50,6 +58,7 @@ public class DefaultGccPlatformToolChain implements GccPlatformToolChain, ToolRe
         this.compilerProbeArgs.addAll(Arrays.asList(args));
     }
 
+    @Nullable
     @Override
     public GccCommandLineToolConfigurationInternal getTool(ToolType toolType) {
         return tools.get(toolType);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
@@ -59,6 +59,10 @@ public class GccMetadataProvider extends AbstractMetadataProvider<GccMetadata> {
         return new GccMetadataProvider(execActionFactory, GccCompilerType.CLANG);
     }
 
+    public static GccMetadata broken(String message) {
+        return new BrokenResult(message);
+    }
+
     GccMetadataProvider(ExecActionFactory execActionFactory, GccCompilerType compilerType) {
         super(execActionFactory);
         this.compilerType = compilerType;
@@ -260,7 +264,7 @@ public class GccMetadataProvider extends AbstractMetadataProvider<GccMetadata> {
         }
     }
 
-    public static class BrokenResult extends AbstractBrokenMetadata implements GccMetadata {
+    private static class BrokenResult extends AbstractBrokenMetadata implements GccMetadata {
 
         public BrokenResult(String message) {
             super(message);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/tools/ToolRegistry.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/tools/ToolRegistry.java
@@ -15,8 +15,13 @@
  */
 package org.gradle.nativeplatform.toolchain.internal.tools;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.nativeplatform.toolchain.internal.ToolType;
 
+import javax.annotation.Nullable;
+
+@NonNullApi
 public interface ToolRegistry {
+    @Nullable
     GccCommandLineToolConfigurationInternal getTool(ToolType toolType);
 }


### PR DESCRIPTION
`getSystemIncludes` needs to support when no compiler is found.
