### PR TITLE
Expose composite build explicitly as ComponentSelectionReason

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -27,23 +27,20 @@ import org.gradle.api.Incubating;
 public interface ComponentSelectionReason {
 
     /**
-     * Informs whether the component was forced.
-     * Users can force components via {@link org.gradle.api.artifacts.ResolutionStrategy}
-     * or when declaring dependencies (see {@link org.gradle.api.artifacts.dsl.DependencyHandler}).
+     * Informs whether the component was forced. Users can force components via {@link org.gradle.api.artifacts.ResolutionStrategy} or when declaring dependencies (see {@link
+     * org.gradle.api.artifacts.dsl.DependencyHandler}).
      */
     boolean isForced();
 
     /**
-     * Informs whether the component was selected by conflict resolution.
-     * For more information about Gradle's conflict resolution please refer to the user
-     * guide. {@link org.gradle.api.artifacts.ResolutionStrategy} contains information
-     * about conflict resolution and includes means to configure it.
+     * Informs whether the component was selected by conflict resolution. For more information about Gradle's conflict resolution please refer to the user guide. {@link
+     * org.gradle.api.artifacts.ResolutionStrategy} contains information about conflict resolution and includes means to configure it.
      */
     boolean isConflictResolution();
 
     /**
-     * Informs whether the component was selected by the dependency substitution rule.
-     * Users can configure dependency substitution rules via {@link org.gradle.api.artifacts.ResolutionStrategy#getDependencySubstitution()}
+     * Informs whether the component was selected by the dependency substitution rule. Users can configure dependency substitution rules via {@link
+     * org.gradle.api.artifacts.ResolutionStrategy#getDependencySubstitution()}
      *
      * @since 1.4
      */
@@ -55,6 +52,13 @@ public interface ComponentSelectionReason {
      * @since 1.11
      */
     boolean isExpected();
+
+    /**
+     * Informs whether the component is selected due to being a composite build.
+     *
+     * @since 4.5
+     */
+    boolean isCompositeBuild();
 
     /**
      * Returns a human-consumable description of this selection reason.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -54,11 +54,11 @@ public interface ComponentSelectionReason {
     boolean isExpected();
 
     /**
-     * Informs whether the component is selected due to being a composite build.
+     * Informs whether the selected component is a project substitute from a build participating in in a composite build.
      *
      * @since 4.5
      */
-    boolean isCompositeBuild();
+    boolean isCompositeParticipant();
 
     /**
      * Returns a human-consumable description of this selection reason.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -58,7 +58,7 @@ public interface ComponentSelectionReason {
      *
      * @since 4.5
      */
-    boolean isCompositeParticipant();
+    boolean isCompositeSubstitution();
 
     /**
      * Returns a human-consumable description of this selection reason.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -48,7 +48,7 @@ public class VersionSelectionReasons {
         private final boolean conflictResolution;
         private final boolean selectedByRule;
         private final boolean expected;
-        private final boolean compositeBuild;
+        private final boolean compositeParticipant;
         private final String description;
 
         private DefaultComponentSelectionReason(boolean forced, boolean conflictResolution, boolean selectedByRule, boolean expected, boolean compositeBuild, String description) {
@@ -56,7 +56,7 @@ public class VersionSelectionReasons {
             this.conflictResolution = conflictResolution;
             this.selectedByRule = selectedByRule;
             this.expected = expected;
-            this.compositeBuild = compositeBuild;
+            this.compositeParticipant = compositeBuild;
             assert description != null;
             this.description = description;
         }
@@ -78,9 +78,8 @@ public class VersionSelectionReasons {
             return expected;
         }
 
-        @Override
-        public boolean isCompositeBuild() {
-            return compositeBuild;
+        public boolean isCompositeParticipant() {
+            return compositeParticipant;
         }
 
         public String getDescription() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -78,7 +78,7 @@ public class VersionSelectionReasons {
             return expected;
         }
 
-        public boolean isCompositeParticipant() {
+        public boolean isCompositeSubstitution() {
             return compositeParticipant;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -19,13 +19,13 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 public class VersionSelectionReasons {
-    public static final ComponentSelectionReason REQUESTED = new DefaultComponentSelectionReason(false, false, false, true, "requested");
-    public static final ComponentSelectionReason ROOT = new DefaultComponentSelectionReason(false, false, false, true, "root");
-    public static final ComponentSelectionReason FORCED = new DefaultComponentSelectionReason(true, false, false, false, "forced");
-    public static final ComponentSelectionReason CONFLICT_RESOLUTION = new DefaultComponentSelectionReason(false, true, false, false, "conflict resolution");
-    public static final ComponentSelectionReason SELECTED_BY_RULE = new DefaultComponentSelectionReason(false, false, true, false, "selected by rule");
-    public static final ComponentSelectionReason CONFLICT_RESOLUTION_BY_RULE = new DefaultComponentSelectionReason(false, true, true, false, "selected by rule and conflict resolution");
-    public static final ComponentSelectionReason COMPOSITE_BUILD = new DefaultComponentSelectionReason(false, false, false, false, "composite build substitution");
+    public static final ComponentSelectionReason REQUESTED = new DefaultComponentSelectionReason(false, false, false, true, false, "requested");
+    public static final ComponentSelectionReason ROOT = new DefaultComponentSelectionReason(false, false, false, true, false, "root");
+    public static final ComponentSelectionReason FORCED = new DefaultComponentSelectionReason(true, false, false, false, false, "forced");
+    public static final ComponentSelectionReason CONFLICT_RESOLUTION = new DefaultComponentSelectionReason(false, true, false, false, false, "conflict resolution");
+    public static final ComponentSelectionReason SELECTED_BY_RULE = new DefaultComponentSelectionReason(false, false, true, false, false, "selected by rule");
+    public static final ComponentSelectionReason CONFLICT_RESOLUTION_BY_RULE = new DefaultComponentSelectionReason(false, true, true, false, false, "selected by rule and conflict resolution");
+    public static final ComponentSelectionReason COMPOSITE_BUILD = new DefaultComponentSelectionReason(false, false, false, false, true, "composite build substitution");
 
     public static ComponentSelectionReason withConflictResolution(ComponentSelectionReason reason) {
         if (reason.isConflictResolution()) {
@@ -48,16 +48,19 @@ public class VersionSelectionReasons {
         private final boolean conflictResolution;
         private final boolean selectedByRule;
         private final boolean expected;
+        private final boolean compositeBuild;
         private final String description;
 
-        private DefaultComponentSelectionReason(boolean forced, boolean conflictResolution, boolean selectedByRule, boolean expected, String description) {
+        private DefaultComponentSelectionReason(boolean forced, boolean conflictResolution, boolean selectedByRule, boolean expected, boolean compositeBuild, String description) {
             this.forced = forced;
             this.conflictResolution = conflictResolution;
             this.selectedByRule = selectedByRule;
             this.expected = expected;
+            this.compositeBuild = compositeBuild;
             assert description != null;
             this.description = description;
         }
+
 
         public boolean isForced() {
             return forced;
@@ -73,6 +76,11 @@ public class VersionSelectionReasons {
 
         public boolean isExpected() {
             return expected;
+        }
+
+        @Override
+        public boolean isCompositeBuild() {
+            return compositeBuild;
         }
 
         public String getDescription() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -512,7 +512,7 @@ allprojects {
          * Marks that this node was substituted in a composite.
          */
         NodeBuilder compositeSubstitute() {
-            reasons << 'compositeBuild'
+            reasons << 'compositeParticipant'
             this
         }
 
@@ -637,8 +637,8 @@ class GenerateGraphTask extends DefaultTask {
         if (reason.selectedByRule) {
             reasons << "selectedByRule"
         }
-        if (reason.compositeBuild) {
-            reasons << "compositeBuild"
+        if (reason.compositeParticipant) {
+            reasons << "compositeParticipant"
         }
         return reasons.empty ? reason.description : reasons.join(',')
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -512,7 +512,7 @@ allprojects {
          * Marks that this node was substituted in a composite.
          */
         NodeBuilder compositeSubstitute() {
-            reasons << 'compositeParticipant'
+            reasons << 'compositeSubstitution'
             this
         }
 
@@ -637,8 +637,8 @@ class GenerateGraphTask extends DefaultTask {
         if (reason.selectedByRule) {
             reasons << "selectedByRule"
         }
-        if (reason.compositeParticipant) {
-            reasons << "compositeParticipant"
+        if (reason.compositeSubstitution) {
+            reasons << "compositeSubstitution"
         }
         return reasons.empty ? reason.description : reasons.join(',')
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -512,7 +512,7 @@ allprojects {
          * Marks that this node was substituted in a composite.
          */
         NodeBuilder compositeSubstitute() {
-            reasons << 'composite build substitution'
+            reasons << 'compositeBuild'
             this
         }
 
@@ -636,6 +636,9 @@ class GenerateGraphTask extends DefaultTask {
         }
         if (reason.selectedByRule) {
             reasons << "selectedByRule"
+        }
+        if (reason.compositeBuild) {
+            reasons << "compositeBuild"
         }
         return reasons.empty ? reason.description : reasons.join(',')
     }


### PR DESCRIPTION
* to have stronger api to detect composite build as selection reason
just relying on the description method is not strong enough.

* This change adds ComponentSelectionReason#isCompositeBuild() that can
be checked by consumers (e.g. Build Scan plugin) to detect this scenario
