### PR TITLE
Let production build environment assertion allow using Java 8 to run the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,7 @@ task verifyIsProductionBuildEnvironment {
                     "Is currently ${javaInstallation.displayName} at $javaInstallationPath. Set -P$propertyName=/path/to/jvm/$javaVersion"
         }
 
-        assertJavaHomeVersion("java7.home", JavaVersion.VERSION_1_7)
+        assertJavaHomeVersion("java7Home", JavaVersion.VERSION_1_7)
         if (javaHomeProperty("testJavaHome")) {
             assertJavaHomeVersion("testJavaHome", JavaVersion.VERSION_1_8)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,10 @@
  */
 
 import org.gradle.build.Install
+import org.gradle.build.DefaultJavaInstallation
 import org.gradle.cleanup.EmptyDirectoryCheck
+
+import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 
 plugins {
     id 'java-base'
@@ -291,9 +294,29 @@ task patchExternalModules(type: PatchExternalModules) {
 
 task verifyIsProductionBuildEnvironment {
     doLast {
-        assert javaVersion.java7: "Must use a Java 7 compatible JVM to perform this build. Current JVM is ${jvm}"
+        assert javaVersion.java8:
+            "Must use a Java 8 compatible JVM to perform this build. Current JVM is ${jvm}"
+
+        def javaHomeProperty = { propertyName -> project.findProperty(propertyName) ?: System.getProperty(propertyName) }
+        def assertJavaHomeVersion = { propertyName, javaVersion ->
+            def javaInstallationPath = javaHomeProperty(propertyName)
+            assert javaInstallationPath:
+                "Must set $propertyName to the path of a Java $javaVersion compatible JVM to perform this build. " +
+                    "Currently unset. Set -P$propertyName=/path/to/jvm/$javaVersion"
+            def javaInstallation = new DefaultJavaInstallation()
+            gradle.services.get(JavaInstallationProbe).checkJdk(file(javaInstallationPath)).configure(javaInstallation)
+            assert javaInstallation.javaVersion == javaVersion:
+                "Must set $propertyName to the path of a Java $javaVersion compatible JVM to perform this build. " +
+                    "Is currently ${javaInstallation.displayName} at $javaInstallationPath. Set -P$propertyName=/path/to/jvm/$javaVersion"
+        }
+
+        assertJavaHomeVersion("java7.home", JavaVersion.VERSION_1_7)
+        if (javaHomeProperty("testJavaHome")) {
+            assertJavaHomeVersion("testJavaHome", JavaVersion.VERSION_1_8)
+        }
+
         def systemCharset = java.nio.charset.Charset.defaultCharset().name()
-        assert systemCharset == "UTF-8": "Platform encoding must be UTF-8. Is currently $systemCharset. Set -Dfile.encoding=UTF-8."
+        assert systemCharset == "UTF-8": "Platform encoding must be UTF-8. Is currently $systemCharset. Set -Dfile.encoding=UTF-8"
     }
 }
 

--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -7,7 +7,7 @@ if (!hasProperty('java7Home')) {
     // possible to set compilation with Java 7 from the command line and from gradle.properties.
     // Note that is this needs to work for buildSrc, too. Gradle properties passed
     // on the command line (-P) are not inherited to buildSrc while system properties are.
-    ext.java7Home = System.getProperty('java7.home')
+    ext.java7Home = System.getProperty('java7Home')
 }
 
 def javaInstallationProbe = gradle.services.get(JavaInstallationProbe)


### PR DESCRIPTION
use Java 8 to run the build
and Java 7 for compilation
and Java 8 for running tests

### Context
As part of [dogfooding the Gradle Kotlin DSL](https://github.com/gradle/kotlin-dsl/issues/592), we need to run the `gradle/gradle` build with Java >=8. This change is a follow up for #3735.
