### PR TITLE
Url-encode test IDs when constructing links

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/GraphIndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/GraphIndexPageGenerator.java
@@ -55,17 +55,17 @@ public class GraphIndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
                     end();
                     div().classAttr("charts");
                         h3().text("Average total time").end();
-                        String totalTimeChartId = "totalTimeChart" + testHistory.getId().replaceAll("[^a-zA-Z]", "_");
+                        String totalTimeChartId = "totalTimeChart" + urlEncode(testHistory.getId());
                         div().id(totalTimeChartId).classAttr("chart");
                             p().text("Loading...").end();
                         end();
                         script();
-                            text("performanceTests.createPerformanceGraph('tests/" + testHistory.getId() + ".json', function(data) { return data.totalTime }, 'total time', 's', '" + totalTimeChartId + "');");
+                            text("performanceTests.createPerformanceGraph('tests/" + urlEncode(testHistory.getId()) + ".json', function(data) { return data.totalTime }, 'total time', 's', '" + totalTimeChartId + "');");
                         end();
                     end();
 
                     div().classAttr("details");
-                        String url = "tests/" + testHistory.getId() + ".html";
+                        String url = "tests/" + urlEncode(testHistory.getId()) + ".html";
                         a().href(url).text("details...").end();
                     end();
                 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
@@ -16,16 +16,19 @@
 
 package org.gradle.performance.results;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.googlecode.jatl.Html;
 import org.gradle.api.Transformer;
-import org.gradle.performance.util.Git;
 import org.gradle.performance.measure.Amount;
 import org.gradle.performance.measure.DataSeries;
+import org.gradle.performance.util.Git;
 import org.gradle.reporting.ReportRenderer;
 import org.gradle.util.GradleVersion;
 
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -209,5 +212,13 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
             }
         }
         return Collections.emptyList();
+    }
+
+    protected String urlEncode(String str) {
+        try {
+            return URLEncoder.encode(str, Charsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -56,7 +56,7 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
                         List<? extends PerformanceTestExecution> results = testHistory.getExecutions();
                         results = filterForRequestedCommit(results);
                         if (results.isEmpty()) {
-                            archived.put(testHistory.getId(), testHistory.getDisplayName());
+                            archived.put(urlEncode(testHistory.getId()), testHistory.getDisplayName());
                             continue;
                         }
                         h2().classAttr("test-execution");
@@ -88,7 +88,7 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
                         }
                         end();
                         div().classAttr("details");
-                            String url = "tests/" + testHistory.getId() + ".html";
+                            String url = "tests/" + urlEncode(testHistory.getId()) + ".html";
                             a().href(url).text("details...").end();
                         end();
                     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -181,7 +181,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 div().id(chartId).classAttr("chart");
                 p().text("Loading...").end();
                 script();
-                text("performanceTests.createPerformanceGraph('" + testHistory.getId() + ".json', function(data) { return data." + jsonFieldName + "}, '" + fieldLabel + "', '" + fieldUnit + "', '" + chartId + "');");
+                text("performanceTests.createPerformanceGraph('" + urlEncode(testHistory.getId()) + ".json', function(data) { return data." + jsonFieldName + "}, '" + fieldLabel + "', '" + fieldUnit + "', '" + chartId + "');");
                 end();
                 end();
             }


### PR DESCRIPTION
This ensures that the graph is rendered even when a test
contains special characters like ':'.

This graph now shows correctly: https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/9668351:id/report-performance-performance-tests.zip%21/report/tests/clean-k9mail:assembleDebug-on-k9AndroidBuild.html