### PR TITLE
Add the file 'build/generated-resources/test' to .classpath only if is it exists

### DIFF
--- a/gradle/eclipse.gradle
+++ b/gradle/eclipse.gradle
@@ -15,7 +15,8 @@ allprojects {
                     classpath.entries.removeAll { it.path.contains("/subprojects") && it.kind == 'lib' }
                     // Add needed resources for running gradle as a non daemon java application
                     classpath.entries.add(new org.gradle.plugins.ide.eclipse.model.SourceFolder("build/generated-resources/main", null))
-                    classpath.entries.add(new org.gradle.plugins.ide.eclipse.model.SourceFolder("build/generated-resources/test", null))
+                    if (file("build/generated-resources/test").exists())
+						classpath.entries.add(new org.gradle.plugins.ide.eclipse.model.SourceFolder("build/generated-resources/test", null))
                 }
             }
             jdt {


### PR DESCRIPTION
### Context
When importing Gradle into Eclipse, adding a non existent file to the `.classpath` as a source makes the project unbuildable.

### Contributor Checklist
- [x ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
