### PR TITLE
Fix Gradle metadata serialization in module cache

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 43),
+    META_DATA(ROOT, "metadata", 44),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -23,7 +23,6 @@ import com.google.gson.stream.JsonToken;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
@@ -33,7 +32,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.changedetection.state.CoercingStringValueSnapshot;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableComponentVariantResolveMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -317,13 +315,7 @@ public class ModuleMetadataParser {
         reader.beginObject();
         while (reader.peek() != END_OBJECT) {
             String attrName = reader.nextName();
-            if (ProjectInternal.STATUS_ATTRIBUTE.getName().equals(attrName)) {
-                String attrValue = reader.nextString();
-                attributes = attributesFactory.concat(attributes, Attribute.of(attrName, String.class), attrValue);
-            } else if (attrName.equals(Usage.USAGE_ATTRIBUTE.getName())) {
-                String attrValue = reader.nextString();
-                attributes = attributesFactory.concat(attributes, Attribute.of(attrName, Usage.class), instantiator.named(Usage.class, attrValue));
-            } else if (reader.peek() == BOOLEAN) {
+            if (reader.peek() == BOOLEAN) {
                 boolean attrValue = reader.nextBoolean();
                 attributes = attributesFactory.concat(attributes, Attribute.of(attrName, Boolean.class), attrValue);
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -124,7 +124,15 @@ public class ModuleMetadataSerializer {
                 encoder.writeString(variant.getName());
                 writeAttributes(variant.getAttributes());
                 writeVariantDependencies(variant.getDependencies());
+                writeVariantConstraints(variant.getDependencyConstraints());
                 writeVariantFiles(variant.getFiles());
+            }
+        }
+
+        private void writeVariantConstraints(ImmutableList<? extends ComponentVariant.DependencyConstraint> constraints) throws IOException {
+            encoder.writeSmallInt(constraints.size());
+            for (ComponentVariant.DependencyConstraint constraint : constraints) {
+                COMPONENT_SELECTOR_SERIALIZER.write(encoder, constraint.getGroup(), constraint.getModule(), constraint.getVersionConstraint());
             }
         }
 
@@ -398,6 +406,7 @@ public class ModuleMetadataSerializer {
                 ImmutableAttributes attributes = readAttributes();
                 MutableComponentVariant variant = metadata.addVariant(name, attributes);
                 readVariantDependencies(variant);
+                readVariantConstraints(variant);
                 readVariantFiles(variant);
             }
         }
@@ -424,6 +433,14 @@ public class ModuleMetadataSerializer {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
                 ImmutableList<ExcludeMetadata> excludes = readVariantDependencyExcludes();
                 variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes);
+            }
+        }
+
+        private void readVariantConstraints(MutableComponentVariant variant) throws IOException {
+            int count = decoder.readSmallInt();
+            for (int i = 0; i < count; i++) {
+                ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
+                variant.addDependencyConstraint(selector.getGroup(), selector.getModule(), selector.getVersionConstraint());
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -72,6 +72,7 @@ public class ModuleMetadataSerializer {
     private static final byte TYPE_MAVEN = 2;
     private static final byte STRING_ATTRIBUTE = 1;
     private static final byte BOOLEAN_ATTRIBUTE = 2;
+
     private static final ModuleComponentSelectorSerializer COMPONENT_SELECTOR_SERIALIZER = new ModuleComponentSelectorSerializer();
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator instantiator;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -230,4 +230,52 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     public synchronized ConfigurationMetadata getConfiguration(final String name) {
         return populateConfigurationFromDescriptor(name, configurationDefinitions, configurations);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractModuleComponentResolveMetadata that = (AbstractModuleComponentResolveMetadata) o;
+
+        if (changing != that.changing) {
+            return false;
+        }
+        if (missing != that.missing) {
+            return false;
+        }
+        if (moduleVersionIdentifier != null ? !moduleVersionIdentifier.equals(that.moduleVersionIdentifier) : that.moduleVersionIdentifier != null) {
+            return false;
+        }
+        if (componentIdentifier != null ? !componentIdentifier.equals(that.componentIdentifier) : that.componentIdentifier != null) {
+            return false;
+        }
+        if (status != null ? !status.equals(that.status) : that.status != null) {
+            return false;
+        }
+        if (statusScheme != null ? !statusScheme.equals(that.statusScheme) : that.statusScheme != null) {
+            return false;
+        }
+        if (variants != null ? !variants.equals(that.variants) : that.variants != null) {
+            return false;
+        }
+        return contentHash != null ? contentHash.equals(that.contentHash) : that.contentHash == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = moduleVersionIdentifier != null ? moduleVersionIdentifier.hashCode() : 0;
+        result = 31 * result + (componentIdentifier != null ? componentIdentifier.hashCode() : 0);
+        result = 31 * result + (changing ? 1 : 0);
+        result = 31 * result + (missing ? 1 : 0);
+        result = 31 * result + (status != null ? status.hashCode() : 0);
+        result = 31 * result + (statusScheme != null ? statusScheme.hashCode() : 0);
+        result = 31 * result + (variants != null ? variants.hashCode() : 0);
+        result = 31 * result + (contentHash != null ? contentHash.hashCode() : 0);
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -295,6 +295,30 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         public String getUri() {
             return uri;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            FileImpl file = (FileImpl) o;
+
+            if (name != null ? !name.equals(file.name) : file.name != null) {
+                return false;
+            }
+            return uri != null ? uri.equals(file.uri) : file.uri == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (uri != null ? uri.hashCode() : 0);
+            return result;
+        }
     }
 
     protected static class DependencyImpl implements ComponentVariant.Dependency {
@@ -329,6 +353,38 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         public ImmutableList<ExcludeMetadata> getExcludes() {
             return excludes;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DependencyImpl that = (DependencyImpl) o;
+
+            if (group != null ? !group.equals(that.group) : that.group != null) {
+                return false;
+            }
+            if (module != null ? !module.equals(that.module) : that.module != null) {
+                return false;
+            }
+            if (versionConstraint != null ? !versionConstraint.equals(that.versionConstraint) : that.versionConstraint != null) {
+                return false;
+            }
+            return excludes != null ? excludes.equals(that.excludes) : that.excludes == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = group != null ? group.hashCode() : 0;
+            result = 31 * result + (module != null ? module.hashCode() : 0);
+            result = 31 * result + (versionConstraint != null ? versionConstraint.hashCode() : 0);
+            result = 31 * result + (excludes != null ? excludes.hashCode() : 0);
+            return result;
+        }
     }
 
     protected static class DependencyConstraintImpl implements ComponentVariant.DependencyConstraint {
@@ -355,6 +411,34 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         @Override
         public VersionConstraint getVersionConstraint() {
             return versionConstraint;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DependencyConstraintImpl that = (DependencyConstraintImpl) o;
+
+            if (group != null ? !group.equals(that.group) : that.group != null) {
+                return false;
+            }
+            if (module != null ? !module.equals(that.module) : that.module != null) {
+                return false;
+            }
+            return versionConstraint != null ? versionConstraint.equals(that.versionConstraint) : that.versionConstraint == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = group != null ? group.hashCode() : 0;
+            result = 31 * result + (module != null ? module.hashCode() : 0);
+            result = 31 * result + (versionConstraint != null ? versionConstraint.hashCode() : 0);
+            return result;
         }
     }
 
@@ -414,5 +498,44 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
             return artifacts;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ImmutableVariantImpl that = (ImmutableVariantImpl) o;
+
+            if (componentId != null ? !componentId.equals(that.componentId) : that.componentId != null) {
+                return false;
+            }
+            if (name != null ? !name.equals(that.name) : that.name != null) {
+                return false;
+            }
+            if (attributes != null ? !attributes.equals(that.attributes) : that.attributes != null) {
+                return false;
+            }
+            if (dependencies != null ? !dependencies.equals(that.dependencies) : that.dependencies != null) {
+                return false;
+            }
+            if (dependencyConstraints != null ? !dependencyConstraints.equals(that.dependencyConstraints) : that.dependencyConstraints != null) {
+                return false;
+            }
+            return files != null ? files.equals(that.files) : that.files == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = componentId != null ? componentId.hashCode() : 0;
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
+            result = 31 * result + (dependencies != null ? dependencies.hashCode() : 0);
+            result = 31 * result + (dependencyConstraints != null ? dependencyConstraints.hashCode() : 0);
+            result = 31 * result + (files != null ? files.hashCode() : 0);
+            return result;
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -230,4 +230,40 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
     public ImmutableList<IvyDependencyDescriptor> getDependencies() {
         return dependencies;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DefaultIvyModuleResolveMetadata that = (DefaultIvyModuleResolveMetadata) o;
+
+        if (dependencies != null ? !dependencies.equals(that.dependencies) : that.dependencies != null) {
+            return false;
+        }
+        if (excludes != null ? !excludes.equals(that.excludes) : that.excludes != null) {
+            return false;
+        }
+        if (extraAttributes != null ? !extraAttributes.equals(that.extraAttributes) : that.extraAttributes != null) {
+            return false;
+        }
+        return branch != null ? branch.equals(that.branch) : that.branch == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (dependencies != null ? dependencies.hashCode() : 0);
+        result = 31 * result + (excludes != null ? excludes.hashCode() : 0);
+        result = 31 * result + (extraAttributes != null ? extraAttributes.hashCode() : 0);
+        result = 31 * result + (branch != null ? branch.hashCode() : 0);
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -140,4 +140,40 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     public ImmutableList<MavenDependencyDescriptor> getDependencies() {
         return dependencies;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        DefaultMavenModuleResolveMetadata that = (DefaultMavenModuleResolveMetadata) o;
+
+        if (relocated != that.relocated) {
+            return false;
+        }
+        if (dependencies != null ? !dependencies.equals(that.dependencies) : that.dependencies != null) {
+            return false;
+        }
+        if (packaging != null ? !packaging.equals(that.packaging) : that.packaging != null) {
+            return false;
+        }
+        return snapshotTimestamp != null ? snapshotTimestamp.equals(that.snapshotTimestamp) : that.snapshotTimestamp == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (dependencies != null ? dependencies.hashCode() : 0);
+        result = 31 * result + (packaging != null ? packaging.hashCode() : 0);
+        result = 31 * result + (relocated ? 1 : 0);
+        result = 31 * result + (snapshotTimestamp != null ? snapshotTimestamp.hashCode() : 0);
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
@@ -237,4 +237,52 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
         }
         return false;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        IvyDependencyDescriptor that = (IvyDependencyDescriptor) o;
+
+        if (changing != that.changing) {
+            return false;
+        }
+        if (transitive != that.transitive) {
+            return false;
+        }
+        if (optional != that.optional) {
+            return false;
+        }
+        if (selector != null ? !selector.equals(that.selector) : that.selector != null) {
+            return false;
+        }
+        if (dynamicConstraintVersion != null ? !dynamicConstraintVersion.equals(that.dynamicConstraintVersion) : that.dynamicConstraintVersion != null) {
+            return false;
+        }
+        if (confs != null ? !confs.equals(that.confs) : that.confs != null) {
+            return false;
+        }
+        if (excludes != null ? !excludes.equals(that.excludes) : that.excludes != null) {
+            return false;
+        }
+        return dependencyArtifacts != null ? dependencyArtifacts.equals(that.dependencyArtifacts) : that.dependencyArtifacts == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = selector != null ? selector.hashCode() : 0;
+        result = 31 * result + (dynamicConstraintVersion != null ? dynamicConstraintVersion.hashCode() : 0);
+        result = 31 * result + (changing ? 1 : 0);
+        result = 31 * result + (transitive ? 1 : 0);
+        result = 31 * result + (optional ? 1 : 0);
+        result = 31 * result + (confs != null ? confs.hashCode() : 0);
+        result = 31 * result + (excludes != null ? excludes.hashCode() : 0);
+        result = 31 * result + (dependencyArtifacts != null ? dependencyArtifacts.hashCode() : 0);
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MavenDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MavenDependencyDescriptor.java
@@ -187,4 +187,44 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
     public boolean isOptional() {
         return optional;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MavenDependencyDescriptor that = (MavenDependencyDescriptor) o;
+
+        if (optional != that.optional) {
+            return false;
+        }
+        if (selector != null ? !selector.equals(that.selector) : that.selector != null) {
+            return false;
+        }
+        if (scope != that.scope) {
+            return false;
+        }
+        if (excludes != null ? !excludes.equals(that.excludes) : that.excludes != null) {
+            return false;
+        }
+        if (dependencyArtifact != null ? !dependencyArtifact.equals(that.dependencyArtifact) : that.dependencyArtifact != null) {
+            return false;
+        }
+        return moduleConfigurations != null ? moduleConfigurations.equals(that.moduleConfigurations) : that.moduleConfigurations == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = selector != null ? selector.hashCode() : 0;
+        result = 31 * result + (scope != null ? scope.hashCode() : 0);
+        result = 31 * result + (optional ? 1 : 0);
+        result = 31 * result + (excludes != null ? excludes.hashCode() : 0);
+        result = 31 * result + (dependencyArtifact != null ? dependencyArtifact.hashCode() : 0);
+        result = 31 * result + (moduleConfigurations != null ? moduleConfigurations.hashCode() : 0);
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -21,7 +21,6 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.DisambiguationRule;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.MultipleCandidatesResult;
-import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Cast;
 
 import java.util.Set;
@@ -37,10 +36,7 @@ import java.util.Set;
  * declaring no preference for a particular variant.
  */
 class PreferJavaRuntimeVariant extends EmptySchema {
-    private static final NamedObjectInstantiator INSTANTIATOR = NamedObjectInstantiator.INSTANCE;
-    private static final Usage JAVA_API = INSTANTIATOR.named(Usage.class, Usage.JAVA_API);
-    private static final Usage JAVA_RUNTIME = INSTANTIATOR.named(Usage.class, Usage.JAVA_RUNTIME);
-    private static final Set<Usage> DEFAULT_JAVA_USAGES = ImmutableSet.of(JAVA_API, JAVA_RUNTIME);
+    private static final Set<String> DEFAULT_JAVA_USAGES = ImmutableSet.of(Usage.JAVA_API, Usage.JAVA_RUNTIME);
 
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
 
@@ -53,12 +49,12 @@ class PreferJavaRuntimeVariant extends EmptySchema {
 
     @Override
     public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
-        if (attribute.getType().equals(Usage.class)) {
-            return Cast.uncheckedCast(new DisambiguationRule<Usage>() {
-                public void execute(MultipleCandidatesResult<Usage> details) {
+        if (Usage.USAGE_ATTRIBUTE.getName().equals(attribute.getName())) {
+            return Cast.uncheckedCast(new DisambiguationRule<String>() {
+                public void execute(MultipleCandidatesResult<String> details) {
                     if (details.getConsumerValue() == null) {
                         if (details.getCandidateValues().equals(DEFAULT_JAVA_USAGES)) {
-                            details.closestMatch(JAVA_RUNTIME);
+                            details.closestMatch(Usage.JAVA_RUNTIME);
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.43'
-        cacheLayout.version == VersionNumber.parse("2.43.0")
-        cacheLayout.formattedVersion == '2.43'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.43')
+        cacheLayout.key == 'metadata-2.44'
+        cacheLayout.version == VersionNumber.parse("2.44.0")
+        cacheLayout.formattedVersion == '2.44'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.44')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache
+
+import org.apache.commons.io.output.ByteArrayOutputStream
+import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyXmlModuleDescriptorParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.model.NamedObjectInstantiator
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultMutableMavenModuleResolveMetadata
+import org.gradle.internal.component.external.model.MutableIvyModuleResolveMetadata
+import org.gradle.internal.component.external.model.MutableMavenModuleResolveMetadata
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
+import org.gradle.internal.resource.local.FileResourceRepository
+import org.gradle.internal.resource.local.LocalFileStandInExternalResource
+import org.gradle.internal.resource.local.LocallyAvailableExternalResource
+import org.gradle.internal.serialize.InputStreamBackedDecoder
+import org.gradle.internal.serialize.OutputStreamBackedEncoder
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ModuleMetadataSerializerTest extends Specification {
+
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
+    private final ModuleMetadataSerializer serializer = new ModuleMetadataSerializer(
+        TestUtil.attributesFactory(),
+        NamedObjectInstantiator.INSTANCE
+    )
+
+    private GradlePomModuleDescriptorParser pomModuleDescriptorParser = new GradlePomModuleDescriptorParser(
+        new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme()),
+        moduleIdentifierFactory,
+        Stub(FileResourceRepository)
+    )
+
+    private MetaDataParser<MutableIvyModuleResolveMetadata> ivyDescriptorParser = new IvyXmlModuleDescriptorParser(
+        new IvyModuleDescriptorConverter(moduleIdentifierFactory),
+        moduleIdentifierFactory,
+        Stub(FileResourceRepository)
+    )
+
+    private ModuleMetadataParser gradleMetadataParser = new ModuleMetadataParser(
+        TestUtil.attributesFactory(),
+        moduleIdentifierFactory,
+        NamedObjectInstantiator.INSTANCE
+    )
+
+    @Unroll
+    def "can write and re-read sample #sample.parentFile.name metadata file #sample.name"() {
+        given:
+        def metadata = parse(sample)
+        def bytes = serialize(metadata)
+
+        when:
+        def deserializedMetadata = deserialize(bytes).asImmutable()
+        def originMetadata = metadata.asImmutable()
+
+        then:
+        deserializedMetadata == originMetadata
+
+        where:
+        sample << sampleFiles()
+
+    }
+
+    private MutableModuleComponentResolveMetadata deserialize(byte[] serializedForm) {
+        serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(serializedForm)), moduleIdentifierFactory)
+    }
+
+    private byte[] serialize(MutableModuleComponentResolveMetadata metadata) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        serializer.write(new OutputStreamBackedEncoder(baos), metadata.asImmutable())
+        baos.toByteArray()
+    }
+
+    static List<File> sampleFiles() {
+        def baseUrl = ModuleMetadataSerializerTest.getResource("${this.simpleName}")
+        def samples = []
+        new File(baseUrl.toURI()).eachFile {
+            samples.addAll(it.listFiles() as List)
+        }
+
+        samples
+    }
+
+    MutableModuleComponentResolveMetadata parse(File file) {
+        switch (file.parentFile.name) {
+            case 'pom':
+                return parsePom(file)
+            case 'ivy':
+                return parseIvy(file)
+            case 'gradle':
+                return parseGradle(file)
+        }
+        throw new IllegalStateException("Unexpected metadata file $file")
+    }
+
+    MutableMavenModuleResolveMetadata parsePom(File pomFile) {
+        pomModuleDescriptorParser.parseMetaData(Mock(DescriptorParseContext), resource(pomFile))
+    }
+
+    MutableIvyModuleResolveMetadata parseIvy(File ivyFile) {
+        ivyDescriptorParser.parseMetaData(Stub(DescriptorParseContext), resource(ivyFile))
+    }
+
+    MutableModuleComponentResolveMetadata parseGradle(File gradleFile) {
+        def metadata = new DefaultMutableMavenModuleResolveMetadata(
+            DefaultModuleVersionIdentifier.newId('test', 'test-module', '1.0'),
+            DefaultModuleComponentIdentifier.newId('test', 'test-module', '1.0')
+        )
+        gradleMetadataParser.parse(resource(gradleFile), metadata)
+        metadata
+    }
+
+    LocallyAvailableExternalResource resource(File testFile) {
+        return new LocalFileStandInExternalResource(testFile, TestFiles.fileSystem())
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -47,28 +47,11 @@ import spock.lang.Unroll
 class ModuleMetadataSerializerTest extends Specification {
 
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    private final ModuleMetadataSerializer serializer = new ModuleMetadataSerializer(
-        TestUtil.attributesFactory(),
-        NamedObjectInstantiator.INSTANCE
-    )
+    private final ModuleMetadataSerializer serializer = moduleMetadataSerializer()
+    private GradlePomModuleDescriptorParser pomModuleDescriptorParser = pomParser()
+    private MetaDataParser<MutableIvyModuleResolveMetadata> ivyDescriptorParser = ivyParser()
+    private ModuleMetadataParser gradleMetadataParser = gradleMetadataParser()
 
-    private GradlePomModuleDescriptorParser pomModuleDescriptorParser = new GradlePomModuleDescriptorParser(
-        new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme()),
-        moduleIdentifierFactory,
-        Stub(FileResourceRepository)
-    )
-
-    private MetaDataParser<MutableIvyModuleResolveMetadata> ivyDescriptorParser = new IvyXmlModuleDescriptorParser(
-        new IvyModuleDescriptorConverter(moduleIdentifierFactory),
-        moduleIdentifierFactory,
-        Stub(FileResourceRepository)
-    )
-
-    private ModuleMetadataParser gradleMetadataParser = new ModuleMetadataParser(
-        TestUtil.attributesFactory(),
-        moduleIdentifierFactory,
-        NamedObjectInstantiator.INSTANCE
-    )
 
     @Unroll
     def "can write and re-read sample #sample.parentFile.name metadata file #sample.name"() {
@@ -105,6 +88,10 @@ class ModuleMetadataSerializerTest extends Specification {
             samples.addAll(it.listFiles() as List)
         }
 
+        String filter = System.getProperty('org.gradle.internal.test.moduleMetadataSerializerFilter', null)
+        if (filter) {
+            samples = samples.findAll { it =~ filter }
+        }
         samples
     }
 
@@ -141,4 +128,34 @@ class ModuleMetadataSerializerTest extends Specification {
         return new LocalFileStandInExternalResource(testFile, TestFiles.fileSystem())
     }
 
+    private ModuleMetadataSerializer moduleMetadataSerializer() {
+        new ModuleMetadataSerializer(
+            TestUtil.attributesFactory(),
+            NamedObjectInstantiator.INSTANCE
+        )
+    }
+
+    private GradlePomModuleDescriptorParser pomParser() {
+        new GradlePomModuleDescriptorParser(
+            new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme()),
+            moduleIdentifierFactory,
+            Stub(FileResourceRepository)
+        )
+    }
+
+    private IvyXmlModuleDescriptorParser ivyParser() {
+        new IvyXmlModuleDescriptorParser(
+            new IvyModuleDescriptorConverter(moduleIdentifierFactory),
+            moduleIdentifierFactory,
+            Stub(FileResourceRepository)
+        )
+    }
+
+    private ModuleMetadataParser gradleMetadataParser() {
+        new ModuleMetadataParser(
+            TestUtil.attributesFactory(),
+            moduleIdentifierFactory,
+            NamedObjectInstantiator.INSTANCE
+        )
+    }
 }

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/boolean-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/boolean-attributes.module
@@ -1,0 +1,10 @@
+{
+    "formatVersion": "0.3",
+    "builtBy": { "gradle": { "version": "123", "buildId": "abc" } },
+    "variants": [
+        {
+            "name": "api",
+            "attributes": { "usage": "compile", "debuggable": true, "testable": false }
+        }
+    ]
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/java-library-with-excludes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/java-library-with-excludes.module
@@ -1,0 +1,185 @@
+{
+    "formatVersion": "0.3",
+    "component": {
+        "group": "org.gradle.test",
+        "module": "publishTest",
+        "version": "1.9",
+        "attributes": {
+            "org.gradle.status": "release"
+        }
+    },
+    "createdBy": {
+        "gradle": {
+            "version": "4.5-20171204230000+0000",
+            "buildId": "mmkppe3smvbgbhp5yeotxkaweq"
+        }
+    },
+    "variants": [
+        {
+            "name": "runtime",
+            "attributes": {
+                "org.gradle.usage": "java-runtime"
+            },
+            "dependencies": [
+                {
+                    "group": "commons-collections",
+                    "module": "commons-collections",
+                    "version": {
+                        "prefers": "3.2.2"
+                    }
+                },
+                {
+                    "group": "org.springframework",
+                    "module": "spring-core",
+                    "version": {
+                        "prefers": "2.5.6"
+                    },
+                    "excludes": [
+                        {
+                            "group": "commons-logging",
+                            "module": "commons-logging"
+                        }
+                    ]
+                },
+                {
+                    "group": "commons-beanutils",
+                    "module": "commons-beanutils",
+                    "version": {
+                        "prefers": "1.8.3"
+                    },
+                    "excludes": [
+                        {
+                            "group": "commons-logging",
+                            "module": "*"
+                        }
+                    ]
+                },
+                {
+                    "group": "commons-dbcp",
+                    "module": "commons-dbcp",
+                    "version": {
+                        "prefers": "1.4"
+                    },
+                    "excludes": [
+                        {
+                            "group": "*",
+                            "module": "*"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.apache.camel",
+                    "module": "camel-jackson",
+                    "version": {
+                        "prefers": "2.15.3"
+                    },
+                    "excludes": [
+                        {
+                            "group": "*",
+                            "module": "camel-core"
+                        }
+                    ]
+                },
+                {
+                    "group": "commons-io",
+                    "module": "commons-io",
+                    "version": {
+                        "prefers": "1.4"
+                    }
+                }
+            ],
+            "files": [
+                {
+                    "name": "publishTest-1.9.jar",
+                    "url": "publishTest-1.9.jar",
+                    "size": 261,
+                    "sha1": "7577e284a8b6daf5cb2fe0d826343f22fadb8ad0",
+                    "md5": "7233c4d2f6a17fd35a2def674868828b"
+                }
+            ]
+        },
+        {
+            "name": "api",
+            "attributes": {
+                "org.gradle.usage": "java-api"
+            },
+            "dependencies": [
+                {
+                    "group": "commons-io",
+                    "module": "commons-io",
+                    "version": {
+                        "prefers": "1.4"
+                    }
+                },
+                {
+                    "group": "commons-collections",
+                    "module": "commons-collections",
+                    "version": {
+                        "prefers": "3.2.2"
+                    }
+                },
+                {
+                    "group": "org.springframework",
+                    "module": "spring-core",
+                    "version": {
+                        "prefers": "2.5.6"
+                    },
+                    "excludes": [
+                        {
+                            "group": "commons-logging",
+                            "module": "commons-logging"
+                        }
+                    ]
+                },
+                {
+                    "group": "commons-beanutils",
+                    "module": "commons-beanutils",
+                    "version": {
+                        "prefers": "1.8.3"
+                    },
+                    "excludes": [
+                        {
+                            "group": "commons-logging",
+                            "module": "*"
+                        }
+                    ]
+                },
+                {
+                    "group": "commons-dbcp",
+                    "module": "commons-dbcp",
+                    "version": {
+                        "prefers": "1.4"
+                    },
+                    "excludes": [
+                        {
+                            "group": "*",
+                            "module": "*"
+                        }
+                    ]
+                },
+                {
+                    "group": "org.apache.camel",
+                    "module": "camel-jackson",
+                    "version": {
+                        "prefers": "2.15.3"
+                    },
+                    "excludes": [
+                        {
+                            "group": "*",
+                            "module": "camel-core"
+                        }
+                    ]
+                }
+            ],
+            "files": [
+                {
+                    "name": "publishTest-1.9.jar",
+                    "url": "publishTest-1.9.jar",
+                    "size": 261,
+                    "sha1": "7577e284a8b6daf5cb2fe0d826343f22fadb8ad0",
+                    "md5": "7233c4d2f6a17fd35a2def674868828b"
+                }
+            ]
+        }
+    ]
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
@@ -1,0 +1,27 @@
+{
+    "formatVersion": "0.3",
+    "variants": [
+        {
+            "name": "api",
+            "dependencyConstraints": [
+                { "group": "g1", "module": "m1", "version": { "prefers": "v1" } },
+                { "version": { "prefers": "v2" }, "group": "g2", "module": "m2" },
+                {
+                    "group": "g3",
+                    "module": "m3",
+                    "version": { "prefers": "v3" }
+                }
+            ],
+            "attributes": { "usage": "compile" }
+        },
+        {
+            "attributes": { "usage": "runtime", "packaging": "zip" },
+            "dependencyConstraints": [
+                { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
+                { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
+                { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"}
+            ],
+            "name": "runtime"
+        }
+    ]
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -1,0 +1,32 @@
+{
+    "formatVersion": "0.3",
+    "variants": [
+        {
+            "name": "api",
+            "dependencies": [
+                { "group": "g0", "module": "m0" },
+                { "group": "g1", "module": "m1", "version": { "prefers": "v1" } },
+                { "version": { "prefers": "v2" }, "group": "g2", "module": "m2" },
+                {
+                    "group": "g3",
+                    "module": "m3",
+                    "version": { "prefers": "v3" },
+                    "excludes": [
+                        {"group": "gx", "module": "mx" },
+                        {"group": "*", "module": "*" }
+                    ]
+                }
+            ],
+            "attributes": { "usage": "compile" }
+        },
+        {
+            "attributes": { "usage": "runtime", "packaging": "zip" },
+            "dependencies": [
+                { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
+                { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
+                { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"}
+            ],
+            "name": "runtime"
+        }
+    ]
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-variants.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-variants.module
@@ -1,0 +1,11 @@
+{
+    "formatVersion": "0.3",
+    "variants": [
+        {
+            "name": "api",
+            "attributes": { "usage": "compile" },
+            "files": [ { "name": "a.zip", "url": "a.zop" } ],
+            "dependencies": [ { "group": "g1", "module": "m1", "version": { "prefers": "v1" } } ]
+        }
+    ]
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-nondefault-status.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-nondefault-status.module
@@ -1,0 +1,11 @@
+{
+    "formatVersion": "0.3",
+    "component": {
+        "group": "org.gradle.test",
+        "module": "publishTest",
+        "version": "1.9",
+        "attributes": {
+            "org.gradle.status": "milestone"
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/ivy/with-dependencies.xml
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/ivy/with-dependencies.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
+    <info organisation="com.android.tools.build" module="builder" revision="1.5.0" status="release" publication="20160825135103">
+        <license name="The Apache Software License, Version 2.0" url="http://www.apache.org/licenses/LICENSE-2.0.txt"/>
+        <description homepage="http://tools.android.com/">Library to build Android applications.</description>
+    </info>
+    <configurations>
+        <conf name="default" visibility="public" description="runtime dependencies and master artifact can be used with this conf" extends="runtime,master"/>
+        <conf name="master" visibility="public" description="contains only the artifact published by this module itself, with no transitive dependencies"/>
+        <conf name="compile" visibility="public" description="this is the default scope, used if none is specified. Compile dependencies are available in all classpaths."/>
+        <conf name="provided" visibility="public" description="this is much like compile, but indicates you expect the JDK or a container to provide it. It is only available on the compilation classpath, and is not transitive."/>
+        <conf name="runtime" visibility="public" description="this scope indicates that the dependency is not required for compilation, but is for execution. It is in the runtime and test classpaths, but not the compile classpath." extends="compile"/>
+        <conf name="test" visibility="private" description="this scope indicates that the dependency is not required for normal use of the application, and is only available for the test compilation and execution phases." extends="runtime"/>
+        <conf name="system" visibility="public" description="this scope is similar to provided except that you have to provide the JAR which contains it explicitly. The artifact is always available and is not looked up in a repository."/>
+        <conf name="sources" visibility="public" description="this configuration contains the source artifact of this module, if any."/>
+        <conf name="javadoc" visibility="public" description="this configuration contains the javadoc artifact of this module, if any."/>
+        <conf name="optional" visibility="public" description="contains all optional dependencies"/>
+    </configurations>
+    <publications/>
+    <dependencies>
+        <dependency org="com.android.tools.build" name="builder-model" rev="1.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools.build" name="builder-test-api" rev="1.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools.build" name="transform-api" rev="1.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools" name="sdklib" rev="24.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools" name="sdk-common" rev="24.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools" name="common" rev="24.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools.build" name="manifest-merger" rev="24.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools.ddms" name="ddmlib" rev="24.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools.jack" name="jack-api" rev="0.9.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.android.tools.jill" name="jill-api" rev="0.9.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="com.squareup" name="javawriter" rev="2.5.0" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="org.bouncycastle" name="bcpkix-jdk15on" rev="1.48" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="org.bouncycastle" name="bcprov-jdk15on" rev="1.48" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="org.ow2.asm" name="asm" rev="5.0.3" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="org.ow2.asm" name="asm-tree" rev="5.0.3" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="org.antlr" name="antlr-runtime" rev="3.5.2" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+        <dependency org="org.antlr" name="antlr" rev="3.5.2" force="true" conf="runtime-&gt;compile(*),runtime(*),master(*)"/>
+    </dependencies>
+</ivy-module>

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/pom/junit-4.12.pom
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/pom/junit-4.12.pom
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.12</version>
+
+    <name>JUnit</name>
+    <description>JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.</description>
+    <url>http://junit.org</url>
+    <inceptionYear>2002</inceptionYear>
+    <organization>
+        <name>JUnit</name>
+        <url>http://www.junit.org</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>Eclipse Public License 1.0</name>
+            <url>http://www.eclipse.org/legal/epl-v10.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>dsaff</id>
+            <name>David Saff</name>
+            <email>david@saff.net</email>
+        </developer>
+        <developer>
+            <id>kcooney</id>
+            <name>Kevin Cooney</name>
+            <email>kcooney@google.com</email>
+        </developer>
+        <developer>
+            <id>stefanbirkner</id>
+            <name>Stefan Birkner</name>
+            <email>mail@stefan-birkner.de</email>
+        </developer>
+        <developer>
+            <id>marcphilipp</id>
+            <name>Marc Philipp</name>
+            <email>mail@marcphilipp.de</email>
+        </developer>
+    </developers>
+    <contributors>
+        <contributor>
+            <name>JUnit contributors</name>
+            <organization>JUnit</organization>
+            <email>junit@yahoogroups.com</email>
+            <url>https://github.com/junit-team/junit/graphs/contributors</url>
+            <roles>
+                <role>developers</role>
+            </roles>
+        </contributor>
+    </contributors>
+
+    <mailingLists>
+        <mailingList>
+            <name>JUnit Mailing List</name>
+            <post>junit@yahoogroups.com</post>
+            <archive>https://groups.yahoo.com/neo/groups/junit/info</archive>
+        </mailingList>
+    </mailingLists>
+
+    <prerequisites>
+        <maven>3.0.4</maven>
+    </prerequisites>
+
+    <scm>
+        <connection>scm:git:git://github.com/junit-team/junit.git</connection>
+        <developerConnection>scm:git:git@github.com:junit-team/junit.git</developerConnection>
+        <url>http://github.com/junit-team/junit/tree/master</url>
+      <tag>r4.12</tag>
+  </scm>
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/junit-team/junit/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>jenkins</system>
+        <url>https://junit.ci.cloudbees.com/</url>
+    </ciManagement>
+    <distributionManagement>
+        <downloadUrl>https://github.com/junit-team/junit/wiki/Download-and-Install</downloadUrl>
+        <snapshotRepository>
+            <id>junit-snapshot-repo</id>
+            <name>Nexus Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>junit-releases-repo</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <site>
+            <id>junit.github.io</id>
+            <url>gitsite:git@github.com/junit-team/junit.git</url>
+        </site>
+    </distributionManagement>
+
+    <properties>
+        <jdkVersion>1.5</jdkVersion>
+        <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
+        <arguments />
+        <gpg.keyname>67893CC4</gpg.keyname>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>LICENSE-junit.txt</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <!--
+            Both "org.apache" and "org.codehaus" are default providers of MOJO plugins
+            which are especially dedicated to Maven projects.
+            The MOJO stands for "Maven plain Old Java Object".
+            Each mojo is an executable goal in Maven, and a plugin is a distribution of
+            one or more related mojos.
+            For more information see http://maven.apache.org/plugin-developers/index.html
+
+            The following plugins are ordered according the Maven build lifecycle.
+            http://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
+            -->
+            <plugin>
+                <!--
+                Checks that the version of user's maven installation is 3.0.4,
+                the JDK is 1.5+, no non-standard repositories are specified in
+                the project, requires only release versions of dependencies of other artifacts.
+                -->
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <fail>true</fail>
+                            <rules>
+                                <requireMavenVersion>
+                                    <!-- Some plugin features require a recent Maven runtime to work properly -->
+                                    <message>Current version of Maven ${maven.version} required to build the project
+                                        should be ${project.prerequisites.maven}, or higher!
+                                    </message>
+                                    <version>[${project.prerequisites.maven},)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <message>Current JDK version ${java.version} should be ${jdkVersion}, or higher!
+                                    </message>
+                                    <version>${jdkVersion}</version>
+                                </requireJavaVersion>
+                                <requireNoRepositories>
+                                    <message>Best Practice is to never define repositories in pom.xml (use a repository
+                                        manager instead).
+                                    </message>
+                                </requireNoRepositories>
+                                <requireReleaseDeps>
+                                    <message>No Snapshots Dependencies Allowed!</message>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                Updates Version#id().
+                -->
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <ignoreMissingFile>false</ignoreMissingFile>
+                    <file>src/main/java/junit/runner/Version.java.template</file>
+                    <outputFile>src/main/java/junit/runner/Version.java</outputFile>
+                    <regex>false</regex>
+                    <token>@version@</token>
+                    <value>${project.version}</value>
+                </configuration>
+            </plugin>
+            <plugin><!-- Using jdk 1.5.0_22, package-info.java files are compiled correctly. -->
+                <!--
+                java compiler plugin forked in extra process
+                -->
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <source>${jdkVersion}</source>
+                    <target>${jdkVersion}</target>
+                    <testSource>${jdkVersion}</testSource>
+                    <testTarget>${jdkVersion}</testTarget>
+                    <compilerVersion>1.5</compilerVersion>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <debug>true</debug>
+                    <fork>true</fork>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                    <maxmem>128m</maxmem>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.11</version>
+                <executions>
+                    <execution>
+                        <id>signature-check</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java15</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--
+                A plugin which uses the JUnit framework in order to start
+                our junit suite "AllTests" after the sources are compiled.
+                -->
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <test>org/junit/tests/AllTests.java</test>
+                    <useSystemClassLoader>true</useSystemClassLoader>
+                    <enableAssertions>false</enableAssertions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin can package the main artifact's sources (src/main/java)
+                in to jar archive. See target/junit-*-sources.jar.
+                -->
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+            </plugin>
+            <plugin>
+                <!--
+                This plugin can generate Javadoc by a forked
+                process and then package the Javadoc
+                in jar archive target/junit-*-javadoc.jar.
+                -->
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
+                    <show>protected</show>
+                    <author>false</author>
+                    <version>false</version>
+                    <detectLinks>false</detectLinks>
+                    <linksource>true</linksource>
+                    <keywords>true</keywords>
+                    <use>false</use>
+                    <windowtitle>JUnit API</windowtitle>
+                    <encoding>UTF-8</encoding>
+                    <locale>en</locale>
+                    <javadocVersion>${jdkVersion}</javadocVersion>
+                    <javaApiLinks>
+                        <property>
+                            <name>api_${jdkVersion}</name>
+                            <value>http://docs.oracle.com/javase/${jdkVersion}.0/docs/api/</value>
+                        </property>
+                    </javaApiLinks>
+                    <excludePackageNames>junit.*,*.internal.*</excludePackageNames>
+                    <verbose>true</verbose>
+                    <minmemory>32m</minmemory>
+                    <maxmemory>128m</maxmemory>
+                    <failOnError>true</failOnError>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>org.hamcrest:hamcrest-core:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <arguments>-Pgenerate-docs,junit-release ${arguments}</arguments>
+                    <tagNameFormat>r@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.3</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.stephenc.wagon</groupId>
+                        <artifactId>wagon-gitsite</artifactId>
+                        <version>0.4.1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.doxia</groupId>
+                        <artifactId>doxia-module-markdown</artifactId>
+                        <version>1.5</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                    <!-- waiting for MPIR-267 -->
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                            <report>dependency-info</report>
+                            <report>modules</report>
+                            <report>license</report>
+                            <report>project-team</report>
+                            <report>scm</report>
+                            <report>issue-tracking</report>
+                            <report>mailing-list</report>
+                            <report>dependency-management</report>
+                            <report>dependencies</report>
+                            <report>dependency-convergence</report>
+                            <report>cim</report>
+                            <report>distribution-management</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <destDir>javadoc/latest</destDir>
+                    <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
+                    <show>protected</show>
+                    <author>false</author>
+                    <version>false</version>
+                    <detectLinks>false</detectLinks>
+                    <linksource>true</linksource>
+                    <keywords>true</keywords>
+                    <use>false</use>
+                    <windowtitle>JUnit API</windowtitle>
+                    <encoding>UTF-8</encoding>
+                    <locale>en</locale>
+                    <javadocVersion>${jdkVersion}</javadocVersion>
+                    <javaApiLinks>
+                        <property>
+                            <name>api_${jdkVersion}</name>
+                            <value>http://docs.oracle.com/javase/${jdkVersion}.0/docs/api/</value>
+                        </property>
+                    </javaApiLinks>
+                    <excludePackageNames>junit.*,*.internal.*</excludePackageNames>
+                    <verbose>true</verbose>
+                    <minmemory>32m</minmemory>
+                    <maxmemory>128m</maxmemory>
+                    <failOnError>true</failOnError>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>org.hamcrest:hamcrest-core:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <profiles>
+        <profile>
+            <id>junit-release</id>
+            <!--
+            Signs all artifacts before deploying to Maven Central.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <!--
+                        The goal is to sign all artifacts so that the user may verify them before downloading.
+                        The automatic build system may reuire your key ID, and passphrase specified using system properties:
+                        -Dgpg.passphrase="<passphrase>" -Dgpg.keyname="<your key ID>"
+                        In order to create the key pair, use the command "gpg &ndash;&ndash;gen-key".
+                        (&ndash;&ndash; stands for double dash)
+                        -->
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>gpg-sign</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>generate-docs</id>
+            <!--
+            Generate the documentation artifacts. 
+            Note: this profile is also required to be active for release
+            builds due to the packaging requirements of the Central repo
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>restrict-doclint</id>
+            <!-- doclint is only supported by JDK 8 -->
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xlint:unchecked</arg>
+                                <arg>-Xdoclint:accessibility,reference,syntax</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:accessibility -Xdoclint:reference</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:accessibility -Xdoclint:reference</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+        <profile>
+            <id>fast-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <parallel>classes</parallel>
+                            <threadCountClasses>2</threadCountClasses>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.maven.surefire</groupId>
+                                <artifactId>surefire-junit47</artifactId>
+                                <version>2.17</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -146,7 +146,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     public VersionNumber getArtifactCacheLayoutVersion() {
         if (isSameOrNewer("4.5-rc-1")) {
-            return VersionNumber.parse("2.43");
+            return VersionNumber.parse("2.44");
         } else if (isSameOrNewer("4.4-rc-1")) {
             return VersionNumber.parse("2.36");
         } else if (isSameOrNewer("4.3-rc-1")) {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -54,6 +54,20 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+/**
+ * <p>The Gradle module metadata file generator is responsible for generating a JSON file
+ * describing module metadata. In particular, this file format is capable of handling different
+ * variants with different dependency sets.</p>
+ *
+ * <p>Whenever you change this class, make sure you also:</p>
+ *
+ * <ul>
+ *     <li>Update the corresponding {@link ModuleMetadataParser module metadata parser}</li>
+ *     <li>Update the module metadata specification (subprojects/docs/src/docs/design/gradle-module-metadata-specification.md)</li>
+ *     <li>Update {@link org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSerializer the module metadata serializer} </li>
+ *     <li>Add a sample for the module metadata serializer test, to make sure that serialized metadata is idempotent</li>
+ * </ul>
+ */
 public class ModuleMetadataFileGenerator {
     private final BuildInvocationScopeId buildInvocationScopeId;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;


### PR DESCRIPTION
This pull request fixes #3712 and https://github.com/gradle/gradle-native/issues/329 , by making sure `Named` attributes are properly serialized, as well as dependency constraints.

To reduce the risks of this happening again, the pull request introduces a new test which makes sure that we can serialize parsed metadata, then read it, and that the deserialized version is the same. This mimics what cached module metadata would do. 

Now both the serializer and the parser are generic and have no special case handling of attributes.