### PR TITLE
Restore steps for importing Gradle into Eclipse

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,13 +42,26 @@ Gradle uses pull requests for contributions. Fork [gradle/gradle](https://github
     git config user.name 'First Last'
     git config user.email user@example.com
 
+### IntelliJ IDEA
+
 You can generate the IntelliJ project by running
 
     ./gradlew idea
 
+    
+### Eclipse
+
 You can generate the Eclipse projects by running
 
     ./gradlew eclipse
+
+1. You will need Eclipse 4.5 (Mars) at least
+2. Install the Groovy Eclipse plugin from http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/
+3. Make sure you have a Java 8 compatible JRE configured in your workspace
+4. In `Window->Preferences->Groovy->Compiler`, check `Enable Script folder support` and add `**/*.gradle`
+5. Run `./gradlew eclipse` from the root directory
+6. Import all projects using the "Import Existing Projects into Workspace" wizard
+   
 
 ### Code Change Guidelines
 


### PR DESCRIPTION
The steps to import Gradle into Eclipse are important, specially the mandatory JDK 8 version.

### Context
Importing Gradle into Eclipse does not work if the JDK is not 1.8 or greater.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
