### PR TITLE
Catch AccessControlException to avoid test worker process hanging

### DIFF
--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -749,6 +749,14 @@ Compile-avoidance is deactivated if annotation processors are found on the compi
 
 The `test` task is an instance of api:org.gradle.api.tasks.testing.Test[]. It automatically detects and executes all unit tests in the `test` source set. It also generates a report once test execution is complete. JUnit and TestNG are both supported. Have a look at api:org.gradle.api.tasks.testing.Test[] for the complete API.
 
+[NOTE]
+====
+
+There're some limitations when running test with Gradle. For example, issues may occur if a https://docs.oracle.com/javase/8/docs/api/java/lang/SecurityManager.html[SecurityManager] is used in tests because
+Gradle's internal message mechanism depends on reflection and socket communication, which may be disrupted by Java security manager. In this case, you should restore the original `SecurityManager` after the test so that the gradle test worker process can continue to function.
+
+====
+
 
 [[sec:test_execution]]
 ==== Test execution

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -749,14 +749,6 @@ Compile-avoidance is deactivated if annotation processors are found on the compi
 
 The `test` task is an instance of api:org.gradle.api.tasks.testing.Test[]. It automatically detects and executes all unit tests in the `test` source set. It also generates a report once test execution is complete. JUnit and TestNG are both supported. Have a look at api:org.gradle.api.tasks.testing.Test[] for the complete API.
 
-[NOTE]
-====
-
-There're some limitations when running test with Gradle. For example, issues may occur if a https://docs.oracle.com/javase/8/docs/api/java/lang/SecurityManager.html[SecurityManager] is used in tests because
-Gradle's internal message mechanism depends on reflection and socket communication, which may be disrupted by Java security manager. In this case, you should restore the original `SecurityManager` after the test so that the gradle test worker process can continue to function.
-
-====
-
 
 [[sec:test_execution]]
 ==== Test execution
@@ -764,6 +756,16 @@ Gradle's internal message mechanism depends on reflection and socket communicati
 Tests are executed in a separate JVM, isolated from the main build process. The api:org.gradle.api.tasks.testing.Test[] task's API allows you some control over how this happens.
 
 There are a number of properties which control how the test process is launched. This includes things such as system properties, JVM arguments, and the Java executable to use.
+
+[NOTE]
+====
+
+The test process can exit unexpectedly if configured incorrectly. For instance, if the Java executable does not exist or an invalid JVM argument is provided, the test process will fail to start.
+Similarly, if a test makes programmatic changes to the test process, this can also cause unexpected failures.  For example, issues may occur if a https://docs.oracle.com/javase/8/docs/api/java/lang/SecurityManager.html[SecurityManager] is modified in a test because
+Gradle's internal messaging depends on reflection and socket communication, which may be disrupted if the permissions on the security manager change. (In this case, you should restore the original `SecurityManager` after the test so that the
+gradle test worker process can continue to function.)
+
+====
 
 You can specify whether or not to execute your tests in parallel. Gradle provides parallel test execution by running multiple test processes concurrently. Each test process executes only a single test at a time, so you generally don't need to do anything special to your tests to take advantage of this. The `maxParallelForks` property specifies the maximum number of test processes to run at any given time. The default is 1, that is, do not execute the tests in parallel.
 
@@ -795,9 +797,9 @@ Starting with Gradle 1.10, it is possible to include only specific tests, based 
 
 Test filtering feature has following characteristic:
 
-* Fully qualified class name or fully qualified method name is supported, e.g. “org.gradle.SomeTest”, “org.gradle.SomeTest.someMethod”
+* Fully qualified class name or fully qualified method name is supported, e.g. ???org.gradle.SomeTest???, ???org.gradle.SomeTest.someMethod???
 * Wildcard '*' is supported for matching any characters
-* Command line option “--tests” is provided to conveniently extend the test filter for an individual Gradle execution. This is especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusions declared in the build script are still honored. That is, the command line filters are always applied on top of the filter definition in the build script. It is possible to supply multiple “--tests” options and tests matching any of those patterns will be included.
+* Command line option ???--tests??? is provided to conveniently extend the test filter for an individual Gradle execution. This is especially useful for the classic 'single test method execution' use case. When the command line option is used, the inclusions declared in the build script are still honored. That is, the command line filters are always applied on top of the filter definition in the build script. It is possible to supply multiple ???--tests??? options and tests matching any of those patterns will be included.
 * Gradle tries to filter the tests given the limitations of the test framework API. Some advanced, synthetic tests may not be fully compatible with filtering. However, the vast majority of tests and use cases should be handled neatly.
 * Test filtering supersedes the file-based test selection. The latter may be completely replaced in future. We will grow the test filtering API and add more kinds of filters.
 
@@ -841,7 +843,7 @@ gradle test --continuous --tests "com.mypackage.foo.*"
 This mechanism has been superseded by 'Test Filtering', described above.
 ====
 
-Setting a system property of __taskName.single__ = __testNamePattern__ will only execute tests that match the specified __testNamePattern__. The __taskName__ can be a full multi-project path like “:sub1:sub2:test” or just the task name. The __testNamePattern__ will be used to form an include pattern of “\**/testNamePattern*.class”. If no tests with this pattern can be found, an exception is thrown. This is to shield you from false security. If tests of more than one subproject are executed, the pattern is applied to each subproject. An exception is thrown if no tests can be found for a particular subproject. In such a case you can use the path notation of the pattern, so that the pattern is applied only to the test task of a specific subproject. Alternatively you can specify the fully qualified task name to be executed. You can also specify multiple patterns. Examples:
+Setting a system property of __taskName.single__ = __testNamePattern__ will only execute tests that match the specified __testNamePattern__. The __taskName__ can be a full multi-project path like ???:sub1:sub2:test??? or just the task name. The __testNamePattern__ will be used to form an include pattern of ???\**/testNamePattern*.class???. If no tests with this pattern can be found, an exception is thrown. This is to shield you from false security. If tests of more than one subproject are executed, the pattern is applied to each subproject. An exception is thrown if no tests can be found for a particular subproject. In such a case you can use the path notation of the pattern, so that the pattern is applied only to the test task of a specific subproject. Alternatively you can specify the fully qualified task name to be executed. You can also specify multiple patterns. Examples:
 
 * `gradle -Dtest.single=ThisUniquelyNamedTest test`
 * `gradle -Dtest.single=a/b/ test`
@@ -866,7 +868,7 @@ When using TestNG, we scan for methods annotated with `@Test`.
 
 Note that abstract classes are not executed. Gradle also scans up the inheritance tree into jar files on the test classpath.
 
-If you don't want to use test class detection, you can disable it by setting `scanForTestClasses` to false. This will make the test task only use includes / excludes to find test classes. If `scanForTestClasses` is false and no include / exclude patterns are specified, the defaults are “`\**/*Tests.class`”, “`*\*/*Test.class`” and “`*\*/Abstract*.class`” for include and exclude, respectively.
+If you don't want to use test class detection, you can disable it by setting `scanForTestClasses` to false. This will make the test task only use includes / excludes to find test classes. If `scanForTestClasses` is false and no include / exclude patterns are specified, the defaults are ???`\**/*Tests.class`???, ???`*\*/*Test.class`??? and ???`*\*/Abstract*.class`??? for include and exclude, respectively.
 
 [[test_grouping]]
 ==== Test grouping

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+class SecurityManagerIntegrationTest extends AbstractIntegrationSpec {
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    def "should not hang when running with security manager"() {
+        given:
+        buildFile << """ 
+apply plugin:"java"
+
+${mavenCentralRepository()}
+
+dependencies {
+    testCompile 'junit:junit:4.12'
+}
+"""
+        file('src/test/java/SecurityManagerTest.java') << '''
+import java.security.AccessControlException;
+
+public class SecurityManagerTest {
+    @org.junit.Test
+    public void testSeqManagerNOTWorking() throws Exception {
+        System.setSecurityManager(new SecurityManager());
+
+        try {
+            System.setProperty("TestProperty", "value");
+        } catch (AccessControlException ex) {
+            System.out.println(ex);
+        }
+        System.setProperty("AnotherProperty", "value");
+    }
+}
+'''
+
+        expect:
+        fails('test')
+        result.error.contains("Process 'Gradle Test Executor 1' finished with non-zero exit value 1")
+        result.error.contains("Please refer to the test chapter in user guide at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_test.html")
+    }
+}

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -56,6 +56,6 @@ public class SecurityManagerTest {
         expect:
         fails('test')
         result.error.contains("Process 'Gradle Test Executor 1' finished with non-zero exit value 1")
-        result.error.contains("Please refer to the test chapter in user guide at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_test.html")
+        result.error.contains("Please refer to the test execution section in the user guide at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_plugin.html#sec:test_execution")
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -128,9 +128,9 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
                 workerProcess.waitForStop();
             } catch (ExecException e) {
                 throw new ExecException(e.getMessage()
-                    + "\nThis problem might be caused by incorrect test configuration."
-                    + "\nPlease refer to the test chapter in user guide at "
-                    + documentationRegistry.getDocumentationFor("java_test"), e.getCause());
+                    + "\nThis problem might be caused by incorrect test process configuration."
+                    + "\nPlease refer to the test execution section in the user guide at "
+                    + documentationRegistry.getDocumentationFor("java_plugin", "sec:test_execution"), e.getCause());
             } finally {
                 completion.leaseFinish();
             }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.worker;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.tasks.testing.JULRedirector;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
@@ -26,6 +27,7 @@ import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.JavaForkOptions;
+import org.gradle.process.internal.ExecException;
 import org.gradle.process.internal.worker.WorkerProcess;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
@@ -47,8 +49,9 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     private WorkerProcess workerProcess;
     private TestResultProcessor resultProcessor;
     private WorkerLeaseRegistry.WorkerLeaseCompletion completion;
+    private DocumentationRegistry documentationRegistry;
 
-    public ForkingTestClassProcessor(WorkerLeaseRegistry.WorkerLease parentWorkerLease, WorkerProcessFactory workerFactory, WorkerTestClassProcessorFactory processorFactory, JavaForkOptions options, Iterable<File> classPath, Action<WorkerProcessBuilder> buildConfigAction, ModuleRegistry moduleRegistry) {
+    public ForkingTestClassProcessor(WorkerLeaseRegistry.WorkerLease parentWorkerLease, WorkerProcessFactory workerFactory, WorkerTestClassProcessorFactory processorFactory, JavaForkOptions options, Iterable<File> classPath, Action<WorkerProcessBuilder> buildConfigAction, ModuleRegistry moduleRegistry, DocumentationRegistry documentationRegistry) {
         this.currentWorkerLease = parentWorkerLease;
         this.workerFactory = workerFactory;
         this.processorFactory = processorFactory;
@@ -56,6 +59,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         this.classPath = classPath;
         this.buildConfigAction = buildConfigAction;
         this.moduleRegistry = moduleRegistry;
+        this.documentationRegistry = documentationRegistry;
     }
 
     @Override
@@ -122,6 +126,11 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
             try {
                 remoteProcessor.stop();
                 workerProcess.waitForStop();
+            } catch (ExecException e) {
+                throw new ExecException(e.getMessage()
+                    + "\nThis problem might be caused by incorrect test configuration."
+                    + "\nPlease refer to the test chapter in user guide at "
+                    + documentationRegistry.getDocumentationFor("java_test"), e.getCause());
             } finally {
                 completion.leaseFinish();
             }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.security.AccessControlException;
 import java.util.concurrent.CountDownLatch;
 
 public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClassProcessor, Serializable {
@@ -106,6 +107,9 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
         Thread.currentThread().setName("Test worker");
         try {
             processor.processTestClass(testClass);
+        } catch (AccessControlException e) {
+            completed.countDown();
+            throw e;
         } finally {
             // Clean the interrupted status
             Thread.interrupted();

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.worker
 
 import org.gradle.api.Action
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.classpath.Module
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo
@@ -39,9 +40,10 @@ class ForkingTestClassProcessorTest extends Specification {
     WorkerProcess workerProcess = Mock(WorkerProcess)
     ModuleRegistry moduleRegistry = Mock(ModuleRegistry)
     JavaForkOptions options = Mock(JavaForkOptions)
+    DocumentationRegistry documentationRegistry = Mock(DocumentationRegistry)
 
     @Subject
-        processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLease, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], Mock(Action), moduleRegistry])
+        processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLease, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], Mock(Action), moduleRegistry, documentationRegistry])
 
     def "acquires worker lease and starts worker process on first test"() {
         def test1 = Mock(TestClassRunInfo)

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing.detection;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
@@ -55,10 +56,11 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
     private final BuildOperationExecutor buildOperationExecutor;
     private final int maxWorkerCount;
     private final Clock clock;
+    private final DocumentationRegistry documentationRegistry;
 
     public DefaultTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory, ModuleRegistry moduleRegistry,
                                WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, int maxWorkerCount,
-                               Clock clock) {
+                               Clock clock, DocumentationRegistry documentationRegistry) {
         this.workerFactory = workerFactory;
         this.actorFactory = actorFactory;
         this.moduleRegistry = moduleRegistry;
@@ -66,6 +68,7 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
         this.buildOperationExecutor = buildOperationExecutor;
         this.maxWorkerCount = maxWorkerCount;
         this.clock = clock;
+        this.documentationRegistry = documentationRegistry;
     }
 
     @Override
@@ -77,7 +80,7 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
         final Factory<TestClassProcessor> forkingProcessorFactory = new Factory<TestClassProcessor>() {
             public TestClassProcessor create() {
                 return new ForkingTestClassProcessor(currentWorkerLease, workerFactory, testInstanceFactory, testExecutionSpec.getJavaForkOptions(),
-                    classpath, testFramework.getWorkerConfigurationAction(), moduleRegistry);
+                    classpath, testFramework.getWorkerConfigurationAction(), moduleRegistry, documentationRegistry);
             }
         };
         final Factory<TestClassProcessor> reforkingProcessorFactory = new Factory<TestClassProcessor>() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -25,6 +25,7 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
@@ -530,7 +531,8 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
                 getServices().get(WorkerLeaseRegistry.class),
                 getServices().get(BuildOperationExecutor.class),
                 getServices().get(StartParameter.class).getMaxWorkerCount(),
-                getServices().get(Clock.class));
+                getServices().get(Clock.class),
+                getServices().get(DocumentationRegistry.class));
         } else {
             return testExecuter;
         }


### PR DESCRIPTION
Partially fix https://github.com/gradle/gradle/issues/3526

If a security manager is set in test, test worker process can no longer
react to message from main process because Gradle's message dispatch mechanism
depends on reflection and socket communication. This PR fix the issue which cause
worker process to hang and provide more readable error messages

### Context

See #3526 

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
