### PR TITLE
Cleanup unused VCS checkouts

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -79,7 +79,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         PathKeyFileStore fileStore = fileStoreFactory.createFileStore(target);
         PersistentCache persistentCache = cacheRepository
             .cache(target)
-            .withCleanup(cleanupActionFactory.create(FixedSizeOldestCacheCleanup.class, targetSizeInMB))
+            .withCleanup(cleanupActionFactory.create(new FixedSizeOldestCacheCleanup(targetSizeInMB)))
             .withDisplayName("Build cache")
             .withLockOptions(mode(None))
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
@@ -19,11 +19,12 @@ package org.gradle.caching.local.internal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
+import org.gradle.cache.CleanupAction
 import org.gradle.cache.internal.CacheScopeMapping
+import org.gradle.cache.internal.CleanupActionFactory
 import org.gradle.cache.internal.VersionStrategy
 import org.gradle.caching.BuildCacheServiceFactory
 import org.gradle.caching.local.DirectoryBuildCache
-import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resource.local.PathKeyFileStore
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -38,7 +39,8 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
     def cacheScopeMapping = Mock(CacheScopeMapping)
     def resolver = Mock(FileResolver)
     def fileStoreFactory = Mock(DirectoryBuildCacheFileStoreFactory)
-    def factory = new DirectoryBuildCacheServiceFactory(cacheRepository, cacheScopeMapping, resolver, new TestBuildOperationExecutor(), fileStoreFactory)
+    def cleanupActionFactory = Mock(CleanupActionFactory)
+    def factory = new DirectoryBuildCacheServiceFactory(cacheRepository, cacheScopeMapping, resolver, fileStoreFactory, cleanupActionFactory)
     def cacheBuilder = Stub(CacheBuilder)
     def config = Mock(DirectoryBuildCache)
     def buildCacheDescriber = new NoopBuildCacheDescriber()
@@ -57,6 +59,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * cacheScopeMapping.getBaseDirectory(null, "build-cache-1", VersionStrategy.SharedCache) >> cacheDir
         1 * fileStoreFactory.createFileStore(cacheDir) >> Mock(PathKeyFileStore)
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
+        1 * cleanupActionFactory.create(_, _) >> Mock(CleanupAction)
         0 * _
     }
 
@@ -72,6 +75,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * resolver.resolve(cacheDir) >> cacheDir
         1 * fileStoreFactory.createFileStore(cacheDir) >> Mock(PathKeyFileStore)
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
+        1 * cleanupActionFactory.create(_, _) >> Mock(CleanupAction)
         0 * _
     }
 

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
@@ -59,7 +59,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * cacheScopeMapping.getBaseDirectory(null, "build-cache-1", VersionStrategy.SharedCache) >> cacheDir
         1 * fileStoreFactory.createFileStore(cacheDir) >> Mock(PathKeyFileStore)
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
-        1 * cleanupActionFactory.create(_, _) >> Mock(CleanupAction)
+        1 * cleanupActionFactory.create(_) >> Mock(CleanupAction)
         0 * _
     }
 
@@ -75,7 +75,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
         1 * resolver.resolve(cacheDir) >> cacheDir
         1 * fileStoreFactory.createFileStore(cacheDir) >> Mock(PathKeyFileStore)
         1 * cacheRepository.cache(cacheDir) >> cacheBuilder
-        1 * cleanupActionFactory.create(_, _) >> Mock(CleanupAction)
+        1 * cleanupActionFactory.create(_) >> Mock(CleanupAction)
         0 * _
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -79,7 +79,6 @@ import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.BuildOperationListenerManager;
 import org.gradle.internal.progress.DefaultBuildOperationExecutor;
 import org.gradle.internal.progress.DefaultBuildOperationListenerManager;
-import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -257,7 +256,7 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new ExperimentalFeatures();
     }
 
-    CleanupActionFactory createCleanupActionFactory(Instantiator instantiator, BuildOperationExecutor buildOperationExecutor) {
-        return new CleanupActionFactory(instantiator, buildOperationExecutor);
+    CleanupActionFactory createCleanupActionFactory(BuildOperationExecutor buildOperationExecutor) {
+        return new CleanupActionFactory(buildOperationExecutor);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -46,6 +46,7 @@ import org.gradle.cache.CacheRepository;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.CacheRepositoryServices;
 import org.gradle.cache.internal.CacheScopeMapping;
+import org.gradle.cache.internal.CleanupActionFactory;
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.VersionStrategy;
@@ -78,6 +79,7 @@ import org.gradle.internal.progress.BuildOperationListener;
 import org.gradle.internal.progress.BuildOperationListenerManager;
 import org.gradle.internal.progress.DefaultBuildOperationExecutor;
 import org.gradle.internal.progress.DefaultBuildOperationListenerManager;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -253,5 +255,9 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
 
     ExperimentalFeatures createExperimentalFeatures() {
         return new ExperimentalFeatures();
+    }
+
+    CleanupActionFactory createCleanupActionFactory(Instantiator instantiator, BuildOperationExecutor buildOperationExecutor) {
+        return new CleanupActionFactory(instantiator, buildOperationExecutor);
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/AbstractVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/AbstractVcsIntegrationTest.groovy
@@ -50,7 +50,7 @@ abstract class AbstractVcsIntegrationTest extends AbstractIntegrationSpec {
 
     TestFile checkoutDir(String repoName, String versionId, String repoId, TestFile baseDir=testDirectory) {
         def hashedRepo = hashRepositoryId(repoId)
-        baseDir.file(".gradle/vcsWorkingDirs/${hashedRepo}/${versionId}/${repoName}")
+        baseDir.file(".gradle/vcsWorkingDirs/${hashedRepo}-${versionId}/${repoName}")
     }
 
     String hashRepositoryId(String repoId) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.vcs.internal
 
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
-import org.gradle.util.GFileUtils
 import org.gradle.vcs.fixtures.GitRepository
 import org.junit.Rule
 import spock.lang.Issue
@@ -31,7 +30,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
 
     def 'can define and use source repositories'() {
         given:
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
 
         settingsFile << """
             sourceControl {
@@ -54,7 +53,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     @Issue('gradle/gradle-native#206')
     def 'can define and use source repositories with initscript resolution present'() {
         given:
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
         temporaryFolder.file('initialize.gradle') << """
         initscript {            
             dependencies {
@@ -86,7 +85,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
     @Issue('gradle/gradle-native#207')
     def 'can use repositories even when clean is run'() {
         given:
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
 
         settingsFile << """
             sourceControl {
@@ -125,12 +124,12 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
                 }
             }
         """
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
         repo.createLightWeightTag('1.3.0')
 
         def javaFile = file('dep/src/main/java/Dep.java')
         javaFile.replace('class', 'interface')
-        repo.commit('Changed Dep to an interface', GFileUtils.listFiles(file('dep'), null, true))
+        repo.commit('Changed Dep to an interface', file('dep'))
 
         buildFile.replace('latest.integration', '1.3.0')
 
@@ -155,12 +154,12 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
                 }
             }
         """
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
         repo.createLightWeightTag('1.3.0')
 
         def javaFile = file('dep/src/main/java/Dep.java')
         javaFile.replace('class', 'interface')
-        repo.commit('Changed Dep to an interface', GFileUtils.listFiles(file('dep'), null, true))
+        repo.commit('Changed Dep to an interface', file('dep'))
 
         buildFile.replace('latest.integration', '1.4.0')
 
@@ -173,7 +172,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
 
         when:
         javaFile.replace('interface', 'class')
-        repo.commit('Switch it back to a class.', GFileUtils.listFiles(file('dep'), null, true))
+        repo.commit('Switch it back to a class.', file('dep'))
         repo.createLightWeightTag('1.4.0')
 
         then:
@@ -204,11 +203,11 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
                 compile "org.test:dep:1.4.0"
             }
         """
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
         repo.createLightWeightTag('1.3.0')
         def javaFile = file('dep/src/main/java/Dep.java')
         javaFile.replace('class', 'interface')
-        def commit2 = repo.commit('Changed Dep to an interface', GFileUtils.listFiles(file('dep'), null, true))
+        def commit2 = repo.commit('Changed Dep to an interface', file('dep'))
         repo.createLightWeightTag('1.4.0')
 
         when:
@@ -259,8 +258,8 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
              }
         """
 
-        def depCommit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
-        def deeperCommit = deeperRepo.commit('initial commit', GFileUtils.listFiles(file('deeperDep'), null, true))
+        def depCommit = repo.commit('initial commit', file('dep'))
+        def deeperCommit = deeperRepo.commit('initial commit', file('deeperDep'))
 
         when:
         succeeds('assemble')
@@ -315,7 +314,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
                 compile project(':bar')
             }
         """
-        def commit = repo.commit('initial commit', GFileUtils.listFiles(file('dep'), null, true))
+        def commit = repo.commit('initial commit', file('dep'))
         def block = server.expectAndBlock("block")
 
         when:
@@ -339,7 +338,7 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
 
         and:
         def hashedRepo = hashRepositoryId(repo.id)
-        file(".gradle/vcsWorkingDirs/${hashedRepo}").listFiles()*.name == [commit.id.name]
+        file(".gradle/vcsWorkingDirs/${hashedRepo}-${commit.id.name}").assertIsDir()
 
         cleanup:
         server.stop()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -63,7 +63,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceA
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.artifacts.vcs.VcsDependencyResolver;
-import org.gradle.api.internal.artifacts.vcs.VcsWorkingDirectoryRoot;
+import org.gradle.vcs.internal.VcsWorkingDirectoryRoot;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.TemporaryFileProvider;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
@@ -17,19 +17,12 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.ResolutionResultsStoreFactory;
-import org.gradle.api.internal.artifacts.vcs.VcsWorkingDirectoryRoot;
 import org.gradle.api.internal.file.TemporaryFileProvider;
-import org.gradle.initialization.layout.ProjectCacheDir;
-
-import java.io.File;
 
 /**
  * The set of dependency management services that are created per build tree.
  */
 class DependencyManagementBuildTreeScopeServices {
-    VcsWorkingDirectoryRoot createVcsWorkingDirectoryRoot(ProjectCacheDir projectCacheDir) {
-        return new VcsWorkingDirectoryRoot(new File(projectCacheDir.getDir(), "vcsWorkingDirs"));
-    }
 
     ResolutionResultsStoreFactory createResolutionResultsStoreFactory(TemporaryFileProvider temporaryFileProvider) {
         return new ResolutionResultsStoreFactory(temporaryFileProvider);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -42,6 +42,7 @@ import org.gradle.vcs.VersionRef;
 import org.gradle.vcs.internal.VcsMappingFactory;
 import org.gradle.vcs.internal.VcsMappingInternal;
 import org.gradle.vcs.internal.VcsMappingsStore;
+import org.gradle.vcs.internal.VcsWorkingDirectoryRoot;
 import org.gradle.vcs.internal.VersionControlSystemFactory;
 
 import java.io.File;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -126,7 +126,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
 
     private File populateWorkingDirectory(File baseWorkingDir, VersionControlSpec spec, VersionControlSystem versionControlSystem, VersionRef selectedVersion) {
         String repositoryId = HashUtil.createCompactMD5(spec.getUniqueId());
-        File versionDirectory = new File(baseWorkingDir, repositoryId + "/" + selectedVersion.getCanonicalId());
+        File versionDirectory = new File(baseWorkingDir, repositoryId + "-" + selectedVersion.getCanonicalId());
         return versionControlSystem.populate(versionDirectory, selectedVersion, spec);
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
@@ -86,7 +86,7 @@ public interface CacheBuilder {
      * Currently, a clean-up action is run after {@value org.gradle.cache.internal.DefaultPersistentDirectoryCache#CLEANUP_INTERVAL} days.
      *
      */
-    CacheBuilder withCleanup(Action<? super PersistentCache> cleanup);
+    CacheBuilder withCleanup(CleanupAction cleanup);
 
     /**
      * Opens the cache. It is the caller's responsibility to close the cache when finished with it.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupAction.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache;
+
+public interface CleanupAction {
+    void clean(PersistentCache persistentCache);
+
+    CleanupAction NO_OP = new CleanupAction() {
+        @Override
+        public void clean(PersistentCache persistentCache) {
+            // no-op
+        }
+    };
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/PersistentCache.java
@@ -19,6 +19,7 @@ import org.gradle.internal.serialize.Serializer;
 
 import java.io.Closeable;
 import java.io.File;
+import java.util.Collection;
 
 /**
  * Represents a directory that can be used for caching.
@@ -38,6 +39,11 @@ public interface PersistentCache extends CacheAccess, Closeable {
      * Returns the base directory for this cache.
      */
     File getBaseDir();
+
+    /**
+     * Returns the files used by this cache for internal tracking.
+     */
+    Collection<File> getReservedCacheFiles();
 
     /**
      * Creates an indexed cache implementation that is contained within this cache. This method may be used at any time.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.Action;
+import org.gradle.cache.PersistentCache;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.List;
+
+abstract class AbstractCacheCleanup implements Action<PersistentCache> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCacheCleanup.class);
+
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public AbstractCacheCleanup(BuildOperationExecutor buildOperationExecutor) {
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public void execute(final PersistentCache persistentCache) {
+        buildOperationExecutor.run(new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                cleanup(persistentCache);
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName("Clean up " + persistentCache);
+            }
+        });
+
+    }
+
+    private void cleanup(final PersistentCache persistentCache) {
+        final File[] filesEligibleForCleanup = buildOperationExecutor.call(new CallableBuildOperation<File[]>() {
+            @Override
+            public File[] call(BuildOperationContext context) {
+                return findEligibleFiles(persistentCache.getBaseDir());
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName("Scan " + persistentCache.getBaseDir());
+            }
+        });
+
+        if (filesEligibleForCleanup.length > 0) {
+            final List<File> filesForDeletion = buildOperationExecutor.call(new CallableBuildOperation<List<File>>() {
+                @Override
+                public List<File> call(BuildOperationContext context) {
+                    return findFilesToDelete(persistentCache, filesEligibleForCleanup);
+                }
+
+                @Override
+                public BuildOperationDescriptor.Builder description() {
+                    return BuildOperationDescriptor.displayName("Choose files to delete from " + persistentCache);
+                }
+            });
+
+            if (!filesForDeletion.isEmpty()) {
+                buildOperationExecutor.run(new RunnableBuildOperation() {
+                    @Override
+                    public void run(BuildOperationContext context) {
+                        cleanupFiles(persistentCache, filesForDeletion);
+                    }
+
+                    @Override
+                    public BuildOperationDescriptor.Builder description() {
+                        return BuildOperationDescriptor.displayName("Delete files for " + persistentCache);
+                    }
+                });
+            }
+        }
+    }
+
+    protected abstract List<File> findFilesToDelete(final PersistentCache persistentCache, File[] filesEligibleForCleanup);
+
+    File[] findEligibleFiles(File cacheDir) {
+        // TODO: This doesn't descend subdirectories.
+        return cacheDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return canBeDeleted(name);
+            }
+        });
+    }
+
+    protected boolean canBeDeleted(String name) {
+        return !(name.endsWith(".properties") || name.endsWith(".lock"));
+    }
+
+    void cleanupFiles(final PersistentCache persistentCache, final List<File> filesForDeletion) {
+        // Need to remove some files
+        long removedSize = deleteFiles(filesForDeletion);
+        LOGGER.info("{} removing {} cache entries ({} reclaimed).", persistentCache, filesForDeletion.size(), FileUtils.byteCountToDisplaySize(removedSize));
+    }
+
+    private long deleteFiles(List<File> files) {
+        long removedSize = 0;
+        for (File file : files) {
+            try {
+                long size = file.length();
+                if (file.delete()) {
+                    removedSize += size;
+                }
+            } catch (Exception e) {
+                LOGGER.debug("Could not clean up cache " + file, e);
+            }
+        }
+        return removedSize;
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -24,6 +24,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.util.GFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +126,7 @@ abstract class AbstractCacheCleanup implements Action<PersistentCache> {
         for (File file : files) {
             try {
                 long size = file.length();
-                if (file.delete()) {
+                if (GFileUtils.deleteQuietly(file)) {
                     removedSize += size;
                 }
             } catch (Exception e) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheFactory.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.CacheValidator;
+import org.gradle.cache.CleanupAction;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
 
@@ -30,5 +31,5 @@ public interface CacheFactory {
     /**
      * Opens a cache with the given options. The caller must close the cache when finished with it.
      */
-    PersistentCache open(File cacheDir, String displayName, @Nullable CacheValidator cacheValidator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable Action<? super PersistentCache> cleanup) throws CacheOpenException;
+    PersistentCache open(File cacheDir, String displayName, @Nullable CacheValidator cacheValidator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CleanupAction cleanup) throws CacheOpenException;
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.gradle.cache.CleanupAction;
+import org.gradle.cache.PersistentCache;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.progress.BuildOperationDescriptor;
+import org.gradle.internal.reflect.Instantiator;
+
+public class CleanupActionFactory {
+    private final Instantiator instantiator;
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public CleanupActionFactory(Instantiator instantiator, BuildOperationExecutor buildOperationExecutor) {
+        this.instantiator = instantiator;
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    public CleanupAction create(Class<? extends CleanupAction> cleanupType, Object... args) {
+        return new BuildOperationCacheCleanupDecorator(instantiator.newInstance(cleanupType, args), buildOperationExecutor);
+    }
+
+    private static class BuildOperationCacheCleanupDecorator implements CleanupAction {
+        private final BuildOperationExecutor buildOperationExecutor;
+        private final CleanupAction delegate;
+
+        public BuildOperationCacheCleanupDecorator(CleanupAction delegate, BuildOperationExecutor buildOperationExecutor) {
+            this.buildOperationExecutor = buildOperationExecutor;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void clean(final PersistentCache persistentCache) {
+            buildOperationExecutor.run(new RunnableBuildOperation() {
+                @Override
+                public void run(BuildOperationContext context) {
+                    delegate.clean(persistentCache);
+                }
+
+                @Override
+                public BuildOperationDescriptor.Builder description() {
+                    return BuildOperationDescriptor.displayName("Clean up " + persistentCache);
+                }
+            });
+        }
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
@@ -22,19 +22,16 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.progress.BuildOperationDescriptor;
-import org.gradle.internal.reflect.Instantiator;
 
 public class CleanupActionFactory {
-    private final Instantiator instantiator;
     private final BuildOperationExecutor buildOperationExecutor;
 
-    public CleanupActionFactory(Instantiator instantiator, BuildOperationExecutor buildOperationExecutor) {
-        this.instantiator = instantiator;
+    public CleanupActionFactory(BuildOperationExecutor buildOperationExecutor) {
         this.buildOperationExecutor = buildOperationExecutor;
     }
 
-    public CleanupAction create(Class<? extends CleanupAction> cleanupType, Object... args) {
-        return new BuildOperationCacheCleanupDecorator(instantiator.newInstance(cleanupType, args), buildOperationExecutor);
+    public CleanupAction create(CleanupAction action) {
+        return new BuildOperationCacheCleanupDecorator(action, buildOperationExecutor);
     }
 
     private static class BuildOperationCacheCleanupDecorator implements CleanupAction {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.CacheValidator;
+import org.gradle.cache.CleanupAction;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
@@ -33,6 +34,7 @@ import org.gradle.internal.serialize.Serializer;
 import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -58,7 +60,7 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
     }
 
     @Override
-    public PersistentCache open(File cacheDir, String displayName, @Nullable CacheValidator cacheValidator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, Action<? super PersistentCache> cleanup) throws CacheOpenException {
+    public PersistentCache open(File cacheDir, String displayName, @Nullable CacheValidator cacheValidator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, CleanupAction cleanup) throws CacheOpenException {
         lock.lock();
         try {
             return doOpen(cacheDir, displayName, cacheValidator, properties, lockTarget, lockOptions, initializer, cleanup);
@@ -77,7 +79,7 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         }
     }
 
-    private PersistentCache doOpen(File cacheDir, String displayName, @Nullable CacheValidator validator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable Action<? super PersistentCache> cleanup) {
+    private PersistentCache doOpen(File cacheDir, String displayName, @Nullable CacheValidator validator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CleanupAction cleanup) {
         File canonicalDir = FileUtils.canonicalize(cacheDir);
         DirCacheReference dirCacheReference = dirCaches.get(canonicalDir);
         if (dirCacheReference == null) {
@@ -163,6 +165,11 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         @Override
         public File getBaseDir() {
             return reference.cache.getBaseDir();
+        }
+
+        @Override
+        public Collection<File> getReservedCacheFiles() {
+            return reference.cache.getReservedCacheFiles();
         }
 
         @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheRepository.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheRepository.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.CacheValidator;
+import org.gradle.cache.CleanupAction;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
@@ -57,7 +58,7 @@ public class DefaultCacheRepository implements CacheRepository {
         Map<String, ?> properties = Collections.emptyMap();
         CacheValidator validator;
         Action<? super PersistentCache> initializer;
-        Action<? super PersistentCache> cleanup;
+        CleanupAction cleanup;
         LockOptions lockOptions = mode(FileLockManager.LockMode.Shared);
         String displayName;
         VersionStrategy versionStrategy = VersionStrategy.CachePerVersion;
@@ -108,7 +109,7 @@ public class DefaultCacheRepository implements CacheRepository {
         }
 
         @Override
-        public CacheBuilder withCleanup(Action<? super PersistentCache> cleanup) {
+        public CacheBuilder withCleanup(CleanupAction cleanup) {
             this.cleanup = cleanup;
             return this;
         }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -104,6 +104,14 @@ public class DefaultFileLockManager implements FileLockManager {
         }
     }
 
+    static File determineLockTargetFile(File target) {
+        if (target.isDirectory()) {
+            return new File(target, target.getName() + ".lock");
+        } else {
+            return new File(target.getParentFile(), target.getName() + ".lock");
+        }
+    }
+
     private class DefaultFileLock extends AbstractFileAccess implements FileLock {
         private final File lockFile;
         private final File target;
@@ -127,11 +135,7 @@ public class DefaultFileLockManager implements FileLockManager {
 
             this.displayName = displayName;
             this.operationDisplayName = operationDisplayName;
-            if (target.isDirectory()) {
-                lockFile = new File(target, target.getName() + ".lock");
-            } else {
-                lockFile = new File(target.getParentFile(), target.getName() + ".lock");
-            }
+            this.lockFile = determineLockTargetFile(target);
 
             GFileUtils.mkdirs(lockFile.getParentFile());
             try {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -18,6 +18,7 @@ package org.gradle.cache.internal;
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheValidator;
+import org.gradle.cache.CleanupAction;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
@@ -41,11 +42,11 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPersistentDirectoryCache.class);
     private final Properties properties = new Properties();
     private final Action<? super PersistentCache> initAction;
-    private final Action<? super PersistentCache> cleanupAction;
+    private final CleanupAction cleanupAction;
     private final CacheValidator validator;
     private boolean didRebuild;
 
-    public DefaultPersistentDirectoryCache(File dir, String displayName, CacheValidator validator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, Action<? super PersistentCache> cleanupAction, FileLockManager lockManager, ExecutorFactory executorFactory) {
+    public DefaultPersistentDirectoryCache(File dir, String displayName, CacheValidator validator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CleanupAction cleanupAction, FileLockManager lockManager, ExecutorFactory executorFactory) {
         super(dir, displayName, lockTarget, lockOptions, lockManager, executorFactory);
         this.validator = validator;
         this.initAction = initAction;
@@ -131,7 +132,7 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
         public void cleanup() {
             if (cleanupAction!=null) {
                 Timer timer = Time.startTimer();
-                cleanupAction.execute(DefaultPersistentDirectoryCache.this);
+                cleanupAction.clean(DefaultPersistentDirectoryCache.this);
                 LOGGER.info("{} cleaned up in {}.", DefaultPersistentDirectoryCache.this, timer.getElapsed());
             }
             gcFile.setLastModified(System.currentTimeMillis());

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -28,6 +28,8 @@ import org.gradle.internal.serialize.Serializer;
 import org.gradle.util.GFileUtils;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
 
 public class DefaultPersistentDirectoryStore implements ReferencablePersistentCache {
     private final File dir;
@@ -120,6 +122,20 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     @Override
     public File getBaseDir() {
         return dir;
+    }
+
+    @Override
+    public Collection<File> getReservedCacheFiles() {
+        return Arrays.asList(propertiesFile, gcFile, determineLockTargetFile(getLockTarget()));
+    }
+
+    // TODO: Duplicated in DefaultFileLockManager
+    static File determineLockTargetFile(File target) {
+        if (target.isDirectory()) {
+            return new File(target, target.getName() + ".lock");
+        } else {
+            return new File(target.getParentFile(), target.getName() + ".lock");
+        }
     }
 
     @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedAgeOldestCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedAgeOldestCacheCleanup.java
@@ -18,7 +18,6 @@ package org.gradle.cache.internal;
 
 import com.google.common.collect.Lists;
 import org.gradle.cache.PersistentCache;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,9 +34,8 @@ public class FixedAgeOldestCacheCleanup extends AbstractCacheCleanup {
 
     private final long minimumTimestamp;
 
-    public FixedAgeOldestCacheCleanup(BuildOperationExecutor buildOperationExecutor, long age, TimeUnit units) {
-        super(buildOperationExecutor);
-        this.minimumTimestamp = Math.max(0, System.currentTimeMillis() - units.toMillis(age));
+    public FixedAgeOldestCacheCleanup(long ageInDays) {
+        this.minimumTimestamp = Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ageInDays));
     }
 
     protected List<File> findFilesToDelete(final PersistentCache persistentCache, File[] filesEligibleForCleanup) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedSizeOldestCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedSizeOldestCacheCleanup.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import org.apache.commons.io.FileUtils;
 import org.gradle.cache.PersistentCache;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +29,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-public final class FixedSizeOldestCacheCleanup extends AbstractCacheCleanup {
+public class FixedSizeOldestCacheCleanup extends AbstractCacheCleanup {
     private static final Logger LOGGER = LoggerFactory.getLogger(FixedSizeOldestCacheCleanup.class);
     private static final Comparator<File> NEWEST_FIRST = Ordering.natural().onResultOf(new Function<File, Comparable<Long>>() {
         @Override
@@ -41,8 +40,7 @@ public final class FixedSizeOldestCacheCleanup extends AbstractCacheCleanup {
 
     private final long targetSizeInMB;
 
-    public FixedSizeOldestCacheCleanup(BuildOperationExecutor buildOperationExecutor, long targetSizeInMB) {
-        super(buildOperationExecutor);
+    public FixedSizeOldestCacheCleanup(long targetSizeInMB) {
         this.targetSizeInMB = targetSizeInMB;
     }
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
@@ -59,6 +59,15 @@ class AbstractCacheCleanupTest extends Specification {
         }
     }
 
+    def "can delete directories"() {
+        def cacheEntry = cacheDir.file(String.format("%032x", r.nextInt())).file("subdir/somefile")
+        cacheEntry.text = "delete me"
+        when:
+        cleanupAction.cleanupFiles(persistentCache, [cacheEntry])
+        then:
+        cacheEntry.assertDoesNotExist()
+    }
+
     private Random r = new Random()
     def createCacheEntry(int size=1024, long timestamp=0) {
         def cacheEntry = cacheDir.file(String.format("%032x", r.nextInt()))

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.cache.PersistentCache
+import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+class AbstractCacheCleanupTest extends Specification {
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    def cacheDir = temporaryFolder.file("cache-dir").createDir()
+    def persistentCache = Mock(PersistentCache)
+    def cleanupAction = new AbstractCacheCleanup(new TestBuildOperationExecutor()) {
+        @Override
+        protected List<File> findFilesToDelete(PersistentCache persistentCache, File[] filesEligibleForCleanup) {
+            // pass through everything
+            return Arrays.asList(filesEligibleForCleanup)
+        }
+    }
+
+    def "filters for cache entry files"() {
+        expect:
+        !cleanupAction.canBeDeleted("cache.properties")
+        !cleanupAction.canBeDeleted("gc.properties")
+        !cleanupAction.canBeDeleted("cache.lock")
+
+        cleanupAction.canBeDeleted("0"*32)
+        cleanupAction.canBeDeleted("ABCDEFABCDEFABCDEFABCDEFABCDEF00")
+        cleanupAction.canBeDeleted("abcdefabcdefabcdefabcdefabcdef00")
+    }
+
+    def "deletes files"() {
+        def cacheEntries = [
+            createCacheEntry(),
+            createCacheEntry(),
+            createCacheEntry(),
+        ]
+        when:
+        cleanupAction.cleanupFiles(persistentCache, cacheEntries)
+        then:
+        cacheEntries.each {
+            it.assertDoesNotExist()
+        }
+    }
+
+    private Random r = new Random()
+    def createCacheEntry(int size=1024, long timestamp=0) {
+        def cacheEntry = cacheDir.file(String.format("%032x", r.nextInt()))
+        def data = new byte[size]
+        r.nextBytes(data)
+        cacheEntry.bytes = data
+        cacheEntry.lastModified = timestamp
+        return cacheEntry
+    }
+}

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheSpec.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheSpec.groovy
@@ -19,8 +19,8 @@ package org.gradle.cache.internal
 import org.gradle.api.Action
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheValidator
+import org.gradle.cache.CleanupAction
 import org.gradle.cache.FileLockManager
-import org.gradle.internal.Actions
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -43,7 +43,7 @@ class DefaultPersistentDirectoryCacheSpec extends Specification {
         def cache = new DefaultPersistentDirectoryCache(
             dir, "test", {
             true
-        } as CacheValidator, [:], CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Exclusive), init, Actions.doNothing(), createDefaultFileLockManager(), Mock(ExecutorFactory)
+        } as CacheValidator, [:], CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory)
         )
 
         when:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.cache.internal
 import org.gradle.api.Action
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheValidator
+import org.gradle.cache.CleanupAction
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
@@ -40,7 +41,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         isValid() >> true
     }
     def initializationAction = Mock(Action)
-    def cleanupAction = Mock(Action)
+    def cleanupAction = Mock(CleanupAction)
 
     def properties = ['prop': 'value', 'prop2': 'other-value']
 
@@ -199,7 +200,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
             cache.close()
         }
         then:
-        1 * cleanupAction.execute(cache)
+        1 * cleanupAction.clean(cache)
         0 * _
     }
 
@@ -207,9 +208,9 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         given:
         def dir = createCacheDir()
         def gcFile = dir.file("gc.properties")
-        def failingCleanupAction = new Action() {
+        def failingCleanupAction = new CleanupAction() {
             @Override
-            void execute(Object o) {
+            void clean(PersistentCache persistentCache) {
                 throw new Exception("Boom")
             }
         }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedAgeOldestCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedAgeOldestCacheCleanupTest.groovy
@@ -23,32 +23,23 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
 
-@Subject(FixedSizeOldestCacheCleanup)
-class FixedSizeOldestCacheCleanupTest extends Specification {
+import java.util.concurrent.TimeUnit
+
+@Subject(FixedAgeOldestCacheCleanup)
+class FixedAgeOldestCacheCleanupTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
     def cacheDir = temporaryFolder.file("cache-dir").createDir()
     def persistentCache = Mock(PersistentCache)
-    def cleanupAction = new FixedSizeOldestCacheCleanup(new TestBuildOperationExecutor(),10)
+    def cleanupAction = new FixedAgeOldestCacheCleanup(new TestBuildOperationExecutor(), 1, TimeUnit.DAYS)
 
-    def "finds eligible files"() {
+    def "finds files to delete when files are old"() {
+        long now = System.currentTimeMillis()
+        long fiveDaysAgo = now - TimeUnit.DAYS.toMillis(5)
         def cacheEntries = [
-            createCacheEntry(1024), // 1KB
-            createCacheEntry(1024*1024), // 1MB
-            createCacheEntry(1024*1024*10), // 10MB
-        ]
-        cacheDir.file("cache.lock").touch()
-        expect:
-        def eligibleFiles = Arrays.asList(cleanupAction.findEligibleFiles(cacheDir))
-        eligibleFiles.size() == cacheEntries.size()
-        eligibleFiles.containsAll(cacheEntries)
-    }
-
-    def "finds files to delete when cache is larger than limit"() {
-        def cacheEntries = [
-            createCacheEntry(1024, 1000), // 1KB, newest file
-            createCacheEntry(1024*1024, 500), // 1MB
-            createCacheEntry(1024*1024*5, 250), // 5MB
-            createCacheEntry(1024*1024*10, 0), // 10MB, oldest file
+            createCacheEntry(1024, now),
+            createCacheEntry(1024, now),
+            createCacheEntry(1024, now),
+            createCacheEntry(1024, fiveDaysAgo),
         ]
         expect:
         def filesToDelete = cleanupAction.findFilesToDelete(persistentCache, cacheEntries as File[])
@@ -57,11 +48,12 @@ class FixedSizeOldestCacheCleanupTest extends Specification {
         filesToDelete[0] == cacheEntries.last()
     }
 
-    def "finds no files to delete when cache is smaller than limit"() {
+    def "finds no files to delete when files are new"() {
+        long now = System.currentTimeMillis()
         def cacheEntries = [
-            createCacheEntry(1024), // 1KB
-            createCacheEntry(1024*1024), // 1MB
-            createCacheEntry(1024*1024*5), // 5MB
+            createCacheEntry(1024, now),
+            createCacheEntry(1024, now - TimeUnit.MINUTES.toMillis(15)),
+            createCacheEntry(1024, now - TimeUnit.HOURS.toMillis(5)),
         ]
         expect:
         def filesToDelete = cleanupAction.findFilesToDelete(persistentCache, cacheEntries as File[])

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedAgeOldestCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedAgeOldestCacheCleanupTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.cache.internal
 
 import org.gradle.cache.PersistentCache
-import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -30,7 +29,7 @@ class FixedAgeOldestCacheCleanupTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
     def cacheDir = temporaryFolder.file("cache-dir").createDir()
     def persistentCache = Mock(PersistentCache)
-    def cleanupAction = new FixedAgeOldestCacheCleanup(new TestBuildOperationExecutor(), 1, TimeUnit.DAYS)
+    def cleanupAction = new FixedAgeOldestCacheCleanup(1)
 
     def "finds files to delete when files are old"() {
         long now = System.currentTimeMillis()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildCacheCleanupOperationsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildCacheCleanupOperationsCrossVersionSpec.groovy
@@ -88,10 +88,7 @@ class BuildCacheCleanupOperationsCrossVersionSpec extends ToolingApiSpecificatio
                     run()
         }
         then:
-        def cleaningUp = listener.operation("Clean up Build cache (" + cacheDir + ")")
-        cleaningUp.child("Scan " + cacheDir)
-        cleaningUp.child("Choose files to delete from Build cache (" + cacheDir + ")")
-        cleaningUp.child("Delete files for Build cache (" + cacheDir + ")")
+        listener.operation("Clean up Build cache (" + cacheDir + ")")
 
         cacheDir.directorySize() <= 2*1024*1024
     }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/git/internal/VcsCleanupIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/git/internal/VcsCleanupIntegrationTest.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.git.internal
+
+import org.eclipse.jgit.revwalk.RevCommit
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.hash.HashUtil
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.vcs.fixtures.GitRepository
+import org.junit.Rule
+
+import java.util.concurrent.TimeUnit
+
+class VcsCleanupIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    GitRepository repo = new GitRepository("dep", testDirectory)
+
+    Map<String, RevCommit> commits = [:]
+
+    def setup() {
+        repo.workTree.file("build.gradle") << """
+            apply plugin: 'java'
+            group = 'org.test'
+            version = file("version").text
+            jar {
+                from file("version")
+            }
+        """
+        repo.workTree.file("settings.gradle") << """
+            rootProject.name = "dep"
+        """
+        commits["initial"] = repo.commit('initial', repo.workTree)
+
+        def versionFile = repo.workTree.file("version")
+        ["1.0", "2.0", "3.0"].each { version ->
+            versionFile.text = version
+            def commit = repo.commit("version is $version", repo.workTree)
+            repo.createLightWeightTag(version)
+            commits[version] = commit
+        }
+
+        versionFile.text = "4.0-SNAPSHOT"
+        commits["latest.integration"] = repo.commit("version is snapshot", repo.workTree)
+
+        buildFile << """
+            apply plugin: 'base'
+            
+            configurations {
+                conf
+            }
+            dependencies {
+                conf "org.test:dep:" + repoVersion
+            }
+            task assertVersion {
+                dependsOn configurations.conf
+                doLast {
+                    def files = zipTree(configurations.conf.singleFile).files
+                    def versionFile = files.find { it.name == "version" }
+                    assert versionFile
+                    assert versionFile.text == repoVersion
+                }
+            }   
+        """
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:dep") {
+                        from vcs(GitVersionControlSpec) {
+                            url = "${repo.url}"
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    def "does not remove vcs checkout on every build"() {
+        succeeds("assertVersion", "-PrepoVersion=1.0")
+        def checkout = checkoutDir("dep", commits.initial.id.name, repo.id)
+
+        // Put new file in the checkout directory that would be deleted if Gradle
+        // deletes the checkout directory
+        def trashFile = checkout.file("trash")
+        trashFile.text = "junk"
+
+        when:
+        succeeds("assertVersion", "-PrepoVersion=1.0")
+        then:
+        trashFile.assertExists()
+
+        when:
+        cleanupNow()
+        succeeds("assertVersion", "-PrepoVersion=1.0")
+        then:
+        // checkout was used recently, so it should still be kept around
+        trashFile.assertExists()
+    }
+
+    def "removes vcs checkout after 7 days"() {
+        succeeds("assertVersion", "-PrepoVersion=1.0")
+        succeeds("assertVersion", "-PrepoVersion=2.0")
+        succeeds("assertVersion", "-PrepoVersion=3.0")
+
+        def checkout = checkoutDir("dep", commits["1.0"].id.name, repo.id).parentFile
+        checkout.setLastModified(checkout.lastModified() - TimeUnit.DAYS.toMillis(10))
+
+        when:
+        cleanupNow()
+        succeeds("assertVersion", "-PrepoVersion=3.0")
+        then:
+        checkoutDir("dep", commits["1.0"].id.name, repo.id).assertDoesNotExist()
+        checkoutDir("dep", commits["2.0"].id.name, repo.id).assertExists()
+        checkoutDir("dep", commits["3.0"].id.name, repo.id).assertExists()
+    }
+
+    def "does not remove vcs checkout that is older than 7 days but recently used"() {
+        def versions = ["1.0", "2.0", "3.0"]
+        // checkout all versions
+        versions.each { version ->
+            succeeds("assertVersion", "-PrepoVersion=${version}")
+        }
+        // mark versions as unused
+        versions.each { version ->
+            def checkout = checkoutDir("dep", commits[version].id.name, repo.id).parentFile
+            checkout.setLastModified(checkout.lastModified() - TimeUnit.DAYS.toMillis(10))
+        }
+
+        when:
+        cleanupNow()
+        succeeds("assertVersion", "-PrepoVersion=1.0")
+        then:
+        checkoutDir("dep", commits["1.0"].id.name, repo.id).assertExists()
+        checkoutDir("dep", commits["2.0"].id.name, repo.id).assertDoesNotExist()
+        checkoutDir("dep", commits["3.0"].id.name, repo.id).assertDoesNotExist()
+    }
+
+    TestFile checkoutDir(String repoName, String versionId, String repoId, TestFile baseDir=testDirectory) {
+        def hashedRepo = hashRepositoryId(repoId)
+        baseDir.file(".gradle/vcsWorkingDirs/${hashedRepo}-${versionId}/${repoName}")
+    }
+
+    String hashRepositoryId(String repoId) {
+        HashUtil.createCompactMD5(repoId)
+    }
+
+    TestFile gcFile() {
+        file(".gradle/vcsWorkingDirs/gc.properties")
+    }
+
+    void cleanupNow() {
+        gcFile().assertIsFile()
+        gcFile().lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60)
+    }
+
+}

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
@@ -21,6 +21,7 @@ import org.gradle.cache.CacheAccess;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
+import org.gradle.cache.internal.FixedAgeOldestCacheCleanup;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -34,6 +35,7 @@ import org.gradle.vcs.internal.spec.DirectoryRepositorySpec;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
@@ -45,6 +47,7 @@ public class DefaultVersionControlSystemFactory implements VersionControlSystemF
             .cache(workingDirectoryRoot.getDir())
             .withLockOptions(mode(FileLockManager.LockMode.None))
             .withDisplayName("VCS Checkout Cache")
+            .withCleanup(new FixedAgeOldestCacheCleanup(buildOperationExecutor, 7, TimeUnit.DAYS))
             .open();
     }
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
@@ -46,7 +46,7 @@ public class DefaultVersionControlSystemFactory implements VersionControlSystemF
             .cache(workingDirectoryRoot.getDir())
             .withLockOptions(mode(FileLockManager.LockMode.None))
             .withDisplayName("VCS Checkout Cache")
-            .withCleanup(cleanupActionFactory.create(FixedAgeOldestCacheCleanup.class, 7L))
+            .withCleanup(cleanupActionFactory.create(new FixedAgeOldestCacheCleanup(7L)))
             .open();
     }
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
@@ -21,10 +21,10 @@ import org.gradle.cache.CacheAccess;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
+import org.gradle.cache.internal.CleanupActionFactory;
 import org.gradle.cache.internal.FixedAgeOldestCacheCleanup;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.util.GFileUtils;
 import org.gradle.vcs.VersionControlSpec;
 import org.gradle.vcs.VersionControlSystem;
@@ -35,19 +35,18 @@ import org.gradle.vcs.internal.spec.DirectoryRepositorySpec;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 public class DefaultVersionControlSystemFactory implements VersionControlSystemFactory, Stoppable {
     private final PersistentCache vcsWorkingDirCache;
 
-    DefaultVersionControlSystemFactory(VcsWorkingDirectoryRoot workingDirectoryRoot, BuildOperationExecutor buildOperationExecutor, CacheRepository cacheRepository) {
+    DefaultVersionControlSystemFactory(VcsWorkingDirectoryRoot workingDirectoryRoot, CacheRepository cacheRepository, CleanupActionFactory cleanupActionFactory) {
         this.vcsWorkingDirCache = cacheRepository
             .cache(workingDirectoryRoot.getDir())
             .withLockOptions(mode(FileLockManager.LockMode.None))
             .withDisplayName("VCS Checkout Cache")
-            .withCleanup(new FixedAgeOldestCacheCleanup(buildOperationExecutor, 7, TimeUnit.DAYS))
+            .withCleanup(cleanupActionFactory.create(FixedAgeOldestCacheCleanup.class, 7L))
             .open();
     }
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VcsWorkingDirectoryRoot.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VcsWorkingDirectoryRoot.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.vcs;
+package org.gradle.vcs.internal;
 
 import java.io.File;
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
@@ -18,11 +18,14 @@ package org.gradle.vcs.internal;
 
 import org.gradle.api.invocation.Gradle;
 import org.gradle.cache.CacheRepository;
+import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.vcs.SourceControl;
 import org.gradle.vcs.VcsMappings;
+
+import java.io.File;
 
 public class VersionControlServices extends AbstractPluginServiceRegistry {
     @Override
@@ -58,8 +61,11 @@ public class VersionControlServices extends AbstractPluginServiceRegistry {
     }
 
     private static class VersionControlBuildSessionServices {
-        VersionControlSystemFactory createVersionControlSystemFactory(CacheRepository cacheRepository) {
-            return new DefaultVersionControlSystemFactory(cacheRepository);
+        VersionControlSystemFactory createVersionControlSystemFactory(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, CacheRepository cacheRepository) {
+            return new DefaultVersionControlSystemFactory(vcsWorkingDirectoryRoot, cacheRepository);
+        }
+        VcsWorkingDirectoryRoot createVcsWorkingDirectoryRoot(ProjectCacheDir projectCacheDir) {
+            return new VcsWorkingDirectoryRoot(new File(projectCacheDir.getDir(), "vcsWorkingDirs"));
         }
     }
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
@@ -19,6 +19,7 @@ package org.gradle.vcs.internal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.cache.CacheRepository;
 import org.gradle.initialization.layout.ProjectCacheDir;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -61,8 +62,8 @@ public class VersionControlServices extends AbstractPluginServiceRegistry {
     }
 
     private static class VersionControlBuildSessionServices {
-        VersionControlSystemFactory createVersionControlSystemFactory(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, CacheRepository cacheRepository) {
-            return new DefaultVersionControlSystemFactory(vcsWorkingDirectoryRoot, cacheRepository);
+        VersionControlSystemFactory createVersionControlSystemFactory(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, BuildOperationExecutor buildOperationExecutor, CacheRepository cacheRepository) {
+            return new DefaultVersionControlSystemFactory(vcsWorkingDirectoryRoot, buildOperationExecutor, cacheRepository);
         }
         VcsWorkingDirectoryRoot createVcsWorkingDirectoryRoot(ProjectCacheDir projectCacheDir) {
             return new VcsWorkingDirectoryRoot(new File(projectCacheDir.getDir(), "vcsWorkingDirs"));

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
@@ -18,8 +18,8 @@ package org.gradle.vcs.internal;
 
 import org.gradle.api.invocation.Gradle;
 import org.gradle.cache.CacheRepository;
+import org.gradle.cache.internal.CleanupActionFactory;
 import org.gradle.initialization.layout.ProjectCacheDir;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -62,8 +62,8 @@ public class VersionControlServices extends AbstractPluginServiceRegistry {
     }
 
     private static class VersionControlBuildSessionServices {
-        VersionControlSystemFactory createVersionControlSystemFactory(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, BuildOperationExecutor buildOperationExecutor, CacheRepository cacheRepository) {
-            return new DefaultVersionControlSystemFactory(vcsWorkingDirectoryRoot, buildOperationExecutor, cacheRepository);
+        VersionControlSystemFactory createVersionControlSystemFactory(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, CleanupActionFactory cleanupActionFactory, CacheRepository cacheRepository) {
+            return new DefaultVersionControlSystemFactory(vcsWorkingDirectoryRoot, cacheRepository, cleanupActionFactory);
         }
         VcsWorkingDirectoryRoot createVcsWorkingDirectoryRoot(ProjectCacheDir projectCacheDir) {
             return new VcsWorkingDirectoryRoot(new File(projectCacheDir.getDir(), "vcsWorkingDirs"));

--- a/subprojects/version-control/src/testFixtures/groovy/org/gradle/vcs/fixtures/GitRepository.java
+++ b/subprojects/version-control/src/testFixtures/groovy/org/gradle/vcs/fixtures/GitRepository.java
@@ -28,6 +28,7 @@ import org.gradle.api.Transformer;
 import org.gradle.internal.UncheckedException;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.util.CollectionUtils;
+import org.gradle.util.GFileUtils;
 import org.junit.rules.ExternalResource;
 
 import java.io.File;
@@ -36,6 +37,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public class GitRepository extends ExternalResource implements Named {
     private final String repoName;
@@ -100,6 +102,15 @@ public class GitRepository extends ExternalResource implements Named {
 
     public RevCommit commit(String message, File... files) throws GitAPIException {
         return commit(message, Arrays.asList(files));
+    }
+
+    public RevCommit commit(String message, File file) throws GitAPIException {
+        // if the file is a directory, list all files in it and add those
+        if (file.isDirectory()) {
+            return commit(message, GFileUtils.listFiles(file, null, true));
+        } else {
+            return commit(message, Collections.singleton(file));
+        }
     }
 
     public Ref createBranch(String branchName) throws GitAPIException {


### PR DESCRIPTION
- Introduces a new cleanup action that deletes any entry older than a given age (currently 7 days).
- As a cache clean-up action, we run this action every 7 days. 
- The VCS checkout directory has changed from `vcsWorkingDirs/repo/commit` to `vcsWorkingDirs/repo-commit` so we have a flattened directory of checkouts.
- Whenever we attempt to populate a checkout, we'll touch the directory to mark it as recently used.
- Instead of locking each individual commit directory (as we do now), we'll lock the VCS working directory.  This means we cannot checkout multiple repos in parallel.
