### PR TITLE
Derive Java Library variants for libraries published with maven

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -19,6 +19,7 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.api.Task
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.DefaultInstantiatorFactory
+import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
@@ -76,6 +77,14 @@ class TestUtil {
 
     static ImmutableAttributesFactory attributesFactory() {
         return new DefaultImmutableAttributesFactory(valueSnapshotter())
+    }
+
+    static NamedObjectInstantiator objectInstantiator() {
+        return NamedObjectInstantiator.INSTANCE
+    }
+
+    static ExperimentalFeatures experimentalFeatures() {
+        return new ExperimentalFeatures()
     }
 
     static TestUtil create(File rootDir) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
  * declared in the build script (instead of published)
  */
 class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
-    private final ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "conf")
+    private final ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "conf").expectDefaultConfiguration('runtime')
 
     def setup() {
         ExperimentalFeaturesFixture.enable(settingsFile)
@@ -45,6 +45,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         settingsFile.text = """
             rootProject.name = 'test'
         """
+        resolve.expectDefaultConfiguration('default')
         mavenRepo.module("org", "foo", '1.0').publish()
         mavenRepo.module("org", "foo", '1.1').publish()
 
@@ -343,6 +344,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
 
     void "dependency constraints defined for a build are applied when resolving a configuration that uses that build as an included build"() {
         given:
+        resolve.expectDefaultConfiguration('default')
         mavenRepo.module("org", "foo", '1.0').publish()
         mavenRepo.module("org", "foo", '1.1').publish()
 
@@ -378,10 +380,10 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution()
+                edge("org:foo:1.0", "org:foo:1.1:runtime").byConflictResolution()
                 edge("org:included:1.0", "project :included", "org:included:1.0") {
                     noArtifacts()
-                    module("org:foo:1.1")
+                    module("org:foo:1.1:runtime")
                 }.compositeSubstitute()
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -40,7 +40,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         if (gradleMetadataEnabled || useIvy()) {
             'customVariant'
         } else {
-            'compile'
+            'runtime'
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.publish.RemoteRepositorySpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.HttpRepository
 import org.gradle.test.fixtures.ivy.IvyModule
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -30,7 +29,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         'default':          '',
         'runtime':          'configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))',
         'api':              'configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))',
-        //'api+experimental': 'configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))',
+        'api+experimental': 'configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))',
     ]
 
     private static boolean leaksRuntime(testVariant, repoType, prevRepoType = null) {
@@ -316,7 +315,6 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         }
     }
 
-    @Ignore
     @Unroll
     def "with experimental resolve behavior, explicit #conf configuration selection still works for maven dependencies"() {
         given:
@@ -408,6 +406,6 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         'ivy'          | true      | false
         'maven-gradle' | false     | false
         'ivy-gradle'   | false     | false
-        //'maven'        | false     | true
+        'maven'        | false     | true
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
@@ -98,8 +98,8 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
         then:
         succeeds ":checkDeps"
 
-        // We are resolving with "legacy" metadata: always gives default configuration
-        resolve.expectDefaultConfiguration("default")
+        // We are resolving with "legacy" metadata: always gives default configuration, unless we derive Java library variants for maven repositories
+        resolve.expectDefaultConfiguration(isExperimentalEnabled() && useMaven() ? "runtime" : "default")
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:projectA:1.+", "org.test:projectA:1.2")
@@ -140,8 +140,8 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
         then:
         succeeds ":checkDeps"
 
-        // We are resolving with `artifact()` metadata: always gives default configuration
-        resolve.expectDefaultConfiguration("default")
+        // We are resolving with `artifact()` metadata: always gives default configuration, unless we derive Java library variants for maven repositories
+        resolve.expectDefaultConfiguration(isExperimentalEnabled() && useMaven() ? "runtime" : "default")
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:projectA:1.+", "org.test:projectA:1.2")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
 
 class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
-    def resolve = new ResolveTestFixture(buildFile)
+    def resolve = new ResolveTestFixture(buildFile).expectDefaultConfiguration('runtime')
     MavenModule bom
     MavenModule moduleA
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -117,7 +117,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2")
+                module("test:a:1.2:runtime")
             }
         }
 
@@ -128,7 +128,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2")
+                module("test:a:1.2:runtime")
             }
         }
 
@@ -144,7 +144,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2")
+                module("test:a:1.2:runtime")
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -185,8 +185,10 @@ class DependencyManagementBuildScopeServices {
         );
     }
 
-    MavenMutableModuleMetadataFactory createMutableMavenMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {
-        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory);
+    MavenMutableModuleMetadataFactory createMutableMavenMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                                                        ImmutableAttributesFactory attributesFactory,
+                                                                        ExperimentalFeatures experimentalFeatures) {
+        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, NamedObjectInstantiator.INSTANCE, experimentalFeatures);
     }
 
     IvyMutableModuleMetadataFactory createMutableIvyMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 45),
+    META_DATA(ROOT, "metadata", 48),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -469,7 +469,17 @@ public class PomReader implements PomParent {
     }
 
     public PomDependencyMgt findDependencyDefaults(MavenDependencyKey dependencyKey) {
-        return getDependencyMgt().get(dependencyKey);
+        PomDependencyMgt candidate = getDependencyMgt().get(dependencyKey);
+        if (candidate != null) {
+            return getDependencyMgt().get(dependencyKey);
+        }
+        // lenient matching that ignores the scopes
+        for (MavenDependencyKey key : getDependencyMgt().keySet()) {
+            if (key.equalsWithoutScope(dependencyKey)) {
+                return getDependencyMgt().get(key);
+            }
+        }
+        return null;
     }
 
     public void resolveGAV() {
@@ -492,7 +502,7 @@ public class PomReader implements PomParent {
         }
 
         public MavenDependencyKey getId() {
-            return new MavenDependencyKey(getGroupId(), getArtifactId(), getType(), getClassifier());
+            return new MavenDependencyKey(getGroupId(), getArtifactId(), getType(), getClassifier(), getScope());
         }
 
         /* (non-Javadoc)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKey.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKey.java
@@ -23,12 +23,14 @@ public class MavenDependencyKey {
     private final String artifactId;
     private final String type;
     private final String classifier;
+    private final String scope;
 
-    public MavenDependencyKey(String groupId, String artifactId, String type, String classifier) {
+    public MavenDependencyKey(String groupId, String artifactId, String type, String classifier, String scope) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.type = type;
         this.classifier = classifier;
+        this.scope = scope;
     }
 
     public String getGroupId() {
@@ -47,6 +49,10 @@ public class MavenDependencyKey {
         return classifier;
     }
 
+    public String getScope() {
+        return scope;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -57,6 +63,10 @@ public class MavenDependencyKey {
         }
 
         MavenDependencyKey that = (MavenDependencyKey) o;
+        return equalsWithoutScope(that) && Objects.equal(scope, that.scope);
+    }
+
+    public boolean equalsWithoutScope(MavenDependencyKey that) {
         return Objects.equal(groupId, that.groupId)
             && Objects.equal(artifactId, that.artifactId)
             && Objects.equal(classifier, that.classifier)
@@ -65,7 +75,7 @@ public class MavenDependencyKey {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(groupId, artifactId, classifier, type);
+        return Objects.hashCode(groupId, artifactId, classifier, type, scope);
     }
 
     @Override
@@ -73,8 +83,11 @@ public class MavenDependencyKey {
         StringBuilder key = new StringBuilder();
         key.append(groupId).append(KEY_SEPARATOR).append(artifactId).append(KEY_SEPARATOR).append(type);
 
-        if(classifier != null) {
+        if (classifier != null) {
             key.append(KEY_SEPARATOR).append(classifier);
+        }
+        if (scope != null) {
+            key.append(KEY_SEPARATOR).append(scope);
         }
 
         return key.toString();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -17,9 +17,11 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.model.DefaultMutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.MavenDependencyDescriptor;
 import org.gradle.internal.component.external.model.MutableMavenModuleResolveMetadata;
@@ -30,16 +32,22 @@ import java.util.List;
 public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataFactory<MutableMavenModuleResolveMetadata> {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private final NamedObjectInstantiator objectInstantiator;
+    private final ExperimentalFeatures experimentalFeatures;
 
-    public MavenMutableModuleMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {
+    public MavenMutableModuleMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                             ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
+                                             ExperimentalFeatures experimentalFeatures) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.attributesFactory = attributesFactory;
+        this.objectInstantiator = objectInstantiator;
+        this.experimentalFeatures = experimentalFeatures;
     }
 
     @Override
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(attributesFactory, mvi, from, Collections.<MavenDependencyDescriptor>emptyList());
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, experimentalFeatures);
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
@@ -55,6 +63,6 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
 
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from, List<MavenDependencyDescriptor> dependencies) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(attributesFactory, mvi, from, dependencies);
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, experimentalFeatures);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -159,9 +159,17 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
      */
     protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules);
 
+    /**
+     * If there are no variants defined in the metadata, but the implementation knows how to provide variants it can do that here.
+     * If it can not provide variants, an empty list needs to be returned to fall back to traditional configuration selection.
+     */
+    protected ImmutableList<? extends ConfigurationMetadata> maybeDeriveVariants() {
+        return ImmutableList.of();
+    }
+
     private ImmutableList<? extends ConfigurationMetadata> buildVariantsForGraphTraversal(List<? extends ComponentVariant> variants) {
         if (variants.isEmpty()) {
-            return ImmutableList.of();
+            return maybeDeriveVariants();
         }
         List<VariantBackedConfigurationMetadata> configurations = new ArrayList<VariantBackedConfigurationMetadata>(variants.size());
         for (ComponentVariant variant : variants) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -46,6 +46,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
     private final ImmutableList<String> hierarchy;
     private final VariantMetadataRules componentMetadataRules;
     private final ImmutableList<ExcludeMetadata> excludes;
+    private final ImmutableAttributes attributes;
 
     // Should be final, and set in constructor
     private ImmutableList<ModuleDependencyMetadata> configDependencies;
@@ -55,6 +56,15 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
                                            ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                            VariantMetadataRules componentMetadataRules,
                                            ImmutableList<ExcludeMetadata> excludes) {
+        this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, ImmutableAttributes.EMPTY, null);
+    }
+
+    private DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
+                                         ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         VariantMetadataRules componentMetadataRules,
+                                         ImmutableList<ExcludeMetadata> excludes,
+                                         ImmutableAttributes attributes,
+                                         ImmutableList<ModuleDependencyMetadata> configDependencies) {
         this.componentId = componentId;
         this.name = name;
         this.transitive = transitive;
@@ -63,6 +73,8 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
         this.hierarchy = hierarchy;
         this.componentMetadataRules = componentMetadataRules;
         this.excludes = excludes;
+        this.attributes = attributes;
+        this.configDependencies = configDependencies;
     }
 
     @Override
@@ -97,7 +109,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
 
     @Override
     public ImmutableAttributes getAttributes() {
-        return componentMetadataRules.applyVariantAttributeRules(ImmutableAttributes.EMPTY);
+        return componentMetadataRules.applyVariantAttributeRules(attributes);
     }
 
     @Override
@@ -142,4 +154,9 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
     public ModuleComponentArtifactMetadata artifact(IvyArtifactName artifact) {
         return new DefaultModuleComponentArtifactMetadata(componentId, artifact);
     }
+
+    protected DefaultConfigurationMetadata withAttributes(ImmutableAttributes attributes) {
+        return new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, attributes, configDependencies);
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -42,7 +42,9 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     public static final String POM_PACKAGING = "pom";
     public static final Collection<String> JAR_PACKAGINGS = Arrays.asList("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = PreferJavaRuntimeVariant.schema();
+    // We need to work with the 'String' version of the usage attribute, since this is expected for all providers by the `PreferJavaRuntimeVariant` schema
     private static final Attribute<String> USAGE_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
+
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
     private final ExperimentalFeatures experimentalFeatures;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -19,7 +19,10 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.descriptor.MavenScope;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -35,14 +38,20 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     public static final String POM_PACKAGING = "pom";
     public static final Collection<String> JAR_PACKAGINGS = Arrays.asList("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = PreferJavaRuntimeVariant.schema();
+    private final ImmutableAttributesFactory attributesFactory;
+    private final NamedObjectInstantiator objectInstantiator;
+    private final ExperimentalFeatures experimentalFeatures;
 
     private final ImmutableList<MavenDependencyDescriptor> dependencies;
     private final String packaging;
     private final boolean relocated;
     private final String snapshotTimestamp;
 
-    DefaultMavenModuleResolveMetadata(DefaultMutableMavenModuleResolveMetadata metadata) {
+    DefaultMavenModuleResolveMetadata(DefaultMutableMavenModuleResolveMetadata metadata, ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, ExperimentalFeatures experimentalFeatures) {
         super(metadata);
+        this.experimentalFeatures = experimentalFeatures;
+        this.attributesFactory = attributesFactory;
+        this.objectInstantiator = objectInstantiator;
         packaging = metadata.getPackaging();
         relocated = metadata.isRelocated();
         snapshotTimestamp = metadata.getSnapshotTimestamp();
@@ -51,6 +60,9 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     private DefaultMavenModuleResolveMetadata(DefaultMavenModuleResolveMetadata metadata, ModuleSource source) {
         super(metadata, source);
+        this.experimentalFeatures = metadata.experimentalFeatures;
+        this.attributesFactory = metadata.attributesFactory;
+        this.objectInstantiator = metadata.objectInstantiator;
         packaging = metadata.packaging;
         relocated = metadata.relocated;
         snapshotTimestamp = metadata.snapshotTimestamp;
@@ -111,7 +123,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     @Override
     public MutableMavenModuleResolveMetadata asMutable() {
-        return new DefaultMutableMavenModuleResolveMetadata(this);
+        return new DefaultMutableMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, experimentalFeatures);
     }
 
     public String getPackaging() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -19,9 +19,13 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.changedetection.state.CoercingStringValueSnapshot;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.descriptor.MavenScope;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -38,6 +42,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     public static final String POM_PACKAGING = "pom";
     public static final Collection<String> JAR_PACKAGINGS = Arrays.asList("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = PreferJavaRuntimeVariant.schema();
+    private static final Attribute<String> USAGE_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
     private final ExperimentalFeatures experimentalFeatures;
@@ -46,6 +51,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     private final String packaging;
     private final boolean relocated;
     private final String snapshotTimestamp;
+
+    private ImmutableList<? extends ConfigurationMetadata> derivedVariants;
 
     DefaultMavenModuleResolveMetadata(DefaultMutableMavenModuleResolveMetadata metadata, ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, ExperimentalFeatures experimentalFeatures) {
         super(metadata);
@@ -77,6 +84,24 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
         DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of());
         configuration.setDependencies(filterDependencies(configuration));
         return configuration;
+    }
+
+    @Override
+    protected ImmutableList<? extends ConfigurationMetadata> maybeDeriveVariants() {
+        return isJavaLibrary() ? getDerivedVariants() : ImmutableList.<ConfigurationMetadata>of();
+    }
+
+    private ImmutableList<? extends ConfigurationMetadata> getDerivedVariants() {
+        if (derivedVariants == null) {
+            derivedVariants = ImmutableList.of(
+                withUsageAttribute((DefaultConfigurationMetadata) getConfiguration("compile"), Usage.JAVA_API, attributesFactory),
+                withUsageAttribute((DefaultConfigurationMetadata) getConfiguration("runtime"), Usage.JAVA_RUNTIME, attributesFactory));
+        }
+        return derivedVariants;
+    }
+
+    private ConfigurationMetadata withUsageAttribute(DefaultConfigurationMetadata conf, String usage, ImmutableAttributesFactory attributesFactory) {
+        return conf.withAttributes(attributesFactory.concat(ImmutableAttributes.EMPTY, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator)));
     }
 
     private ImmutableList<? extends ModuleComponentArtifactMetadata> getArtifactsForConfiguration(String name) {
@@ -140,6 +165,10 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     public boolean isKnownJarPackaging() {
         return JAR_PACKAGINGS.contains(packaging);
+    }
+
+    private boolean isJavaLibrary() {
+        return experimentalFeatures.isEnabled() && (isKnownJarPackaging() || isPomPackaging());
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
@@ -20,8 +20,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.descriptor.Configuration;
 
 import javax.annotation.Nullable;
@@ -31,27 +33,40 @@ import static org.gradle.internal.component.external.model.DefaultMavenModuleRes
 import static org.gradle.internal.component.external.model.DefaultMavenModuleResolveMetadata.POM_PACKAGING;
 
 public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableModuleComponentResolveMetadata implements MutableMavenModuleResolveMetadata {
+    private final ImmutableAttributesFactory attributesFactory;
+    private final NamedObjectInstantiator objectInstantiator;
+    private final ExperimentalFeatures experimentalFeatures;
     private String packaging = "jar";
     private boolean relocated;
     private String snapshotTimestamp;
     private ImmutableList<MavenDependencyDescriptor> dependencies;
 
-    public DefaultMutableMavenModuleResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, Collection<MavenDependencyDescriptor> dependencies) {
+    public DefaultMutableMavenModuleResolveMetadata(ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, Collection<MavenDependencyDescriptor> dependencies,
+                                                    ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
+                                                    ExperimentalFeatures experimentalFeatures) {
         super(attributesFactory, id, componentIdentifier);
         this.dependencies = ImmutableList.copyOf(dependencies);
+        this.attributesFactory = attributesFactory;
+        this.objectInstantiator = objectInstantiator;
+        this.experimentalFeatures = experimentalFeatures;
     }
 
-    DefaultMutableMavenModuleResolveMetadata(MavenModuleResolveMetadata metadata) {
+    DefaultMutableMavenModuleResolveMetadata(MavenModuleResolveMetadata metadata,
+                                             ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
+                                             ExperimentalFeatures experimentalFeatures) {
         super(metadata);
         this.packaging = metadata.getPackaging();
         this.relocated = metadata.isRelocated();
         this.snapshotTimestamp = metadata.getSnapshotTimestamp();
         this.dependencies = metadata.getDependencies();
+        this.attributesFactory = attributesFactory;
+        this.objectInstantiator = objectInstantiator;
+        this.experimentalFeatures = experimentalFeatures;
     }
 
     @Override
     public MavenModuleResolveMetadata asImmutable() {
-        return new DefaultMavenModuleResolveMetadata(this);
+        return new DefaultMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, experimentalFeatures);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
@@ -33,9 +33,11 @@ import static org.gradle.internal.component.external.model.DefaultMavenModuleRes
 import static org.gradle.internal.component.external.model.DefaultMavenModuleResolveMetadata.POM_PACKAGING;
 
 public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableModuleComponentResolveMetadata implements MutableMavenModuleResolveMetadata {
+
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
     private final ExperimentalFeatures experimentalFeatures;
+
     private String packaging = "jar";
     private boolean relocated;
     private String snapshotTimestamp;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -53,7 +53,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
     RuleActionAdapter<ComponentMetadataDetails> adapter = Mock(RuleActionAdapter)
     def mockedHandler = new DefaultComponentMetadataHandler(DirectInstantiator.INSTANCE, adapter, moduleIdentifierFactory)
     def ruleAction = Stub(RuleAction)
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
     def "does nothing when no rules registered"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.45'
-        cacheLayout.version == VersionNumber.parse("2.45.0")
-        cacheLayout.formattedVersion == '2.45'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.45')
+        cacheLayout.key == 'metadata-2.48'
+        cacheLayout.version == VersionNumber.parse("2.48.0")
+        cacheLayout.formattedVersion == '2.48'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.48')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -42,7 +42,7 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
     final FileResourceRepository fileRepository = TestFiles.fileRepository()
     final GradlePomModuleDescriptorParser parser = new GradlePomModuleDescriptorParser(new DefaultVersionSelectorScheme(), moduleIdentifierFactory, fileRepository, mavenMetadataFactory)
     final parseContext = Mock(DescriptorParseContext)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
@@ -202,6 +202,58 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         hasDefaultDependencyArtifact(dep)
     }
 
+    def "can provide different values for different scopes in dependency management section"() {
+        given:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-one</groupId>
+    <artifactId>artifact-one</artifactId>
+    <version>version-one</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>group-two</groupId>
+                <artifactId>artifact-two</artifactId>
+                <version>1.1</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>group-two</groupId>
+                <artifactId>artifact-two</artifactId>
+                <version>1.2</version>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+"""
+
+        when:
+        parsePom()
+
+        then:
+        def depCompile = metadata.dependencies[0]
+        depCompile.selector == moduleId('group-two', 'artifact-two', '1.1')
+        depCompile.scope == MavenScope.Compile
+        def depRuntime = metadata.dependencies[1]
+        depRuntime.selector == moduleId('group-two', 'artifact-two', '1.2')
+        depRuntime.scope == MavenScope.Runtime
+    }
+
     def "uses empty version if parent pom dependency management section does not provide default values for dependency"() {
         given:
         def parent = tmpDir.file("parent.xml") << """

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderProfileTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderProfileTest.groovy
@@ -176,9 +176,9 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         !pomReader.properties.containsKey('prop1')
         !pomReader.properties.containsKey('prop3')
         pomReader.properties['prop2'] == 'myproperty2'
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-four', 'artifact-four', 'jar', null))
-        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-four', 'artifact-four', 'jar', null, null))
+        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
     }
 
     def "cannot use POM property to set profile ID"() {
@@ -373,7 +373,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -424,7 +424,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -469,7 +469,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -525,8 +525,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyDep1 = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyDep2 = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyDep1 = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyDep2 = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 2
@@ -563,7 +563,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
@@ -606,7 +606,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
@@ -657,7 +657,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -705,8 +705,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -761,7 +761,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -824,8 +824,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 2
@@ -891,8 +891,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -964,7 +964,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey key = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1005,8 +1005,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 2
@@ -1048,7 +1048,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1110,9 +1110,9 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
-        MavenDependencyKey keyArtifactFour = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null)
+        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyArtifactFour = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 3
@@ -1163,7 +1163,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1204,7 +1204,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1246,7 +1246,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1290,7 +1290,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -1336,7 +1336,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -1379,7 +1379,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1429,7 +1429,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1495,8 +1495,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 2
@@ -1563,7 +1563,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1668,7 +1668,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -1834,8 +1834,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
-        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -1891,8 +1891,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         activePomProfiles.size() == 1
         activePomProfiles[0].id == 'profile-1'
         pomReader.properties['prop1'] == 'myproperty1'
-        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
-        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null), 'version-three')
+        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null), 'version-three')
     }
 
     def "activates profile for negated property if system property is provided"() {
@@ -1946,8 +1946,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         activePomProfiles.size() == 1
         activePomProfiles[0].id == 'profile-1'
         pomReader.properties['prop1'] == 'myproperty1'
-        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
-        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null), 'version-three')
+        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null), 'version-three')
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -2002,8 +2002,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
-        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
     }
 
     def "does not activate profile if property value is not declared and system property is set with any value"() {
@@ -2056,8 +2056,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
-        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -2194,10 +2194,10 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         !pomReader.properties.containsKey('prop4')
         pomReader.properties['prop2'] == 'myproperty2'
         pomReader.properties['prop3'] == 'myproperty3'
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-one', 'jar', null))
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-four', 'jar', null))
-        assertResolvedPomDependencyManagement(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null), 'version-three')
-        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null), 'version-three')
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-one', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-four', 'jar', null, null))
+        assertResolvedPomDependencyManagement(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null), 'version-three')
+        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null), 'version-three')
     }
 
     def "parse POM with multiple active profiles activated by absence of system property"() {
@@ -2313,8 +2313,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -151,7 +151,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -182,7 +182,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -225,7 +225,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -268,9 +268,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
-        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test')
-        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client')
+        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
+        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test', null)
+        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client', null)
 
         then:
         pomReader.getDependencies().size() == 3
@@ -300,7 +300,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -333,7 +333,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -377,7 +377,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -421,9 +421,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
-        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test')
-        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client')
+        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
+        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test', null)
+        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client', null)
 
         then:
         pomReader.getDependencyMgt().size() == 3
@@ -636,9 +636,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
-        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null, null)
 
         then:
         pomReader.getDependencies().size() == 3
@@ -681,9 +681,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
-        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 3
@@ -724,8 +724,8 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -782,8 +782,8 @@ class PomReaderTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
 
         then:
         pomReader.getDependencyMgt().size() == 1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKeyTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKeyTest.groovy
@@ -23,29 +23,33 @@ import static org.gradle.util.Matchers.strictlyEquals
 
 class MavenDependencyKeyTest extends Specification {
     @Unroll
-    def "can compare with other instance (#groupId, #artifactId, #type, #classifier)"() {
+    def "can compare with other instance (#groupId, #artifactId, #type, #classifier, #scope)"() {
         expect:
-        MavenDependencyKey key1 = new MavenDependencyKey('group-one', 'artifact-one', 'jar', 'sources')
-        MavenDependencyKey key2 = new MavenDependencyKey(groupId, artifactId, type, classifier)
+        MavenDependencyKey key1 = new MavenDependencyKey('group-one', 'artifact-one', 'jar', 'sources', 'runtime')
+        MavenDependencyKey key2 = new MavenDependencyKey(groupId, artifactId, type, classifier, scope)
         strictlyEquals(key1, key2) == equality
         (key1.hashCode() == key2.hashCode()) == hashCode
         (key1.toString() == key2.toString()) == stringRepresentation
+        key1.equalsWithoutScope(key2) == equalityWithoutScope
+        key2.equalsWithoutScope(key1) == equalityWithoutScope
 
         where:
-        groupId     | artifactId     | type  | classifier | equality | hashCode | stringRepresentation
-        'group-one' | 'artifact-one' | 'jar' | null       | false    | false    | false
-        'group-one' | 'artifact-one' | 'jar' | 'sources'  | true     | true     | true
+        groupId     | artifactId     | type  | classifier | scope     | equality | hashCode | stringRepresentation | equalityWithoutScope
+        'group-one' | 'artifact-one' | 'jar' | null       | null      | false    | false    | false                | false
+        'group-one' | 'artifact-one' | 'jar' | 'sources'  | null      | false    | false    | false                | true
+        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'compile' | false    | false    | false                 | true
+        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'runtime' | true     | true     | true                 | true
     }
 
     @Unroll
-    def "builds String representation (#groupId, #artifactId, #type, #classifier)"() {
+    def "builds String representation (#groupId, #artifactId, #type, #classifier, #scope)"() {
         expect:
-        MavenDependencyKey key = new MavenDependencyKey(groupId, artifactId, type, classifier)
+        MavenDependencyKey key = new MavenDependencyKey(groupId, artifactId, type, classifier, scope)
         key.toString() == stringRepresentation
 
         where:
-        groupId     | artifactId     | type  | classifier | stringRepresentation
-        'group-one' | 'artifact-one' | 'jar' | null       | 'group-one:artifact-one:jar'
-        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'group-one:artifact-one:jar:sources'
+        groupId     | artifactId     | type  | classifier | scope     | stringRepresentation
+        'group-one' | 'artifact-one' | 'jar' | null       | null      | 'group-one:artifact-one:jar'
+        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'runtime' | 'group-one:artifact-one:jar:sources:runtime'
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -48,7 +48,7 @@ import spock.lang.Unroll
 class ModuleMetadataSerializerTest extends Specification {
 
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    private final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    private final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
     private final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
     private final ModuleMetadataSerializer serializer = moduleMetadataSerializer()
     private GradlePomModuleDescriptorParser pomModuleDescriptorParser = pomParser()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -40,7 +40,7 @@ class ModuleMetadataStoreTest extends Specification {
     ModuleComponentIdentifier moduleComponentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "testArtifact", "1.0")
     ModuleMetadataSerializer serializer = Mock()
     ModuleMetadataStore store = new ModuleMetadataStore(pathKeyFileStore, serializer, moduleIdentifierFactory)
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     def "getModuleDescriptorFile returns null for not cached descriptors"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -51,7 +51,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ivyContextManager = Mock(IvyContextManager)
     final AuthenticationSchemeRegistry authenticationSchemeRegistry = new DefaultAuthenticationSchemeRegistry()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
     final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
 
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -45,7 +45,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final ModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
         resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), new ExperimentalFeatures(), mavenMetadataFactory)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -42,7 +42,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final ModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(resolver,
         transportFactory,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -42,7 +42,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     def variantDefinedInGradleMetadata
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -49,7 +49,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     @Shared attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     @Shared schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())
-    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
     @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     @Shared defaultVariant
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadataTest.groovy
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableListMultimap
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.descriptor.Configuration
-import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.ModuleSource
 import spock.lang.Specification
 
@@ -32,7 +31,7 @@ abstract class AbstractModuleComponentResolveMetadataTest extends Specification 
     def configurations = []
     def dependencies = []
 
-    abstract AbstractModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List<DependencyMetadata> dependencies)
+    abstract ModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List dependencies)
 
     ModuleComponentResolveMetadata getMetadata() {
         return createMetadata(id, configurations, dependencies)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.internal.component.external.descriptor.Artifact
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.model.DefaultIvyArtifactName
-import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.Exclude
 import org.gradle.util.TestUtil
 
@@ -36,9 +35,8 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractModuleComponentResolve
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
     @Override
-    AbstractModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List<DependencyMetadata> dependencies) {
-        def metadata = ivyMetadataFactory.create(id, dependencies, configurations, artifacts, excludes)
-        return metadata.asImmutable()
+    ModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List dependencies) {
+        ivyMetadataFactory.create(id, dependencies, configurations, artifacts, excludes).asImmutable()
     }
 
     List<Artifact> artifacts = []

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -17,7 +17,11 @@
 
 package org.gradle.internal.component.external.model
 
+import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -26,6 +30,7 @@ import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.util.TestUtil
+import spock.lang.Unroll
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
@@ -126,6 +131,45 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractModuleComponentResol
         "jar"          | false | true
         "war"          | false | false
         "maven-plugin" | false | true
+    }
+
+    @Unroll
+    def "recognises java library for packaging=#packaging and experimental=#experimental"() {
+        given:
+        def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
+        def experimentalFeatures = Mock(ExperimentalFeatures)
+        experimentalFeatures.enabled >> experimental
+        def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id)
+        metadata.packaging = packaging
+
+        when:
+        def immutableMetadata = metadata.asImmutable()
+        def compileConf = immutableMetadata.getConfiguration("compile")
+        def runtimeConf = immutableMetadata.getConfiguration("runtime")
+        def variantsForGraphTraversal = immutableMetadata.getVariantsForGraphTraversal(TestUtil.attributesFactory(), experimentalFeatures)
+
+        then:
+        compileConf.attributes.empty
+        runtimeConf.attributes.empty
+        isJavaLibrary ? variantsForGraphTraversal.size() == 2 : variantsForGraphTraversal.empty
+
+        if (isJavaLibrary) {
+            assert variantsForGraphTraversal[0].name == "compile"
+            assert variantsForGraphTraversal[0].attributes.getAttribute(stringUsageAttribute) == "java-api"
+            assert variantsForGraphTraversal[1].name == "runtime"
+            assert variantsForGraphTraversal[1].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+        }
+
+        where:
+        packaging      | experimental | isJavaLibrary
+        "pom"          | false        | false
+        "jar"          | false        | false
+        "maven-plugin" | false        | false
+        "war"          | false        | false
+        "pom"          | true         | true
+        "jar"          | true         | true
+        "maven-plugin" | true         | true
+        "war"          | true         | false
     }
 
     def dependency(String org, String module, String version, String scope) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.internal.hash.HashValue
 import org.gradle.util.TestUtil
 
 class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModuleComponentResolveMetadataTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     @Override
     AbstractMutableModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List<DependencyMetadata> dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.TestUtil
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRulesTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     @Override
     boolean addAllDependenciesAsConstraints() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -46,6 +46,10 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         GradleMetadataResolveRunner.isExperimentalResolveBehaviorEnabled()
     }
 
+    boolean usesJavaLibraryVariants() {
+        GradleMetadataResolveRunner.isGradleMetadataEnabled() || (useMaven() && isExperimentalEnabled())
+    }
+
     String getTestConfiguration() { 'conf' }
 
     String getRootProjectName() { 'test' }
@@ -119,7 +123,7 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
 
     def setup() {
         resolve = new ResolveTestFixture(buildFile, testConfiguration)
-        resolve.expectDefaultConfiguration(GradleMetadataResolveRunner.isGradleMetadataEnabled() ? "runtime" : "default")
+        resolve.expectDefaultConfiguration(usesJavaLibraryVariants() ? "runtime" : "default")
         settingsFile << "rootProject.name = '$rootProjectName'"
         if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
             ExperimentalFeaturesFixture.enable(settingsFile)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -146,7 +146,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     public VersionNumber getArtifactCacheLayoutVersion() {
         if (isSameOrNewer("4.5-rc-1")) {
-            return VersionNumber.parse("2.45");
+            return VersionNumber.parse("2.48");
         } else if (isSameOrNewer("4.4-rc-1")) {
             return VersionNumber.parse("2.36");
         } else if (isSameOrNewer("4.3-rc-1")) {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -85,7 +85,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
             }
             withoutModuleMetadata {
-                expectFiles "bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
             }
         }
 
@@ -536,9 +536,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
             withModuleMetadata {
                 expectFiles "bar-1.0.jar"
             }
-            // Maven POM compile scope contains 'implementation' dependencies (and constraints)
             withoutModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar"
+                expectFiles "bar-1.0.jar"
             }
         }
         resolveRuntimeArtifacts(javaLibrary) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+
+class JavaLibraryConsumptionIntegrationTest extends AbstractIntegrationSpec {
+
+    def "runtime dependencies from maven modules do not leak into compile classpath"() {
+        given:
+        ExperimentalFeaturesFixture.enable(settingsFile)
+        buildFile << """
+            apply plugin: 'java-library'
+            ${jcenterRepository()}
+            dependencies {
+                implementation 'io.reactivex:rxnetty:0.4.4'
+            }
+            task checkForRxJavaDependency {
+                assert configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.find { it.requested.displayName == 'io.reactivex:rxjava:1.0.1' }
+                assert !configurations.compileClasspath.incoming.resolutionResult.allDependencies.find { it.requested.displayName == 'io.reactivex:rxjava:1.0.1' }
+            }
+        """
+
+        when:
+        //compilation should fail, as `rx.observers.Observable` is part of RxJava 1.x, which is a runtime-only dependency.
+        file('src/main/java/App.java') << 'public class App { public void run() { rx.observers.Observers.empty(); } }'
+
+        then:
+        fails 'checkForRxJavaDependency', 'build'
+        failure.assertHasCause('Compilation failed; see the compiler error output for details.')
+        failure.error.contains('error: package rx.observers does not exist')
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -111,6 +111,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
             module("org.springframework:spring-test:4.3.12.RELEASE")
         }
 
+        resolve.expectDefaultConfiguration('compile')
         resolve.expectGraph {
             root(':', ':springbootproject:') {
                 if (directBomDependency) {


### PR DESCRIPTION
See: #3360

Each commit should be considered separately during review. 5 of the 7 commits are about tests or injecting additional services (and adjusting tests for that). The actual production code changes are:
- 77c8c358ff1ebf5d49eedde0a916cce009ada422 - derive the Java library variants
- aec15561550b39c5175bebc9159774366f61caf7 - allow different entries for different scopes in `<dependencyManagemet>`; this became necessary as we could now, for example, define different versions for the same dependency in `compile` and `runtime`.