### PR TITLE
FunctionalTest always use Java 8 to run the build & set testJavaHome

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -16,10 +16,11 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
     } + testCoverage.testType.name + "Test"
     val quickTest = testCoverage.testType == TestType.quick
     applyDefaults(model, this, testTask, notQuick = !quickTest, os = testCoverage.os,
+            extraParameters = "-PtestJavaHome=%${testCoverage.os}.${testCoverage.version}.${testCoverage.vendor}.64bit%",
             timeout = if (quickTest) 60 else 180)
 
     params {
-        param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.version}.${testCoverage.vendor}.64bit%")
+        param("env.JAVA_HOME", "%${testCoverage.os}.java8.oracle.64bit%")
         if (testCoverage.os == OS.linux) {
             param("env.JAVA_9", "%linux.java9.oracle.64bit%")
             param("env.ANDROID_HOME", "/opt/android/sdk")

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -16,7 +16,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
     } + testCoverage.testType.name + "Test"
     val quickTest = testCoverage.testType == TestType.quick
     applyDefaults(model, this, testTask, notQuick = !quickTest, os = testCoverage.os,
-            extraParameters = "-PtestJavaHome=%${testCoverage.os}.${testCoverage.version}.${testCoverage.vendor}.64bit%",
+            extraParameters = """"-PtestJavaHome=%${testCoverage.os}.${testCoverage.version}.${testCoverage.vendor}.64bit%"""",
             timeout = if (quickTest) 60 else 180)
 
     params {


### PR DESCRIPTION
to run tests using the selected JVM.

Follow up for #3735