### PR TITLE
Allow dependency resolve rules and substitution rules to provide descriptive reason for selection

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentModuleMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentModuleMetadataDetails.java
@@ -18,6 +18,8 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
+
 /**
  * Contains and allows configuring component module metadata information.
  * For information and examples please see {@link org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler}
@@ -38,4 +40,20 @@ public interface ComponentModuleMetadataDetails extends ComponentModuleMetadata 
      * @param moduleNotation a String like 'com.google.guava:guava', an instance of {@link org.gradle.api.artifacts.ModuleVersionIdentifier}, null is not permitted
      */
     void replacedBy(Object moduleNotation);
+
+    /**
+     * Configures a replacement module for this module and provides an explanation for the replacement.
+     *
+     * A real world example: 'com.google.collections:google-collections' is replaced by 'com.google.guava:guava'.
+     *
+     * Subsequent invocations of this method replace the previous 'replacedBy' value.
+     *
+     * For information and examples please see {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler}.
+     *
+     * @param moduleNotation a String like 'com.google.guava:guava', an instance of {@link org.gradle.api.artifacts.ModuleVersionIdentifier}, null is not permitted
+     * @param reason the reason for the replacement, for diagnostics
+     *
+     * @since 4.5
+     */
+    void replacedBy(Object moduleNotation, @Nullable String reason);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyResolveDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyResolveDetails.java
@@ -70,4 +70,16 @@ public interface DependencyResolveDetails {
      * Never returns null. Target module is updated when methods like {@link #useVersion(String)} are used.
      */
     ModuleVersionSelector getTarget();
+
+    /**
+     * Sets a human readable description for the reason the component is selected. The description will only
+     * be used if the rule is actually selecting a target, either using {@link #useVersion(String)} or {@link #useTarget(Object)}
+     *
+     * @param description a description of the selection reason
+     *
+     * @return this details object
+     *
+     * @since 4.5
+     */
+    DependencyResolveDetails because(String description);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitution.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitution.java
@@ -51,4 +51,23 @@ public interface DependencySubstitution {
      * @param notation the notation that gets parsed into an instance of {@link ComponentSelector}.
      */
     void useTarget(Object notation);
+
+    /**
+     * This method can be used to replace a dependency before it is resolved,
+     * e.g. change group, name or version (or all three of them), or replace it
+     * with a project dependency and provides a human readable reason for diagnostics.
+     *
+     * Accepted notations are:
+     * <ul>
+     *     <li>Strings encoding group:module:version, like 'org.gradle:gradle-core:2.4'</li>
+     *     <li>Maps like [group: 'org.gradle', name: 'gradle-core', version: '2.4']</li>
+     *     <li>Project instances like <code>project(":api")</code></li>
+     *     <li>Any instance of <code>ModuleComponentSelector</code> or <code>ProjectComponentSelector</code></li>
+     * </ul>
+     *
+     * @param notation the notation that gets parsed into an instance of {@link ComponentSelector}.
+     *
+     * @since 4.5
+     */
+    void useTarget(Object notation, String reason);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
@@ -95,6 +95,17 @@ public interface DependencySubstitutions {
      */
     interface Substitution {
         /**
+         * Specify a reason for the substition. This is optional
+         * @param reason the reason for the selection
+         *
+         * @since 4.5
+         *
+         * @return the substitution
+         */
+        @Incubating
+        Substitution because(String reason);
+
+        /**
          * Specify the target of the substitution.
          */
         void with(ComponentSelector notation);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts.result;
 
 import org.gradle.api.Incubating;
+import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -26,6 +27,7 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  */
 @UsedByScanPlugin
 @Incubating
+@HasInternalProtocol
 public interface ComponentSelectionReason {
 
     /**

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyResolveRulesIntegrationTest.groovy
@@ -863,6 +863,56 @@ conf
         run("check")
     }
 
+    def "custom selection reasons are available in resolution result"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "foo", "2.0").publish()
+        mavenRepo.module("org", "bar", "1.0").publish()
+        mavenRepo.module("org.test", "bar", "2.0").publish()
+        mavenRepo.module("org", "baz", "1.0").publish()
+
+        file("build.gradle") << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf {
+                    resolutionStrategy.eachDependency {
+                        switch (it.requested.name) {
+                           case 'foo':
+                              it.because('because I am in control').useVersion('2.0')
+                              break
+                           case 'bar':
+                              it.because('why not?').useTarget('org.test:bar:2.0')
+                              break
+                           default:
+                              useVersion(it.requested.version)
+                        }
+                    }
+                }
+            }
+            dependencies {
+                conf 'org:foo:1.0'
+                conf 'org:bar:1.0'
+                conf 'org:baz:1.0'
+            }
+            task check {
+                doLast {
+                    def modules = configurations.conf.incoming.resolutionResult.allComponents.findAll { it.id instanceof ModuleComponentIdentifier } as List
+                    assert modules.find { it.id.module == 'foo' }.selectionReason.description == 'because I am in control'
+                    assert modules.find { it.id.module == 'bar' }.selectionReason.description == 'why not?'
+                    assert modules.find { it.id.module == 'baz' }.selectionReason.description == 'selected by rule'
+                }
+            }
+        """
+
+        when:
+        run "check"
+
+        then:
+        noExceptionThrown()
+    }
+
     String getCommon() {
         """configurations { conf }
         repositories {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleReplacementsData.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleReplacementsData.java
@@ -24,7 +24,7 @@ public interface ModuleReplacementsData {
     ModuleReplacementsData NO_OP = new ModuleReplacementsData() {
         @Nullable
         @Override
-        public ModuleIdentifier getReplacementFor(ModuleIdentifier sourceModule) {
+        public Replacement getReplacementFor(ModuleIdentifier sourceModule) {
             return null;
         }
 
@@ -34,7 +34,25 @@ public interface ModuleReplacementsData {
         }
     };
 
-    @Nullable ModuleIdentifier getReplacementFor(ModuleIdentifier sourceModule);
+    @Nullable Replacement getReplacementFor(ModuleIdentifier sourceModule);
 
     boolean participatesInReplacements(ModuleIdentifier moduleId);
+
+    class Replacement {
+        private final ModuleIdentifier target;
+        private final String reason;
+
+        Replacement(ModuleIdentifier target, String reason) {
+            this.target = target;
+            this.reason = reason;
+        }
+
+        public ModuleIdentifier getTarget() {
+            return target;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
@@ -47,7 +47,7 @@ public class DefaultDependencyResolveDetails implements DependencyResolveDetails
     private ComponentSelectionReasonInternal selectionReason() {
         ComponentSelectionReasonInternal reason = VersionSelectionReasons.SELECTED_BY_RULE;
         if (customDescription != null) {
-            reason = reason.withDescription(customDescription);
+            reason = reason.withReason(customDescription);
         }
         return reason;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
@@ -44,6 +44,11 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
     }
 
     @Override
+    public void useTarget(Object notation, String reason) {
+        useTarget(notation, VersionSelectionReasons.SELECTED_BY_RULE.withReason(reason));
+    }
+
+    @Override
     public void useTarget(Object notation, ComponentSelectionReason selectionReason) {
         this.target = ComponentSelectorParsers.parser().parseNotation(notation);
         this.selectionReason = selectionReason;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
@@ -18,14 +18,17 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.UncheckedException;
 
 import javax.annotation.Nullable;
+import java.util.Set;
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.PotentialConflictFactory.potentialConflict;
 
@@ -47,7 +50,8 @@ public class DefaultConflictHandler implements ConflictHandler {
      */
     @Nullable
     public PotentialConflict registerModule(CandidateModule newModule) {
-        ModuleIdentifier replacedBy = moduleReplacements.getReplacementFor(newModule.getId());
+        ModuleReplacementsData.Replacement replacement = moduleReplacements.getReplacementFor(newModule.getId());
+        ModuleIdentifier replacedBy = replacement == null ? null : replacement.getTarget();
         return potentialConflict(conflicts.newElement(newModule.getId(), newModule.getVersions(), replacedBy));
     }
 
@@ -69,9 +73,24 @@ public class DefaultConflictHandler implements ConflictHandler {
         if (details.hasFailure()) {
             throw UncheckedException.throwAsUncheckedException(details.getFailure());
         }
-        ConflictResolutionResult result = new DefaultConflictResolutionResult(conflict.participants, details.getSelected(), conflict.candidates);
+        ComponentResolutionState selected = details.getSelected();
+        ConflictResolutionResult result = new DefaultConflictResolutionResult(conflict.participants, selected, conflict.candidates);
         resolutionAction.execute(result);
-        LOGGER.debug("Selected {} from conflicting modules {}.", details.getSelected(), conflict.candidates);
+        maybeSetReason(conflict.participants, selected);
+        LOGGER.debug("Selected {} from conflicting modules {}.", selected, conflict.candidates);
+    }
+
+    private void maybeSetReason(Set<ModuleIdentifier> partifipants, ComponentResolutionState selected) {
+        for (ModuleIdentifier identifier : partifipants) {
+            ModuleReplacementsData.Replacement replacement = moduleReplacements.getReplacementFor(identifier);
+            if (replacement != null) {
+                String reason = replacement.getReason();
+                if (reason != null) {
+                    ComponentSelectionReason selectionReason = selected.getSelectionReason();
+                    selected.setSelectionReason(((ComponentSelectionReasonInternal) selectionReason).withReason(reason));
+                }
+            }
+        }
     }
 
     public void registerResolver(ModuleConflictResolver conflictResolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
+
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
+
+public interface ComponentSelectionReasonInternal extends ComponentSelectionReason {
+    ComponentSelectionReasonInternal withDescription(String description);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonInternal.java
@@ -18,5 +18,5 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 public interface ComponentSelectionReasonInternal extends ComponentSelectionReason {
-    ComponentSelectionReasonInternal withDescription(String description);
+    ComponentSelectionReasonInternal withReason(String description);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -105,12 +105,12 @@ public class VersionSelectionReasons {
                 return false;
             }
             DefaultComponentSelectionReason that = (DefaultComponentSelectionReason) o;
-            return forced == that.forced &&
-                conflictResolution == that.conflictResolution &&
-                selectedByRule == that.selectedByRule &&
-                expected == that.expected &&
-                compositeParticipant == that.compositeParticipant &&
-                Objects.equal(description, that.description);
+            return forced == that.forced
+                && conflictResolution == that.conflictResolution
+                && selectedByRule == that.selectedByRule
+                && expected == that.expected
+                && compositeParticipant == that.compositeParticipant
+                && Objects.equal(description, that.description);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -19,13 +19,13 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 public class VersionSelectionReasons {
-    public static final ComponentSelectionReason REQUESTED = new DefaultComponentSelectionReason(false, false, false, true, false, "requested");
-    public static final ComponentSelectionReason ROOT = new DefaultComponentSelectionReason(false, false, false, true, false, "root");
-    public static final ComponentSelectionReason FORCED = new DefaultComponentSelectionReason(true, false, false, false, false, "forced");
-    public static final ComponentSelectionReason CONFLICT_RESOLUTION = new DefaultComponentSelectionReason(false, true, false, false, false, "conflict resolution");
-    public static final ComponentSelectionReason SELECTED_BY_RULE = new DefaultComponentSelectionReason(false, false, true, false, false, "selected by rule");
-    public static final ComponentSelectionReason CONFLICT_RESOLUTION_BY_RULE = new DefaultComponentSelectionReason(false, true, true, false, false, "selected by rule and conflict resolution");
-    public static final ComponentSelectionReason COMPOSITE_BUILD = new DefaultComponentSelectionReason(false, false, false, false, true, "composite build substitution");
+    public static final ComponentSelectionReasonInternal REQUESTED = new DefaultComponentSelectionReason(false, false, false, true, false, "requested");
+    public static final ComponentSelectionReasonInternal ROOT = new DefaultComponentSelectionReason(false, false, false, true, false, "root");
+    public static final ComponentSelectionReasonInternal FORCED = new DefaultComponentSelectionReason(true, false, false, false, false, "forced");
+    public static final ComponentSelectionReasonInternal CONFLICT_RESOLUTION = new DefaultComponentSelectionReason(false, true, false, false, false, "conflict resolution");
+    public static final ComponentSelectionReasonInternal SELECTED_BY_RULE = new DefaultComponentSelectionReason(false, false, true, false, false, "selected by rule");
+    public static final ComponentSelectionReasonInternal CONFLICT_RESOLUTION_BY_RULE = new DefaultComponentSelectionReason(false, true, true, false, false, "selected by rule and conflict resolution");
+    public static final ComponentSelectionReasonInternal COMPOSITE_BUILD = new DefaultComponentSelectionReason(false, false, false, false, true, "composite build substitution");
 
     public static ComponentSelectionReason withConflictResolution(ComponentSelectionReason reason) {
         if (reason.isConflictResolution()) {
@@ -42,7 +42,7 @@ public class VersionSelectionReasons {
         throw new IllegalArgumentException("Cannot create conflict resolution selection reason for input: " + reason);
     }
 
-    private static class DefaultComponentSelectionReason implements ComponentSelectionReason {
+    private static class DefaultComponentSelectionReason implements ComponentSelectionReasonInternal {
 
         private final boolean forced;
         private final boolean conflictResolution;
@@ -88,6 +88,11 @@ public class VersionSelectionReasons {
 
         public String toString() {
             return description;
+        }
+
+        @Override
+        public ComponentSelectionReasonInternal withDescription(String description) {
+            return new DefaultComponentSelectionReason(forced, conflictResolution, selectedByRule, expected, compositeParticipant, description);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 public class VersionSelectionReasons {
@@ -91,8 +92,30 @@ public class VersionSelectionReasons {
         }
 
         @Override
-        public ComponentSelectionReasonInternal withDescription(String description) {
+        public ComponentSelectionReasonInternal withReason(String description) {
             return new DefaultComponentSelectionReason(forced, conflictResolution, selectedByRule, expected, compositeParticipant, description);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DefaultComponentSelectionReason that = (DefaultComponentSelectionReason) o;
+            return forced == that.forced &&
+                conflictResolution == that.conflictResolution &&
+                selectedByRule == that.selectedByRule &&
+                expected == that.expected &&
+                compositeParticipant == that.compositeParticipant &&
+                Objects.equal(description, that.description);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(forced, conflictResolution, selectedByRule, expected, compositeParticipant, description);
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentModuleMetadataContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentModuleMetadataContainerTest.groovy
@@ -35,11 +35,12 @@ class ComponentModuleMetadataContainerTest extends Specification {
 
     def "keeps track of replacements"() {
         replacements.module("com.google.collections:google-collections").replacedBy("com.google.guava:guava");
-        replacements.module(newId("foo", "bar")).replacedBy(newId("foo", "xxx"));
+        replacements.module(newId("foo", "bar")).replacedBy(newId("foo", "xxx"), 'custom');
 
         expect:
-        replacements.getReplacementFor(newId("com.google.collections", "google-collections")) == newId("com.google.guava", "guava")
-        replacements.getReplacementFor(newId("foo", "bar")) == newId("foo", "xxx")
+        replacements.getReplacementFor(newId("com.google.collections", "google-collections")).target == newId("com.google.guava", "guava")
+        replacements.getReplacementFor(newId("foo", "bar")).target == newId("foo", "xxx")
+        replacements.getReplacementFor(newId("foo", "bar")).reason == 'custom'
 
         !replacements.getReplacementFor(newId("com.google.guava", "guava"))
         !replacements.getReplacementFor(newId("bar", "foo"))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -140,6 +140,66 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.target.toString() == 'com:bar:5.0'
     }
 
+    def "can provide a custom selection reason with useTarget"() {
+        def details = newDependencyResolveDetails("org", "foo", "1.0")
+
+        when:
+        details.because("forcefully upgrade dependency")
+        details.useTarget("org:bar:2.0")
+
+        then:
+        details.target.toString() == 'org:bar:2.0'
+        details.updated
+        details.selectionReason.selectedByRule
+        details.selectionReason.description == "forcefully upgrade dependency"
+
+    }
+
+    def "can provide a custom selection reason with useVersion"() {
+        def details = newDependencyResolveDetails("org", "foo", "1.0")
+
+        when:
+        details.because("forcefully upgrade dependency")
+        details.useVersion("2.0")
+
+        then:
+        details.target.toString() == 'org:foo:2.0'
+        details.updated
+        details.selectionReason.selectedByRule
+        details.selectionReason.description == "forcefully upgrade dependency"
+
+    }
+
+    def "can provide a custom selection reason with useTarget before calling withDescription"() {
+        def details = newDependencyResolveDetails("org", "foo", "1.0")
+
+        when:
+        details.useTarget("org:bar:2.0")
+        details.because("forcefully upgrade dependency")
+
+        then:
+        details.target.toString() == 'org:bar:2.0'
+        details.updated
+        details.selectionReason.selectedByRule
+        details.selectionReason.description == "forcefully upgrade dependency"
+
+    }
+
+    def "can provide a custom selection reason with useVersion before calling withDescription"() {
+        def details = newDependencyResolveDetails("org", "foo", "1.0")
+
+        when:
+        details.useVersion("2.0")
+        details.because("forcefully upgrade dependency")
+
+        then:
+        details.target.toString() == 'org:foo:2.0'
+        details.updated
+        details.selectionReason.selectedByRule
+        details.selectionReason.description == "forcefully upgrade dependency"
+
+    }
+
     private static def newDependencyResolveDetails(String group, String name, String version) {
         return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version)), newVersionSelector(group, name, version))
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -71,6 +71,17 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE
     }
 
+    def "can specify custom selection reason"() {
+        when:
+        details.useTarget("org:bar:2.0", 'with custom reason')
+
+        then:
+        details.target instanceof ModuleComponentSelector
+        details.target.toString() == 'org:bar:2.0'
+        details.updated
+        details.selectionReason == VersionSelectionReasons.SELECTED_BY_RULE.withReason('with custom reason')
+    }
+
     def "can specify target project"() {
         def project = Mock(ProjectInternal)
         def services = new DefaultServiceRegistry()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -146,7 +146,7 @@ class DependencyGraphBuilderTest extends Specification {
         doesNotResolve a, c
         traverses b, d
 
-        moduleReplacements.getReplacementFor(new DefaultModuleIdentifier("group", "a")) >> new DefaultModuleIdentifier("group", "b")
+        moduleReplacements.getReplacementFor(DefaultModuleIdentifier.newId("group", "a")) >> new ModuleReplacementsData.Replacement(DefaultModuleIdentifier.newId("group", "b"), null)
         1 * conflictResolver.select(!null) >> {  args ->
             def details = args[0]
             Collection<ComponentResolutionState> candidates = details.candidates

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
@@ -61,7 +61,7 @@ class DefaultConflictHandlerTest extends Specification {
         def a = candidate("org", "a", "1", "2")
         def b = candidate("org", "b", "1")
 
-        replacements.getReplacementFor(DefaultModuleIdentifier.newId("org", "a")) >> DefaultModuleIdentifier.newId("org", "b")
+        replacements.getReplacementFor(DefaultModuleIdentifier.newId("org", "a")) >> new ModuleReplacementsData.Replacement(DefaultModuleIdentifier.newId("org", "b"), null)
 
         when:
         def aX = handler.registerModule(a)

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -440,6 +440,51 @@ org:leaf:2.0 -> org:new-leaf:77
 """
     }
 
+    def "shows substituted modules with a custom description"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "foo", "2.0").publish()
+        mavenRepo.module("org", "bar", "1.0").publish()
+        mavenRepo.module("org", "bar", "2.0").publish()
+
+        file("build.gradle") << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf {
+                    resolutionStrategy.dependencySubstitution {
+                        substitute module('org:foo:1.0') because('I want to') with module('org:foo:2.0')
+                        substitute module('org:bar:1.0') because('I am not sure I want to explain') with module('org:bar:2.0')
+                    }
+                }
+            }
+            dependencies {
+                conf 'org:foo:1.0', 'org:bar:1.0'
+            }
+            task insight(type: DependencyInsightReportTask) {
+                configuration = configurations.conf
+                setDependencySpec { true }
+            }
+        """
+
+        when:
+        run "insight"
+
+        then:
+        output.contains """
+org:bar:2.0 (I am not sure I want to explain)
+
+org:bar:1.0 -> 2.0
+\\--- conf
+
+org:foo:2.0 (I want to)
+
+org:foo:1.0 -> 2.0
+\\--- conf
+"""
+    }
+
     def "shows version resolved from dynamic selectors"() {
         given:
         ivyRepo.module("org", "leaf", "1.6").publish()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -336,6 +336,65 @@ org:leaf:2.0 -> 1.0
 """
     }
 
+    def "shows custom selection reason using eachDependency"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "foo", "2.0").publish()
+        mavenRepo.module("org", "bar", "1.0").publish()
+        mavenRepo.module("org.test", "bar", "2.0").publish()
+        mavenRepo.module("org", "baz", "1.0").publish()
+
+        file("build.gradle") << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf {
+                    resolutionStrategy.eachDependency {
+                        switch (it.requested.name) {
+                           case 'foo':
+                              it.because('because I am in control').useVersion('2.0')
+                              break
+                           case 'bar':
+                              it.because('why not?').useTarget('org.test:bar:2.0')
+                              break
+                           default:
+                              useVersion(it.requested.version)
+                        }
+                    }
+                }
+            }
+            dependencies {
+                conf 'org:foo:1.0'
+                conf 'org:bar:1.0'
+                conf 'org:baz:1.0'
+            }
+            task insight(type: DependencyInsightReportTask) {
+                configuration = configurations.conf
+                setDependencySpec { true }
+            }
+        """
+
+        when:
+        run "insight"
+
+        then:
+        output.contains """
+org.test:bar:2.0 (why not?)
+
+org:bar:1.0 -> org.test:bar:2.0
+\\--- conf
+
+org:baz:1.0 (selected by rule)
+\\--- conf
+
+org:foo:2.0 (because I am in control)
+
+org:foo:1.0 -> 2.0
+\\--- conf
+"""
+    }
+
     def "shows substituted modules"() {
         given:
         mavenRepo.module("org", "new-leaf", "77").publish()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -395,6 +395,45 @@ org:foo:1.0 -> 2.0
 """
     }
 
+
+    def "shows custom selection reason with dependency substitution"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "bar", "1.0").publish()
+
+        file("build.gradle") << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+               conf {
+                  resolutionStrategy.dependencySubstitution {
+                     all {
+                        it.useTarget('org:bar:1.0', 'foo superceded by bar')
+                     }
+                  }
+               }
+            }
+            dependencies {
+                conf 'org:foo:1.0'
+            }
+            task insight(type: DependencyInsightReportTask) {
+                configuration = configurations.conf
+                setDependencySpec { true }
+            }
+        """
+
+        when:
+        run "insight"
+
+        then:
+        output.contains """org:bar:1.0 (foo superceded by bar)
+
+org:foo:1.0 -> org:bar:1.0
+\\--- conf
+"""
+    }
+
     def "shows substituted modules"() {
         given:
         mavenRepo.module("org", "new-leaf", "77").publish()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.classloader.ClasspathUtil
@@ -642,17 +643,26 @@ class GenerateGraphTask extends DefaultTask {
 
     def formatReason(ComponentSelectionReason reason) {
         def reasons = []
-        if (reason.conflictResolution) {
-            reasons << "conflict"
-        }
-        if (reason.forced) {
-            reasons << "forced"
-        }
-        if (reason.selectedByRule) {
-            reasons << "selectedByRule"
-        }
-        if (reason.compositeSubstitution) {
-            reasons << "compositeSubstitution"
+        if (reason in [VersionSelectionReasons.COMPOSITE_BUILD,
+                       VersionSelectionReasons.CONFLICT_RESOLUTION,
+                       VersionSelectionReasons.FORCED,
+                       VersionSelectionReasons.REQUESTED,
+                       VersionSelectionReasons.ROOT,
+                       VersionSelectionReasons.CONFLICT_RESOLUTION_BY_RULE,
+                       VersionSelectionReasons.SELECTED_BY_RULE
+        ]) {
+            if (reason.conflictResolution) {
+                reasons << "conflict"
+            }
+            if (reason.forced) {
+                reasons << "forced"
+            }
+            if (reason.selectedByRule) {
+                reasons << "selectedByRule"
+            }
+            if (reason.compositeSubstitution) {
+                reasons << "compositeSubstitution"
+            }
         }
         return reasons.empty ? reason.description : reasons.join(',')
     }


### PR DESCRIPTION
### Context

See #3719

Custom reasons are visible when running the dependency insight report:

![substitution_360](https://user-images.githubusercontent.com/316357/34059829-16e06394-e1e1-11e7-8cd0-d05d60f4d82b.gif)
