### PR TITLE
Clean up .part files in build cache

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.IOUtils;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.util.internal.LimitedDescription;
 
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -159,7 +160,7 @@ public class GFileUtils {
         }
     }
 
-    public static boolean deleteQuietly(File file) {
+    public static boolean deleteQuietly(@Nullable File file) {
         return FileUtils.deleteQuietly(file);
     }
 

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -88,7 +88,7 @@ public class DefaultBuildCacheController implements BuildCacheController {
         } else {
             this.local = NullLocalBuildCacheServiceHandle.INSTANCE;
             this.legacyLocal = toHandle(config.local, config.localPush, BuildCacheServiceRole.LOCAL, buildOperationExecutor, logStackTraces);
-            this.tmp = new DefaultBuildCacheTempFileStore(new File(gradleUserHomeDir, "build-cache-tmp"), BuildCacheTempFileStore.PARTIAL_FILE_SUFFIX);
+            this.tmp = new DefaultBuildCacheTempFileStore(new File(gradleUserHomeDir, "build-cache-tmp"));
         }
 
         this.remote = toHandle(config.remote, config.remotePush, BuildCacheServiceRole.REMOTE, buildOperationExecutor, logStackTraces);

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DefaultBuildCacheTempFileStore.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DefaultBuildCacheTempFileStore.java
@@ -27,25 +27,22 @@ import java.io.IOException;
 public class DefaultBuildCacheTempFileStore implements BuildCacheTempFileStore {
 
     private final File dir;
-    private final String partialFileSuffix;
 
-    public DefaultBuildCacheTempFileStore(File dir, String partialFileSuffix) {
+    public DefaultBuildCacheTempFileStore(File dir) {
         this.dir = dir;
-        this.partialFileSuffix = partialFileSuffix;
         GFileUtils.mkdirs(this.dir);
     }
 
     @Override
     public void withTempFile(BuildCacheKey key, Action<? super File> action) {
         String hashCode = key.getHashCode();
-        final File tempFile;
+        File tempFile = null;
         try {
-            tempFile = File.createTempFile(hashCode, partialFileSuffix, dir);
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-
-        try {
+            try {
+                tempFile = File.createTempFile(hashCode, PARTIAL_FILE_SUFFIX, dir);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
             action.execute(tempFile);
         } finally {
             GFileUtils.deleteQuietly(tempFile);

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -79,12 +79,12 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         PathKeyFileStore fileStore = fileStoreFactory.createFileStore(target);
         PersistentCache persistentCache = cacheRepository
             .cache(target)
-            .withCleanup(new FixedSizeOldestCacheCleanup(buildOperationExecutor, targetSizeInMB, BuildCacheTempFileStore.PARTIAL_FILE_SUFFIX))
+            .withCleanup(new FixedSizeOldestCacheCleanup(buildOperationExecutor, targetSizeInMB))
             .withDisplayName("Build cache")
             .withLockOptions(mode(None))
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
             .open();
-        BuildCacheTempFileStore tempFileStore = new DefaultBuildCacheTempFileStore(target, BuildCacheTempFileStore.PARTIAL_FILE_SUFFIX);
+        BuildCacheTempFileStore tempFileStore = new DefaultBuildCacheTempFileStore(target);
 
         return new DirectoryBuildCacheService(fileStore, persistentCache, tempFileStore, FAILED_READ_SUFFIX);
     }

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
@@ -35,7 +35,7 @@ class DirectoryBuildCacheServiceTest extends Specification {
     def persistentCache = Mock(PersistentCache) {
         getBaseDir() >> cacheDir
     }
-    def tempFileStore = new DefaultBuildCacheTempFileStore(cacheDir, ".part")
+    def tempFileStore = new DefaultBuildCacheTempFileStore(cacheDir)
     def service = new DirectoryBuildCacheService(fileStore, persistentCache, tempFileStore, ".failed")
     def key = Mock(BuildCacheKey)
 
@@ -51,7 +51,7 @@ class DirectoryBuildCacheServiceTest extends Specification {
 
                 def partialCacheFile = cacheDirFiles[0]
                 assert partialCacheFile.name.startsWith(hashCode)
-                assert partialCacheFile.name.endsWith(".part")
+                assert partialCacheFile.name.endsWith(BuildCacheTempFileStore.PARTIAL_FILE_SUFFIX)
 
                 output << "abcd"
                 throw new RuntimeException("Simulated write error")

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedSizeOldestCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedSizeOldestCacheCleanup.java
@@ -47,12 +47,10 @@ public final class FixedSizeOldestCacheCleanup implements Action<PersistentCache
 
     private final BuildOperationExecutor buildOperationExecutor;
     private final long targetSizeInMB;
-    private final String partialFileSuffix;
 
-    public FixedSizeOldestCacheCleanup(BuildOperationExecutor buildOperationExecutor, long targetSizeInMB, String partialFileSuffix) {
+    public FixedSizeOldestCacheCleanup(BuildOperationExecutor buildOperationExecutor, long targetSizeInMB) {
         this.buildOperationExecutor = buildOperationExecutor;
         this.targetSizeInMB = targetSizeInMB;
-        this.partialFileSuffix = partialFileSuffix;
     }
 
     @Override
@@ -167,6 +165,6 @@ public final class FixedSizeOldestCacheCleanup implements Action<PersistentCache
     }
 
     boolean canBeDeleted(String name) {
-        return !(name.endsWith(".properties") || name.endsWith(".lock") || name.endsWith(partialFileSuffix));
+        return !(name.endsWith(".properties") || name.endsWith(".lock"));
     }
 }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedSizeOldestCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedSizeOldestCacheCleanupTest.groovy
@@ -28,7 +28,7 @@ class FixedSizeOldestCacheCleanupTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
     def cacheDir = temporaryFolder.file("cache-dir").createDir()
     def persistentCache = Mock(PersistentCache)
-    def cleanupAction = new FixedSizeOldestCacheCleanup(new TestBuildOperationExecutor(),10, ".part")
+    def cleanupAction = new FixedSizeOldestCacheCleanup(new TestBuildOperationExecutor(),10)
 
     def "filters for cache entry files"() {
         expect:


### PR DESCRIPTION
Previously '.part' files were left behind after local cache failures, because we expected they would be useful in debugging these cases. That never happened, so we are now removing them even if there's an error, and also during garbage collection.