### PR TITLE
Sample projects should provide root project name as best practice

### DIFF
--- a/subprojects/docs/src/samples/announce/settings.gradle
+++ b/subprojects/docs/src/samples/announce/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'announce'

--- a/subprojects/docs/src/samples/antlr/settings.gradle
+++ b/subprojects/docs/src/samples/antlr/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'antlr'

--- a/subprojects/docs/src/samples/application/settings.gradle
+++ b/subprojects/docs/src/samples/application/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'application'

--- a/subprojects/docs/src/samples/buildCache/configure-by-init-script/settings.gradle
+++ b/subprojects/docs/src/samples/buildCache/configure-by-init-script/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-by-init-script'

--- a/subprojects/docs/src/samples/buildDashboard/settings.gradle
+++ b/subprojects/docs/src/samples/buildDashboard/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'build-dashboard'

--- a/subprojects/docs/src/samples/codeQuality/settings.gradle
+++ b/subprojects/docs/src/samples/codeQuality/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'code-quality'

--- a/subprojects/docs/src/samples/componentMetadataRules/settings.gradle
+++ b/subprojects/docs/src/samples/componentMetadataRules/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'component-metadata-rules'

--- a/subprojects/docs/src/samples/componentSelectionRules/settings.gradle
+++ b/subprojects/docs/src/samples/componentSelectionRules/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'component-selection-rules'

--- a/subprojects/docs/src/samples/customModel/componentType/settings.gradle
+++ b/subprojects/docs/src/samples/customModel/componentType/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'component-type'

--- a/subprojects/docs/src/samples/customModel/internalViews/settings.gradle
+++ b/subprojects/docs/src/samples/customModel/internalViews/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'internal-view'

--- a/subprojects/docs/src/samples/customPlugin/consumer/settings.gradle
+++ b/subprojects/docs/src/samples/customPlugin/consumer/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'consumer'

--- a/subprojects/docs/src/samples/eclipse/settings.gradle
+++ b/subprojects/docs/src/samples/eclipse/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'eclipse'

--- a/subprojects/docs/src/samples/groovy/crossCompilation/settings.gradle
+++ b/subprojects/docs/src/samples/groovy/crossCompilation/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'cross-compilation'

--- a/subprojects/docs/src/samples/groovy/customizedLayout/settings.gradle
+++ b/subprojects/docs/src/samples/groovy/customizedLayout/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'customized-layout'

--- a/subprojects/docs/src/samples/groovy/customizedLayout/settings.gradle
+++ b/subprojects/docs/src/samples/groovy/customizedLayout/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'customized-layout'
+rootProject.name = 'customizedLayout'

--- a/subprojects/docs/src/samples/groovy/mixedJavaAndGroovy/settings.gradle
+++ b/subprojects/docs/src/samples/groovy/mixedJavaAndGroovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'mixed-java-and-groovy'

--- a/subprojects/docs/src/samples/groovy/mixedJavaAndGroovy/settings.gradle
+++ b/subprojects/docs/src/samples/groovy/mixedJavaAndGroovy/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'mixed-java-and-groovy'
+rootProject.name = 'mixedJavaAndGroovy'

--- a/subprojects/docs/src/samples/groovy/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/groovy/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/idea/settings.gradle
+++ b/subprojects/docs/src/samples/idea/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'idea'

--- a/subprojects/docs/src/samples/ivy-publish/descriptor-customization/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/descriptor-customization/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'descriptor-customization'

--- a/subprojects/docs/src/samples/ivy-publish/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/java-library/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/java-library/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/java/apiAndImpl/settings.gradle
+++ b/subprojects/docs/src/samples/java/apiAndImpl/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'api-and-impl'
+rootProject.name = 'apiAndImpl'

--- a/subprojects/docs/src/samples/java/apiAndImpl/settings.gradle
+++ b/subprojects/docs/src/samples/java/apiAndImpl/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'api-and-impl'

--- a/subprojects/docs/src/samples/java/apt/settings.gradle
+++ b/subprojects/docs/src/samples/java/apt/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'apt'

--- a/subprojects/docs/src/samples/java/crossCompilation/settings.gradle
+++ b/subprojects/docs/src/samples/java/crossCompilation/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'cross-compilation'

--- a/subprojects/docs/src/samples/java/customizedLayout/settings.gradle
+++ b/subprojects/docs/src/samples/java/customizedLayout/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'customized-layout'

--- a/subprojects/docs/src/samples/java/customizedLayout/settings.gradle
+++ b/subprojects/docs/src/samples/java/customizedLayout/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'customized-layout'
+rootProject.name = 'customizedLayout'

--- a/subprojects/docs/src/samples/java/onlyif/settings.gradle
+++ b/subprojects/docs/src/samples/java/onlyif/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'only-if'

--- a/subprojects/docs/src/samples/java/onlyif/settings.gradle
+++ b/subprojects/docs/src/samples/java/onlyif/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'only-if'
+rootProject.name = 'onlyIf'

--- a/subprojects/docs/src/samples/java/onlyif/settings.gradle
+++ b/subprojects/docs/src/samples/java/onlyif/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'onlyIf'
+rootProject.name = 'onlyif'

--- a/subprojects/docs/src/samples/java/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/java/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/java/testListener/settings.gradle
+++ b/subprojects/docs/src/samples/java/testListener/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'test-listener'

--- a/subprojects/docs/src/samples/java/withIntegrationTests/settings.gradle
+++ b/subprojects/docs/src/samples/java/withIntegrationTests/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'with-integration-tests'

--- a/subprojects/docs/src/samples/javaGradlePlugin/settings.gradle
+++ b/subprojects/docs/src/samples/javaGradlePlugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-gradle-plugin'

--- a/subprojects/docs/src/samples/javaLibraryPlugin/apispec-support/settings.gradle
+++ b/subprojects/docs/src/samples/javaLibraryPlugin/apispec-support/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'apispec-support'

--- a/subprojects/docs/src/samples/javaLibraryPlugin/apispec/settings.gradle
+++ b/subprojects/docs/src/samples/javaLibraryPlugin/apispec/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-library-plugin'

--- a/subprojects/docs/src/samples/javaLibraryPlugin/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/javaLibraryPlugin/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/javaLibraryPlugin/testing-junit-component-under-test/settings.gradle
+++ b/subprojects/docs/src/samples/javaLibraryPlugin/testing-junit-component-under-test/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testing-junit-component-under-test'

--- a/subprojects/docs/src/samples/javaLibraryPlugin/testing-junit-standalone/settings.gradle
+++ b/subprojects/docs/src/samples/javaLibraryPlugin/testing-junit-standalone/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testing-junit-standalone'

--- a/subprojects/docs/src/samples/javaLibraryPlugin/toolchains/settings.gradle
+++ b/subprojects/docs/src/samples/javaLibraryPlugin/toolchains/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'toolchains'

--- a/subprojects/docs/src/samples/jvmComponents/scala/settings.gradle
+++ b/subprojects/docs/src/samples/jvmComponents/scala/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'scala'

--- a/subprojects/docs/src/samples/maven-publish/javaProject/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/javaProject/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-project'

--- a/subprojects/docs/src/samples/maven-publish/javaProject/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/javaProject/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'java-project'
+rootProject.name = 'javaProject'

--- a/subprojects/docs/src/samples/maven-publish/pomCustomization/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/pomCustomization/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'pom-customizations'

--- a/subprojects/docs/src/samples/maven-publish/pomCustomization/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/pomCustomization/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'pom-customizations'
+rootProject.name = 'pomCustomization'

--- a/subprojects/docs/src/samples/maven-publish/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/maven/pomGeneration/settings.gradle
+++ b/subprojects/docs/src/samples/maven/pomGeneration/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'pom-generation'

--- a/subprojects/docs/src/samples/maven/pomGeneration/settings.gradle
+++ b/subprojects/docs/src/samples/maven/pomGeneration/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'pom-generation'
+rootProject.name = 'pomGeneration'

--- a/subprojects/docs/src/samples/maven/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/maven/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/modelRules/basicRuleSourcePlugin/settings.gradle
+++ b/subprojects/docs/src/samples/modelRules/basicRuleSourcePlugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'basic-rule-source-plugin'

--- a/subprojects/docs/src/samples/modelRules/language-support/settings.gradle
+++ b/subprojects/docs/src/samples/modelRules/language-support/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'language-support'

--- a/subprojects/docs/src/samples/modelRules/modelDsl/settings.gradle
+++ b/subprojects/docs/src/samples/modelRules/modelDsl/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'model-dsl'

--- a/subprojects/docs/src/samples/modelRules/modelDslCoercion/settings.gradle
+++ b/subprojects/docs/src/samples/modelRules/modelDslCoercion/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'model-dsl-coercion'

--- a/subprojects/docs/src/samples/modelRules/ruleSourcePluginEach/settings.gradle
+++ b/subprojects/docs/src/samples/modelRules/ruleSourcePluginEach/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'rule-source-plugin-each'

--- a/subprojects/docs/src/samples/multiProjectBuildSrc/settings.gradle
+++ b/subprojects/docs/src/samples/multiProjectBuildSrc/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'multi-project-build-src'

--- a/subprojects/docs/src/samples/native-binaries/assembler/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/assembler/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'assembler'

--- a/subprojects/docs/src/samples/native-binaries/c/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/c/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'c'

--- a/subprojects/docs/src/samples/native-binaries/cpp/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/cpp/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'cpp'

--- a/subprojects/docs/src/samples/native-binaries/custom-check/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/custom-check/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-check'

--- a/subprojects/docs/src/samples/native-binaries/custom-layout/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/custom-layout/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-layout'

--- a/subprojects/docs/src/samples/native-binaries/flavors/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/flavors/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'flavors'

--- a/subprojects/docs/src/samples/native-binaries/google-test/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/google-test/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'google-test'

--- a/subprojects/docs/src/samples/native-binaries/idl/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/idl/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'idl'

--- a/subprojects/docs/src/samples/native-binaries/objective-c/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/objective-c/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'objective-c'

--- a/subprojects/docs/src/samples/native-binaries/objective-cpp/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/objective-cpp/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'objective-cpp'

--- a/subprojects/docs/src/samples/native-binaries/pre-compiled-headers/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/pre-compiled-headers/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'pre-compiled-headers'

--- a/subprojects/docs/src/samples/native-binaries/prebuilt/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/prebuilt/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'prebuilt'

--- a/subprojects/docs/src/samples/native-binaries/sourceset-variant/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/sourceset-variant/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sourceset-variant'

--- a/subprojects/docs/src/samples/native-binaries/target-platforms/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/target-platforms/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'target-platforms'

--- a/subprojects/docs/src/samples/native-binaries/tool-chains/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/tool-chains/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'tool-chains'

--- a/subprojects/docs/src/samples/native-binaries/variants/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/variants/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'variants'

--- a/subprojects/docs/src/samples/native-binaries/visual-studio/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/visual-studio/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'visual-studio'

--- a/subprojects/docs/src/samples/native-binaries/windows-resources/settings.gradle
+++ b/subprojects/docs/src/samples/native-binaries/windows-resources/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'windows-resources'

--- a/subprojects/docs/src/samples/osgi/settings.gradle
+++ b/subprojects/docs/src/samples/osgi/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'osgi'

--- a/subprojects/docs/src/samples/play/advanced/settings.gradle
+++ b/subprojects/docs/src/samples/play/advanced/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'advanced'

--- a/subprojects/docs/src/samples/play/basic/settings.gradle
+++ b/subprojects/docs/src/samples/play/basic/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'basic'

--- a/subprojects/docs/src/samples/play/configure-compiler/settings.gradle
+++ b/subprojects/docs/src/samples/play/configure-compiler/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-compiler'

--- a/subprojects/docs/src/samples/play/custom-assets/settings.gradle
+++ b/subprojects/docs/src/samples/play/custom-assets/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-assets'

--- a/subprojects/docs/src/samples/play/custom-distribution/settings.gradle
+++ b/subprojects/docs/src/samples/play/custom-distribution/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-distribution'

--- a/subprojects/docs/src/samples/play/play-2.4/settings.gradle
+++ b/subprojects/docs/src/samples/play/play-2.4/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'play-2.4'

--- a/subprojects/docs/src/samples/play/play-2.6/settings.gradle
+++ b/subprojects/docs/src/samples/play/play-2.6/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'play-2.6'

--- a/subprojects/docs/src/samples/play/sourcesets/settings.gradle
+++ b/subprojects/docs/src/samples/play/sourcesets/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sourcesets'

--- a/subprojects/docs/src/samples/plugins/buildscript/settings.gradle
+++ b/subprojects/docs/src/samples/plugins/buildscript/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'buildscript'

--- a/subprojects/docs/src/samples/plugins/dsl/settings.gradle
+++ b/subprojects/docs/src/samples/plugins/dsl/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dsl'

--- a/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/settings.gradle
+++ b/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'file-and-directory-property'

--- a/subprojects/docs/src/samples/providers/implicitTaskDependency/settings.gradle
+++ b/subprojects/docs/src/samples/providers/implicitTaskDependency/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'implicit-task-dependency'

--- a/subprojects/docs/src/samples/providers/listProperty/settings.gradle
+++ b/subprojects/docs/src/samples/providers/listProperty/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'list-property'

--- a/subprojects/docs/src/samples/providers/propertyAndProvider/settings.gradle
+++ b/subprojects/docs/src/samples/providers/propertyAndProvider/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'property-and-provider'

--- a/subprojects/docs/src/samples/scala/crossCompilation/settings.gradle
+++ b/subprojects/docs/src/samples/scala/crossCompilation/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'cross-compilation'

--- a/subprojects/docs/src/samples/scala/customizedLayout/settings.gradle
+++ b/subprojects/docs/src/samples/scala/customizedLayout/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'customized-layout'

--- a/subprojects/docs/src/samples/scala/customizedLayout/settings.gradle
+++ b/subprojects/docs/src/samples/scala/customizedLayout/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'customized-layout'
+rootProject.name = 'customizedLayout'

--- a/subprojects/docs/src/samples/scala/force/settings.gradle
+++ b/subprojects/docs/src/samples/scala/force/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'force'

--- a/subprojects/docs/src/samples/scala/mixedJavaAndScala/settings.gradle
+++ b/subprojects/docs/src/samples/scala/mixedJavaAndScala/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'mixed-java-and-scala'

--- a/subprojects/docs/src/samples/scala/mixedJavaAndScala/settings.gradle
+++ b/subprojects/docs/src/samples/scala/mixedJavaAndScala/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'mixed-java-and-scala'
+rootProject.name = 'mixedJavaAndScala'

--- a/subprojects/docs/src/samples/scala/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/scala/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/scala/zinc/settings.gradle
+++ b/subprojects/docs/src/samples/scala/zinc/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'zinc'

--- a/subprojects/docs/src/samples/signing/conditional/settings.gradle
+++ b/subprojects/docs/src/samples/signing/conditional/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'conditional'

--- a/subprojects/docs/src/samples/signing/maven/settings.gradle
+++ b/subprojects/docs/src/samples/signing/maven/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'maven'

--- a/subprojects/docs/src/samples/signing/tasks/settings.gradle
+++ b/subprojects/docs/src/samples/signing/tasks/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'tasks'

--- a/subprojects/docs/src/samples/testKit/gradleRunner/automaticClasspathInjectionCustomTestSourceSet/settings.gradle
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/automaticClasspathInjectionCustomTestSourceSet/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'automatic-classpath-injection-custom-test-sourceset'

--- a/subprojects/docs/src/samples/testKit/gradleRunner/automaticClasspathInjectionQuickstart/settings.gradle
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/automaticClasspathInjectionQuickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'automatic-classpath-injection-quickstart'

--- a/subprojects/docs/src/samples/testKit/gradleRunner/manualClasspathInjection/settings.gradle
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/manualClasspathInjection/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'manual-classpath-injection'

--- a/subprojects/docs/src/samples/testing/filtering/settings.gradle
+++ b/subprojects/docs/src/samples/testing/filtering/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testing'

--- a/subprojects/docs/src/samples/testing/jacoco/application/settings.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/application/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'application'

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/testing/junit/categories/settings.gradle
+++ b/subprojects/docs/src/samples/testing/junit/categories/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'junit'

--- a/subprojects/docs/src/samples/testing/testng/groupbyinstances/settings.gradle
+++ b/subprojects/docs/src/samples/testing/testng/groupbyinstances/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'group-by-instances'

--- a/subprojects/docs/src/samples/testing/testng/groups/settings.gradle
+++ b/subprojects/docs/src/samples/testing/testng/groups/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groups'

--- a/subprojects/docs/src/samples/testing/testng/java-passing/settings.gradle
+++ b/subprojects/docs/src/samples/testing/testng/java-passing/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-passing'

--- a/subprojects/docs/src/samples/testing/testng/preserveorder/settings.gradle
+++ b/subprojects/docs/src/samples/testing/testng/preserveorder/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'preserve-order'

--- a/subprojects/docs/src/samples/testing/testng/suitexmlbuilder/settings.gradle
+++ b/subprojects/docs/src/samples/testing/testng/suitexmlbuilder/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'suite-xml-builder'

--- a/subprojects/docs/src/samples/toolingApi/customModel/plugin/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/customModel/plugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plugin'

--- a/subprojects/docs/src/samples/toolingApi/customModel/sampleBuild/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/customModel/sampleBuild/settings.gradle
@@ -1,16 +1,1 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+rootProject.name = 'sample-build'

--- a/subprojects/docs/src/samples/toolingApi/customModel/tooling/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/customModel/tooling/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'tooling'

--- a/subprojects/docs/src/samples/toolingApi/eclipse/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/eclipse/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'eclipse'

--- a/subprojects/docs/src/samples/toolingApi/idea/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/idea/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'idea'

--- a/subprojects/docs/src/samples/toolingApi/model/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/model/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'model'

--- a/subprojects/docs/src/samples/toolingApi/runBuild/settings.gradle
+++ b/subprojects/docs/src/samples/toolingApi/runBuild/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'run-build'

--- a/subprojects/docs/src/samples/userguide/ant/addBehaviourToAntTarget/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/addBehaviourToAntTarget/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'add-behavior-to-ant-target'

--- a/subprojects/docs/src/samples/userguide/ant/antLogging/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/antLogging/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ant-logging'

--- a/subprojects/docs/src/samples/userguide/ant/dependsOnAntTarget/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/dependsOnAntTarget/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'depends-on-ant-target'

--- a/subprojects/docs/src/samples/userguide/ant/dependsOnTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/dependsOnTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'depends-on-task'

--- a/subprojects/docs/src/samples/userguide/ant/hello/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/hello/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello'

--- a/subprojects/docs/src/samples/userguide/ant/properties/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/properties/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'properties'

--- a/subprojects/docs/src/samples/userguide/ant/renameTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/renameTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'rename-task'

--- a/subprojects/docs/src/samples/userguide/ant/taskWithNestedElements/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/taskWithNestedElements/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'task-with-nested-elements'

--- a/subprojects/docs/src/samples/userguide/ant/taskWithNestedText/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/taskWithNestedText/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'task-with-nested-text'

--- a/subprojects/docs/src/samples/userguide/ant/useAntTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/useAntTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'use-ant-task'

--- a/subprojects/docs/src/samples/userguide/ant/useAntType/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/useAntType/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'use-ant-type'

--- a/subprojects/docs/src/samples/userguide/ant/useExternalAntTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/useExternalAntTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'use-external-ant-task'

--- a/subprojects/docs/src/samples/userguide/ant/useExternalAntTaskWithConfig/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/ant/useExternalAntTaskWithConfig/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'use-external-ant-task-with-config'

--- a/subprojects/docs/src/samples/userguide/artifacts/componentModuleMetadata/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/componentModuleMetadata/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'component-module-metadata'

--- a/subprojects/docs/src/samples/userguide/artifacts/configurationHandling/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/configurationHandling/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configuration-handling'

--- a/subprojects/docs/src/samples/userguide/artifacts/defineConfiguration/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineConfiguration/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'define-configuration'

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'define-repository'

--- a/subprojects/docs/src/samples/userguide/artifacts/dependency-substitution/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/dependency-substitution/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dependency-substitution'

--- a/subprojects/docs/src/samples/userguide/artifacts/dependencyBasics/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/dependencyBasics/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dependency-basics'

--- a/subprojects/docs/src/samples/userguide/artifacts/excludesAndClassifiers/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/excludesAndClassifiers/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'excludes-and-classifiers'

--- a/subprojects/docs/src/samples/userguide/artifacts/externalDependencies/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/externalDependencies/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'external-dependencies'

--- a/subprojects/docs/src/samples/userguide/artifacts/generatedFileDependencies/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/generatedFileDependencies/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'generated-file-dependencies'

--- a/subprojects/docs/src/samples/userguide/artifacts/maven/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/maven/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'maven'

--- a/subprojects/docs/src/samples/userguide/artifacts/resolutionStrategy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/resolutionStrategy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'resolution-strategy'

--- a/subprojects/docs/src/samples/userguide/artifacts/uploading/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/uploading/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'uploading'

--- a/subprojects/docs/src/samples/userguide/buildlifecycle/taskCreationEvents/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/buildlifecycle/taskCreationEvents/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'task-creation-events'

--- a/subprojects/docs/src/samples/userguide/buildlifecycle/taskExecutionEvents/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/buildlifecycle/taskExecutionEvents/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'task-execution-events'

--- a/subprojects/docs/src/samples/userguide/distribution/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/distribution/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'distribution'

--- a/subprojects/docs/src/samples/userguide/files/archives/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/archives/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'archives'

--- a/subprojects/docs/src/samples/userguide/files/copy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/copy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'copy'

--- a/subprojects/docs/src/samples/userguide/files/file/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/file/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'file'

--- a/subprojects/docs/src/samples/userguide/files/fileCollections/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/fileCollections/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'file-collections'

--- a/subprojects/docs/src/samples/userguide/files/fileTrees/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/fileTrees/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'file-trees'

--- a/subprojects/docs/src/samples/userguide/files/inputFiles/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/inputFiles/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'input-files'

--- a/subprojects/docs/src/samples/userguide/files/sync/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/files/sync/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sync'

--- a/subprojects/docs/src/samples/userguide/groovy/groovyDependency/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/groovy/groovyDependency/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy-dependency'

--- a/subprojects/docs/src/samples/userguide/initScripts/configurationInjection/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/initScripts/configurationInjection/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configuration-injection'

--- a/subprojects/docs/src/samples/userguide/initScripts/customLogger/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/initScripts/customLogger/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-logger'

--- a/subprojects/docs/src/samples/userguide/initScripts/externalDependency/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/initScripts/externalDependency/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'external-dependency'

--- a/subprojects/docs/src/samples/userguide/initScripts/plugins/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/initScripts/plugins/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plugins'

--- a/subprojects/docs/src/samples/userguide/java/sourceSets/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/java/sourceSets/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sourcesets'

--- a/subprojects/docs/src/samples/userguide/javaLibraryDistribution/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/javaLibraryDistribution/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'java-library-distribution'

--- a/subprojects/docs/src/samples/userguide/modelRules/configureAsRequired/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/modelRules/configureAsRequired/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-as-required'

--- a/subprojects/docs/src/samples/userguide/modelRules/configureElementsOfMap/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/modelRules/configureElementsOfMap/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-elements-of-map'

--- a/subprojects/docs/src/samples/userguide/modelRules/initializationRuleRunsBeforeConfigurationRules/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/modelRules/initializationRuleRunsBeforeConfigurationRules/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'initialization-rule-runs-before-configuration-rules'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPlugin/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPlugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-plugin'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithAdvancedConvention/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithAdvancedConvention/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-plugin-with-advanced-convention'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithConvention/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithConvention/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-plugin-with-convention'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithDomainObjectContainer/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithDomainObjectContainer/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-plugin-with-domain-object-container'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithNestedDsl/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/customPluginWithNestedDsl/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-plugin-with-nested-dsl'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/externalDependency/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/externalDependency/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'external-dependency'

--- a/subprojects/docs/src/samples/userguide/organizeBuildLogic/nestedBuild/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/organizeBuildLogic/nestedBuild/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'nested-build'

--- a/subprojects/docs/src/samples/userguide/scala/ideaTargetVersion/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/scala/ideaTargetVersion/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'idea-target-version'

--- a/subprojects/docs/src/samples/userguide/scala/scalaDependency/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/scala/scalaDependency/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'scala-dependency'

--- a/subprojects/docs/src/samples/userguide/scala/zincDependency/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/scala/zincDependency/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'zinc-dependency'

--- a/subprojects/docs/src/samples/userguide/scala/zincOverride/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/scala/zincOverride/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'zinc-override'

--- a/subprojects/docs/src/samples/userguide/tasks/accessAsProperty/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/accessAsProperty/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'access-as-property'

--- a/subprojects/docs/src/samples/userguide/tasks/accessFromTaskContainer/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/accessFromTaskContainer/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'access-from-task-container'

--- a/subprojects/docs/src/samples/userguide/tasks/addDependencyUsingClosure/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/addDependencyUsingClosure/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'add-dependency-using-closure'

--- a/subprojects/docs/src/samples/userguide/tasks/addDependencyUsingTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/addDependencyUsingTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'add-dependency-using-task'

--- a/subprojects/docs/src/samples/userguide/tasks/addRules/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/addRules/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'add-rules'

--- a/subprojects/docs/src/samples/userguide/tasks/addToTaskContainer/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/addToTaskContainer/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'add-to-task-container'

--- a/subprojects/docs/src/samples/userguide/tasks/configureUsingClosure/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/configureUsingClosure/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-using-closure'

--- a/subprojects/docs/src/samples/userguide/tasks/configureUsingVar/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/configureUsingVar/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-using-var'

--- a/subprojects/docs/src/samples/userguide/tasks/customTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/customTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-task'

--- a/subprojects/docs/src/samples/userguide/tasks/customTaskUsingConvention/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/customTaskUsingConvention/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-task-using-convention'

--- a/subprojects/docs/src/samples/userguide/tasks/customTaskWithFileProperty/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/customTaskWithFileProperty/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-task-with-file-property'

--- a/subprojects/docs/src/samples/userguide/tasks/customTaskWithProperty/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/customTaskWithProperty/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-task-with-property'

--- a/subprojects/docs/src/samples/userguide/tasks/defineAndConfigure/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/defineAndConfigure/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'define-and-configure'

--- a/subprojects/docs/src/samples/userguide/tasks/defineAsExpression/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/defineAsExpression/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'define-as-expression'

--- a/subprojects/docs/src/samples/userguide/tasks/defineUsingStringTaskNames/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/defineUsingStringTaskNames/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'define-using-string-task-names'

--- a/subprojects/docs/src/samples/userguide/tasks/finalizers/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/finalizers/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'finalizers'

--- a/subprojects/docs/src/samples/userguide/tasks/finalizersWithFailure/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/finalizersWithFailure/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'finalizers-with-failure'

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/customTaskClass/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/customTaskClass/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-task-class'

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/incrementalBuildAdvanced/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/incrementalBuildAdvanced/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'incremental-build-advanced'

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/inputsAndOutputs/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/inputsAndOutputs/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'inputs-and-outputs'

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/noInputsAndOutputs/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/noInputsAndOutputs/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'no-inputs-and-outputs'

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'incremental-task'

--- a/subprojects/docs/src/samples/userguide/tasks/inputNormalization/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/inputNormalization/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'input-normalization'

--- a/subprojects/docs/src/samples/userguide/tasks/mapExtensionPropertiesToTaskProperties/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/mapExtensionPropertiesToTaskProperties/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'map-extension-properties-to-task-properties'

--- a/subprojects/docs/src/samples/userguide/tasks/mustRunAfter/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/mustRunAfter/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'must-run-after'

--- a/subprojects/docs/src/samples/userguide/tasks/shouldRunAfter/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/shouldRunAfter/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'should-run-after'

--- a/subprojects/docs/src/samples/userguide/tasks/shouldRunAfterWithCycle/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/shouldRunAfterWithCycle/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'should-run-after-cycle'

--- a/subprojects/docs/src/samples/userguide/tutorial/announce/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/announce/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'announce'

--- a/subprojects/docs/src/samples/userguide/tutorial/antLoadfile/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/antLoadfile/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ant-load-file'

--- a/subprojects/docs/src/samples/userguide/tutorial/antLoadfileWithMethod/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/antLoadfileWithMethod/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'ant-load-file-withh-method'

--- a/subprojects/docs/src/samples/userguide/tutorial/archiveContent/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/archiveContent/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'archive-content'

--- a/subprojects/docs/src/samples/userguide/tutorial/configByDag/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/configByDag/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'config-dag'

--- a/subprojects/docs/src/samples/userguide/tutorial/configureObject/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/configureObject/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-object'

--- a/subprojects/docs/src/samples/userguide/tutorial/configureObjectUsingScript/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/configureObjectUsingScript/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-object-using-script'

--- a/subprojects/docs/src/samples/userguide/tutorial/configureProjectUsingScript/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/configureProjectUsingScript/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'configure-project-using-script'

--- a/subprojects/docs/src/samples/userguide/tutorial/configureProjectUsingScript/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/configureProjectUsingScript/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'configure-project-using-script'
+rootProject.name = 'configureProjectUsingScript'

--- a/subprojects/docs/src/samples/userguide/tutorial/count/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/count/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'count'

--- a/subprojects/docs/src/samples/userguide/tutorial/defaultTasks/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/defaultTasks/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'default-tasks'

--- a/subprojects/docs/src/samples/userguide/tutorial/disableTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/disableTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'disable-task'

--- a/subprojects/docs/src/samples/userguide/tutorial/dynamic/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/dynamic/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dynamic'

--- a/subprojects/docs/src/samples/userguide/tutorial/dynamicDepends/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/dynamicDepends/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dynamic-depends'

--- a/subprojects/docs/src/samples/userguide/tutorial/excludeTasks/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/excludeTasks/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'exclude-tasks'

--- a/subprojects/docs/src/samples/userguide/tutorial/extraProperties/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/extraProperties/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'extra-properties'

--- a/subprojects/docs/src/samples/userguide/tutorial/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy'

--- a/subprojects/docs/src/samples/userguide/tutorial/groovyWithFlatDir/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/groovyWithFlatDir/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy-with-flat-dir'

--- a/subprojects/docs/src/samples/userguide/tutorial/hello/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/hello/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello'

--- a/subprojects/docs/src/samples/userguide/tutorial/helloEnhanced/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/helloEnhanced/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello-enhanced'

--- a/subprojects/docs/src/samples/userguide/tutorial/helloShortcut/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/helloShortcut/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello-shortcut'

--- a/subprojects/docs/src/samples/userguide/tutorial/helloWithShortCut/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/helloWithShortCut/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello-with-shortcut'

--- a/subprojects/docs/src/samples/userguide/tutorial/intro/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/intro/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'intro'

--- a/subprojects/docs/src/samples/userguide/tutorial/lazyDependsOn/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/lazyDependsOn/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'lazy-depends-on'

--- a/subprojects/docs/src/samples/userguide/tutorial/localVariables/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/localVariables/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'local-variables'

--- a/subprojects/docs/src/samples/userguide/tutorial/logging/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/logging/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'logging'

--- a/subprojects/docs/src/samples/userguide/tutorial/manifest/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/manifest/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'manifest'

--- a/subprojects/docs/src/samples/userguide/tutorial/mkdirTrap/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/mkdirTrap/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'mkdir-trap'

--- a/subprojects/docs/src/samples/userguide/tutorial/osgi/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/osgi/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'osgi'

--- a/subprojects/docs/src/samples/userguide/tutorial/pluginAccessConvention/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/pluginAccessConvention/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plugin-access-convention'

--- a/subprojects/docs/src/samples/userguide/tutorial/pluginConfig/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/pluginConfig/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plugin-config'

--- a/subprojects/docs/src/samples/userguide/tutorial/pluginConvention/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/pluginConvention/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plugin-convention'

--- a/subprojects/docs/src/samples/userguide/tutorial/pluginIntro/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/pluginIntro/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'plugin-intro'

--- a/subprojects/docs/src/samples/userguide/tutorial/projectApi/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/projectApi/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'project-api'

--- a/subprojects/docs/src/samples/userguide/tutorial/projectApi/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/projectApi/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'project-api'
+rootProject.name = 'projectApi'

--- a/subprojects/docs/src/samples/userguide/tutorial/properties/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/properties/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'properties'

--- a/subprojects/docs/src/samples/userguide/tutorial/replaceTask/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/replaceTask/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'replace-task'

--- a/subprojects/docs/src/samples/userguide/tutorial/rerun/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/rerun/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'rerun'

--- a/subprojects/docs/src/samples/userguide/tutorial/selectProject/subdir/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/selectProject/subdir/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'select-project'

--- a/subprojects/docs/src/samples/userguide/tutorial/stopExecutionException/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/stopExecutionException/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'stop-execution-exception'

--- a/subprojects/docs/src/samples/userguide/tutorial/taskOnlyIf/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/taskOnlyIf/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'task-only-if'

--- a/subprojects/docs/src/samples/userguide/tutorial/upper/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/upper/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'upper'

--- a/subprojects/docs/src/samples/userguide/tutorial/zipWithArguments/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/zipWithArguments/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'zip-with-arguments'

--- a/subprojects/docs/src/samples/userguide/tutorial/zipWithCustomName/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/zipWithCustomName/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'zip-with-custom-name'

--- a/subprojects/docs/src/samples/userguide/wrapper/customized-task/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/wrapper/customized-task/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'customized-task'

--- a/subprojects/docs/src/samples/userguide/wrapper/sha256-verification/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/wrapper/sha256-verification/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sha256-verification'

--- a/subprojects/docs/src/samples/userguide/wrapper/simple/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/wrapper/simple/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'simple'

--- a/subprojects/docs/src/samples/webApplication/customized/settings.gradle
+++ b/subprojects/docs/src/samples/webApplication/customized/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'customized'

--- a/subprojects/docs/src/samples/webApplication/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/webApplication/quickstart/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'quickstart'

--- a/subprojects/docs/src/samples/workerApi/noIsolation/settings.gradle
+++ b/subprojects/docs/src/samples/workerApi/noIsolation/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'no-isolation'

--- a/subprojects/docs/src/samples/workerApi/waitForCompletion/settings.gradle
+++ b/subprojects/docs/src/samples/workerApi/waitForCompletion/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'wait-for-completion'

--- a/subprojects/docs/src/samples/workerApi/workerDaemon/settings.gradle
+++ b/subprojects/docs/src/samples/workerApi/workerDaemon/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'worker-daemon'


### PR DESCRIPTION
### Context

This change is a follow-up to @oehme's comment in https://github.com/gradle/gradle/pull/3651:

> If we want to show good practice, the settings.gradle files in the samples should set the root project name. This can be done in a follow-up change though.