### PR TITLE
Deprecate TaskInputs.getProperties()

### DIFF
--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.wrapper
 
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.AbstractTaskTest
+import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GUtil
 import org.gradle.util.GradleVersion
@@ -147,7 +148,7 @@ class WrapperTest extends AbstractTaskTest {
 
     def "check inputs"() {
         expect:
-        wrapper.getInputs().getProperties().keySet() == WrapUtil.toSet(
+        TaskPropertyTestUtils.getProperties(wrapper).keySet() == WrapUtil.toSet(
             "distributionBase", "distributionPath", "distributionUrl", "distributionSha256Sum",
             "distributionType", "archiveBase", "archivePath", "gradleVersion")
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -75,7 +75,10 @@ public interface TaskInputs extends CompatibilityAdapterForTaskInputs {
      * Returns the set of input properties for this task.
      *
      * @return The properties.
+     *
+     * @deprecated Use {@link #property(String, Object)} and {@link #properties(Map)} to declare input properties.
      */
+    @Deprecated
     Map<String, Object> getProperties();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -88,6 +88,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         "getHasInputs"      | "The TaskInputs.getHasInputs() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access input files."
         "getHasSourceFiles" | "The TaskInputs.getHasSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
         "getSourceFiles"    | "The TaskInputs.getSourceFiles() method has been deprecated and is scheduled to be removed in Gradle 5.0. Declare individual task properties to access source files."
+        "getProperties"     | "The TaskInputs.getProperties() method has been deprecated and is scheduled to be removed in Gradle 5.0. Use the property() and properties() methods to declare input properties instead."
     }
 
     @Unroll

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -147,8 +147,10 @@ public class DefaultTaskInputs implements TaskInputsInternal {
     }
 
     public Map<String, Object> getProperties() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.getProperties()", "Use the property() and properties() methods to declare input properties instead.");
         GetInputPropertiesVisitor visitor = new GetInputPropertiesVisitor(task.getName());
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
+        //noinspection ConstantConditions
         return visitor.getPropertyValuesFactory().create();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -146,6 +146,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         return allSourceFiles;
     }
 
+    @Override
     public Map<String, Object> getProperties() {
         DeprecationLogger.nagUserOfDiscontinuedMethod("TaskInputs.getProperties()", "Use the property() and properties() methods to declare input properties instead.");
         GetInputPropertiesVisitor visitor = new GetInputPropertiesVisitor(task.getName());

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -22,6 +22,9 @@ import org.gradle.api.GradleException
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.ClassGenerator
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.tasks.properties.DefaultPropertyMetadataStore
+import org.gradle.api.internal.tasks.properties.DefaultPropertyWalker
+import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.api.tasks.TaskValidationException
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -37,6 +40,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     private AnnotationProcessingTaskFactory factory
     private ITaskFactory delegate
     private TaskClassInfoStore taskClassInfoStore
+    def propertyWalker = new DefaultPropertyWalker(new DefaultPropertyMetadataStore([]))
 
     private Map args = new HashMap()
 
@@ -555,7 +559,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         def task = (value == null) ? expectTaskCreated(type) : expectTaskCreated(type, value)
 
         expect:
-        task.inputs.properties[prop] == expected
+        inputProperties(task)[prop] == expected
 
         where:
         type                                      | prop         | value                    | expected
@@ -635,14 +639,15 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     def propertyExtractionJavaBeanSpec() {
         given:
         def task = expectTaskCreated(TaskWithJavaBeanCornerCaseProperties, "c", "C", "d", "U", "a", "b")
+        def properties = inputProperties(task)
 
         expect:
-        task.inputs.properties["cCompiler"] != null
-        task.inputs.properties["CFlags"] != null
-        task.inputs.properties["dns"] != null
-        task.inputs.properties["URL"] != null
-        task.inputs.properties["a"] != null
-        task.inputs.properties["b"] != null
+        properties["cCompiler"] != null
+        properties["CFlags"] != null
+        properties["dns"] != null
+        properties["URL"] != null
+        properties["a"] != null
+        properties["b"] != null
     }
 
     private TaskInternal expectTaskCreated(final Class type, final Object... params) {
@@ -670,5 +675,9 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         def expectedMessage = causes.length > 1 ? "Some problems were found with the configuration of $task" : "A problem was found with the configuration of $task"
         assert exception.message.contains(expectedMessage)
         assert exception.causes.collect({ it.message }) as Set == causes as Set
+    }
+
+    private Map<String, Object> inputProperties(TaskInternal task) {
+        TaskPropertyTestUtils.getProperties(task, propertyWalker)
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TaskPropertyTestUtils.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TaskPropertyTestUtils.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.tasks.TaskPropertyUtils
+import org.gradle.api.internal.tasks.properties.GetInputPropertiesVisitor
+import org.gradle.api.internal.tasks.properties.PropertyWalker
+
+class TaskPropertyTestUtils {
+    static Map<String, Object> getProperties(AbstractTask task) {
+        getProperties(task, task.getServices().get(PropertyWalker))
+    }
+
+    static Map<String, Object> getProperties(TaskInternal task, PropertyWalker propertyWalker) {
+        GetInputPropertiesVisitor visitor = new GetInputPropertiesVisitor(task.getName());
+        TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
+        //noinspection ConstantConditions
+        return visitor.getPropertyValuesFactory().create();
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -87,9 +87,10 @@ Gradle 5.0 will remove support for the following methods:
 - `TaskInputs.getHasInputs()`
 - `TaskInputs.getHasSourceFiles()`
 - `TaskInputs.getSourceFiles()`
+- `TaskInputs.getProperties()`
 - `TaskOutputs.getHasOutput()`
 
-You can declare individual task properties and observe their values instead of calling these methods.
+You can declare individual task properties and observe their values instead of calling these methods. The `TaskInputs.property()` and `properties()` methods can be used to declare non-file inputs.
 
 ## Potential breaking changes
 

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskReportContainerTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskReportContainerTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.reporting.Report
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -72,7 +73,7 @@ class TaskReportContainerTest extends Specification {
     }
 
     List<String> getInputPropertyValue() {
-        task.inputs.properties["reports.enabledReportNames"] as List<String>
+        TaskPropertyTestUtils.getProperties(task)["reports.enabledReportNames"] as List<String>
     }
 
     @Unroll("tasks inputs and outputs are wired correctly A: #aEnabled, B: #bEnabled")


### PR DESCRIPTION
This method exposes internal state that is expensive to maintain.
There should be no need to query properties from user code, and
declaring new ones can be achieved via the property() and
properties() methods.
