### PR TITLE
Better relocation tests

### DIFF
--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
@@ -16,15 +16,14 @@
 
 package org.gradle.testing.jacoco.plugins
 
-import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
+import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
 
 import static org.gradle.util.BinaryDiffUtils.levenshteinDistance
 import static org.gradle.util.BinaryDiffUtils.toHexStrings
 
-class JacocoTestRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
-
-    private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)
+class JacocoTestRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
@@ -32,9 +31,10 @@ class JacocoTestRelocationIntegrationTest extends AbstractTaskRelocationIntegrat
     }
 
     @Override
-    protected void setupProjectInOriginalLocation() {
+    protected void setupProjectIn(TestFile projectDir) {
+        def javaProjectUnderTest = new JavaProjectUnderTest(projectDir)
         javaProjectUnderTest.writeBuildScript().writeSourceFiles()
-        buildFile << """
+        projectDir.file("build.gradle") << """
             test {
                 jacoco {
                     // No caching when append is enabled
@@ -45,16 +45,8 @@ class JacocoTestRelocationIntegrationTest extends AbstractTaskRelocationIntegrat
     }
 
     @Override
-    protected void moveFilesAround() {
-        buildFile << """
-            sourceSets.test.java.outputDir = file("build/test-classes")
-        """
-        file("build/classes/java/test").assertIsDir().deleteDir()
-    }
-
-    @Override
-    protected extractResults() {
-        file("build/jacoco/test.exec").bytes
+    protected extractResultsFrom(TestFile projectDir) {
+        projectDir.file("build/jacoco/test.exec").bytes
     }
 
     @Override

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.api.tasks.compile
 
-import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
+import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.test.fixtures.file.TestFile
 
 import static org.gradle.util.JarUtils.jarWithContents
 
-class JavaCompileRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
+class JavaCompileRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
@@ -28,37 +29,26 @@ class JavaCompileRelocationIntegrationTest extends AbstractTaskRelocationIntegra
     }
 
     @Override
-    protected void setupProjectInOriginalLocation() {
-        file("libs").createDir()
-        file("libs/lib1.jar") << jarWithContents("data.txt": "data1")
-        file("libs/lib2.jar") << jarWithContents("data.txt": "data2")
-        file("src/main/java/sub-dir").createDir()
-        file("src/main/java/Foo.java") << "public class Foo {}"
+    protected void setupProjectIn(TestFile projectDir) {
+        projectDir.file("libs").createDir()
+        projectDir.file("libs/lib1.jar") << jarWithContents("data.txt": "data1")
+        projectDir.file("libs/lib2.jar") << jarWithContents("data.txt": "data2")
+        projectDir.file("src/main/java/sub-dir").createDir()
+        projectDir.file("src/main/java/Foo.java") << "public class Foo {}"
 
-        buildFile << buildFileWithClasspath("libs")
-    }
-
-    private static String buildFileWithClasspath(String classpath) {
-        """
+        projectDir.file("build.gradle") << """
             task compile(type: JavaCompile) {
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()
                 destinationDir = file("build/classes")
                 source "src/main/java"
-                classpath = files('$classpath')
+                classpath = files('libs')
             }
         """
     }
 
     @Override
-    protected void moveFilesAround() {
-        file("src/main/java/Foo.java").moveToDirectory(file("src/main/java/sub-dir"))
-        file("libs").renameTo(file("lobs"))
-        buildFile.text = buildFileWithClasspath("lobs")
-    }
-
-    @Override
-    protected extractResults() {
-        return file("build/classes/Foo.class").bytes
+    protected extractResultsFrom(TestFile projectDir) {
+        return projectDir.file("build/classes/Foo.class").bytes
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskRelocationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskRelocationIntegrationTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.testing
 
-import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
+import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.test.fixtures.file.TestFile
 
 import static org.gradle.util.TextUtil.normaliseLineSeparators
 
-class TestTaskRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
+class TestTaskRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
@@ -28,9 +29,9 @@ class TestTaskRelocationIntegrationTest extends AbstractTaskRelocationIntegratio
     }
 
     @Override
-    protected void setupProjectInOriginalLocation() {
-        file("src/main/java/Foo.java") << "public class Foo {}"
-        file("src/test/java/FooTest.java") << """
+    protected void setupProjectIn(TestFile projectDir) {
+        projectDir.file("src/main/java/Foo.java") << "public class Foo {}"
+        projectDir.file("src/test/java/FooTest.java") << """
             import org.junit.*;
 
             public class FooTest {
@@ -41,7 +42,7 @@ class TestTaskRelocationIntegrationTest extends AbstractTaskRelocationIntegratio
             }
         """
 
-        file("build.gradle") << """
+        projectDir.file("build.gradle") << """
             apply plugin: "java"
 
             ${mavenCentralRepository()}
@@ -55,16 +56,8 @@ class TestTaskRelocationIntegrationTest extends AbstractTaskRelocationIntegratio
     }
 
     @Override
-    protected void moveFilesAround() {
-        buildFile << """
-            sourceSets.test.java.outputDir = file("build/test-classes")
-        """
-        file("build/classes/test").assertIsDir().deleteDir()
-    }
-
-    @Override
-    protected extractResults() {
-        def contents = normaliseLineSeparators(file("build/reports/tests/test/index.html").text)
+    protected extractResultsFrom(TestFile projectDir) {
+        def contents = normaliseLineSeparators(projectDir.file("build/reports/tests/test/index.html").text)
         contents = contents.replaceAll(/(<a href=".*">Gradle .*?<\/a>) at [^<]+/, '$1 at [DATE]' )
         contents = contents.replaceAll(/\b\d+(\.\d+)?s\b/, "[TIME]")
         return contents


### PR DESCRIPTION

This test reporduces the same project in two locations, and runs the following checks:

- does the results load from cache when the project is executed from a different location?
- does the task in question stay up-to-date when there are no changes?
- does the task produce the same (normalized) results in both locations?

This test is more capable and allows for simpler tests than
AbstractTaskRelocationIntegrationTest, which relies on changing individual parameters of
a task to simulate relocation.