### PR TITLE
Load docs fonts from Gradle CDN

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -62,7 +62,6 @@ configurations {
     userGuideTask
     jquery
     jqueryTipTip
-    fonts
 }
 
 dependencies {
@@ -77,16 +76,6 @@ dependencies {
     userGuideStyleSheets 'docbook:docbook-xsl:1.75.2@zip'
     jquery "jquery:jquery.min:1.8.0@js"
     jqueryTipTip "com.drewwilson.code:jquery.tipTip:1.3:minified@js"
-
-    fonts \
-        "lato:regular:6:v0SdcGFAl2aezM9Vq_aFTQ@ttf",
-        "lato:regular-italic:6:LqowQDslGv4DmUBAfWa2Vw@ttf",
-        "lato:bold:6:DvlFBScY1r-FMtZSYIYoYw@ttf",
-        "lato:bold-italic:6:HkF_qI1x_noxlxhrhMQYEKCWcynf_cDxXwCLxiixG1c@ttf",
-        "ubuntumono:regular:3:ViZhet7Ak-LRXZMXzuAfkZ0EAVxt0G0biEntp43Qt6E@ttf",
-        "ubuntumono:regular-italic:3:KAKuHXAHZOeECOWAHsRKA-LrC4Du4e_yfTJ8Ol60xk0@ttf",
-        "ubuntumono:bold:3:ceqTZGKHipo8pJj4molytp_TkvowlIOtbR7ePgFOpF4@ttf",
-        "ubuntumono:bold-italic:3:n_d8tv_JOIiYyMXR4eaV9WsGzsqhEorxQDpu60nfWEc@ttf"
 
     testCompile "org.pegdown:pegdown:1.1.0"
     testCompile libraries.jsoup
@@ -188,16 +177,10 @@ tasks.withType(AssembleDslDocTask) {
 
 task configureCss {
     doLast {
-        def images = fileTree(dir: "src/docs/css/images", include: "*.*").files.collectEntries {
+        def tokens = fileTree(dir: "src/docs/css/images", include: "*.*").files.collectEntries {
             [it.name, it.bytes.encodeBase64().toString()]
         }
 
-        def fonts = configurations.fonts.resolvedConfiguration.resolvedArtifacts.collectEntries {
-            def id = it.moduleVersion.id
-            ["${id.group}-${id.name}".toString(), it.file.bytes.encodeBase64().toString()]
-        }
-
-        ext.tokens = images + fonts
         css.inputs.property 'tokens', tokens
         css.filter ReplaceTokens, tokens: tokens
     }

--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -1,5 +1,36 @@
 /*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */html{line-height:1.15;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,footer,header,nav,section{display:block}h1{font-size:2em;margin:.67em 0}figcaption,figure,main{display:block}figure{margin:1em 40px}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent;-webkit-text-decoration-skip:objects}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:inherit}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}dfn{font-style:italic}mark{background-color:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}audio,video{display:inline-block}audio:not([controls]){display:none;height:0}img{border-style:none}svg:not(:root){overflow:hidden}button,input,optgroup,select,textarea{font-family:sans-serif;font-size:100%;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=reset],[type=submit],button,html [type=button]{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{padding:.35em .75em .625em}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{display:inline-block;vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details,menu{display:block}summary{display:list-item}canvas{display:inline-block}template{display:none}[hidden]{display:none}
 
+/* Lato (normal, regular) */
+@font-face {
+  font-display: optional;
+  font-family: Lato;
+  font-weight: 400;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+  src: url("https://assets.gradle.com/lato/fonts/lato-normal/lato-normal.woff2") format("woff2"),
+       url("https://assets.gradle.com/lato/fonts/lato-normal/lato-normal.woff") format("woff");
+}
+/* Lato (normal, italic) */
+@font-face {
+  font-display: optional;
+  font-family: Lato;
+  font-weight: 400;
+  font-style: italic;
+  text-rendering: optimizeLegibility;
+  src: url("https://assets.gradle.com/lato/fonts/lato-normal-italic/lato-normal-italic.woff2") format("woff2"),
+       url("https://assets.gradle.com/lato/fonts/lato-normal-italic/lato-normal-italic.woff") format("woff");
+}
+
+/* Lato (bold, regular) */
+@font-face {
+  font-display: optional;
+  font-family: Lato;
+  font-weight: 500;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+  src: url("https://assets.gradle.com/lato/fonts/lato-semibold/lato-semibold.woff2") format("woff2"),
+       url("https://assets.gradle.com/lato/fonts/lato-semibold/lato-semibold.woff") format("woff");
+}
 
 * {
     -webkit-box-sizing: border-box;
@@ -72,7 +103,7 @@ th {
 h1, h2, h3, h4, h5, h6 {
     margin-top: 0;
     margin-bottom: .5rem;
-    font-weight: 700;
+    font-weight: 500;
     line-height: 1.2;
     color: #02303A;
     text-rendering: optimizeLegibility;
@@ -160,8 +191,8 @@ abbr[title], acronym[title] {
     border-bottom: 1px dotted #e5e5e5;
 }
 
-strong, dfn {
-    font-weight: bold;
+b, strong, dfn {
+    font-weight: 500;
 }
 
 em, dfn {
@@ -394,27 +425,5 @@ h3.releaseinfo {
     color: #999;
     font-weight: normal;
     margin-top: -0.5em;
-}
-
-/* font declarations */
-@font-face {
-    font-family: 'Lato';
-    font-style: normal;
-    font-weight: 400;
-    src: local('Lato Regular'), local('Lato-Regular'), url('data:font/opentype;base64,@lato-regular@') format('truetype');
-}
-
-@font-face {
-    font-family: 'Lato';
-    font-style: italic;
-    font-weight: 400;
-    src: local('Lato Italic'), local('Lato-Italic'), url('data:font/opentype;base64,@lato-regular-italic@') format('truetype');
-}
-
-@font-face {
-    font-family: 'Lato';
-    font-style: normal;
-    font-weight: 700;
-    src: local('Lato Bold'), local('Lato-Bold'), url('data:font/opentype;base64,@lato-bold@') format('truetype');
 }
 

--- a/subprojects/docs/src/docs/css/docs.css
+++ b/subprojects/docs/src/docs/css/docs.css
@@ -316,7 +316,7 @@
     width: 100px;
     background-color: #1DA2BD;
     color: white;
-    font-weight: 700;
+    font-weight: 500;
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
     border-style: none;

--- a/subprojects/docs/src/docs/stylesheets/dslHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/dslHtml.xsl
@@ -36,6 +36,7 @@
 
     <!-- customize the stylesheets to add to the <head> element -->
     <xsl:template name="output.html.stylesheets">
+        <link rel="preconnect" href="//assets.gradle.com" crossorigin="crossorigin"/>
         <link href="base.css" rel="stylesheet" type="text/css"/>
         <link href="docs.css" rel="stylesheet" type="text/css"/>
         <link href="dsl.css" rel="stylesheet" type="text/css"/>

--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -40,6 +40,7 @@
     <!-- Use custom style sheet content -->
     <xsl:param name="html.stylesheet">DUMMY</xsl:param>
     <xsl:template name="output.html.stylesheets">
+        <link rel="preconnect" href="//assets.gradle.com" crossorigin="crossorigin"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <link href="base.css" rel="stylesheet" type="text/css"/>
         <link href="docs.css" rel="stylesheet" type="text/css"/>

--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -29,7 +29,8 @@ transformDocument {
     head().
             append("<meta charset='utf-8'>").
             append("<meta name='viewport' content='width=device-width, initial-scale=1'>").
-            append("<title>Gradle @version@ Release Notes</title>")
+            append("<title>Gradle @version@ Release Notes</title>").
+            append("<link rel='stylesheet' type='text/css' href='https://assets.gradle.com/lato/css/lato-font.css'/>")
 
     head().append("<style>p{}</style>").children().last().childNode(0).attr("data", baseStyleFile.text + releaseNotesStyleFile.text)
 


### PR DESCRIPTION
This significantly improves time to first meaningful paint
according to Google's Lighthouse:
 - WOFF2 fonts are smaller than TTF
 - Fonts are loaded in parallel to the rest of CSS, instead of
   inline. Not only reducing the time to first paint, but also giving
   a chance for the browser to layout the DOM in parallel

This change basically stops our inlining TTF fonts and loads them from Google Fonts. I considered manually subsetting the fonts or loading with [webfontloader](https://github.com/typekit/webfontloader), but decided this a reasonable first step with performance benefits I am certain of.

### Context
I was digging into Google Analytics and found the load times of Gradle docs to be poor, especially in Asia (which is 26% of traffic)

![screenshot 2017-12-01 16 32 09](https://user-images.githubusercontent.com/51534/33517649-382ab578-d745-11e7-91cf-da9459fbf58f.png)

This results in 2 behavior changes when I compare them:
 * 30% fewer page views from Asia compared to all users
 * Many more visits (6x) to userguide_single.html compared to the rest of world, presumably so they don't have to load multiple pages to get most of the user guide content.

I'm suggesting this against `release` for Gradle 4.4 because if we can achieve even 10% more page views from Asia, that is 18,000 more views and I believe this is a low enough risk change that we can fix it separately from the Gradle distribution.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
