### PR TITLE
Make ServiceRegistry simpler and faster

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -269,7 +269,8 @@ class DefaultServiceRegistryTest extends Specification {
 
         then:
         e = thrown()
-        e.message == "Cannot create service of type String using StringProvider.createString() as required service of type Runnable is not available."
+        e.message == "Cannot create service of type Integer using StringProvider.createInteger() as there is a problem with parameter #1 of type String."
+        e.cause.message == "Cannot create service of type String using StringProvider.createString() as required service of type Runnable is not available."
     }
 
     def failsWhenProviderFactoryMethodThrowsException() {
@@ -437,16 +438,19 @@ class DefaultServiceRegistryTest extends Specification {
 
         then:
         ServiceCreationException e = thrown()
-        e.message == "Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String."
-        e.cause.message == 'A service dependency cycle was detected: Integer > String > String.'
+        e.message == 'Cannot create service of type String using ProviderWithCycle.createString() as there is a problem with parameter #1 of type Integer.'
+        e.cause.message == 'Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String.'
+        e.cause.cause.message == 'This service depends on itself'
 
         when:
         registry.getAll(Number)
 
         then:
         e = thrown()
-        e.message == "Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String."
-        e.cause.message == 'A service dependency cycle was detected: Integer > String > String.'
+
+        e.message == 'Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String.'
+        e.cause.message == 'Cannot create service of type String using ProviderWithCycle.createString() as there is a problem with parameter #1 of type Integer.'
+        e.cause.cause.message == 'This service depends on itself'
     }
 
     def failsWhenAProviderFactoryMethodReturnsNull() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -1131,14 +1131,14 @@ class DefaultServiceRegistryTest extends Specification {
 
         then:
         IllegalStateException e = thrown()
-        e.message == "Cannot locate service of type String, as TestRegistry has been closed."
+        e.message == "TestRegistry has been closed."
 
         when:
         registry.getAll(String)
 
         then:
         e = thrown()
-        e.message == "Cannot locate service of type String, as TestRegistry has been closed."
+        e.message == "TestRegistry has been closed."
     }
 
     def cannotLookupFactoriesWhenClosed() {
@@ -1151,7 +1151,8 @@ class DefaultServiceRegistryTest extends Specification {
 
         then:
         IllegalStateException e = thrown()
-        e.message == "Cannot locate factory for objects of type BigDecimal, as TestRegistry has been closed."
+        e.message == "" +
+            "TestRegistry has been closed."
     }
 
     /*

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -448,7 +448,7 @@ class DefaultServiceRegistryTest extends Specification {
         ServiceCreationException e = thrown()
         e.message == 'Cannot create service of type String using ProviderWithCycle.createString() as there is a problem with parameter #1 of type Integer.'
         e.cause.message == 'Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String.'
-        e.cause.cause.message == 'This service depends on itself'
+        e.cause.cause.message == 'Cycle in dependencies of Service String at ProviderWithCycle.createString() detected'
 
         when:
         registry.getAll(Number)
@@ -458,7 +458,7 @@ class DefaultServiceRegistryTest extends Specification {
 
         e.message == 'Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String.'
         e.cause.message == 'Cannot create service of type String using ProviderWithCycle.createString() as there is a problem with parameter #1 of type Integer.'
-        e.cause.cause.message == 'This service depends on itself'
+        e.cause.cause.message == 'Cycle in dependencies of Service Integer at ProviderWithCycle.createInteger() detected'
     }
 
     def failsWhenAProviderFactoryMethodReturnsNull() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
@@ -63,6 +63,8 @@ import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory
 import org.gradle.internal.operations.logging.DefaultBuildOperationLoggerFactory
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.service.DefaultServiceRegistry
+import org.gradle.internal.service.ServiceLookupException
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.buildevents.BuildStartedTime
 import org.gradle.internal.time.Clock
@@ -139,9 +141,11 @@ class BuildScopeServicesTest extends Specification {
         def plugin1 = Mock(PluginServiceRegistry)
 
         given:
-        def sessionServices = Mock(BuildSessionScopeServices) {
-            getAll(PluginServiceRegistry) >> [plugin1, plugin2]
-            hasService(_) >> true
+        def sessionServices = new DefaultServiceRegistry() {
+            @Override
+            def <T> List<T> getAll(Class<T> serviceType) throws ServiceLookupException {
+                [plugin1, plugin2]
+            }
         }
 
         when:


### PR DESCRIPTION
@melix this is the follow-up I promised you on the service registry. It is now significantly simpler and more performant, especially when called concurrently. I removed pretty much all object allocation during lookups and allowed concurrent access to services. See the individual commits for more explanations.