### PR TITLE
Introduce BuildOperationNotificationsFixture to mimic “delayed observation” behaviour of build scan plugin

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
@@ -24,6 +25,7 @@ import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegrationSpec {
 
     final buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+    final BuildOperationNotificationsFixture operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
     def "requested and filtered tasks are exposed"() {
         settingsFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -25,7 +25,9 @@ import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegrationSpec {
 
     final buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
-    final BuildOperationNotificationsFixture operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
+
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    final operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
     def "requested and filtered tasks are exposed"() {
         settingsFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -26,7 +26,8 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
 
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
-    BuildOperationNotificationsFixture operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    def operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
     def "resolved configurations are exposed via build operation"() {
         setup:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.internal.operations.notify.BuildOperationFinishedNotification
+import org.gradle.internal.operations.notify.BuildOperationNotificationListener2
+import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar
+import org.gradle.internal.operations.notify.BuildOperationProgressNotification
+import org.gradle.internal.operations.notify.BuildOperationStartedNotification
+import org.gradle.test.fixtures.file.TestDirectoryProvider
+
+class BuildOperationNotificationsFixture {
+
+    private final File initScript
+
+    BuildOperationNotificationsFixture(GradleExecuter executer, TestDirectoryProvider projectDir) {
+        this.initScript = projectDir.testDirectory.file("injectBuildOpFixture.gradle")
+        this.initScript.text = injectNotificationListenerBuildLogic()
+        executer.beforeExecute {
+            it.usingInitScript(this.initScript)
+        }
+        executer.afterExecute {
+            it.reset()
+        }
+    }
+
+    String injectNotificationListenerBuildLogic() {
+        return """
+        rootProject {
+            if(gradle.getParent() == null) {
+                def listener = new BuildOperationNotificationsEvaluationListener();
+                def registrar = project.services.get($BuildOperationNotificationListenerRegistrar.name)
+                registrar.register(listener)
+            }
+        } 
+        
+        class BuildOperationNotificationsEvaluationListener implements $BuildOperationNotificationListener2.name {
+            private final static Logger LOGGER = Logging.getLogger(BuildOperationNotificationsEvaluationListener)
+            
+            @Override
+            void started($BuildOperationStartedNotification.name notification) {
+                triggerGetters(notification.notificationOperationDetails)
+            }
+    
+            @Override
+            void progress($BuildOperationProgressNotification.name notification) {
+                triggerGetters(notification.notificationOperationProgressDetails)
+            }
+    
+            @Override
+            void finished($BuildOperationFinishedNotification.name notification) {
+                triggerGetters(notification.notificationOperationResult)
+            }
+            
+            
+            void triggerGetters(Object object) {
+                def clazz = object.getClass()
+    
+                Class<?>[] interfaces = clazz.getInterfaces()
+                def found = false
+                for (Class<?> i : interfaces) {
+                    def interfaceName = i.name
+                    if (interfaceName.endsWith('Details') || interfaceName.endsWith('Result')) {
+                        found = true
+                        LOGGER.info "   Checking \$interfaceName"   
+                        def methods = i.getMethods()
+                        for (java.lang.reflect.Method method : methods) {
+                            LOGGER.info "       \${method.name} - \${method.invoke(object)}"
+                        }
+                    }
+    
+                }
+                if(!found) {
+                    throw new GradleException("Havn't found BuildOperationNotification Details/Result interface to inspect")
+                }
+                
+            }
+        }
+        """
+    }
+
+    static class BuildOperationNotificationsEvaluationListener implements BuildOperationNotificationListener2 {
+
+        @Override
+        void started(BuildOperationStartedNotification notification) {
+            triggerGetters(notification.notificationOperationDetails)
+            notification.notificationOperationDetails.
+                println "BuildOperationNotificationsEvaluationListener.started"
+        }
+
+        @Override
+        void progress(BuildOperationProgressNotification notification) {
+            println "BuildOperationNotificationsEvaluationListener.progress"
+        }
+
+        @Override
+        void finished(BuildOperationFinishedNotification notification) {
+            println "BuildOperationNotificationsEvaluationListener.finished"
+        }
+
+        void triggerGetters(Object object) {
+            def clazz = object.getClass()
+
+            Class<?>[] interfaces = clazz.getInterfaces()
+            for (Class<?> i : interfaces) {
+                def interfaceName = i.name
+                if (interfaceName.endsWith('Details') || interfaceName.endsWith('Result')) {
+                    def methods = i.getMethods()
+                    for (java.lang.reflect.Method method : methods) {
+                        println method.name
+                    }
+                }
+
+            }
+        }
+    }
+
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
@@ -107,7 +107,7 @@ class BuildOperationNotificationsFixture {
                 void invokeMethods(Object object, Class<?> clazz) {
                     for (def method : clazz.methods) {
                         try {
-                            if (method.parameterTypes.empty) {
+                            if (method.parameterTypes.size() == 0) {
                                 method.invoke(object)
                             }
                         } catch (any) {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixtureTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+import org.gradle.internal.operations.notify.BuildOperationFinishedNotification
+import org.gradle.internal.operations.notify.BuildOperationProgressNotification
+import org.gradle.internal.operations.notify.BuildOperationStartedNotification
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BuildOperationNotificationsFixtureTest extends Specification {
+
+
+    @Unroll
+    def "listener evaluates build op #notificationMethod notifications (#testedIf.simpleName)"() {
+        given:
+        def logger = Mock(Logger)
+        def listener = listener(logger)
+
+        when:
+        listener."$notificationMethod"(notificationEvent)
+
+        then:
+        expectedOutputs.each { expectedOutput ->
+            1 * logger.info(_) >> {
+                assert it[0].trim() == expectedOutput
+            }
+        }
+        _ * logger.info(_)
+
+        where:
+        notificationMethod | testedIf       | notificationEvent                    | expectedOutputs
+        'started'          | SimpleDetails  | startedNotification(SimpleDetails)   | ["Checking $SimpleDetails.name", "simpleDetailsMethod() -> simpleDetailsValue"]
+        'started'          | EmptyDetails   | startedNotification(EmptyDetails)    | ["Checking $EmptyDetails.name"]
+        'progress'         | SimpleProgress | progressNotification(SimpleProgress) | ["Checking $SimpleProgress.name", "output() -> output"]
+        'finished'         | SimpleResult   | finishedNotification(SimpleResult)   | ["Checking $SimpleResult.name", 'simpleResultMethod() -> simpleResultValue']
+        'finished'         | NestedResult   | finishedNotification(NestedResult)   | ["Checking $NestedResult.name", "getNested() -> Nested"]
+    }
+
+    @Unroll
+    def "listener throws GradleException when no valid object has been found to d"() {
+        given:
+        def listener = listener(Mock(Logger))
+
+        when:
+        listener."$notificationMethod"(notificationEvent)
+
+        then:
+        def e = thrown(GradleException)
+
+        e.message == expectedMessage
+
+        where:
+        notificationMethod | notificationEvent                 | expectedMessage
+        'started'          | startedNotification(SimpleResult) | "No interface with postfix 'Details' found."
+        'progress'         | progressNotification()            | "No interface implemented by class java.lang.Object."
+        'finished'         | finishedNotification(Nested)      | "No interface with postfix 'Result' found."
+
+    }
+
+    def listener(Logger logger) {
+        GroovyClassLoader groovyClassLoader = new GroovyClassLoader(BuildOperationNotificationsFixture.getClassLoader())
+        Class theParsedClass = groovyClassLoader.parseClass(BuildOperationNotificationsFixture.EVALUATION_LISTENER_SOURCE)
+        return theParsedClass.newInstance(logger)
+    }
+
+    def progressNotification(Class<SimpleProgress> progressClazz = null) {
+        BuildOperationProgressNotification buildOperationProgressNotification = Mock()
+        1 * buildOperationProgressNotification.notificationOperationProgressDetails >> (progressClazz == null ? new Object()
+            : new Object().withTraits(progressClazz))
+        buildOperationProgressNotification
+    }
+
+    def finishedNotification(Class<SimpleResult> resultClazz) {
+        BuildOperationFinishedNotification buildOperationFinishedNotification = Mock()
+        1 * buildOperationFinishedNotification.getNotificationOperationResult() >> new Object().withTraits(resultClazz)
+        buildOperationFinishedNotification
+    }
+
+    BuildOperationStartedNotification startedNotification(Class<?> detailsClazz) {
+        BuildOperationStartedNotification buildOperationStartedNotification = Mock()
+        1 * buildOperationStartedNotification.getNotificationOperationDetails() >> new Object().withTraits(detailsClazz)
+        buildOperationStartedNotification
+    }
+
+    static trait EmptyDetails {}
+
+    static trait SimpleDetails {
+        String simpleDetailsMethod() { "simpleDetailsValue" }
+    }
+
+    static trait SimpleProgress {
+        String output() { "output" }
+    }
+
+    static trait SimpleResult {
+        String simpleResultMethod() { "simpleResultValue" }
+    }
+
+    static trait NestedResult {
+        Nested getNested() { new Object().withTraits(Nested) }
+    }
+
+    static trait Nested {
+        String getNestedValue() { "nestedValue" }
+
+        String toString() { "Nested" }
+    }
+
+}


### PR DESCRIPTION
This PullRequest introduces a new fixture BuildOperationNotificationsFixture that registers a  `BuildOperationNotificationListener2` to mimic how the build scan plugin consumes build operation. 

With `BuildOperationsFixture` build operations are traced and consumed directly when they are produced without e.g. mimicing the delayed consumption of recorded build operations. Solely relying on this fixture caused issues in the past where problems in consuming Details/Results from recorded build operations didn't work (e.g. in ResolveConfigurationDependenciesBuildOperationIntegrationTest when dependency information is cached to disk)
 
On purpose I have put the whole listener code into the init script and not injecting it via initscript classpath to avoid altering initscript handling/testing.
 
All `Details`/`Result`/`ProgressDetails` methods are invoked via reflection to verify the data exposed by typed build operations can be exposed.

For now we only apply this fixture on the mentioned `ResolveConfigurationDependenciesBuildOperationIntegrationTest` but more usages will follow in the future 

CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=breskeby%2Fbuildop-notification-fixture