### PR TITLE
Reduce impact of JGit in Gradle's runtime API

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
@@ -24,6 +24,8 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -81,8 +83,24 @@ class ImplementationDependencyRelocator extends Remapper {
     }
 
     public boolean keepOriginalResource(String resource) {
-        return resource == null || maybeRelocateResource(resource) == null
-            || !resource.startsWith("com/sun/jna"); // in order to use a newer version of jna the resources must not be available in the old location
+        return resource == null
+            || maybeRelocateResource(resource) == null
+            || !mustBeRelocated(resource);
+    }
+
+    private final List<String> mustRelocateList = Arrays.asList(
+        // In order to use a newer version of jna the resources must not be available in the old location
+        "com/sun/jna",
+        // JGit properties work from their relocated locations and conflict if they are left in place.
+        "org/eclipse/jgit");
+
+    private final boolean mustBeRelocated(String resource) {
+        for (String mustRelocate : mustRelocateList) {
+            if (resource.startsWith(mustRelocate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public ClassLiteralRemapping maybeRemap(String literal) {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
@@ -16,8 +16,9 @@
 
 package org.gradle.plugin.devel.impldeps
 
-import groovy.transform.NotYetImplemented
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 
 class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsIntegrationTest {
@@ -149,8 +150,8 @@ class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsInteg
         succeeds 'test'
     }
 
-    @NotYetImplemented
     @Issue("https://github.com/gradle/gradle/issues/3780")
+    @Requires(TestPrecondition.JDK8_OR_LATER)
     def "can use different JGit API"() {
         when:
         buildFile << testableGroovyProject()
@@ -169,11 +170,12 @@ class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsInteg
                 void loadJGitResources() {
                     assert org.eclipse.jgit.internal.JGitText.getPackage().getImplementationVersion() == "4.9.1.201712030800-r"
                     assert org.eclipse.jgit.internal.JGitText.get() != null
+                    assert org.gradle.internal.impldep.org.eclipse.jgit.internal.JGitText.get() != null
                 }
             }
         '''.stripIndent()
 
         then:
-        succeeds 'test', '-i'
+        succeeds 'test'
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.plugin.devel.impldeps
 
+import groovy.transform.NotYetImplemented
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Issue
 
@@ -146,5 +147,33 @@ class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsInteg
 
         then:
         succeeds 'test'
+    }
+
+    @NotYetImplemented
+    @Issue("https://github.com/gradle/gradle/issues/3780")
+    def "can use different JGit API"() {
+        when:
+        buildFile << testableGroovyProject()
+
+        buildFile << """
+            dependencies {
+                testCompile 'org.eclipse.jgit:org.eclipse.jgit:4.9.1.201712030800-r'
+            }
+        """
+
+        file('src/test/groovy/JGitTest.groovy') << '''
+            import org.junit.Test
+            
+            class JGitTest {
+                @Test
+                void loadJGitResources() {
+                    assert org.eclipse.jgit.internal.JGitText.getPackage().getImplementationVersion() == "4.9.1.201712030800-r"
+                    assert org.eclipse.jgit.internal.JGitText.get() != null
+                }
+            }
+        '''.stripIndent()
+
+        then:
+        succeeds 'test', '-i'
     }
 }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
