### PR TITLE
Add --warning to suppress deprecation warnings (#3726)

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -25,7 +25,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.CompositeInitScriptFinder;
@@ -149,16 +149,16 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * {@inheritDoc}
      */
     @Override
-    public WarningType getWarningType() {
-        return loggingConfiguration.getWarningType();
+    public WarningMode getWarningMode() {
+        return loggingConfiguration.getWarningMode();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void setWarningType(WarningType warningType) {
-        loggingConfiguration.setWarningType(warningType);
+    public void setWarningMode(WarningMode warningMode) {
+        loggingConfiguration.setWarningMode(warningMode);
     }
 
     /**
@@ -207,7 +207,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     protected StartParameter prepareNewInstance(StartParameter p) {
         prepareNewBuild(p);
-        p.setWarningType(getWarningType());
+        p.setWarningMode(getWarningMode());
         p.buildFile = buildFile;
         p.projectDir = projectDir;
         p.settingsFile = settingsFile;
@@ -242,7 +242,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.setLogLevel(getLogLevel());
         p.setConsoleOutput(getConsoleOutput());
         p.setShowStacktrace(getShowStacktrace());
-        p.setWarningType(getWarningType());
+        p.setWarningMode(getWarningMode());
         p.profile = profile;
         p.continueOnFailure = continueOnFailure;
         p.offline = offline;

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -145,6 +145,9 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         loggingConfiguration.setConsoleOutput(consoleOutput);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Set<WarningType> getWarningTypes() {
         return loggingConfiguration.getWarningTypes();
@@ -201,6 +204,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     protected StartParameter prepareNewInstance(StartParameter p) {
         prepareNewBuild(p);
+        p.setWarningTypes(getWarningTypes());
         p.buildFile = buildFile;
         p.projectDir = projectDir;
         p.settingsFile = settingsFile;

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -149,13 +149,16 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * {@inheritDoc}
      */
     @Override
-    public Set<WarningType> getWarningTypes() {
-        return loggingConfiguration.getWarningTypes();
+    public WarningType getWarningType() {
+        return loggingConfiguration.getWarningType();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void setWarningTypes(Set<WarningType> warningTypes) {
-        loggingConfiguration.setWarningTypes(warningTypes);
+    public void setWarningType(WarningType warningType) {
+        loggingConfiguration.setWarningType(warningType);
     }
 
     /**
@@ -204,7 +207,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     protected StartParameter prepareNewInstance(StartParameter p) {
         prepareNewBuild(p);
-        p.setWarningTypes(getWarningTypes());
+        p.setWarningType(getWarningType());
         p.buildFile = buildFile;
         p.projectDir = projectDir;
         p.settingsFile = settingsFile;
@@ -239,7 +242,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.setLogLevel(getLogLevel());
         p.setConsoleOutput(getConsoleOutput());
         p.setShowStacktrace(getShowStacktrace());
-        p.setWarningTypes(getWarningTypes());
+        p.setWarningType(getWarningType());
         p.profile = profile;
         p.continueOnFailure = continueOnFailure;
         p.offline = offline;

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -25,6 +25,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
+import org.gradle.api.logging.configuration.WarningType;
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.CompositeInitScriptFinder;
@@ -144,6 +145,16 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         loggingConfiguration.setConsoleOutput(consoleOutput);
     }
 
+    @Override
+    public Set<WarningType> getWarningTypes() {
+        return loggingConfiguration.getWarningTypes();
+    }
+
+    @Override
+    public void setWarningTypes(Set<WarningType> warningTypes) {
+        loggingConfiguration.setWarningTypes(warningTypes);
+    }
+
     /**
      * Sets the project's cache location. Set to null to use the default location.
      */
@@ -224,6 +235,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.setLogLevel(getLogLevel());
         p.setConsoleOutput(getConsoleOutput());
         p.setShowStacktrace(getShowStacktrace());
+        p.setWarningTypes(getWarningTypes());
         p.profile = profile;
         p.continueOnFailure = continueOnFailure;
         p.offline = offline;

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
@@ -54,7 +54,7 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
         def stdOut = new ByteArrayOutputStream()
         def args = [deprecatedArgs]
         if (warningsType != null) {
-            args.add("--warnings=" + warningsType.getBuildOption())
+            args.add("--warnings=" + warningsType.toString().toLowerCase(Locale.ENGLISH))
         }
         toolingApi.withConnection { connection -> connection.newBuild().withArguments(args).forTasks('help').setStandardOutput(stdOut).run() }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.initialization
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.logging.configuration.WarningType
+import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.tooling.fixture.ToolingApi
 import spock.lang.Unroll
@@ -45,7 +45,7 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    def "deprecation warning appears when using #deprecatedArgs and warningtype #warningsType in Tooling API"() {
+    def "deprecation warning appears when using #deprecatedArgs and warning mode #warningsType in Tooling API"() {
         given:
         ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
         toolingApi.requireIsolatedDaemons()
@@ -54,7 +54,7 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
         def stdOut = new ByteArrayOutputStream()
         def args = [deprecatedArgs]
         if (warningsType != null) {
-            args.add("--warnings=" + warningsType.toString().toLowerCase(Locale.ENGLISH))
+            args.add("--warning-mode=" + warningsType.toString().toLowerCase(Locale.ENGLISH))
         }
         toolingApi.withConnection { connection -> connection.newBuild().withArguments(args).forTasks('help').setStandardOutput(stdOut).run() }
 
@@ -64,12 +64,12 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         issue                                          | deprecatedArgs        | warningsType     | warningCountInConsole | warningCountInSummary | message
-        'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | WarningType.All  | 1                     | 0                     | RECOMPILE_SCRIPTS_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | WarningType.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | WarningMode.All  | 1                     | 0                     | RECOMPILE_SCRIPTS_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | WarningMode.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningMode.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningMode.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
         'https://github.com/gradle/gradle/issues/3077' | '-a'                  | null             | 0                     | 1                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.None | 0                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningMode.None | 0                     | 0                     | NO_REBUILD_MESSAGE
     }
 
     def incrementWarningCountIfJava7(int warningCount) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
@@ -52,20 +52,24 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         def stdOut = new ByteArrayOutputStream()
-        toolingApi.withConnection { connection -> connection.newBuild().withArguments(deprecatedArgs, "--warnings=" + warningsType.getBuildOption()).forTasks('help').setStandardOutput(stdOut).run() }
+        def args = [deprecatedArgs]
+        if (warningsType != null) {
+            args.add("--warnings=" + warningsType.getBuildOption())
+        }
+        toolingApi.withConnection { connection -> connection.newBuild().withArguments(args).forTasks('help').setStandardOutput(stdOut).run() }
 
         then:
         warningCountInConsole == stdOut.toString().count(message)
         warningCountInSummary == stdOut.toString().count("There're ${incrementWarningCountIfJava7(warningCountInSummary)} deprecation warnings")
 
         where:
-        issue                                          | deprecatedArgs        | warningsType              | warningCountInConsole | warningCountInSummary | message
-        'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | WarningType.All           | 1                     | 0                     | RECOMPILE_SCRIPTS_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | WarningType.All           | 1                     | 0                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All     | 1 | 0 | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All     | 1 | 0 | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.Summary | 0 | 1 | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.None    | 0 | 0 | NO_REBUILD_MESSAGE
+        issue                                          | deprecatedArgs        | warningsType     | warningCountInConsole | warningCountInSummary | message
+        'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | WarningType.All  | 1                     | 0                     | RECOMPILE_SCRIPTS_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | WarningType.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | null             | 0                     | 1                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.None | 0                     | 0                     | NO_REBUILD_MESSAGE
     }
 
     def incrementWarningCountIfJava7(int warningCount) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.initialization
 
+import org.gradle.api.JavaVersion
+import org.gradle.api.logging.configuration.WarningType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.tooling.fixture.ToolingApi
 import spock.lang.Unroll
@@ -24,7 +26,6 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String RECOMPILE_SCRIPTS_MESSAGE = '--recompile-scripts has been deprecated and is scheduled to be removed in Gradle'
     private static final String NO_REBUILD_MESSAGE = '--no-rebuild/-a has been deprecated and is scheduled to be removed in Gradle'
-    private static final String NO_SEARCH_UPWARD_MESSAGE = '--no-search-upward/-u has been deprecated and is scheduled to be removed in Gradle'
 
     @Unroll
     def "deprecation warning appears when using #deprecatedArgs"() {
@@ -41,30 +42,33 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
         'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | RECOMPILE_SCRIPTS_MESSAGE
         'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | NO_REBUILD_MESSAGE
         'https://github.com/gradle/gradle/issues/3077' | '-a'                  | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3334' | '--no-search-upward'  | NO_SEARCH_UPWARD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3334' | '-u'                  | NO_SEARCH_UPWARD_MESSAGE
     }
 
     @Unroll
-    def "deprecation warning appears when using #deprecatedArgs in Tooling API"() {
+    def "deprecation warning appears when using #deprecatedArgs and warningtype #warningsType in Tooling API"() {
         given:
         ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
         toolingApi.requireIsolatedDaemons()
 
         when:
         def stdOut = new ByteArrayOutputStream()
-        toolingApi.withConnection { connection -> connection.newBuild().withArguments(deprecatedArgs).forTasks('help').setStandardOutput(stdOut).run() }
+        toolingApi.withConnection { connection -> connection.newBuild().withArguments(deprecatedArgs, "--warnings=" + warningsType.getBuildOption()).forTasks('help').setStandardOutput(stdOut).run() }
 
         then:
-        stdOut.toString().contains(message)
+        warningCountInConsole == stdOut.toString().count(message)
+        warningCountInSummary == stdOut.toString().count("There're ${incrementWarningCountIfJava7(warningCountInSummary)} deprecation warnings")
 
         where:
-        issue                                          | deprecatedArgs        | message
-        'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | RECOMPILE_SCRIPTS_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3334' | '--no-search-upward'  | NO_SEARCH_UPWARD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3334' | '-u'                  | NO_SEARCH_UPWARD_MESSAGE
+        issue                                          | deprecatedArgs        | warningsType              | warningCountInConsole | warningCountInSummary | message
+        'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | WarningType.All           | 1                     | 0                     | RECOMPILE_SCRIPTS_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | WarningType.All           | 1                     | 0                     | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All     | 1 | 0 | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.All     | 1 | 0 | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.Summary | 0 | 1 | NO_REBUILD_MESSAGE
+        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningType.None    | 0 | 0 | NO_REBUILD_MESSAGE
     }
 
+    def incrementWarningCountIfJava7(int warningCount) {
+        return JavaVersion.current().isJava7() ? warningCount + 1 : warningCount
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -169,7 +169,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             default:
                 LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false);
         }
-        DeprecationLogger.useLocationReporter(usageLocationReporter);
+        DeprecationLogger.init(usageLocationReporter, startParameter.getWarningTypes());
 
         SettingsLoaderFactory settingsLoaderFactory = serviceRegistry.get(SettingsLoaderFactory.class);
         SettingsLoader settingsLoader = parent != null ? settingsLoaderFactory.forNestedBuild() : settingsLoaderFactory.forTopLevelBuild();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -169,7 +169,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             default:
                 LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false);
         }
-        DeprecationLogger.init(usageLocationReporter, startParameter.getWarningTypes());
+        DeprecationLogger.init(usageLocationReporter, startParameter.getWarningType());
 
         SettingsLoaderFactory settingsLoaderFactory = serviceRegistry.get(SettingsLoaderFactory.class);
         SettingsLoader settingsLoader = parent != null ? settingsLoaderFactory.forNestedBuild() : settingsLoaderFactory.forTopLevelBuild();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -169,7 +169,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             default:
                 LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false);
         }
-        DeprecationLogger.init(usageLocationReporter, startParameter.getWarningType());
+        DeprecationLogger.init(usageLocationReporter, startParameter.getWarningMode());
 
         SettingsLoaderFactory settingsLoaderFactory = serviceRegistry.get(SettingsLoaderFactory.class);
         SettingsLoader settingsLoader = parent != null ? settingsLoaderFactory.forNestedBuild() : settingsLoaderFactory.forTopLevelBuild();

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -47,7 +47,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')
-            withWarnings([] as Set)
+            withWarningType(null)
         }.run()
 
         then:

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -47,7 +47,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')
-            withWarningType(null)
+            withWarningMode(null)
         }.run()
 
         then:

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -47,6 +47,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')
+            withWarnings([] as Set)
         }.run()
 
         then:

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -26,12 +26,12 @@ Think of every feature section as a mini blog post.
 
 ### Deprecation warning improvements
 
-In this release, deprecation warnings are no longer displayed in the build by default. Instead, all deprecation warnings in the build will be collected and a single "summary" will be rendered at the end of the build:
+In this release, deprecation warnings are no longer displayed in the console output by default. Instead, all deprecation warnings in the build will be collected and a single "summary" will be rendered at the end of the build:
 
-    There're X deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
+    There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
 
-As said by this warning, you can run the build with command line option `--warnings=all` or property `org.gradle.warnings=all` to have all warnings displayed as before.
-Of course, you can use command line option `--warnings=none` or property `org.gradle.warnings=none` to suppress all warnings, including the one displayed at the end of the build.
+You can run the build with the command line option `--warnings=all` or the property `org.gradle.warnings=all` to have all warnings displayed as earlier version of Gradle.
+Of course, you can use the command line option `--warnings=none` or the property `org.gradle.warnings=none` to suppress all warnings, including the one displayed at the end of the build.
 
 ### Provider API documentation
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -28,10 +28,10 @@ Think of every feature section as a mini blog post.
 
 In this release, deprecation warnings are no longer displayed in the console output by default. Instead, all deprecation warnings in the build will be collected and a single "summary" will be rendered at the end of the build:
 
-    There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
+    There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warning-mode=all to see them.
 
-You can run the build with the command line option `--warnings=all` or the property `org.gradle.warnings=all` to have all warnings displayed as earlier version of Gradle.
-Of course, you can use the command line option `--warnings=none` or the property `org.gradle.warnings=none` to suppress all warnings, including the one displayed at the end of the build.
+You can run the build with the command line option `--warning-mode=all` or the property `org.gradle.warning.mode=all` to have all warnings displayed as earlier version of Gradle.
+Of course, you can use the command line option `--warning-mode=none` or the property `org.gradle.warning.mode=none` to suppress all warnings, including the one displayed at the end of the build.
 
 ### Provider API documentation
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -24,6 +24,15 @@ Think of every feature section as a mini blog post.
   NOTE: Totally fine to just link to an example that show the feature.
 -->
 
+### Deprecation warning improvements
+
+In this release, deprecation warnings are no longer displayed in the build by default. Instead, all deprecation warnings in the build will be collected and a single "summary" will be rendered at the end of the build:
+
+    There're X deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
+
+As said by this warning, you can run the build with command line option `--warnings=all` or property `org.gradle.warnings=all` to have all warnings displayed as before.
+Of course, you can use command line option `--warnings=none` or property `org.gradle.warnings=none` to suppress all warnings, including the one displayed at the end of the build.
+
 ### Provider API documentation
 
 In this release, the Gradle team added a new chapter in the user guide documenting the [Provider API](userguide/lazy_configuration.html).

--- a/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
+++ b/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
@@ -52,6 +52,8 @@ When set to false, Gradle will not monitor the memory usage of running daemons. 
 When set to true, Gradle will try to reuse outputs from previous builds. See <<sec:build_cache_intro>>.
 `org.gradle.console`::
 When set to plain, auto or rich, Gradle will use different type of console. See <<sec:console_build_output>>.
+`org.gradle.warnings`::
+When set to `all` or `none`, Gradle will use different warning type display. See <<sec:command_line_logging>> for details.
 
 [[sec:forked_java_processes]]
 ==== Forked Java processes

--- a/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
+++ b/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
@@ -53,7 +53,7 @@ When set to true, Gradle will try to reuse outputs from previous builds. See <<s
 `org.gradle.console`::
 When set to plain, auto or rich, Gradle will use different type of console. See <<sec:console_build_output>>.
 `org.gradle.warnings`::
-When set to `all` or `none`, Gradle will use different warning type display. See <<sec:command_line_logging>> for details.
+When set to `all`, `summary` or `none`, Gradle will use different warning type display. See <<sec:command_line_logging>> for details.
 
 [[sec:forked_java_processes]]
 ==== Forked Java processes

--- a/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
+++ b/subprojects/docs/src/docs/userguide/buildEnvironment.adoc
@@ -52,7 +52,7 @@ When set to false, Gradle will not monitor the memory usage of running daemons. 
 When set to true, Gradle will try to reuse outputs from previous builds. See <<sec:build_cache_intro>>.
 `org.gradle.console`::
 When set to plain, auto or rich, Gradle will use different type of console. See <<sec:console_build_output>>.
-`org.gradle.warnings`::
+`org.gradle.warning.mode`::
 When set to `all`, `summary` or `none`, Gradle will use different warning type display. See <<sec:command_line_logging>> for details.
 
 [[sec:forked_java_processes]]

--- a/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
+++ b/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
@@ -279,10 +279,10 @@ Features:
 By default, to avoid bothering users, Gradle won't display all warnings (e.g. deprecation warnings). Instead, Gradle will collect them and render a summary at the end of the build:
 
 ----
-There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
+There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warning-mode=all to see them.
 ----
 
-`--warnings=(all,summary,none)`::
+`--warning-mode=(all,summary,none)`::
 Specifies which type of warnings to display.
 +
 Set to `all` to display all warnings.

--- a/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
+++ b/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
@@ -274,6 +274,22 @@ Features:
  * Progress bar and timer visually describe overall status
  * Parallel work-in-progress lines below describe what is happening now
 
+==== Fine-grained Control of Warnings
+
+By default, to avoid bothering users, Gradle won't display all warnings (e.g. deprecation warnings). Instead, Gradle will collect them and render a summary at the end of the build:
+
+----
+There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
+----
+
+`--warnings=(all,none)`::
+Specifies which type of warnings to display.
++
+Set to `all` to display all warnings.
++
+Set to `none` to suppress all warnings, including the summary at the end of the build.
+
+
 === Execution Options
 The following options affect how builds are executed, by changing what is built or how dependencies are resolved.
 

--- a/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
+++ b/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
@@ -282,10 +282,12 @@ By default, to avoid bothering users, Gradle won't display all warnings (e.g. de
 There're <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warnings=all to see them.
 ----
 
-`--warnings=(all,none)`::
+`--warnings=(all,summary,none)`::
 Specifies which type of warnings to display.
 +
 Set to `all` to display all warnings.
++
+Set to `summary` to suppress all warnings and display a summary at the end of the build.
 +
 Set to `none` to suppress all warnings, including the summary at the end of the build.
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -878,7 +878,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         }
 
         for (WarningType type : warningTypes) {
-            allArgs.add("--warnings=" + type.getBuildOption());
+            allArgs.add("--warnings=" + type.toString().toLowerCase(Locale.ENGLISH));
         }
 
         allArgs.addAll(args);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -31,7 +31,7 @@ import org.gradle.api.internal.initialization.DefaultClassLoaderScope;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.configuration.ConsoleOutput;
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer;
 import org.gradle.internal.ImmutableActionSet;
@@ -154,7 +154,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean requiresGradleDistribution;
     private boolean useOwnUserHomeServices;
     private ConsoleOutput consoleType;
-    protected WarningType warningType = WarningType.All;
+    protected WarningMode warningMode = WarningMode.All;
     private boolean showStacktrace = true;
 
     private int expectedDeprecationWarnings;
@@ -235,7 +235,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         checkDeprecations = true;
         durationMeasurement = null;
         consoleType = null;
-        warningType = WarningType.All;
+        warningMode = WarningMode.All;
         return this;
     }
 
@@ -386,7 +386,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             executer.withConsole(consoleType);
         }
 
-        executer.withWarningType(warningType);
+        executer.withWarningMode(warningMode);
 
         if (!showStacktrace) {
             executer.withStacktraceDisabled();
@@ -741,8 +741,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     }
 
     @Override
-    public GradleExecuter withWarningType(WarningType warningType) {
-        this.warningType = warningType;
+    public GradleExecuter withWarningMode(WarningMode warningMode) {
+        this.warningMode = warningMode;
         return this;
     }
 
@@ -871,8 +871,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             allArgs.add("--console=" + consoleType.toString().toLowerCase());
         }
 
-        if (warningType != null) {
-            allArgs.add("--warnings=" + warningType.toString().toLowerCase(Locale.ENGLISH));
+        if (warningMode != null) {
+            allArgs.add("--warning-mode=" + warningMode.toString().toLowerCase(Locale.ENGLISH));
         }
 
         allArgs.addAll(args);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.initialization.DefaultClassLoaderScope;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.configuration.ConsoleOutput;
+import org.gradle.api.logging.configuration.WarningType;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer;
 import org.gradle.internal.ImmutableActionSet;
@@ -153,6 +154,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean requiresGradleDistribution;
     private boolean useOwnUserHomeServices;
     private ConsoleOutput consoleType;
+    protected Set<WarningType> warningTypes = Sets.newHashSet(WarningType.All);
     private boolean showStacktrace = true;
 
     private int expectedDeprecationWarnings;
@@ -233,6 +235,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         checkDeprecations = true;
         durationMeasurement = null;
         consoleType = null;
+        warningTypes = Sets.newHashSet(WarningType.All);
         return this;
     }
 
@@ -382,6 +385,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (consoleType != null) {
             executer.withConsole(consoleType);
         }
+
+        executer.withWarnings(warningTypes);
 
         if (!showStacktrace) {
             executer.withStacktraceDisabled();
@@ -736,6 +741,18 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     }
 
     @Override
+    public GradleExecuter withWarnings(WarningType... warningTypes) {
+        this.warningTypes = Sets.newHashSet(warningTypes);
+        return this;
+    }
+
+    @Override
+    public GradleExecuter withWarnings(Set<WarningType> warningTypes) {
+        this.warningTypes = warningTypes;
+        return this;
+    }
+
+    @Override
     public GradleExecuter withConsole(ConsoleOutput consoleType) {
         this.consoleType = consoleType;
         return this;
@@ -858,6 +875,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
         if (consoleType != null) {
             allArgs.add("--console=" + consoleType.toString().toLowerCase());
+        }
+
+        for (WarningType type : warningTypes) {
+            allArgs.add("--warnings=" + type.getBuildOption());
         }
 
         allArgs.addAll(args);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -154,7 +154,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean requiresGradleDistribution;
     private boolean useOwnUserHomeServices;
     private ConsoleOutput consoleType;
-    protected Set<WarningType> warningTypes = Sets.newHashSet(WarningType.All);
+    protected WarningType warningType = WarningType.All;
     private boolean showStacktrace = true;
 
     private int expectedDeprecationWarnings;
@@ -235,7 +235,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         checkDeprecations = true;
         durationMeasurement = null;
         consoleType = null;
-        warningTypes = Sets.newHashSet(WarningType.All);
+        warningType = WarningType.All;
         return this;
     }
 
@@ -386,7 +386,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             executer.withConsole(consoleType);
         }
 
-        executer.withWarnings(warningTypes);
+        executer.withWarningType(warningType);
 
         if (!showStacktrace) {
             executer.withStacktraceDisabled();
@@ -741,14 +741,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     }
 
     @Override
-    public GradleExecuter withWarnings(WarningType... warningTypes) {
-        withWarnings(Sets.newHashSet(warningTypes));
-        return this;
-    }
-
-    @Override
-    public GradleExecuter withWarnings(Set<WarningType> warningTypes) {
-        this.warningTypes = warningTypes;
+    public GradleExecuter withWarningType(WarningType warningType) {
+        this.warningType = warningType;
         return this;
     }
 
@@ -877,8 +871,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             allArgs.add("--console=" + consoleType.toString().toLowerCase());
         }
 
-        for (WarningType type : warningTypes) {
-            allArgs.add("--warnings=" + type.toString().toLowerCase(Locale.ENGLISH));
+        if (warningType != null) {
+            allArgs.add("--warnings=" + warningType.toString().toLowerCase(Locale.ENGLISH));
         }
 
         allArgs.addAll(args);
@@ -1021,9 +1015,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         return null;
     }
 
-    private boolean isJava7Home(String path){
-        for(String jdk7Path: JDK7_PATHS){
-            if(path.contains(jdk7Path)){
+    private boolean isJava7Home(String path) {
+        for (String jdk7Path : JDK7_PATHS) {
+            if (path.contains(jdk7Path)) {
                 return true;
             }
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -742,7 +742,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
     @Override
     public GradleExecuter withWarnings(WarningType... warningTypes) {
-        this.warningTypes = Sets.newHashSet(warningTypes);
+        withWarnings(Sets.newHashSet(warningTypes));
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -54,7 +54,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext);
+        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarnings();
     }
 
     public boolean worksWith(Jvm jvm) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -54,7 +54,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarningType(null);
+        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarningMode(null);
     }
 
     public boolean worksWith(Jvm jvm) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -54,7 +54,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarnings();
+        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarningType(null);
     }
 
     public boolean worksWith(Jvm jvm) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -30,7 +30,6 @@ import java.io.PipedOutputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 public interface GradleExecuter extends Stoppable {
     /**
@@ -433,9 +432,7 @@ public interface GradleExecuter extends Stoppable {
      *
      * @see WarningType
      */
-    GradleExecuter withWarnings(WarningType... warningTypes);
-
-    GradleExecuter withWarnings(Set<WarningType> warningTypes);
+    GradleExecuter withWarningType(WarningType warningType);
 
     /**
      * Execute the builds without adding the {@code "--stacktrace"} argument.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -19,6 +19,7 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.logging.configuration.ConsoleOutput;
+import org.gradle.api.logging.configuration.WarningType;
 import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
@@ -29,6 +30,7 @@ import java.io.PipedOutputStream;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public interface GradleExecuter extends Stoppable {
     /**
@@ -425,6 +427,15 @@ public interface GradleExecuter extends Stoppable {
      * @see AbstractConsoleFunctionalSpec
      */
     GradleExecuter withConsole(ConsoleOutput consoleOutput);
+
+    /**
+     * Executes the build with {@code "--warnings=none, summary, all"} argument.
+     *
+     * @see WarningType
+     */
+    GradleExecuter withWarnings(WarningType... warningTypes);
+
+    GradleExecuter withWarnings(Set<WarningType> warningTypes);
 
     /**
      * Execute the builds without adding the {@code "--stacktrace"} argument.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -19,7 +19,7 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.logging.configuration.ConsoleOutput;
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
@@ -428,11 +428,11 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withConsole(ConsoleOutput consoleOutput);
 
     /**
-     * Executes the build with {@code "--warnings=none, summary, all"} argument.
+     * Executes the build with {@code "--warning-mode=none, summary, all"} argument.
      *
-     * @see WarningType
+     * @see WarningMode
      */
-    GradleExecuter withWarningType(WarningType warningType);
+    GradleExecuter withWarningMode(WarningMode warningMode);
 
     /**
      * Execute the builds without adding the {@code "--stacktrace"} argument.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/UnderDevelopmentGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/UnderDevelopmentGradleDistribution.java
@@ -34,7 +34,7 @@ public class UnderDevelopmentGradleDistribution extends DefaultGradleDistributio
 
     @Override
     public GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new GradleContextualExecuter(this, testDirectoryProvider, buildContext).withWarningType(null);
+        return new GradleContextualExecuter(this, testDirectoryProvider, buildContext).withWarningMode(null);
     }
 }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/UnderDevelopmentGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/UnderDevelopmentGradleDistribution.java
@@ -34,7 +34,7 @@ public class UnderDevelopmentGradleDistribution extends DefaultGradleDistributio
 
     @Override
     public GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new GradleContextualExecuter(this, testDirectoryProvider, buildContext);
+        return new GradleContextualExecuter(this, testDirectoryProvider, buildContext).withWarnings();
     }
 }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/UnderDevelopmentGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/UnderDevelopmentGradleDistribution.java
@@ -34,7 +34,7 @@ public class UnderDevelopmentGradleDistribution extends DefaultGradleDistributio
 
     @Override
     public GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new GradleContextualExecuter(this, testDirectoryProvider, buildContext).withWarnings();
+        return new GradleContextualExecuter(this, testDirectoryProvider, buildContext).withWarningType(null);
     }
 }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
@@ -17,10 +17,10 @@
 package org.gradle.performance.fixture
 
 import groovy.transform.CompileStatic
-import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GFileUtils
@@ -53,7 +53,7 @@ class PerformanceTestGradleDistribution implements GradleDistribution {
     }
 
     GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarnings([] as Set)
+        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarningType(null)
     }
 
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
@@ -53,7 +53,7 @@ class PerformanceTestGradleDistribution implements GradleDistribution {
     }
 
     GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarningType(null)
+        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarningMode(null)
     }
 
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestGradleDistribution.groovy
@@ -53,7 +53,7 @@ class PerformanceTestGradleDistribution implements GradleDistribution {
     }
 
     GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {
-        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext);
+        return new NoDaemonGradleExecuter(this, testDirectoryProvider, version, buildContext).withWarnings([] as Set)
     }
 
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/StartParamsValidatingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/StartParamsValidatingActionExecuter.java
@@ -17,7 +17,6 @@
 package org.gradle.tooling.internal.provider;
 
 import org.gradle.StartParameter;
-import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.service.ServiceRegistry;
@@ -60,10 +59,6 @@ public class StartParamsValidatingActionExecuter implements BuildExecuter {
                 }
                 throw new IllegalArgumentException(String.format("The specified settings file '%s' is not a file.", startParameter.getSettingsFile()));
             }
-        }
-
-        if (startParameter instanceof StartParameterInternal) {
-            StartParameterInternal.class.cast(startParameter).checkDeprecation();
         }
 
         return delegate.execute(action, requestContext, actionParameters, contextServices);

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -88,8 +88,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         if (warningsCountInConsole > 0) {
             executer.expectDeprecationWarnings(warningsCountInConsole)
         }
-        def warningTypes = warnings == null ? [] : [warnings]
-        executer.withWarnings(warningTypes as Set)
+        executer.withWarningType(warnings)
         run('deprecated', 'broken')
 
         then:
@@ -111,13 +110,13 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         assertFullStacktraceResult(fullStacktraceEnabled, warningsCountInConsole)
 
         where:
-        scenario                                 | warnings         | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
-        'without stacktrace and --warnings=all'  | WarningType.All  | 4                      | 0                      | false
-        'with stacktrace and --warnings=all'     | WarningType.All  | 4                      | 0                      | true
-        'without stacktrace and --warnings=no'   | WarningType.None | 0                      | 0                      | false
-        'with stacktrace and --warnings=no'      | WarningType.None | 0                      | 0                      | true
-        'without stacktrace and --warnings=auto' | null             | 0                      | 4                      | false
-        'with stacktrace and --warnings=auto'    | null             | 0                      | 4                      | true
+        scenario                                    | warnings            | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
+        'without stacktrace and --warnings=all'     | WarningType.All     | 4                      | 0                      | false
+        'with stacktrace and --warnings=all'        | WarningType.All     | 4                      | 0                      | true
+        'without stacktrace and --warnings=no'      | WarningType.None    | 0                      | 0                      | false
+        'with stacktrace and --warnings=no'         | WarningType.None    | 0                      | 0                      | true
+        'without stacktrace and --warnings=summary' | WarningType.Summary | 0                      | 4                      | false
+        'with stacktrace and --warnings=summary'    | WarningType.Summary | 0                      | 4                      | true
     }
 
     def incrementWarningCountIfJava7(int warningCount) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.logging.configuration.WarningType
+import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
@@ -88,7 +88,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         if (warningsCountInConsole > 0) {
             executer.expectDeprecationWarnings(warningsCountInConsole)
         }
-        executer.withWarningType(warnings)
+        executer.withWarningMode(warnings)
         run('deprecated', 'broken')
 
         then:
@@ -111,12 +111,12 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         scenario                                    | warnings            | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
-        'without stacktrace and --warnings=all'     | WarningType.All     | 4                      | 0                      | false
-        'with stacktrace and --warnings=all'        | WarningType.All     | 4                      | 0                      | true
-        'without stacktrace and --warnings=no'      | WarningType.None    | 0                      | 0                      | false
-        'with stacktrace and --warnings=no'         | WarningType.None    | 0                      | 0                      | true
-        'without stacktrace and --warnings=summary' | WarningType.Summary | 0                      | 4                      | false
-        'with stacktrace and --warnings=summary'    | WarningType.Summary | 0                      | 4                      | true
+        'without stacktrace and --warning-mode=all'     | WarningMode.All     | 4                      | 0                      | false
+        'with stacktrace and --warning-mode=all'        | WarningMode.All     | 4                      | 0                      | true
+        'without stacktrace and --warning-mode=no'      | WarningMode.None    | 0                      | 0                      | false
+        'with stacktrace and --warning-mode=no'         | WarningMode.None    | 0                      | 0                      | true
+        'without stacktrace and --warning-mode=summary' | WarningMode.Summary | 0                      | 4                      | false
+        'with stacktrace and --warning-mode=summary'    | WarningMode.Summary | 0                      | 4                      | true
     }
 
     def incrementWarningCountIfJava7(int warningCount) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -88,7 +88,8 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         if (warningsCountInConsole > 0) {
             executer.expectDeprecationWarnings(warningsCountInConsole)
         }
-        executer.withWarnings(warnings)
+        def warningTypes = warnings == null ? [] : [warnings]
+        executer.withWarnings(warningTypes as Set)
         run('deprecated', 'broken')
 
         then:
@@ -110,13 +111,13 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         assertFullStacktraceResult(fullStacktraceEnabled, warningsCountInConsole)
 
         where:
-        scenario                                 | warnings            | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
-        'without stacktrace and --warnings=all'  | WarningType.All     | 4                      | 0                      | false
-        'with stacktrace and --warnings=all'     | WarningType.All     | 4                      | 0                      | true
-        'without stacktrace and --warnings=no'   | WarningType.None    | 0                      | 0                      | false
-        'with stacktrace and --warnings=no'      | WarningType.None    | 0                      | 0                      | true
-        'without stacktrace and --warnings=auto' | WarningType.Summary | 0                      | 4                      | false
-        'with stacktrace and --warnings=auto'    | WarningType.Summary | 0                      | 4                      | true
+        scenario                                 | warnings         | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
+        'without stacktrace and --warnings=all'  | WarningType.All  | 4                      | 0                      | false
+        'with stacktrace and --warnings=all'     | WarningType.All  | 4                      | 0                      | true
+        'without stacktrace and --warnings=no'   | WarningType.None | 0                      | 0                      | false
+        'with stacktrace and --warnings=no'      | WarningType.None | 0                      | 0                      | true
+        'without stacktrace and --warnings=auto' | null             | 0                      | 4                      | false
+        'with stacktrace and --warnings=auto'    | null             | 0                      | 4                      | true
     }
 
     def incrementWarningCountIfJava7(int warningCount) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -16,10 +16,14 @@
 
 package org.gradle
 
+import org.gradle.api.JavaVersion
+import org.gradle.api.logging.configuration.WarningType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
     public static final String PLUGIN_DEPRECATION_MESSAGE = 'The DeprecatedPlugin plugin has been deprecated'
+    private static final String RUN_WITH_STACKTRACE = '(Run with --stacktrace to get the full stack trace of this deprecation warning.)'
 
     def setup() {
         file('buildSrc/src/main/java/DeprecatedTask.java') << """
@@ -61,7 +65,8 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
     }
 
-    def 'DeprecatedPlugin and DeprecatedTask - without full stacktrace.'() {
+    @Unroll
+    def 'DeprecatedPlugin and DeprecatedTask - #scenario'() {
         given:
         buildFile << """
             apply plugin: DeprecatedPlugin // line 2
@@ -77,60 +82,55 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
-        executer.withFullDeprecationStackTraceDisabled()
-        executer.expectDeprecationWarnings(4)
+        if (!fullStacktraceEnabled) {
+            executer.withFullDeprecationStackTraceDisabled()
+        }
+        if (warningsCountInConsole > 0) {
+            executer.expectDeprecationWarnings(warningsCountInConsole)
+        }
+        executer.withWarnings(warnings)
         run('deprecated', 'broken')
 
         then:
-        output.contains('build.gradle:2)')
-        output.contains('build.gradle:4)')
-        output.contains('build.gradle:9)')
-        !output.contains('(Native Method)')
+        output.contains('build.gradle:2)') == warningsCountInConsole > 0
+        output.contains('build.gradle:4)') == warningsCountInConsole > 0
+        output.contains('build.gradle:9)') == warningsCountInConsole > 0
+        output.contains('(Native Method)') == (fullStacktraceEnabled && warningsCountInConsole > 0)
 
         and:
-        output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
-        output.count('The someFeature() method has been deprecated') == 1
-        output.count('The otherFeature() method has been deprecated') == 1
-        output.count('The deprecated task has been deprecated') == 1
+        output.contains(PLUGIN_DEPRECATION_MESSAGE) == warningsCountInConsole > 0
+        output.contains('The someFeature() method has been deprecated') == warningsCountInConsole > 0
+        output.contains('The otherFeature() method has been deprecated') == warningsCountInConsole > 0
+        output.contains('The deprecated task has been deprecated') == warningsCountInConsole > 0
 
         and:
-        output.count('\tat') == 3
-        output.count('(Run with --stacktrace to get the full stack trace of this deprecation warning.)') == 3
+        output.contains("There're ${incrementWarningCountIfJava7(warningsCountInSummary)} deprecation warnings") == (warningsCountInSummary > 0)
+
+        and:
+        assertFullStacktraceResult(fullStacktraceEnabled, warningsCountInConsole)
+
+        where:
+        scenario                                 | warnings            | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
+        'without stacktrace and --warnings=all'  | WarningType.All     | 4                      | 0                      | false
+        'with stacktrace and --warnings=all'     | WarningType.All     | 4                      | 0                      | true
+        'without stacktrace and --warnings=no'   | WarningType.None    | 0                      | 0                      | false
+        'with stacktrace and --warnings=no'      | WarningType.None    | 0                      | 0                      | true
+        'without stacktrace and --warnings=auto' | WarningType.Summary | 0                      | 4                      | false
+        'with stacktrace and --warnings=auto'    | WarningType.Summary | 0                      | 4                      | true
     }
 
-    def 'DeprecatedPlugin and DeprecatedTask - with full stacktrace.'() {
-        given:
-        buildFile << """
-            apply plugin: DeprecatedPlugin // line 2
+    def incrementWarningCountIfJava7(int warningCount) {
+        return JavaVersion.current().isJava7() ? warningCount + 1 : warningCount
+    }
 
-            DeprecatedTask.someFeature() // line 4
-            DeprecatedTask.someFeature()
-
-            task broken(type: DeprecatedTask) {
-                doLast {
-                    otherFeature() // line 9
-                }
-            }
-        """.stripIndent()
-
-        when:
-        executer.expectDeprecationWarnings(4)
-        run('deprecated', 'broken')
-
-        then:
-        output.contains('build.gradle:2)')
-        output.contains('build.gradle:4)')
-        output.contains('build.gradle:9)')
-
-        and:
-        output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
-        output.count('The someFeature() method has been deprecated') == 1
-        output.count('The otherFeature() method has been deprecated') == 1
-        output.count('The deprecated task has been deprecated') == 1
-
-        and:
-        output.count('\tat') > 3
-        output.count('(Run with --stacktrace to get the full stack trace of this deprecation warning.)') == 0
+    boolean assertFullStacktraceResult(boolean fullStacktraceEnabled, int warningsCountInConsole) {
+        if (warningsCountInConsole == 0) {
+            output.count('\tat') == 0 && output.count(RUN_WITH_STACKTRACE) == 0
+        } else if (fullStacktraceEnabled) {
+            output.count('\tat') > 3 && output.count(RUN_WITH_STACKTRACE) == 0
+        } else {
+            output.count('\tat') == 3 && output.count(RUN_WITH_STACKTRACE) == 3
+        }
     }
 
     def 'DeprecatedPlugin from init script - without full stacktrace.'() {
@@ -156,7 +156,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         output.count('(Run with --stacktrace to get the full stack trace of this deprecation warning.)') == 1
     }
 
-    def 'DeprecatedPlugin from applied script - without full stacktrace.'() {
+    def 'DeprecatedPlugin from applied script - #scenario'() {
         given:
         file("project.gradle") << """
             apply plugin:  DeprecatedPlugin // line 2
@@ -169,42 +169,23 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
-        executer.withFullDeprecationStackTraceDisabled()
+        if (!withFullStacktrace) {
+            executer.withFullDeprecationStackTraceDisabled()
+        }
         executer.expectDeprecationWarning()
         run()
 
         then:
         output.contains('project.gradle:2)')
-
+        output.contains('build.gradle:2)') == withFullStacktrace
         output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
 
-        output.count('\tat') == 1
-        output.count('(Run with --stacktrace to get the full stack trace of this deprecation warning.)') == 1
-    }
+        withFullStacktrace ? (output.count('\tat') > 1) : (output.count('\tat') == 1)
+        withFullStacktrace == !output.contains(RUN_WITH_STACKTRACE)
 
-    def 'DeprecatedPlugin from applied script - with full stacktrace.'() {
-        given:
-        file("project.gradle") << """
-            apply plugin:  DeprecatedPlugin // line 2
-        """.stripIndent()
-
-        buildFile << """
-            allprojects {
-                apply from: 'project.gradle' // line 2
-            }
-        """.stripIndent()
-
-        when:
-        executer.expectDeprecationWarning()
-        run()
-
-        then:
-        output.contains('project.gradle:2)')
-        output.contains('build.gradle:2)')
-
-        output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
-
-        output.count('\tat') > 1
-        output.count('(Run with --stacktrace to get the full stack trace of this deprecation warning.)') == 0
+        where:
+        scenario                  | withFullStacktrace
+        'without full stacktrace' | false
+        'with full stacktrace'    | true
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -50,14 +50,14 @@ public interface LoggingConfiguration {
      * @since 4.5
      */
     @Incubating
-    WarningType getWarningType();
+    WarningMode getWarningMode();
 
     /**
      * Specifies which type of warnings should be written to the console.
      * @since 4.5
      */
     @Incubating
-    void setWarningType(WarningType warningType);
+    void setWarningMode(WarningMode warningMode);
 
     /**
      * Returns the detail that should be included in stacktraces. Defaults to {@link ShowStacktrace#INTERNAL_EXCEPTIONS}.

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -49,7 +49,6 @@ public interface LoggingConfiguration {
 
     /**
      * Specifies if deprecation warnings should be written to the console.
-     * Defaults to {@link WarningType#Summary}
      * @since 4.5
      */
     @Incubating

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -16,7 +16,10 @@
 
 package org.gradle.api.logging.configuration;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.logging.LogLevel;
+
+import java.util.Set;
 
 /**
  * A {@code LoggingConfiguration} defines the logging settings for a Gradle build.
@@ -43,6 +46,21 @@ public interface LoggingConfiguration {
      * Specifies the style of logging output that should be written to the console.
      */
     void setConsoleOutput(ConsoleOutput consoleOutput);
+
+    /**
+     * Specifies if deprecation warnings should be written to the console.
+     * Defaults to {@link WarningType#Summary}
+     * @since 4.5
+     */
+    @Incubating
+    Set<WarningType> getWarningTypes();
+
+    /**
+     * Specifies if deprecation warnings should be written to the console.
+     * @since 4.5
+     */
+    @Incubating
+    void setWarningTypes(Set<WarningType> warningTypes);
 
     /**
      * Returns the detail that should be included in stacktraces. Defaults to {@link ShowStacktrace#INTERNAL_EXCEPTIONS}.

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/LoggingConfiguration.java
@@ -19,8 +19,6 @@ package org.gradle.api.logging.configuration;
 import org.gradle.api.Incubating;
 import org.gradle.api.logging.LogLevel;
 
-import java.util.Set;
-
 /**
  * A {@code LoggingConfiguration} defines the logging settings for a Gradle build.
  */
@@ -48,18 +46,18 @@ public interface LoggingConfiguration {
     void setConsoleOutput(ConsoleOutput consoleOutput);
 
     /**
-     * Specifies if deprecation warnings should be written to the console.
+     * Specifies which type of warnings should be written to the console.
      * @since 4.5
      */
     @Incubating
-    Set<WarningType> getWarningTypes();
+    WarningType getWarningType();
 
     /**
-     * Specifies if deprecation warnings should be written to the console.
+     * Specifies which type of warnings should be written to the console.
      * @since 4.5
      */
     @Incubating
-    void setWarningTypes(Set<WarningType> warningTypes);
+    void setWarningType(WarningType warningType);
 
     /**
      * Returns the detail that should be included in stacktraces. Defaults to {@link ShowStacktrace#INTERNAL_EXCEPTIONS}.

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningMode.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningMode.java
@@ -19,12 +19,12 @@ package org.gradle.api.logging.configuration;
 import org.gradle.api.Incubating;
 
 /**
- * Specifies the warning type a user wants to see.
+ * Specifies the warning mode a user wants to see.
  *
  * @since 4.5
  */
 @Incubating
-public enum WarningType {
+public enum WarningMode {
     /**
      * Show all warnings.
      */

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
@@ -19,43 +19,24 @@ package org.gradle.api.logging.configuration;
 import org.gradle.api.Incubating;
 
 /**
- * Specifies the warning type a user wants to see
+ * Specifies the warning type a user wants to see.
  *
  * @since 4.5
  */
 @Incubating
 public enum WarningType {
     /**
-     * Show all warnings
+     * Show all warnings.
      */
-    All("all"),
+    All,
 
     /**
-     * Show deprecation warnings
+     * Show deprecation warnings.
      */
-    Deprecation("deprecation"),
+    Deprecation,
 
     /**
      * No deprecation warnings at all.
      */
-    None("none");
-
-    private String buildOption;
-
-    WarningType(String buildOption) {
-        this.buildOption = buildOption;
-    }
-
-    public String getBuildOption() {
-        return this.buildOption;
-    }
-
-    public static WarningType fromBuildOption(String value) {
-        for (WarningType warningType : values()) {
-            if (warningType.buildOption.equalsIgnoreCase(value)) {
-                return warningType;
-            }
-        }
-        throw new IllegalArgumentException("No enum constant WarningType." + value);
-    }
+    None
 }

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.logging.configuration;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Specifies the warning type a user wants to see
+ *
+ * @since 4.5
+ */
+@Incubating
+public enum WarningType {
+    /**
+     * Show all warnings (e.g. deprecation warnings)
+     */
+    All("all"),
+
+    /**
+     * Default value. By default, all deprecation warnings will be suppressed and a single summary message will be displayed at the end of a build indicating how many deprecation warnings suppressed.
+     */
+    Summary("summary"),
+
+    /**
+     * No deprecation warnings at all.
+     */
+    None("none");
+
+    private String buildOption;
+
+    WarningType(String buildOption) {
+        this.buildOption = buildOption;
+    }
+
+    public String getBuildOption() {
+        return this.buildOption;
+    }
+
+    public static WarningType fromBuildOption(String value) {
+        for (WarningType warningType : values()) {
+            if (warningType.buildOption.equalsIgnoreCase(value)) {
+                return warningType;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant WarningType." + value);
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
@@ -26,14 +26,14 @@ import org.gradle.api.Incubating;
 @Incubating
 public enum WarningType {
     /**
-     * Show all warnings (e.g. deprecation warnings)
+     * Show all warnings
      */
     All("all"),
 
     /**
-     * Default value. By default, all deprecation warnings will be suppressed and a single summary message will be displayed at the end of a build indicating how many deprecation warnings suppressed.
+     * Show deprecation warnings
      */
-    Summary("summary"),
+    Deprecation("deprecation"),
 
     /**
      * No deprecation warnings at all.

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningType.java
@@ -31,9 +31,9 @@ public enum WarningType {
     All,
 
     /**
-     * Show deprecation warnings.
+     * Display a summary at the end of the build instead of rendering all warnings into the console output.
      */
-    Deprecation,
+    Summary,
 
     /**
      * No deprecation warnings at all.

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -36,7 +36,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
     private static boolean traceLoggingEnabled;
     private final Set<String> messages = new HashSet<String>();
     private UsageLocationReporter locationReporter;
-    private Set<WarningType> warningTypes = new HashSet<WarningType>();
+    private WarningType warningType;
 
     public LoggingDeprecatedFeatureHandler() {
         this(new UsageLocationReporter() {
@@ -49,9 +49,9 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
         this.locationReporter = locationReporter;
     }
 
-    public void init(UsageLocationReporter reporter, Set<WarningType> warningTypes) {
+    public void init(UsageLocationReporter reporter, WarningType warningType) {
         this.locationReporter = reporter;
-        this.warningTypes = warningTypes;
+        this.warningType = warningType;
     }
 
     public void reset() {
@@ -68,22 +68,18 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             }
             message.append(usage.getMessage());
             logTraceIfNecessary(usage.getStack(), message);
-            if (warningTypes.contains(WarningType.All) || warningTypes.contains(WarningType.Deprecation)) {
+            if (warningType==WarningType.All) {
                 LOGGER.warn(message.toString());
             }
         }
     }
 
     public void reportSuppressedDeprecations() {
-        if (defaultWarningType() && !messages.isEmpty()) {
+        if (warningType == WarningType.Summary && !messages.isEmpty()) {
             LOGGER.warn("\nThere're {} deprecation warnings, which may break the build in Gradle {}. Please run with --warnings=all to see them.",
                 messages.size(),
                 GradleVersion.current().getNextMajor().getVersion());
         }
-    }
-
-    private boolean defaultWarningType() {
-        return warningTypes.isEmpty();
     }
 
     private static void logTraceIfNecessary(List<StackTraceElement> stack, StringBuilder message) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -68,18 +68,22 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             }
             message.append(usage.getMessage());
             logTraceIfNecessary(usage.getStack(), message);
-            if (warningTypes.contains(WarningType.All)) {
+            if (warningTypes.contains(WarningType.All) || warningTypes.contains(WarningType.Deprecation)) {
                 LOGGER.warn(message.toString());
             }
         }
     }
 
     public void reportSuppressedDeprecations() {
-        if (warningTypes.contains(WarningType.Summary) && !messages.isEmpty()) {
+        if (defaultWarningType() && !messages.isEmpty()) {
             LOGGER.warn("\nThere're {} deprecation warnings, which may break the build in Gradle {}. Please run with --warnings=all to see them.",
                 messages.size(),
                 GradleVersion.current().getNextMajor().getVersion());
         }
+    }
+
+    private boolean defaultWarningType() {
+        return warningTypes.isEmpty();
     }
 
     private static void logTraceIfNecessary(List<StackTraceElement> stack, StringBuilder message) {
@@ -142,7 +146,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
 
     static boolean isTraceLoggingEnabled() {
         String value = System.getProperty(ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME);
-        if(value == null) {
+        if (value == null) {
             return traceLoggingEnabled;
         }
         return Boolean.parseBoolean(value);

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.featurelifecycle;
 
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.internal.SystemProperties;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
@@ -36,7 +36,7 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
     private static boolean traceLoggingEnabled;
     private final Set<String> messages = new HashSet<String>();
     private UsageLocationReporter locationReporter;
-    private WarningType warningType;
+    private WarningMode warningMode;
 
     public LoggingDeprecatedFeatureHandler() {
         this(new UsageLocationReporter() {
@@ -49,9 +49,9 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
         this.locationReporter = locationReporter;
     }
 
-    public void init(UsageLocationReporter reporter, WarningType warningType) {
+    public void init(UsageLocationReporter reporter, WarningMode warningMode) {
         this.locationReporter = reporter;
-        this.warningType = warningType;
+        this.warningMode = warningMode;
     }
 
     public void reset() {
@@ -68,15 +68,15 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
             }
             message.append(usage.getMessage());
             logTraceIfNecessary(usage.getStack(), message);
-            if (warningType==WarningType.All) {
+            if (warningMode == WarningMode.All) {
                 LOGGER.warn(message.toString());
             }
         }
     }
 
     public void reportSuppressedDeprecations() {
-        if (warningType == WarningType.Summary && !messages.isEmpty()) {
-            LOGGER.warn("\nThere're {} deprecation warnings, which may break the build in Gradle {}. Please run with --warnings=all to see them.",
+        if (warningMode == WarningMode.Summary && !messages.isEmpty()) {
+            LOGGER.warn("\nThere're {} deprecation warnings, which may break the build in Gradle {}. Please run with --warning-mode=all to see them.",
                 messages.size(),
                 GradleVersion.current().getNextMajor().getVersion());
         }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -22,7 +22,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 
 import java.io.Serializable;
 
@@ -30,7 +30,7 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
-    private WarningType warningType =  WarningType.Summary;
+    private WarningMode warningMode =  WarningMode.Summary;
 
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj);
@@ -63,13 +63,13 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     }
 
     @Override
-    public WarningType getWarningType() {
-        return warningType;
+    public WarningMode getWarningMode() {
+        return warningMode;
     }
 
     @Override
-    public void setWarningType(WarningType warningType) {
-        this.warningType = warningType;
+    public void setWarningMode(WarningMode warningMode) {
+        this.warningMode = warningMode;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -32,7 +32,7 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
-    private Set<WarningType> warningTypes = Sets.newHashSet(WarningType.Summary);
+    private Set<WarningType> warningTypes = Sets.newHashSet();
 
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj);

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.logging;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.gradle.api.Incubating;
@@ -26,13 +25,12 @@ import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.logging.configuration.WarningType;
 
 import java.io.Serializable;
-import java.util.Set;
 
 public class DefaultLoggingConfiguration implements Serializable, LoggingConfiguration {
     private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
-    private Set<WarningType> warningTypes = Sets.newHashSet();
+    private WarningType warningType =  WarningType.Summary;
 
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj);
@@ -65,13 +63,13 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     }
 
     @Override
-    public Set<WarningType> getWarningTypes() {
-        return warningTypes;
+    public WarningType getWarningType() {
+        return warningType;
     }
 
     @Override
-    public void setWarningTypes(Set<WarningType> warningTypes) {
-        this.warningTypes = warningTypes;
+    public void setWarningType(WarningType warningType) {
+        this.warningType = warningType;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/DefaultLoggingConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.logging;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.gradle.api.Incubating;
@@ -22,13 +23,16 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
+import org.gradle.api.logging.configuration.WarningType;
 
 import java.io.Serializable;
+import java.util.Set;
 
 public class DefaultLoggingConfiguration implements Serializable, LoggingConfiguration {
     private LogLevel logLevel = LogLevel.LIFECYCLE;
     private ShowStacktrace showStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private ConsoleOutput consoleOutput = ConsoleOutput.Auto;
+    private Set<WarningType> warningTypes = Sets.newHashSet(WarningType.Summary);
 
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj);
@@ -58,6 +62,16 @@ public class DefaultLoggingConfiguration implements Serializable, LoggingConfigu
     @Incubating
     public void setConsoleOutput(ConsoleOutput consoleOutput) {
         this.consoleOutput = consoleOutput;
+    }
+
+    @Override
+    public Set<WarningType> getWarningTypes() {
+        return warningTypes;
+    }
+
+    @Override
+    public void setWarningTypes(Set<WarningType> warningTypes) {
+        this.warningTypes = warningTypes;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -34,7 +34,6 @@ import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -189,11 +188,10 @@ public class LoggingConfigurationBuildOptions {
         @Override
         public void applyTo(List<String> values, LoggingConfiguration settings, final Origin origin) {
             Iterable<WarningType> warningTypes = Iterables.transform(values, new Function<String, WarningType>() {
-                @Nullable
                 @Override
-                public WarningType apply(@Nullable String input) {
+                public WarningType apply(String input) {
                     try {
-                        return WarningType.fromBuildOption(input);
+                        return WarningType.valueOf(StringUtils.capitalize(input.toLowerCase(Locale.ENGLISH)));
                     } catch (IllegalArgumentException e) {
                         origin.handleInvalidValue(input);
                         return null;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -16,9 +16,6 @@
 
 package org.gradle.internal.logging;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
@@ -30,7 +27,6 @@ import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.buildoption.AbstractBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
-import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
@@ -177,7 +173,7 @@ public class LoggingConfigurationBuildOptions {
         }
     }
 
-    public static class WarningsOption extends ListBuildOption<LoggingConfiguration> {
+    public static class WarningsOption extends StringBuildOption<LoggingConfiguration> {
         public static final String LONG_OPTION = "warnings";
         public static final String GRADLE_PROPERTY = "org.gradle.warnings";
 
@@ -186,20 +182,12 @@ public class LoggingConfigurationBuildOptions {
         }
 
         @Override
-        public void applyTo(List<String> values, LoggingConfiguration settings, final Origin origin) {
-            Iterable<WarningType> warningTypes = Iterables.transform(values, new Function<String, WarningType>() {
-                @Override
-                public WarningType apply(String input) {
-                    try {
-                        return WarningType.valueOf(StringUtils.capitalize(input.toLowerCase(Locale.ENGLISH)));
-                    } catch (IllegalArgumentException e) {
-                        origin.handleInvalidValue(input);
-                        return null;
-                    }
-                }
-            });
-            settings.setWarningTypes(Sets.newHashSet(warningTypes));
+        public void applyTo(String value, LoggingConfiguration settings, final Origin origin) {
+            try {
+                settings.setWarningType(WarningType.valueOf(StringUtils.capitalize(value.toLowerCase(Locale.ENGLISH))));
+            } catch (IllegalArgumentException e) {
+                origin.handleInvalidValue(value);
+            }
         }
     }
-
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -21,7 +21,7 @@ import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.buildoption.AbstractBuildOption;
@@ -174,17 +174,17 @@ public class LoggingConfigurationBuildOptions {
     }
 
     public static class WarningsOption extends StringBuildOption<LoggingConfiguration> {
-        public static final String LONG_OPTION = "warnings";
-        public static final String GRADLE_PROPERTY = "org.gradle.warnings";
+        public static final String LONG_OPTION = "warning-mode";
+        public static final String GRADLE_PROPERTY = "org.gradle.warning.mode";
 
         public WarningsOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which type of warnings to generate. Values are 'all', 'summary' (default) or 'no'"));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which mode of warnings to generate. Values are 'all', 'summary'(default) or 'no'"));
         }
 
         @Override
         public void applyTo(String value, LoggingConfiguration settings, final Origin origin) {
             try {
-                settings.setWarningType(WarningType.valueOf(StringUtils.capitalize(value.toLowerCase(Locale.ENGLISH))));
+                settings.setWarningMode(WarningMode.valueOf(StringUtils.capitalize(value.toLowerCase(Locale.ENGLISH))));
             } catch (IllegalArgumentException e) {
                 origin.handleInvalidValue(value);
             }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -16,19 +16,25 @@
 
 package org.gradle.internal.logging;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
+import org.gradle.api.logging.configuration.WarningType;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.internal.buildoption.AbstractBuildOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
+import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,6 +50,7 @@ public class LoggingConfigurationBuildOptions {
         options.add(new LogLevelOption());
         options.add(new StacktraceOption());
         options.add(new ConsoleOption());
+        options.add(new WarningsOption());
         LoggingConfigurationBuildOptions.options = Collections.unmodifiableList(options);
     }
 
@@ -170,4 +177,31 @@ public class LoggingConfigurationBuildOptions {
             }
         }
     }
+
+    public static class WarningsOption extends ListBuildOption<LoggingConfiguration> {
+        public static final String LONG_OPTION = "warnings";
+        public static final String GRADLE_PROPERTY = "org.gradle.warnings";
+
+        public WarningsOption() {
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which type of warnings to generate. Values are 'all', 'summary' (default) or 'no'"));
+        }
+
+        @Override
+        public void applyTo(List<String> values, LoggingConfiguration settings, final Origin origin) {
+            Iterable<WarningType> warningTypes = Iterables.transform(values, new Function<String, WarningType>() {
+                @Nullable
+                @Override
+                public WarningType apply(@Nullable String input) {
+                    try {
+                        return WarningType.fromBuildOption(input);
+                    } catch (IllegalArgumentException e) {
+                        origin.handleInvalidValue(input);
+                        return null;
+                    }
+                }
+            });
+            settings.setWarningTypes(Sets.newHashSet(warningTypes));
+        }
+    }
+
 }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -78,10 +78,10 @@ public class SingleMessageLogger {
         }
     }
 
-    public static void init(UsageLocationReporter reporter, Set<WarningType> warningTypes) {
+    public static void init(UsageLocationReporter reporter, WarningType warningType) {
         LOCK.lock();
         try {
-            handler.init(reporter, warningTypes);
+            handler.init(reporter, warningType);
         } finally {
             LOCK.unlock();
         }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -18,6 +18,7 @@ package org.gradle.util;
 
 import net.jcip.annotations.ThreadSafe;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.logging.configuration.WarningType;
 import org.gradle.internal.Factory;
 import org.gradle.internal.featurelifecycle.DeprecatedFeatureUsage;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
@@ -71,16 +72,25 @@ public class SingleMessageLogger {
         FEATURES.clear();
         LOCK.lock();
         try {
-            handler = new LoggingDeprecatedFeatureHandler();
+            handler.reset();
         } finally {
             LOCK.unlock();
         }
     }
 
-    public static void useLocationReporter(UsageLocationReporter reporter) {
+    public static void init(UsageLocationReporter reporter, Set<WarningType> warningTypes) {
         LOCK.lock();
         try {
-            handler.setLocationReporter(reporter);
+            handler.init(reporter, warningTypes);
+        } finally {
+            LOCK.unlock();
+        }
+    }
+
+    public static void reportSuppressedDeprecations() {
+        LOCK.lock();
+        try {
+            handler.reportSuppressedDeprecations();
         } finally {
             LOCK.unlock();
         }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -18,7 +18,7 @@ package org.gradle.util;
 
 import net.jcip.annotations.ThreadSafe;
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.logging.configuration.WarningType;
+import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.internal.Factory;
 import org.gradle.internal.featurelifecycle.DeprecatedFeatureUsage;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
@@ -78,10 +78,10 @@ public class SingleMessageLogger {
         }
     }
 
-    public static void init(UsageLocationReporter reporter, WarningType warningType) {
+    public static void init(UsageLocationReporter reporter, WarningMode warningMode) {
         LOCK.lock();
         try {
-            handler.init(reporter, warningType);
+            handler.init(reporter, warningMode);
         } finally {
             LOCK.unlock();
         }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.internal.featurelifecycle
 
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningType
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
+import org.gradle.testing.internal.util.Specification
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TextUtil
 import org.junit.Rule
-import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
@@ -35,6 +36,10 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     SetSystemProperties systemProperties = new SetSystemProperties()
     final locationReporter = Mock(UsageLocationReporter)
     final handler = new LoggingDeprecatedFeatureHandler(locationReporter)
+
+    def setup() {
+        handler.init(locationReporter, [WarningType.All] as Set)
+    }
 
     def 'logs each deprecation warning only once'() {
         when:
@@ -62,6 +67,18 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         def event = outputEventListener.events[0]
         event.message == 'feature'
         event.logLevel == LogLevel.WARN
+    }
+
+    def "no warnings should be displayed in #mode"() {
+        when:
+        handler.init(locationReporter, [type] as Set)
+        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature1'))
+
+        then:
+        outputEventListener.events.empty
+
+        where:
+        type << [WarningType.None, WarningType.Summary]
     }
 
     @Unroll

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -71,14 +71,15 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def "no warnings should be displayed in #mode"() {
         when:
-        handler.init(locationReporter, [type] as Set)
+        def warningTypes = type == null ? [] : [type]
+        handler.init(locationReporter, warningTypes as Set)
         handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature1'))
 
         then:
         outputEventListener.events.empty
 
         where:
-        type << [WarningType.None, WarningType.Summary]
+        type << [WarningType.None, null]
     }
 
     @Unroll

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.featurelifecycle
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.configuration.WarningType
+import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.testing.internal.util.Specification
@@ -38,7 +38,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     final handler = new LoggingDeprecatedFeatureHandler(locationReporter)
 
     def setup() {
-        handler.init(locationReporter, WarningType.All)
+        handler.init(locationReporter, WarningMode.All)
     }
 
     def 'logs each deprecation warning only once'() {
@@ -78,7 +78,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         outputEventListener.events.empty
 
         where:
-        type << [WarningType.None, null]
+        type << [WarningMode.None, null]
     }
 
     @Unroll

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -38,7 +38,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     final handler = new LoggingDeprecatedFeatureHandler(locationReporter)
 
     def setup() {
-        handler.init(locationReporter, [WarningType.All] as Set)
+        handler.init(locationReporter, WarningType.All)
     }
 
     def 'logs each deprecation warning only once'() {
@@ -71,8 +71,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def "no warnings should be displayed in #mode"() {
         when:
-        def warningTypes = type == null ? [] : [type]
-        handler.init(locationReporter, warningTypes as Set)
+        handler.init(locationReporter, type)
         handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature1'))
 
         then:

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.api.logging.configuration.LoggingConfiguration
 import org.gradle.api.logging.configuration.ShowStacktrace
-import org.gradle.api.logging.configuration.WarningType
+import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.cli.CommandLineArgumentException
 import spock.lang.Specification
 
@@ -117,10 +117,10 @@ class LoggingCommandLineConverterTest extends Specification {
         converter.logLevels == [LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET, LogLevel.WARN] as Set
     }
 
-    def getsAllWarningTypes() {
-        expectedConfig.warningType = WarningType.All
+    def getsWarningMode() {
+        expectedConfig.warningMode = WarningMode.All
         expect:
-        checkConversion(['--warnings=all'])
+        checkConversion(['--warning-mode=all'])
     }
 
     void checkConversion(List<String> args) {
@@ -128,6 +128,6 @@ class LoggingCommandLineConverterTest extends Specification {
         assert actual.logLevel == expectedConfig.logLevel
         assert actual.consoleOutput == expectedConfig.consoleOutput
         assert actual.showStacktrace == expectedConfig.showStacktrace
-        assert actual.warningType == expectedConfig.warningType
+        assert actual.warningMode == expectedConfig.warningMode
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.api.logging.configuration.LoggingConfiguration
 import org.gradle.api.logging.configuration.ShowStacktrace
+import org.gradle.api.logging.configuration.WarningType
 import org.gradle.cli.CommandLineArgumentException
 import spock.lang.Specification
 
@@ -56,12 +57,12 @@ class LoggingCommandLineConverterTest extends Specification {
     }
 
     def convertsWarnLevel() {
-         expectedConfig.logLevel = LogLevel.WARN
+        expectedConfig.logLevel = LogLevel.WARN
 
-         expect:
-         checkConversion(['-w'])
-         checkConversion(['--warn'])
-     }
+        expect:
+        checkConversion(['-w'])
+        checkConversion(['--warn'])
+    }
 
     def convertsConsole() {
         expectedConfig.consoleOutput = consoleOutput
@@ -116,10 +117,17 @@ class LoggingCommandLineConverterTest extends Specification {
         converter.logLevels == [LogLevel.DEBUG, LogLevel.INFO, LogLevel.LIFECYCLE, LogLevel.QUIET, LogLevel.WARN] as Set
     }
 
+    def getsAllWarningTypes() {
+        expectedConfig.warningTypes = [WarningType.All, WarningType.Deprecation, WarningType.None] as Set
+        expect:
+        checkConversion(['--warnings=all', '--warnings=deprecation', '--warnings=none'])
+    }
+
     void checkConversion(List<String> args) {
         def actual = converter.convert(args, new DefaultLoggingConfiguration())
         assert actual.logLevel == expectedConfig.logLevel
         assert actual.consoleOutput == expectedConfig.consoleOutput
         assert actual.showStacktrace == expectedConfig.showStacktrace
+        assert actual.warningTypes == expectedConfig.warningTypes
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -118,9 +118,9 @@ class LoggingCommandLineConverterTest extends Specification {
     }
 
     def getsAllWarningTypes() {
-        expectedConfig.warningTypes = [WarningType.All, WarningType.Deprecation, WarningType.None] as Set
+        expectedConfig.warningType = WarningType.All
         expect:
-        checkConversion(['--warnings=all', '--warnings=deprecation', '--warnings=none'])
+        checkConversion(['--warnings=all'])
     }
 
     void checkConversion(List<String> args) {
@@ -128,6 +128,6 @@ class LoggingCommandLineConverterTest extends Specification {
         assert actual.logLevel == expectedConfig.logLevel
         assert actual.consoleOutput == expectedConfig.consoleOutput
         assert actual.showStacktrace == expectedConfig.showStacktrace
-        assert actual.warningTypes == expectedConfig.warningTypes
+        assert actual.warningType == expectedConfig.warningType
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.util
 
-import org.gradle.api.logging.configuration.WarningType
+import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.internal.Factory
 import org.gradle.internal.featurelifecycle.UsageLocationReporter
 import org.gradle.internal.logging.CollectingTestOutputEventListener
@@ -32,7 +32,7 @@ class SingleMessageLoggerTest extends ConcurrentSpec {
     final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
 
     def setup() {
-        SingleMessageLogger.init(Mock(UsageLocationReporter), WarningType.All)
+        SingleMessageLogger.init(Mock(UsageLocationReporter), WarningMode.All)
     }
 
     def cleanup() {

--- a/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
@@ -32,7 +32,7 @@ class SingleMessageLoggerTest extends ConcurrentSpec {
     final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
 
     def setup() {
-        SingleMessageLogger.init(Mock(UsageLocationReporter), [WarningType.All] as Set)
+        SingleMessageLogger.init(Mock(UsageLocationReporter), WarningType.All)
     }
 
     def cleanup() {

--- a/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/util/SingleMessageLoggerTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.util
 
+import org.gradle.api.logging.configuration.WarningType
 import org.gradle.internal.Factory
+import org.gradle.internal.featurelifecycle.UsageLocationReporter
 import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -28,6 +30,10 @@ class SingleMessageLoggerTest extends ConcurrentSpec {
     final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
     @Rule
     final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    def setup() {
+        SingleMessageLogger.init(Mock(UsageLocationReporter), [WarningType.All] as Set)
+    }
 
     def cleanup() {
         SingleMessageLogger.reset()

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
@@ -81,7 +81,7 @@ class PluginUnderTest {
         new NoDaemonGradleExecuter(new UnderDevelopmentGradleDistribution(), testDirectoryProvider)
             .usingProjectDirectory(projectDir)
             .withArguments('classes', '--no-daemon')
-            .withWarningType(null)
+            .withWarningMode(null)
             .run()
         this
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
@@ -81,7 +81,7 @@ class PluginUnderTest {
         new NoDaemonGradleExecuter(new UnderDevelopmentGradleDistribution(), testDirectoryProvider)
             .usingProjectDirectory(projectDir)
             .withArguments('classes', '--no-daemon')
-            .withWarnings([] as Set)
+            .withWarningType(null)
             .run()
         this
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
@@ -81,6 +81,7 @@ class PluginUnderTest {
         new NoDaemonGradleExecuter(new UnderDevelopmentGradleDistribution(), testDirectoryProvider)
             .usingProjectDirectory(projectDir)
             .withArguments('classes', '--no-daemon')
+            .withWarnings([] as Set)
             .run()
         this
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing.worker;
 
 import org.gradle.api.Action;
 import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.api.internal.tasks.testing.JULRedirector;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
@@ -66,6 +67,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     public void processTestClass(TestClassRunInfo testClass) {
         if (remoteProcessor == null) {
             completion = currentWorkerLease.startChild();
+            JULRedirector.checkDeprecatedProperty(options);
             remoteProcessor = forkProcess();
         }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
@@ -38,9 +38,10 @@ class ForkingTestClassProcessorTest extends Specification {
     WorkerProcessBuilder workerProcessBuilder = Mock(WorkerProcessBuilder)
     WorkerProcess workerProcess = Mock(WorkerProcess)
     ModuleRegistry moduleRegistry = Mock(ModuleRegistry)
+    JavaForkOptions options = Mock(JavaForkOptions)
 
     @Subject
-        processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLease, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), Mock(JavaForkOptions), [new File("classpath.jar")], Mock(Action), moduleRegistry])
+        processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLease, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], Mock(Action), moduleRegistry])
 
     def "acquires worker lease and starts worker process on first test"() {
         def test1 = Mock(TestClassRunInfo)
@@ -54,6 +55,7 @@ class ForkingTestClassProcessorTest extends Specification {
 
         then:
         1 * workerLease.startChild()
+        1 * options.getSystemProperties() >> [:]
         1 * processor.forkProcess() >> remoteProcessor
         1 * remoteProcessor.processTestClass(test1)
         1 * remoteProcessor.processTestClass(test2)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
@@ -36,7 +36,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         def workDir = temporaryFolder.file("work")
         def implJar = workDir.file("action-impl.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningType(null), workDir)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningMode(null), workDir)
 
         given:
         builder.sourceFile('ActionImpl.java') << """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.integtests.tooling.r22
 
-import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.fixtures.executer.GradleBackedArtifactBuilder
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.BuildAction
@@ -36,7 +36,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         def workDir = temporaryFolder.file("work")
         def implJar = workDir.file("action-impl.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarnings([] as Set), workDir)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningType(null), workDir)
 
         given:
         builder.sourceFile('ActionImpl.java') << """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
@@ -36,7 +36,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         def workDir = temporaryFolder.file("work")
         def implJar = workDir.file("action-impl.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder), workDir)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarnings([] as Set), workDir)
 
         given:
         builder.sourceFile('ActionImpl.java') << """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
@@ -36,7 +36,7 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
         println "Building plugin with $gradleDist"
         def pluginDir = file("plugin")
         def pluginJar = pluginDir.file("plugin.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarningType(null), pluginDir)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarningMode(null), pluginDir)
         builder.sourceFile("com/example/MyTask.java") << """
             package com.example;
             

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
@@ -36,7 +36,7 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
         println "Building plugin with $gradleDist"
         def pluginDir = file("plugin")
         def pluginJar = pluginDir.file("plugin.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder), pluginDir)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarnings([] as Set), pluginDir)
         builder.sourceFile("com/example/MyTask.java") << """
             package com.example;
             

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
@@ -36,7 +36,7 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
         println "Building plugin with $gradleDist"
         def pluginDir = file("plugin")
         def pluginJar = pluginDir.file("plugin.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarnings([] as Set), pluginDir)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarningType(null), pluginDir)
         builder.sourceFile("com/example/MyTask.java") << """
             package com.example;
             

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
@@ -34,7 +34,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
     def "can load custom action from url containing whitespaces"() {
         setup:
         toolingApi.requireIsolatedDaemons()
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder), temporaryFolder.testDirectory)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarnings([] as Set), temporaryFolder.testDirectory)
         builder.sourceFile('ActionImpl.java') << """
             public class ActionImpl implements ${BuildAction.name}<Void> {
                 public Void execute(${BuildController.name} controller) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.integtests.tooling.r34
 
-import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.fixtures.executer.GradleBackedArtifactBuilder
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
@@ -34,7 +34,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
     def "can load custom action from url containing whitespaces"() {
         setup:
         toolingApi.requireIsolatedDaemons()
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarnings([] as Set), temporaryFolder.testDirectory)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningType(null), temporaryFolder.testDirectory)
         builder.sourceFile('ActionImpl.java') << """
             public class ActionImpl implements ${BuildAction.name}<Void> {
                 public Void execute(${BuildController.name} controller) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
@@ -34,7 +34,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
     def "can load custom action from url containing whitespaces"() {
         setup:
         toolingApi.requireIsolatedDaemons()
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningType(null), temporaryFolder.testDirectory)
+        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningMode(null), temporaryFolder.testDirectory)
         builder.sourceFile('ActionImpl.java') << """
             public class ActionImpl implements ${BuildAction.name}<Void> {
                 public Void execute(${BuildController.name} controller) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedBuildJvmCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedBuildJvmCrossVersionSpec.groovy
@@ -33,12 +33,14 @@ class ToolingApiDeprecatedBuildJvmCrossVersionSpec extends ToolingApiSpecificati
         toolingApi.requireDaemons()
     }
 
-    def configureJava7(){
-        projectDir.file("gradle.properties").writeProperties("org.gradle.java.home": AvailableJavaHomes.jdk7.javaHome.absolutePath)
+    def configureJava7() {
+        projectDir.file("gradle.properties").writeProperties(
+            ["org.gradle.java.home": AvailableJavaHomes.jdk7.javaHome.absolutePath, 'org.gradle.warnings': 'all'])
     }
 
-    def configureJava8(){
-        projectDir.file("gradle.properties").writeProperties("org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.absolutePath)
+    def configureJava8() {
+        projectDir.file("gradle.properties").writeProperties(
+            ["org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.absolutePath, 'org.gradle.warnings': 'all'])
     }
 
     @IgnoreIf({ AvailableJavaHomes.jdk7 == null })

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedBuildJvmCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedBuildJvmCrossVersionSpec.groovy
@@ -35,12 +35,12 @@ class ToolingApiDeprecatedBuildJvmCrossVersionSpec extends ToolingApiSpecificati
 
     def configureJava7() {
         projectDir.file("gradle.properties").writeProperties(
-            ["org.gradle.java.home": AvailableJavaHomes.jdk7.javaHome.absolutePath, 'org.gradle.warnings': 'all'])
+            ["org.gradle.java.home": AvailableJavaHomes.jdk7.javaHome.absolutePath, 'org.gradle.warning.mode': 'all'])
     }
 
     def configureJava8() {
         projectDir.file("gradle.properties").writeProperties(
-            ["org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.absolutePath, 'org.gradle.warnings': 'all'])
+            ["org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.absolutePath, 'org.gradle.warning.mode': 'all'])
     }
 
     @IgnoreIf({ AvailableJavaHomes.jdk7 == null })

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedClientJvmCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedClientJvmCrossVersionSpec.groovy
@@ -59,7 +59,7 @@ public class TestClient {
             .useGradleUserHomeDir(new File("${temporaryFolder.file("userHome").toString().replace(File.separator,"/")}"))
             .connect()
             .newBuild()
-            .withArguments("--warnings=all")
+            .withArguments("--warning-mode=all")
             .forTasks("help")
             .setStandardOutput(System.out)
             .setStandardError(System.out)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedClientJvmCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedClientJvmCrossVersionSpec.groovy
@@ -26,7 +26,6 @@ import org.gradle.internal.jvm.UnsupportedJavaRuntimeException
 import org.gradle.util.GradleVersion
 import spock.lang.IgnoreIf
 
-
 class ToolingApiDeprecatedClientJvmCrossVersionSpec extends ToolingApiSpecification {
     def setup() {
         settingsFile << "rootProject.name = 'test'"
@@ -43,22 +42,28 @@ repositories {
         url '${buildContext.libsRepo.toURI()}'
     }
 }
-
 ${mavenCentralRepository()}
-
 dependencies {
     compile "org.gradle:gradle-tooling-api:${GradleVersion.current().version}"
     runtime 'org.slf4j:slf4j-simple:1.7.10'
 }
-
 mainClassName = 'TestClient'
 """
         file('src/main/java/TestClient.java') << """
 import org.gradle.tooling.GradleConnector;
-
+import java.io.File;
 public class TestClient {
-    public static void main(String[] args) {
-        GradleConnector.newConnector();
+    public static void main(String[] args) throws Exception {
+        GradleConnector.newConnector().forProjectDirectory(new File("."))
+            .useDistribution(new java.net.URI("${dist.binDistribution.toURI()}"))
+            .useGradleUserHomeDir(new File("${temporaryFolder.file("userHome").toString().replace(File.separator,"/")}"))
+            .connect()
+            .newBuild()
+            .withArguments("--warnings=all")
+            .forTasks("help")
+            .setStandardOutput(System.out)
+            .setStandardError(System.out)
+            .run();
         System.exit(0);
     }
 }
@@ -94,6 +99,7 @@ public class TestClient {
         executer.environment(JAVA_HOME: javaHome)
         executer.workingDir(projectDir)
         executer.errorOutput = outStr // simple slf4j writes warnings to stderr
+        executer.standardOutput = outStr
         executer.commandLine("build/install/test/bin/test")
         executer.run().assertNormalExitValue()
 

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
@@ -44,7 +44,7 @@ class WrapperCrossVersionIntegrationTest extends CrossVersionIntegrationSpec {
 
     void canUseWrapperFromCurrentVersionToRunPreviousVersion() {
         when:
-        GradleExecuter executer = prepareWrapperExecuter(current, previous).withWarningType(null)
+        GradleExecuter executer = prepareWrapperExecuter(current, previous).withWarningMode(null)
 
         then:
         checkWrapperWorksWith(executer, previous)

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
@@ -44,7 +44,7 @@ class WrapperCrossVersionIntegrationTest extends CrossVersionIntegrationSpec {
 
     void canUseWrapperFromCurrentVersionToRunPreviousVersion() {
         when:
-        GradleExecuter executer = prepareWrapperExecuter(current, previous)
+        GradleExecuter executer = prepareWrapperExecuter(current, previous).withWarningType(null)
 
         then:
         checkWrapperWorksWith(executer, previous)


### PR DESCRIPTION
### Context

This is a first-step implementation of #3728 . More design spec please see https://docs.google.com/document/d/1x5pasO5z5wZWLJBKHbgVbEsSX60jSv9s3uJn8e8bwQc/edit

In short, we don't want users to see deprecation warnings by default. This PR suppresses all warnings by default and adds `--warnings` to control this behavior:

- No option. By default don't display all warnings and render a summary at the end of the build: "There're {} warnings in your build, please run --warnings=all to see them."
- `--warnings=none` Don't display warnings and summary.
- `--warnings=all` Just like what Gradle does now.

This PR removes the refactoring part in #3751 to make review a bit easier.