### PR TITLE
Deprecate TaskInputs query methods

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -118,6 +118,9 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
      * A task is skipped if it has declared it accepts source files, and this collection is empty.
      *
      * @return The set of source files for this task.
+     *
+     * @deprecated Declare individual task properties to access source files.
      */
+    @Deprecated
     FileCollection getSourceFiles();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -33,7 +33,10 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
      * Returns true if this task has declared the inputs that it consumes.
      *
      * @return true if this task has declared any inputs.
+     *
+     * @deprecated Declare individual task properties to access input files.
      */
+    @Deprecated
     boolean getHasInputs();
 
     /**
@@ -104,7 +107,10 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
      * Returns true if this task has declared that it accepts source files.
      *
      * @return true if this task has source files, false if not.
+     *
+     * @deprecated Declare individual task properties to access source files.
      */
+    @Deprecated
     boolean getHasSourceFiles();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -68,4 +68,24 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         where:
         method << ["file", "dir"]
     }
+
+    @Unroll
+    def "TaskInputs.#method shows deprecation warning"() {
+        buildFile << """
+            task test {
+                inputs.$method()
+            }
+        """
+
+        expect:
+        executer.expectDeprecationWarning()
+        succeeds "test"
+
+        output.contains warning
+
+        where:
+        method              | warning
+        "getHasInputs"      | "The TaskInputs.getHasInputs() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access input files."
+        "getHasSourceFiles" | "The TaskInputs.getHasSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -87,5 +87,6 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         method              | warning
         "getHasInputs"      | "The TaskInputs.getHasInputs() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access input files."
         "getHasSourceFiles" | "The TaskInputs.getHasSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
+        "getSourceFiles"    | "The TaskInputs.getSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -142,6 +142,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
 
     @Override
     public FileCollection getSourceFiles() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.getSourceFiles()", "Declare individual task properties to access source files.");
         return allSourceFiles;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -64,6 +64,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
 
     @Override
     public boolean getHasInputs() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.getHasInputs()", "Declare individual task properties to access input files.");
         HasInputsVisitor visitor = new HasInputsVisitor();
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.hasInputs();
@@ -133,6 +134,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
 
     @Override
     public boolean getHasSourceFiles() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.getHasSourceFiles()", "Declare individual task properties to access source files.");
         GetInputFilesVisitor visitor = new GetInputFilesVisitor(task.toString());
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.hasSourceFiles();

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -86,6 +86,7 @@ Gradle 5.0 will remove support for the following methods:
 
 - `TaskInputs.getHasInputs()`
 - `TaskInputs.getHasSourceFiles()`
+- `TaskInputs.getSourceFiles()`
 
 You can declare individual task properties and observe their values instead of calling these methods.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -80,6 +80,15 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 The command line options for searching in parent directories for a `settings.gradle` file (`-u`/`--no-search-upward`) has been deprecated and will be removed in Gradle 5.0. A Gradle project should always define a `settings.gradle` file to avoid the performance overhead of walking parent directories.
 
+### Deprecation of `TaskInputs` and `TaskOutputs` methods
+
+Gradle 5.0 will remove support for the following methods:
+
+- `TaskInputs.getHasInputs()`
+- `TaskInputs.getHasSourceFiles()`
+
+You can declare individual task properties and observe their values instead of calling these methods.
+
 ## Potential breaking changes
 
 * Two overloaded `ValidateTaskProperties.setOutputFile()` methods were removed. They are replaced with auto-generated setters when the task is accessed from a build script.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/plugins/JvmComponentPlugin.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/plugins/JvmComponentPlugin.java
@@ -291,18 +291,11 @@ public class JvmComponentPlugin implements Plugin<Project> {
                     apiJarTask.setDescription("Creates the API binary file for " + binary + ".");
                     apiJarTask.setOutputFile(apiJarFile.getFile());
                     apiJarTask.setExportedPackages(exportedPackages);
-                    configureApiJarInputs(apiJarTask, assembly);
+                    apiJarTask.source(assembly.getClassDirectories());
                     apiJarTask.dependsOn(assembly);
                     apiJarFile.setBuildTask(apiJarTask);
                 }
             });
-        }
-
-        private void configureApiJarInputs(ApiJar apiJarTask, JvmAssembly assembly) {
-            int counter = 0;
-            for (File classDir : assembly.getClassDirectories()) {
-                apiJarTask.getInputs().dir(classDir).withPropertyName("classes$" + (++counter)).skipWhenEmpty();
-            }
         }
 
         private String apiJarTaskName(JarBinarySpecInternal binary) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/api/ApiJar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/api/ApiJar.java
@@ -16,11 +16,12 @@
 
 package org.gradle.jvm.tasks.api;
 
-import org.gradle.api.DefaultTask;
+import com.google.common.collect.Lists;
 import org.gradle.api.Incubating;
 import org.gradle.api.internal.tasks.compile.ApiClassExtractor;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.ErroringAction;
 import org.objectweb.asm.ClassReader;
@@ -29,7 +30,8 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -70,7 +72,7 @@ import static org.gradle.internal.IoActions.withResource;
  * @see org.gradle.jvm.plugins.JvmComponentPlugin
  */
 @Incubating
-public class ApiJar extends DefaultTask {
+public class ApiJar extends SourceTask {
 
     private Set<String> exportedPackages;
     private File outputFile;
@@ -96,7 +98,7 @@ public class ApiJar extends DefaultTask {
     @TaskAction
     public void createApiJar() throws IOException {
         // Make sure all entries are always written in the same order
-        final File[] sourceFiles = sortedSourceFiles();
+        final List<File> sourceFiles = sortedSourceFiles();
         final ApiClassExtractor apiClassExtractor = new ApiClassExtractor(getExportedPackages());
         withResource(
             new JarOutputStream(new BufferedOutputStream(new FileOutputStream(getOutputFile()), 65536)),
@@ -151,9 +153,9 @@ public class ApiJar extends DefaultTask {
         return hasExtension(file, ".class");
     }
 
-    private File[] sortedSourceFiles() {
-        final File[] sourceFiles = (File[]) getInputs().getSourceFiles().asType(File[].class);
-        Arrays.sort(sourceFiles);
+    private List<File> sortedSourceFiles() {
+        List<File> sourceFiles = Lists.newArrayList(getSource().getFiles());
+        Collections.sort(sourceFiles);
         return sourceFiles;
     }
 }


### PR DESCRIPTION
These methods expose internal state that is expensive to calculate. Instead of using them, user code can rely on declared task properties.