### PR TITLE
Remove useCache in DefaultArtifactResolutionQuery

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.artifactreuse
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+import spock.lang.Issue
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
+
+class ArtifactResolutionQueryIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    def setup() {
+        server.start()
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/3579')
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    def 'can use artifact resolution queries in parallel to file resolution'() {
+        given:
+        def module = mavenHttpRepo.module('group', "artifact", '1.0').publish()
+        def handler = server.expectConcurrentAndBlock(server.file(module.pom.path, module.pom.file), server.resource('/sync'))
+        server.expect(server.file(module.artifact.path, module.artifact.file))
+
+        settingsFile << 'include "query", "resolve"'
+        buildFile << """ 
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier 
+
+allprojects {
+    apply plugin: 'java'
+    repositories {
+       maven { url '${server.uri}/repo' }
+    }
+    
+    dependencies {
+        compile 'group:artifact:1.0'
+    }
+}
+
+project('query') {
+    task query {
+        doLast {
+            '${server.uri}/sync'.toURL().text
+            dependencies.createArtifactResolutionQuery()
+                        .forComponents(new DefaultModuleComponentIdentifier('group','artifact','1.0'))
+                        .withArtifacts(JvmLibrary)
+                        .execute()
+        }
+    }    
+}
+
+project('resolve') {
+    task resolve {
+        doLast {
+            configurations.compile.files.collect { it.file }
+        }
+    }  
+}
+"""
+        executer.requireOwnGradleUserHomeDir().requireIsolatedDaemons()
+
+        expect:
+        def build = executer.withArguments('query:query', ':resolve:resolve', '--parallel').start()
+
+        handler.waitForAllPendingCalls()
+        handler.release('/sync')
+        Thread.sleep(1000)
+        handler.release(module.pom.path)
+
+        build.waitForFinish()
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -40,7 +40,6 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConst
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultConfigurationResolver;
 import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
@@ -299,8 +298,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         ArtifactResolutionQueryFactory createArtifactResolutionQueryFactory(ConfigurationContainerInternal configurationContainer, RepositoryHandler repositoryHandler,
                                                                             ResolveIvyFactory ivyFactory, GlobalDependencyResolutionRules metadataHandler,
-                                                                            CacheLockingManager cacheLockingManager, ComponentTypeRegistry componentTypeRegistry) {
-            return new DefaultArtifactResolutionQueryFactory(configurationContainer, repositoryHandler, ivyFactory, metadataHandler, cacheLockingManager, componentTypeRegistry);
+                                                                            ComponentTypeRegistry componentTypeRegistry) {
+            return new DefaultArtifactResolutionQueryFactory(configurationContainer, repositoryHandler, ivyFactory, metadataHandler, componentTypeRegistry);
 
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -29,7 +29,6 @@ import org.gradle.api.component.Component;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ErrorHandlingArtifactResolver;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
@@ -42,7 +41,6 @@ import org.gradle.api.internal.artifacts.result.DefaultUnresolvedComponentResult
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
-import org.gradle.internal.Factory;
 import org.gradle.internal.Transformers;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -69,7 +67,6 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
     private final RepositoryHandler repositoryHandler;
     private final ResolveIvyFactory ivyFactory;
     private final GlobalDependencyResolutionRules metadataHandler;
-    private final CacheLockingManager lockingManager;
     private final ComponentTypeRegistry componentTypeRegistry;
 
     private Set<ComponentIdentifier> componentIds = Sets.newLinkedHashSet();
@@ -77,13 +74,12 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
     private Set<Class<? extends Artifact>> artifactTypes = Sets.newLinkedHashSet();
 
     public DefaultArtifactResolutionQuery(ConfigurationContainerInternal configurationContainer, RepositoryHandler repositoryHandler,
-                                          ResolveIvyFactory ivyFactory, GlobalDependencyResolutionRules metadataHandler, CacheLockingManager lockingManager,
+                                          ResolveIvyFactory ivyFactory, GlobalDependencyResolutionRules metadataHandler,
                                           ComponentTypeRegistry componentTypeRegistry) {
         this.configurationContainer = configurationContainer;
         this.repositoryHandler = repositoryHandler;
         this.ivyFactory = ivyFactory;
         this.metadataHandler = metadataHandler;
-        this.lockingManager = lockingManager;
         this.componentTypeRegistry = componentTypeRegistry;
     }
 
@@ -121,37 +117,36 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
         }
         List<ResolutionAwareRepository> repositories = CollectionUtils.collect(repositoryHandler, Transformers.cast(ResolutionAwareRepository.class));
         ResolutionStrategyInternal resolutionStrategy = configurationContainer.detachedConfiguration().getResolutionStrategy();
-        final ComponentResolvers componentResolvers = ivyFactory.create(resolutionStrategy, repositories, metadataHandler.getComponentMetadataProcessor());
-        final ComponentMetaDataResolver componentMetaDataResolver = componentResolvers.getComponentResolver();
-        final ArtifactResolver artifactResolver = new ErrorHandlingArtifactResolver(componentResolvers.getArtifactResolver());
+        ComponentResolvers componentResolvers = ivyFactory.create(resolutionStrategy, repositories, metadataHandler.getComponentMetadataProcessor());
+        ComponentMetaDataResolver componentMetaDataResolver = componentResolvers.getComponentResolver();
+        ArtifactResolver artifactResolver = new ErrorHandlingArtifactResolver(componentResolvers.getArtifactResolver());
+        return createResult(componentMetaDataResolver, artifactResolver);
+    }
 
-        return lockingManager.useCache(new Factory<ArtifactResolutionResult>() {
-            public ArtifactResolutionResult create() {
-                Set<ComponentResult> componentResults = Sets.newHashSet();
+    private ArtifactResolutionResult createResult(ComponentMetaDataResolver componentMetaDataResolver, ArtifactResolver artifactResolver) {
+        Set<ComponentResult> componentResults = Sets.newHashSet();
 
-                for (ComponentIdentifier componentId : componentIds) {
-                    try {
-                        ComponentIdentifier validId = validateComponentIdentifier(componentId);
-                        componentResults.add(buildComponentResult(validId, componentMetaDataResolver, artifactResolver));
-                    } catch (Throwable t) {
-                        componentResults.add(new DefaultUnresolvedComponentResult(componentId, t));
-                    }
-                }
-
-                return new DefaultArtifactResolutionResult(componentResults);
+        for (ComponentIdentifier componentId : componentIds) {
+            try {
+                ComponentIdentifier validId = validateComponentIdentifier(componentId);
+                componentResults.add(buildComponentResult(validId, componentMetaDataResolver, artifactResolver));
+            } catch (Throwable t) {
+                componentResults.add(new DefaultUnresolvedComponentResult(componentId, t));
             }
+        }
 
-            private ComponentIdentifier validateComponentIdentifier(ComponentIdentifier componentId) {
-                if (componentId instanceof ModuleComponentIdentifier) {
-                    return componentId;
-                }
-                if(componentId instanceof ProjectComponentIdentifier) {
-                    throw new IllegalArgumentException(String.format("Cannot query artifacts for a project component (%s).", componentId.getDisplayName()));
-                }
+        return new DefaultArtifactResolutionResult(componentResults);
+    }
 
-                throw new IllegalArgumentException(String.format("Cannot resolve the artifacts for component %s with unsupported type %s.", componentId.getDisplayName(), componentId.getClass().getName()));
-            }
-        });
+    private ComponentIdentifier validateComponentIdentifier(ComponentIdentifier componentId) {
+        if (componentId instanceof ModuleComponentIdentifier) {
+            return componentId;
+        }
+        if (componentId instanceof ProjectComponentIdentifier) {
+            throw new IllegalArgumentException(String.format("Cannot query artifacts for a project component (%s).", componentId.getDisplayName()));
+        }
+
+        throw new IllegalArgumentException(String.format("Cannot resolve the artifacts for component %s with unsupported type %s.", componentId.getDisplayName(), componentId.getClass().getName()));
     }
 
     private ComponentArtifactsResult buildComponentResult(ComponentIdentifier componentId, ComponentMetaDataResolver componentMetaDataResolver, ArtifactResolver artifactResolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryFactory.java
@@ -19,7 +19,6 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 
@@ -28,21 +27,19 @@ public class DefaultArtifactResolutionQueryFactory implements ArtifactResolution
     private final RepositoryHandler repositoryHandler;
     private final ResolveIvyFactory ivyFactory;
     private final GlobalDependencyResolutionRules metadataHandler;
-    private final CacheLockingManager cacheLockingManager;
     private final ComponentTypeRegistry componentTypeRegistry;
 
     public DefaultArtifactResolutionQueryFactory(ConfigurationContainerInternal configurationContainer, RepositoryHandler repositoryHandler,
                                                  ResolveIvyFactory ivyFactory, GlobalDependencyResolutionRules metadataHandler,
-                                                 CacheLockingManager cacheLockingManager, ComponentTypeRegistry componentTypeRegistry) {
+                                                 ComponentTypeRegistry componentTypeRegistry) {
         this.configurationContainer = configurationContainer;
         this.repositoryHandler = repositoryHandler;
         this.ivyFactory = ivyFactory;
         this.metadataHandler = metadataHandler;
-        this.cacheLockingManager = cacheLockingManager;
         this.componentTypeRegistry = componentTypeRegistry;
     }
 
     public ArtifactResolutionQuery createArtifactResolutionQuery() {
-        return new DefaultArtifactResolutionQuery(configurationContainer, repositoryHandler, ivyFactory, metadataHandler, cacheLockingManager, componentTypeRegistry);
+        return new DefaultArtifactResolutionQuery(configurationContainer, repositoryHandler, ivyFactory, metadataHandler, componentTypeRegistry);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
@@ -25,12 +25,10 @@ import org.gradle.api.component.Artifact
 import org.gradle.api.component.Component
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory
 import org.gradle.api.internal.component.ComponentTypeRegistration
 import org.gradle.api.internal.component.ComponentTypeRegistry
-import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentOverrideMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
@@ -46,7 +44,6 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     def repositoryHandler = Stub(RepositoryHandler)
     def resolveIvyFactory = Mock(ResolveIvyFactory)
     def globalDependencyResolutionRules = Mock(GlobalDependencyResolutionRules)
-    def cacheLockingManager = Mock(CacheLockingManager)
     def componentTypeRegistry = Mock(ComponentTypeRegistry)
     def artifactResolver = Mock(ArtifactResolver)
     def repositoryChain = Mock(ComponentResolvers)
@@ -127,9 +124,6 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     }
 
     private def withArtifactResolutionInteractions(int numberOfComponentsToResolve = 1) {
-        1 * cacheLockingManager.useCache(_) >> { Factory action ->
-            action.create()
-        }
         1 * resolveIvyFactory.create(_, _, _) >> repositoryChain
         1 * repositoryChain.artifactResolver >> artifactResolver
         1 * repositoryChain.componentResolver >> componentMetaDataResolver
@@ -139,7 +133,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     }
 
     private DefaultArtifactResolutionQuery createArtifactResolutionQuery(ComponentTypeRegistry componentTypeRegistry) {
-        new DefaultArtifactResolutionQuery(configurationContainerInternal, repositoryHandler, resolveIvyFactory, globalDependencyResolutionRules, cacheLockingManager, componentTypeRegistry)
+        new DefaultArtifactResolutionQuery(configurationContainerInternal, repositoryHandler, resolveIvyFactory, globalDependencyResolutionRules, componentTypeRegistry)
     }
 
     private ComponentTypeRegistry createTestComponentTypeRegistry() {


### PR DESCRIPTION
Fix https://github.com/gradle/gradle/issues/3579

The inappropriate usage of `useCache` in DefaultArtifactResolutionQuery might cause dead lock.
This PR remove the usage of `useCache`.
