### PR TITLE
Let the JVM used to run tests in the gradle/gradle build be set by a Gradle/System property

### DIFF
--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -23,7 +23,9 @@ ext {
     jarTasks = tasks.withType(Jar)
 }
 
-def testJavaHome = System.getenv('TEST_JAVA_HOME')
+if(!hasProperty("testJavaHome")) {
+    ext.testJavaHome = System.getProperty("testJavaHome")
+}
 if (testJavaHome) {
     def testJavaHomeFile = new File(testJavaHome)
     javaInstallationForTest.javaHome = testJavaHomeFile

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -1,5 +1,8 @@
 import org.gradle.build.ClasspathManifest
+import org.gradle.build.DefaultJavaInstallation
 import org.gradle.testing.DistributionTest
+
+import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 
 import java.util.jar.Attributes
 
@@ -9,12 +12,25 @@ archivesBaseName = "gradle-${name.replaceAll("\\p{Upper}") { "-${it.toLowerCase(
 
 sourceCompatibility = 1.7
 
+def javaInstallationProbe = gradle.services.get(JavaInstallationProbe)
+
 ext {
     compileTasks = tasks.matching { it instanceof JavaCompile || it instanceof GroovyCompile }
     testTasks = tasks.withType(Test)
+    javaInstallationForTest = new DefaultJavaInstallation()
     generatedResourcesDir = file("$buildDir/generated-resources/main")
     generatedTestResourcesDir = file("$buildDir/generated-resources/test")
     jarTasks = tasks.withType(Jar)
+}
+
+def testJavaHome = System.getenv('TEST_JAVA_HOME')
+if (testJavaHome) {
+    def testJavaHomeFile = new File(testJavaHome)
+    javaInstallationForTest.javaHome = testJavaHomeFile
+    javaInstallationProbe.checkJdk(testJavaHomeFile).configure(javaInstallationForTest)
+} else {
+    javaInstallationForTest.javaHome = jvm.javaHome
+    javaInstallationProbe.current(javaInstallationForTest)
 }
 
 dependencies {
@@ -49,12 +65,15 @@ testTasks.all { task ->
             }
         }
     }
-    if (javaVersion.java7) {
+    executable = file("${javaInstallationForTest.javaHome}/bin/java")
+    environment['JAVA_HOME'] = javaInstallationForTest.javaHome.absolutePath
+    if (javaInstallationForTest.javaVersion.java7) {
         // enable class unloading
         task.jvmArgs '-XX:+UseConcMarkSweepGC', '-XX:+CMSClassUnloadingEnabled'
     }
     task.inputs.property('javaInstallation') {
-        currentJavaInstallation.displayName
+        // Includes JVM vendor and major version
+        javaInstallationForTest.displayName
     }
     doFirst {
         if (isCiServer) {

--- a/gradle/groovyProject.gradle
+++ b/gradle/groovyProject.gradle
@@ -2,6 +2,7 @@ import org.gradle.build.ClasspathManifest
 import org.gradle.build.DefaultJavaInstallation
 import org.gradle.testing.DistributionTest
 
+import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 
 import java.util.jar.Attributes
@@ -67,7 +68,7 @@ testTasks.all { task ->
             }
         }
     }
-    executable = file("${javaInstallationForTest.javaHome}/bin/java")
+    executable = Jvm.forHome(javaInstallationForTest.javaHome).javaExecutable
     environment['JAVA_HOME'] = javaInstallationForTest.javaHome.absolutePath
     if (javaInstallationForTest.javaVersion.java7) {
         // enable class unloading


### PR DESCRIPTION
### Context
As part of [dogfooding the Gradle Kotlin DSL](https://github.com/gradle/kotlin-dsl/issues/592), we need to run the `gradle/gradle` build with Java >=8. This change is a first step toward this and let the `testJavaHome` Gradle or System property set the JVM used for test execution.
