### PR TITLE
Remove docs auto labeling

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -26,9 +26,14 @@
     <xsl:param name="use.extensions">1</xsl:param>
     <xsl:param name="toc.section.depth">1</xsl:param>
     <xsl:param name="toc.max.depth">2</xsl:param>
-    <xsl:param name="section.autolabel">1</xsl:param>
-    <xsl:param name="section.autolabel.max.depth">2</xsl:param>
-    <xsl:param name="section.label.includes.component.label">1</xsl:param>
+    <xsl:param name="part.autolabel">0</xsl:param>
+    <xsl:param name="chapter.autolabel">0</xsl:param>
+    <xsl:param name="section.autolabel">0</xsl:param>
+    <xsl:param name="preface.autolabel">0</xsl:param>
+    <xsl:param name="figure.autolabel">0</xsl:param>
+    <xsl:param name="example.autolabel">0</xsl:param>
+    <xsl:param name="table.autolabel">0</xsl:param>
+    <xsl:param name="xref.with.number.and.title">0</xsl:param>
     <xsl:param name="css.decoration">0</xsl:param>
     <xsl:param name="highlight.source" select="1"/>
 


### PR DESCRIPTION
This fulfills a small part of @aweida's design where we drop chapter, section, etc numbers. 

#### Before
![screenshot 2017-12-04 20 28 42](https://user-images.githubusercontent.com/51534/33589176-349b0840-d934-11e7-9567-4d65c11c93f4.png)

#### After
![screenshot 2017-12-04 20 26 57](https://user-images.githubusercontent.com/51534/33589180-3a1b3e2a-d934-11e7-92c4-ecda2c1b30dc.png)

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
