### PR TITLE
Add a way to reject all versions of a component

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
@@ -52,4 +52,12 @@ public interface MutableVersionConstraint extends VersionConstraint {
      */
     void reject(String... versions);
 
+    /**
+     * Rejects all versions of this component. Can be used to declare that a component is incompatible with another
+     * (typically, cannot have both a 2 different implementations of the same API).
+     *
+     * @since 4.5
+     */
+    void rejectAll();
+
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -738,4 +738,32 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         '[1.0,)'         | "'1.5', '[1.1, 1.3]', '1.4'" | 0        | false
         'latest.release' | "'1.5', '[1.1, 1.3]', '1.4'" | 0        | true
     }
+
+    def "adding rejectAll on a dependency is pointless and make it fail"() {
+        given:
+        repository {
+            'org:foo' {
+                '1.0'()
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0') {
+                   version {
+                      rejectAll()
+                   }
+                }
+            }           
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        // TODO CC: This is the generic error message for a failing dependency,
+        // but we can probably do better, even though it's not specific to rejectAll
+        failure.assertHasCause("""Could not find org:foo:.""")
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.artifacts.dependencies;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.InvalidUserDataException;
+import com.google.common.collect.Lists;
+import org.gradle.api.InvalidUserDataException;
 import com.google.common.base.Strings;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -17,8 +17,6 @@ package org.gradle.api.internal.artifacts.dependencies;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.InvalidUserDataException;
-import com.google.common.collect.Lists;
-import org.gradle.api.InvalidUserDataException;
 import com.google.common.base.Strings;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
@@ -96,6 +94,13 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
             throw new InvalidUserDataException("The 'reject' clause requires at least one rejected version");
         }
         Collections.addAll(rejects, versions);
+    }
+
+    @Override
+    public void rejectAll() {
+        this.prefer = "";
+        this.rejects.clear();
+        this.rejects.add("+");
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -217,6 +217,11 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
         return module.getUnattachedEdgesTo(this);
     }
 
+    @Override
+    public boolean isFromPendingNode() {
+        return selectedBy != null && selectedBy.getDependencyMetadata().isPending();
+    }
+
     boolean isSelected() {
         return state == ModuleState.Selected;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentStateWithDependents.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentStateWithDependents.java
@@ -27,4 +27,5 @@ import java.util.List;
 public interface ComponentStateWithDependents<T extends ComponentResolutionState> extends ComponentResolutionState {
     List<T> getDependents();
     List<T> getUnattachedDependencies();
+    boolean isFromPendingNode();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -154,4 +154,17 @@ class DefaultMutableVersionConstraintTest extends Specification {
         e.message == "The 'reject' clause requires at least one rejected version"
     }
 
+    def "calling rejectAll is equivalent to having empty preferred version and '+' reject"() {
+        given:
+        def version = new DefaultMutableVersionConstraint('1.0')
+        version.reject('1.1', '1.2')
+
+        when:
+        version.rejectAll()
+
+        then:
+        version.preferredVersion == ''
+        version.getRejectedVersions() == ['+']
+    }
+
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelectorTest.groovy
@@ -41,6 +41,16 @@ class SubVersionSelectorTest extends AbstractStringVersionSelectorTest {
         !accept("1.2.3+", "1.2")
     }
 
+    def "'+' is a valid selector which accepts everything"() {
+        expect:
+        accept("+", "11")
+        accept("+", "1.2")
+        accept("+", "1.2.3.11")
+        accept("+", "2")
+        accept("+", "11")
+        accept("+", "1.2")
+    }
+
     def "metadata-aware accept method delivers same results"() {
         def metadata = Stub(ComponentMetadata) {
             getId() >> Stub(ModuleVersionIdentifier) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -152,5 +152,10 @@ abstract class AbstractConflictResolverTest extends Specification {
         List<TestComponent> getUnattachedDependencies() {
             []
         }
+
+        @Override
+        boolean isFromPendingNode() {
+            false
+        }
     }
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -659,6 +659,67 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         ]
     }
 
+    def "can publish java-library with rejected versions"() {
+        given:
+        createBuildScripts("""
+
+            ${jcenterRepository()}
+
+            dependencies {
+                api "org.springframework:spring-core:2.5.6"
+                implementation("commons-collections:commons-collections") {
+                    version { 
+                        prefer '[3.2, 4)'
+                        reject '3.2.1', '[3.2.2,)'
+                    }
+                }
+            }
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.assertPublished()
+
+        javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
+        javaLibrary.parsedIvy.assertDependsOn("org.springframework:spring-core:2.5.6@compile", "commons-collections:commons-collections:[3.2, 4)@runtime")
+
+        and:
+        javaLibrary.parsedModuleMetadata.variant('api') {
+            dependency('org.springframework:spring-core:2.5.6') {
+                noMoreExcludes()
+                rejects()
+            }
+            noMoreDependencies()
+        }
+
+        javaLibrary.parsedModuleMetadata.variant('runtime') {
+            dependency('commons-collections:commons-collections:[3.2, 4)') {
+                noMoreExcludes()
+                rejects '3.2.1', '[3.2.2,)'
+            }
+            dependency('org.springframework:spring-core:2.5.6') {
+                noMoreExcludes()
+                rejects()
+            }
+            noMoreDependencies()
+        }
+
+        and:
+        resolveArtifacts(javaLibrary) == [
+            'commons-collections-3.2.jar', 'commons-logging-1.1.1.jar', 'publishTest-1.9.jar', 'spring-core-2.5.6.jar'
+        ]
+    }
+
     private void createBuildScripts(def append) {
         settingsFile << "rootProject.name = 'publishTest' "
 


### PR DESCRIPTION
This pull request is built on top of #3673 which needs to be reviewed first. It implements a `rejectAll` method which is just a shorthand notation for prefer anything, reject everything.

