### PR TITLE
Remove some wrong timing loggings

### DIFF
--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactoryTest.groovy
@@ -76,7 +76,7 @@ class TaskOutputCacheCommandFactoryTest extends Specification {
             prop("outputDir", DIRECTORY, outputDir),
             prop("outputFile", FILE, outputFile),
         ] as SortedSet
-        def load = commandFactory.createLoad(key, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState, timer)
+        def load = commandFactory.createLoad(key, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState)
 
         def outputDirSnapshot = new DirectoryFileSnapshot(outputDir.path, RelativePath.EMPTY_ROOT, true)
         def outputDirFileContent = new FileHashSnapshot(HashCode.fromInt(123))
@@ -128,7 +128,7 @@ class TaskOutputCacheCommandFactoryTest extends Specification {
         def input = Mock(InputStream)
         def outputFile = temporaryFolder.file("output.txt")
         def outputProperties = props("output", FILE, outputFile)
-        def command = commandFactory.createLoad(key, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState, timer)
+        def command = commandFactory.createLoad(key, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState)
 
         when:
         command.load(input)
@@ -163,7 +163,7 @@ class TaskOutputCacheCommandFactoryTest extends Specification {
     def "error during cleanup of failed unpacking is reported"() {
         def input = Mock(InputStream)
         def outputProperties = Mock(SortedSet)
-        def command = commandFactory.createLoad(key, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState, timer)
+        def command = commandFactory.createLoad(key, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState)
 
         when:
         command.load(input)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -102,7 +102,7 @@ public class CreateEmptyDirectory extends DefaultTask {
         '''
 
         def customTask = ':customTask'
-        def notUpToDateBecause = /Up-to-date check for task '${customTask}' took .* secs\. It is not up-to-date because:/
+        def notUpToDateBecause = /Up-to-date check for task '${customTask}' completed\. It is not up-to-date because:/
         when:
         run customTask, '-Pcontent=first', '--info'
         then:
@@ -121,6 +121,6 @@ public class CreateEmptyDirectory extends DefaultTask {
         run customTask, '-Pcontent=second', '--info'
         then:
         skipped customTask
-        result.output =~ /Skipping task '${customTask}' as it is up-to-date \(took .* secs\)\./
+        result.output =~ /Skipping task '${customTask}' as it is up-to-date\./
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -102,7 +102,7 @@ public class CreateEmptyDirectory extends DefaultTask {
         '''
 
         def customTask = ':customTask'
-        def notUpToDateBecause = /Up-to-date check for task '${customTask}' completed\. It is not up-to-date because:/
+        def notUpToDateBecause = /Task '${customTask}' is not up-to-date because:/
         when:
         run customTask, '-Pcontent=first', '--info'
         then:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks;
 import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.internal.tasks.execution.TaskProperties;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
-import org.gradle.internal.time.Timer;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -41,14 +40,6 @@ public interface TaskExecutionContext {
     OriginTaskExecutionMetadata getOriginExecutionMetadata();
 
     void setOriginExecutionMetadata(OriginTaskExecutionMetadata originExecutionMetadata);
-
-    /**
-     * The timer that started at the very start of executing this task.
-     *
-     * This is not precisely aligned with the start time of the corresponding build operation,
-     * but should be extremely close.
-     */
-    Timer getExecutionTimer();
 
     /**
      * Sets the execution time of the task to be the elapsed time since start to now.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -70,11 +70,6 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
         this.originExecutionMetadata = originExecutionMetadata;
     }
 
-    @Override
-    public Timer getExecutionTimer() {
-        return executionTimer;
-    }
-
     public long markExecutionTime() {
         if (this.executionTime != null) {
             throw new IllegalStateException("execution time already set");

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
@@ -77,7 +77,7 @@ public class SkipCachedTaskExecuter implements TaskExecuter {
                 if (taskState.isAllowedToUseCachedResults()) {
                     try {
                         OriginTaskExecutionMetadata originMetadata = buildCache.load(
-                            buildCacheCommandFactory.createLoad(cacheKey, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskState, context.getExecutionTimer())
+                            buildCacheCommandFactory.createLoad(cacheKey, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskState)
                         );
                         if (originMetadata != null) {
                             state.setOutcome(TaskExecutionOutcome.FROM_CACHE);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
@@ -62,7 +62,7 @@ public class SkipUpToDateTaskExecuter implements TaskExecuter {
     private void logOutOfDateMessages(List<String> messages, TaskInternal task) {
         if (LOGGER.isInfoEnabled()) {
             Formatter formatter = new Formatter();
-            formatter.format("Up-to-date check for %s completed. It is not up-to-date because:", task);
+            formatter.format("Task '%s' is not up-to-date because:", task.getIdentityPath());
             for (String message : messages) {
                 formatter.format("%n  %s", message);
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipUpToDateTaskExecuter.java
@@ -24,8 +24,6 @@ import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
-import org.gradle.internal.time.Time;
-import org.gradle.internal.time.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,26 +44,25 @@ public class SkipUpToDateTaskExecuter implements TaskExecuter {
 
     public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
         LOGGER.debug("Determining if {} is up-to-date", task);
-        Timer clock = Time.startTimer();
         TaskArtifactState taskArtifactState = context.getTaskArtifactState();
 
         List<String> messages = new ArrayList<String>(TaskUpToDateState.MAX_OUT_OF_DATE_MESSAGES);
         if (taskArtifactState.isUpToDate(messages)) {
-            LOGGER.info("Skipping {} as it is up-to-date (took {}).", task, clock.getElapsed());
+            LOGGER.info("Skipping {} as it is up-to-date.", task);
             state.setOutcome(TaskExecutionOutcome.UP_TO_DATE);
             context.setOriginExecutionMetadata(taskArtifactState.getExecutionHistory().getOriginExecutionMetadata());
             return;
         }
         context.setUpToDateMessages(ImmutableList.copyOf(messages));
-        logOutOfDateMessages(messages, task, clock.getElapsed());
+        logOutOfDateMessages(messages, task);
 
         executer.execute(task, state, context);
     }
 
-    private void logOutOfDateMessages(List<String> messages, TaskInternal task, String took) {
+    private void logOutOfDateMessages(List<String> messages, TaskInternal task) {
         if (LOGGER.isInfoEnabled()) {
             Formatter formatter = new Formatter();
-            formatter.format("Up-to-date check for %s took %s. It is not up-to-date because:", task, took);
+            formatter.format("Up-to-date check for %s completed. It is not up-to-date because:", task);
             for (String message : messages) {
                 formatter.format("%n  %s", message);
             }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TaskOutputCacheCommandFactory.java
@@ -47,7 +47,6 @@ import org.gradle.caching.internal.controller.BuildCacheLoadCommand;
 import org.gradle.caching.internal.controller.BuildCacheStoreCommand;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginFactory;
 import org.gradle.internal.file.FileType;
-import org.gradle.internal.time.Timer;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,8 +81,8 @@ public class TaskOutputCacheCommandFactory {
         this.stringInterner = stringInterner;
     }
 
-    public BuildCacheLoadCommand<OriginTaskExecutionMetadata> createLoad(TaskOutputCachingBuildCacheKey cacheKey, SortedSet<ResolvedTaskOutputFilePropertySpec> outputProperties, TaskInternal task, TaskProperties taskProperties, TaskOutputsGenerationListener taskOutputsGenerationListener, TaskArtifactState taskArtifactState, Timer clock) {
-        return new LoadCommand(cacheKey, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState, clock);
+    public BuildCacheLoadCommand<OriginTaskExecutionMetadata> createLoad(TaskOutputCachingBuildCacheKey cacheKey, SortedSet<ResolvedTaskOutputFilePropertySpec> outputProperties, TaskInternal task, TaskProperties taskProperties, TaskOutputsGenerationListener taskOutputsGenerationListener, TaskArtifactState taskArtifactState) {
+        return new LoadCommand(cacheKey, outputProperties, task, taskProperties, taskOutputsGenerationListener, taskArtifactState);
     }
 
     public BuildCacheStoreCommand createStore(TaskOutputCachingBuildCacheKey cacheKey, SortedSet<ResolvedTaskOutputFilePropertySpec> outputProperties, Map<String, Map<String, FileContentSnapshot>> outputSnapshots, TaskInternal task, long taskExecutionTime) {
@@ -98,16 +97,14 @@ public class TaskOutputCacheCommandFactory {
         private final TaskProperties taskProperties;
         private final TaskOutputsGenerationListener taskOutputsGenerationListener;
         private final TaskArtifactState taskArtifactState;
-        private final Timer clock;
 
-        private LoadCommand(TaskOutputCachingBuildCacheKey cacheKey, SortedSet<ResolvedTaskOutputFilePropertySpec> outputProperties, TaskInternal task, TaskProperties taskProperties, TaskOutputsGenerationListener taskOutputsGenerationListener, TaskArtifactState taskArtifactState, Timer clock) {
+        private LoadCommand(TaskOutputCachingBuildCacheKey cacheKey, SortedSet<ResolvedTaskOutputFilePropertySpec> outputProperties, TaskInternal task, TaskProperties taskProperties, TaskOutputsGenerationListener taskOutputsGenerationListener, TaskArtifactState taskArtifactState) {
             this.cacheKey = cacheKey;
             this.outputProperties = outputProperties;
             this.task = task;
             this.taskProperties = taskProperties;
             this.taskOutputsGenerationListener = taskOutputsGenerationListener;
             this.taskArtifactState = taskArtifactState;
-            this.clock = clock;
         }
 
         @Override
@@ -135,7 +132,7 @@ public class TaskOutputCacheCommandFactory {
             } finally {
                 cleanLocalState();
             }
-            LOGGER.info("Unpacked output for {} from cache (took {}).", task, clock.getElapsed());
+            LOGGER.info("Unpacked output for {} from cache.", task);
 
             return new BuildCacheLoadCommand.Result<OriginTaskExecutionMetadata>() {
                 @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -33,7 +33,6 @@ import org.gradle.caching.internal.tasks.TaskOutputCacheCommandFactory
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey
 import org.gradle.caching.internal.tasks.UnrecoverableTaskOutputUnpackingException
 import org.gradle.internal.id.UniqueId
-import org.gradle.internal.time.Time
 import spock.lang.Specification
 
 class SkipCachedTaskExecuterTest extends Specification {
@@ -70,14 +69,13 @@ class SkipCachedTaskExecuterTest extends Specification {
         interaction { cachingEnabled() }
 
         then:
-        1 * taskContext.getExecutionTimer() >> Time.startTimer()
         1 * taskProperties.getOutputFileProperties() >> ImmutableSortedSet.of()
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.isAllowedToUseCachedResults() >> true
         1 * cacheKey.isValid() >> true
 
         then:
-        1 * buildCacheCommandFactory.createLoad(cacheKey, _, task, taskProperties, taskOutputGenerationListener, _, _) >> loadCommand
+        1 * buildCacheCommandFactory.createLoad(cacheKey, _, task, taskProperties, taskOutputGenerationListener, _) >> loadCommand
 
         then:
         1 * buildCacheController.load(loadCommand) >> metadata
@@ -98,14 +96,13 @@ class SkipCachedTaskExecuterTest extends Specification {
         interaction { cachingEnabled() }
 
         then:
-        1 * taskContext.getExecutionTimer() >> Time.startTimer()
         1 * taskProperties.getOutputFileProperties() >> ImmutableSortedSet.of()
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.isAllowedToUseCachedResults() >> true
         1 * cacheKey.isValid() >> true
 
         then:
-        1 * buildCacheCommandFactory.createLoad(cacheKey, _, task, taskProperties, taskOutputGenerationListener, _, _) >> loadCommand
+        1 * buildCacheCommandFactory.createLoad(cacheKey, _, task, taskProperties, taskOutputGenerationListener, _) >> loadCommand
 
         then:
         1 * buildCacheController.load(loadCommand) >> null
@@ -169,7 +166,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         interaction { cachingEnabled() }
 
         then:
-        1 * taskContext.getExecutionTimer() >> Time.startTimer()
         1 * taskProperties.getOutputFileProperties() >> ImmutableSortedSet.of()
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.isAllowedToUseCachedResults() >> true
@@ -230,7 +226,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         interaction { cachingEnabled() }
 
         then:
-        1 * taskContext.getExecutionTimer() >> Time.startTimer()
         1 * cacheKey.isValid() >> true
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.isAllowedToUseCachedResults() >> true
@@ -268,7 +263,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         interaction { cachingEnabled() }
 
         then:
-        1 * taskContext.getExecutionTimer() >> Time.startTimer()
         1 * cacheKey.isValid() >> true
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskArtifactState.isAllowedToUseCachedResults() >> true
@@ -295,7 +289,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         interaction { cachingEnabled() }
 
         then:
-        1 * taskContext.getExecutionTimer() >> Time.startTimer()
         1 * taskContext.getTaskArtifactState() >> taskArtifactState
         1 * taskProperties.getOutputFileProperties() >> ImmutableSortedSet.of()
         1 * cacheKey.isValid() >> true


### PR DESCRIPTION
The time which was captured for up-to-date checks is wrong, since it
did not include actual snapshotting any more.
The time captured how long it took to load/unpack from the cache now
would have included the time it took to snapshot the inputs, too.
These timings are much better captured by the corresponding build
operations, so we remove them for now.
