### PR TITLE
Remove tree root canonicalization

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -151,15 +151,15 @@ task work {
         inFile.createLink(copy)
         run("work")
 
+        /*
+         * This documents the current behavior, which is optimizing
+         * for performance at the expense of not detecting some corner
+         * cases. If there actually is a task that needs to distinguish
+         * between links and real files, we should probably provide an
+         * opt-in to canonical snapshotting, as it's quite expensive.
+         */
         then:
-        // TODO - should not be skipped
-        result.assertTasksSkipped(":work")
-
-        when:
-        run("work")
-
-        then:
-        result.assertTasksSkipped(":work")
+        result.assertTaskSkipped(":work")
 
         when:
         copy.text = "new content"
@@ -187,14 +187,15 @@ task work {
 
         run("work")
 
+        /*
+         * This documents the current behavior, which is optimizing
+         * for performance at the expense of not detecting some corner
+         * cases. If there actually is a task that needs to distinguish
+         * between links and real files, we should probably provide an
+         * opt-in to canonical snapshotting, as it's quite expensive.
+         */
         then:
-        result.assertTasksNotSkipped(":work")
-
-        when:
-        run("work")
-
-        then:
-        result.assertTasksSkipped(":work")
+        result.assertTaskSkipped(":work")
 
         when:
         copy.file("file").text = "new content"
@@ -221,15 +222,16 @@ task work {
         outFile.createLink(copy)
         run("work")
 
-        then:
-        // TODO - should not be skipped
-        result.assertTasksSkipped(":work")
 
-        when:
-        run("work")
-
+        /*
+         * This documents the current behavior, which is optimizing
+         * for performance at the expense of not detecting some corner
+         * cases. If there actually is a task that needs to distinguish
+         * between links and real files, we should probably provide an
+         * opt-in to canonical snapshotting, as it's quite expensive.
+         */
         then:
-        result.assertTasksSkipped(":work")
+        result.assertTaskSkipped(":work")
 
         when:
         copy.text = "new content"
@@ -257,14 +259,15 @@ task work {
 
         run("work")
 
+        /*
+         * This documents the current behavior, which is optimizing
+         * for performance at the expense of not detecting some corner
+         * cases. If there actually is a task that needs to distinguish
+         * between links and real files, we should probably provide an
+         * opt-in to canonical snapshotting, as it's quite expensive.
+         */
         then:
-        result.assertTasksNotSkipped(":work")
-
-        when:
-        run("work")
-
-        then:
-        result.assertTasksSkipped(":work")
+        result.assertTaskSkipped(":work")
 
         when:
         copy.listFiles().each { it.text = 'new content' }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -30,7 +30,6 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
-import org.gradle.internal.FileUtils;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.services.FileSystems;
 import org.gradle.util.GUtil;
@@ -60,7 +59,7 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
     private final Factory<DirectoryWalker> directoryWalkerFactory;
 
     public DirectoryFileTree(File dir, PatternSet patternSet, FileSystem fileSystem) {
-        this(FileUtils.canonicalize(dir), patternSet, DEFAULT_DIRECTORY_WALKER_FACTORY, fileSystem, false);
+        this(dir, patternSet, DEFAULT_DIRECTORY_WALKER_FACTORY, fileSystem, false);
     }
 
     DirectoryFileTree(File dir, PatternSet patternSet, Factory<DirectoryWalker> directoryWalkerFactory, FileSystem fileSystem, boolean postfix) {


### PR DESCRIPTION
This removes some configuration time overhead and makes
input/output snapshotting consistent with regards to changes
in symlink. We now always ignore the fact that a file/directory
was replaced by a symlink (but the content stayed the same). There
might be some tasks that actually need to make a difference between
a file and a link to a file, but for those we should provide an
opt-in to canonical snapshotting, as it is quite expensive to do it
consistently (i.e. canonicalize every file in the whole tree).