### PR TITLE
Add cast (BuildOutcomeComparisonResult<?>) otherwise Eclipse Java Compiler fails to compile

### DIFF
--- a/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/compare/internal/DefaultBuildComparator.java
+++ b/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/compare/internal/DefaultBuildComparator.java
@@ -65,7 +65,7 @@ public class DefaultBuildComparator implements BuildComparator {
                 }
 
                 @SuppressWarnings("unchecked")
-                BuildOutcomeComparisonResult<?> comparisonResult = comparator.compare((BuildOutcomeAssociation) outcomeAssociation);
+                BuildOutcomeComparisonResult<?> comparisonResult = (BuildOutcomeComparisonResult<?>) comparator.compare((BuildOutcomeAssociation) outcomeAssociation);
 
                 results.add(comparisonResult);
             }


### PR DESCRIPTION
### Context
When importing Gradle into Eclipse, the Eclipse Java Compiler requires to explicitly cast comparator.compare((BuildOutcomeAssociation) outcomeAssociation by  (BuildOutcomeComparisonResult<?>) 

### Contributor Checklist
- [x ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x ] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
