### PR TITLE
Deprecate TaskOutputs.getHasOutput

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
@@ -107,7 +107,10 @@ public interface TaskOutputs extends CompatibilityAdapterForTaskOutputs {
      * still have an empty set of output files.
      *
      * @return true if this task has declared any outputs, otherwise false.
+     *
+     * @deprecated Declare individual task properties to access output files.
      */
+    @Deprecated
     boolean getHasOutput();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -89,4 +89,19 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         "getHasSourceFiles" | "The TaskInputs.getHasSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
         "getSourceFiles"    | "The TaskInputs.getSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
     }
+
+    @Unroll
+    def "TaskOutputs.getHasOutput() shows deprecation warning"() {
+        buildFile << """
+            task test {
+                outputs.hasOutput
+            }
+        """
+
+        expect:
+        executer.expectDeprecationWarning()
+        succeeds "test"
+
+        output.contains "The TaskOutputs.getHasOutput() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access output files."
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
@@ -48,9 +48,4 @@ public interface TaskOutputsInternal extends TaskOutputs {
      */
     TaskOutputCachingState getCachingState(TaskProperties taskProperties);
 
-    /**
-     * Returns whether the task has declared any outputs.
-     */
-    boolean hasDeclaredOutputs();
-
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -38,6 +38,7 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -184,11 +185,10 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public boolean getHasOutput() {
-        return hasDeclaredOutputs() || !upToDateSpec.isEmpty();
-    }
-
-    @Override
-    public boolean hasDeclaredOutputs() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskOutputs.getHasOutput()", "Declare individual task properties to access output files.");
+        if (!upToDateSpec.isEmpty()) {
+            return true;
+        }
         HasDeclaredOutputsVisitor visitor = new HasDeclaredOutputsVisitor();
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.hasDeclaredOutputs();

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -87,6 +87,7 @@ Gradle 5.0 will remove support for the following methods:
 - `TaskInputs.getHasInputs()`
 - `TaskInputs.getHasSourceFiles()`
 - `TaskInputs.getSourceFiles()`
+- `TaskOutputs.getHasOutput()`
 
 You can declare individual task properties and observe their values instead of calling these methods.
 


### PR DESCRIPTION
This method expose internal state that is expensive to maintain.
Instead of using it, user code can rely on declared task properties.
