### PR TITLE
Discover task dependencies via Buildable task inputs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
@@ -19,7 +19,6 @@ import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.TaskOutputs;
@@ -54,9 +53,7 @@ public class BuildDependenciesOnlyFileCollectionResolveContext implements FileCo
     @Override
     public FileCollectionResolveContext add(Object element) {
         // TODO - need to sync with DefaultFileCollectionResolveContext
-        if (element instanceof FileCollection) {
-            taskContext.add(element);
-        } else if (element instanceof MinimalFileCollection && element instanceof Buildable) {
+        if (element instanceof Buildable) {
             taskContext.add(element);
         } else if (element instanceof Task) {
             taskContext.add(element);


### PR DESCRIPTION
When registering task input files that implement Buildable and Iterable<File>,
now task dependencies are discovered via getBuildDependencies().

Fixes #3792.