### PR TITLE
Remove duplicate '--no-daemon' option from the CLI options documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradleCommandLine.adoc
+++ b/subprojects/docs/src/docs/userguide/gradleCommandLine.adoc
@@ -120,12 +120,10 @@ The <<gradle_daemon>> contains more information about the daemon. For example it
 
 `--daemon`::
 Uses the Gradle daemon to run the build. Starts the daemon if not running or existing daemon busy. <<gradle_daemon>> contains more detailed information when new daemon processes are started.
-`--no-daemon`::
-Does not use the Gradle daemon to run the build.
 `--foreground`::
 Starts the Gradle daemon in the foreground. Useful for debugging or troubleshooting because you can easily monitor the build execution.
 `--no-daemon`::
-Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+Does not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
 `--status`::
 List running and recently stopped Gradle daemons. Only displays daemons of the same Gradle version.
 `--stop`::


### PR DESCRIPTION
Signed-off-by: Stefan Neuhaus <stefan@stefanneuhaus.org>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
