### PR TITLE
Rework variant dependency/constraint/attributes rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -65,4 +65,13 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      */
     void withVariant(String name, Action<? super VariantMetadata> action);
 
+    /**
+     * Add a rule for adjusting all variants of a component.
+     *
+     * @param action the action to be executed on each variant.
+     *
+     * @since 4.5
+     */
+    void allVariants(Action<? super VariantMetadata> action);
+
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -576,28 +576,6 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         }
     }
 
-    def "fails when attempting to select a variant that does not exist"() {
-        when:
-        buildFile << """
-            dependencies {
-                components {
-                    withModule('org.test:moduleA') {
-                        withVariant("testBlue") { }
-                    }
-                }
-            }
-        """
-        repositoryInteractions {
-            'org.test:moduleA:1.0' {
-                expectGetMetadata()
-            }
-        }
-
-        then:
-        fails 'checkDep'
-        failure.assertHasCause("Variant testBlue is not declared for org.test:moduleA:1.0")
-    }
-
     def "resolving one configuration does not influence the result of resolving another configuration."() {
         given:
         repository {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -44,7 +44,6 @@ import org.gradle.internal.resolve.result.BuildableComponentResolveResult;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class ClientModuleResolver implements ComponentMetaDataResolver {
@@ -172,8 +171,8 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
-        public Map<String, VariantMetadataRules> getComponentMetadataRules() {
-            return delegate.getComponentMetadataRules();
+        public VariantMetadataRules getVariantMetadataRules() {
+            return delegate.getVariantMetadataRules();
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -128,7 +128,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactTypeRegistry artifactTypeRegistry, ModuleExclusion exclusions) {
         if (isProjectModule(component.getComponentId())) {
-            return DefaultArtifactSet.multipleVariants(component.getComponentId(), component.getId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, component.getComponentMetadataRules());
+            return DefaultArtifactSet.multipleVariants(component.getComponentId(), component.getId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, component.getVariantMetadataRules());
         } else {
             return null;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -47,8 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.gradle.internal.component.external.model.VariantMetadataRules.getOrDefault;
-
 /**
  * Contains zero or more variants of a particular component.
  */
@@ -61,23 +59,23 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
         this.schema = schema;
     }
 
-    public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, Set<? extends VariantMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, Map<String, VariantMetadataRules> componentMetadataRulesMap) {
+    public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, Set<? extends VariantMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules variantMetadataRules) {
         if (variants.size() == 1) {
             VariantMetadata variantMetadata = variants.iterator().next();
-            ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, getOrDefault(componentMetadataRulesMap.get(variantMetadata.getName())));
+            ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, variantMetadataRules);
             return new SingleVariantAttributeSet(componentIdentifier, schema, resolvedVariant);
         }
         ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builder();
         for (VariantMetadata variant : variants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, getOrDefault(componentMetadataRulesMap.get(variant.getName())));
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, variantMetadataRules);
             result.add(resolvedVariant);
         }
         return new MultipleVariantAttributeSet(componentIdentifier, schema, result.build());
     }
 
-    public static ArtifactSet singleVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, DisplayName displayName, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSource moduleSource, ModuleExclusion exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, Map<String, VariantMetadataRules> componentMetadataRules) {
+    public static ArtifactSet singleVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, DisplayName displayName, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSource moduleSource, ModuleExclusion exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules componentMetadataRules) {
         VariantMetadata variantMetadata = new DefaultVariantMetadata(displayName, ImmutableAttributes.EMPTY, ImmutableList.copyOf(artifacts));
-        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, getOrDefault(componentMetadataRules.get(variantMetadata.getName())));
+        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, componentMetadataRules);
         return new SingleVariantAttributeSet(componentIdentifier, schema, resolvedVariant);
     }
 
@@ -102,7 +100,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
             }
             resolvedArtifacts.add(resolvedArtifact);
         }
-        attributes = componentMetadataRules.applyVariantAttributeRules(attributes);
+        attributes = componentMetadataRules.applyVariantAttributeRules(variant, attributes);
         return ArtifactBackedResolvedVariant.create(variant.asDescribable(), attributes, resolvedArtifacts.build());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -23,6 +23,8 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VariantMetadata;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -80,7 +82,12 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
 
     @Override
     public void withVariant(String name, Action<? super VariantMetadata> action) {
-        action.execute(instantiator.newInstance(VariantMetadataAdapter.class, name, metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser));
+        action.execute(instantiator.newInstance(VariantMetadataAdapter.class, new VariantNameSpec(name), metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser));
+    }
+
+    @Override
+    public void allVariants(Action<? super VariantMetadata> action) {
+        action.execute(instantiator.newInstance(VariantMetadataAdapter.class, Specs.satisfyAll(), metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser));
     }
 
     @Override
@@ -99,6 +106,20 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     @Override
     public String toString() {
         return metadata.getId().toString();
+    }
+
+
+    private static class VariantNameSpec implements Spec<org.gradle.internal.component.model.VariantMetadata> {
+        private final String name;
+
+        private VariantNameSpec(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(org.gradle.internal.component.model.VariantMetadata element) {
+            return name.equals(element.getName());
+        }
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
@@ -81,7 +80,6 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
 
     @Override
     public void withVariant(String name, Action<? super VariantMetadata> action) {
-        assertVariantExists(name);
         action.execute(instantiator.newInstance(VariantMetadataAdapter.class, name, metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser));
     }
 
@@ -103,9 +101,4 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
         return metadata.getId().toString();
     }
 
-    private void assertVariantExists(String name) {
-        if (!metadata.definesVariant(name)) {
-            throw new GradleException("Variant " + name + " is not declared for " + metadata.getId());
-        }
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -42,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.gradle.internal.component.external.model.VariantMetadataRules.getOrDefault;
-
 abstract class AbstractModuleComponentResolveMetadata implements ModuleComponentResolveMetadata {
     private final ImmutableAttributesFactory attributesFactory;
     private final ModuleVersionIdentifier moduleVersionIdentifier;
@@ -55,7 +53,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     @Nullable
     private final ModuleSource moduleSource;
     private final ImmutableMap<String, Configuration> configurationDefinitions;
-    private final Map<String, VariantMetadataRules> componentMetadataRules;
+    private final VariantMetadataRules variantMetadataRules;
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue contentHash;
     private final ImmutableAttributes attributes;
@@ -73,7 +71,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         statusScheme = metadata.getStatusScheme();
         moduleSource = metadata.getSource();
         configurationDefinitions = metadata.getConfigurationDefinitions();
-        componentMetadataRules = metadata.componentMetadataRules;
+        variantMetadataRules = metadata.getVariantMetadataRules();
         contentHash = metadata.getContentHash();
         attributesFactory = metadata.getAttributesFactory();
         attributes = extractAttributes(metadata);
@@ -101,7 +99,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         statusScheme = metadata.statusScheme;
         moduleSource = source;
         configurationDefinitions = metadata.configurationDefinitions;
-        componentMetadataRules = metadata.componentMetadataRules;
+        variantMetadataRules = metadata.variantMetadataRules;
         contentHash = metadata.contentHash;
         attributesFactory = metadata.getAttributesFactory();
         attributes = metadata.attributes;
@@ -132,7 +130,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         ImmutableList<String> hierarchy = constructHierarchy(descriptorConfiguration);
         boolean transitive = descriptorConfiguration.isTransitive();
         boolean visible = descriptorConfiguration.isVisible();
-        populated = createConfiguration(componentIdentifier, name, transitive, visible, hierarchy, getOrDefault(componentMetadataRules.get(name)));
+        populated = createConfiguration(componentIdentifier, name, transitive, visible, hierarchy, variantMetadataRules);
         configurations.put(name, populated);
         return populated;
     }
@@ -173,7 +171,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         }
         List<VariantBackedConfigurationMetadata> configurations = new ArrayList<VariantBackedConfigurationMetadata>(variants.size());
         for (ComponentVariant variant : variants) {
-            configurations.add(new VariantBackedConfigurationMetadata(getComponentId(), variant, attributes, attributesFactory, getOrDefault(componentMetadataRules.get(variant.getName()))));
+            configurations.add(new VariantBackedConfigurationMetadata(getComponentId(), variant, attributes, attributesFactory, variantMetadataRules));
         }
         return ImmutableList.copyOf(configurations);
     }
@@ -265,8 +263,8 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
 
     @Override
-    public Map<String, VariantMetadataRules> getComponentMetadataRules() {
-        return componentMetadataRules;
+    public VariantMetadataRules getVariantMetadataRules() {
+        return variantMetadataRules;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -19,12 +19,6 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependencyConstraintMetadata;
-import org.gradle.api.artifacts.DependencyConstraintsMetadata;
-import org.gradle.api.artifacts.DirectDependenciesMetadata;
-import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -44,13 +38,10 @@ import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantMetadata;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
-import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.gradle.internal.component.model.ComponentResolveMetadata.DEFAULT_STATUS_SCHEME;
 
@@ -68,7 +59,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
     private HashValue contentHash = EMPTY_CONTENT;
     private AttributeContainer componentLevelAttributes;
 
-    final Map<String, VariantMetadataRules> componentMetadataRules = Maps.newHashMap();
+    private final VariantMetadataRules variantMetadataRules = new VariantMetadataRules();
 
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
@@ -195,47 +186,8 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
     }
 
     @Override
-    public void addDependencyMetadataRule(final String variantName, final Action<? super DirectDependenciesMetadata> action,
-                                          final Instantiator instantiator,
-                                          final NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser,
-                                          final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser) {
-        withRulesContainer(variantName, new Action<VariantMetadataRules>() {
-            @Override
-            public void execute(VariantMetadataRules componentMetadataRules) {
-                componentMetadataRules.addDependencyAction(instantiator, dependencyNotationParser, dependencyConstraintNotationParser, action);
-            }
-        });
-    }
-
-    @Override
-    public void addDependencyConstraintMetadataRule(String variantName, final Action<? super DependencyConstraintsMetadata> action, final Instantiator instantiator,
-                                                    final NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser,
-                                                    final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser) {
-        withRulesContainer(variantName, new Action<VariantMetadataRules>() {
-            @Override
-            public void execute(VariantMetadataRules componentMetadataRules) {
-                componentMetadataRules.addDependencyConstraintAction(instantiator, dependencyNotationParser, dependencyConstraintNotationParser, action);
-            }
-        });
-    }
-
-    @Override
-    public void addAttributesRule(String variantName, final Action<? super AttributeContainer> action) {
-        withRulesContainer(variantName, new Action<VariantMetadataRules>() {
-            @Override
-            public void execute(VariantMetadataRules variantMetadataRules) {
-                variantMetadataRules.addAttributesAction(attributesFactory, action);
-            }
-        });
-    }
-
-    private void withRulesContainer(String variantName, Action<? super VariantMetadataRules> action) {
-        VariantMetadataRules rules = componentMetadataRules.get(variantName);
-        if (rules == null) {
-            rules = new VariantMetadataRules();
-            componentMetadataRules.put(variantName, rules);
-        }
-        action.execute(rules);
+    public VariantMetadataRules getVariantMetadataRules() {
+        return variantMetadataRules;
     }
 
     public MutableComponentVariant addVariant(String variantName, ImmutableAttributes attributes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * Effectively immutable implementation of ConfigurationMetadata.
  * Used to represent Ivy and Maven modules in the dependency graph.
  */
-public class DefaultConfigurationMetadata implements ConfigurationMetadata {
+public class DefaultConfigurationMetadata implements ConfigurationMetadata, VariantMetadata {
     private final ModuleComponentIdentifier componentId;
     private final String name;
     private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
@@ -109,7 +109,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
 
     @Override
     public ImmutableAttributes getAttributes() {
-        return componentMetadataRules.applyVariantAttributeRules(attributes);
+        return componentMetadataRules.applyVariantAttributeRules(this, attributes);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata {
     @Override
     public List<? extends DependencyMetadata> getDependencies() {
         if (calculatedDependencies == null) {
-            calculatedDependencies = componentMetadataRules.applyDependencyMetadataRules(configDependencies);
+            calculatedDependencies = componentMetadataRules.applyDependencyMetadataRules(this, configDependencies);
         }
         return calculatedDependencies;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
@@ -48,6 +48,6 @@ public class FixedComponentArtifacts implements ComponentArtifacts {
 
     @Override
     public ArtifactSet getArtifactsFor(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ModuleExclusion exclusions) {
-        return DefaultArtifactSet.singleVariant(component.getComponentId(), component.getId(), configuration.asDescribable(), artifacts, component.getSource(), exclusions, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getComponentMetadataRules());
+        return DefaultArtifactSet.singleVariant(component.getComponentId(), component.getId(), configuration.asDescribable(), artifacts, component.getSource(), exclusions, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getVariantMetadataRules());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MetadataSourcedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MetadataSourcedComponentArtifacts.java
@@ -35,6 +35,6 @@ import java.util.Map;
 public class MetadataSourcedComponentArtifacts implements ComponentArtifacts {
     @Override
     public ArtifactSet getArtifactsFor(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ModuleExclusion exclusions) {
-        return DefaultArtifactSet.multipleVariants(component.getComponentId(), component.getId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getComponentMetadataRules());
+        return DefaultArtifactSet.multipleVariants(component.getComponentId(), component.getId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getVariantMetadataRules());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -15,20 +15,13 @@
  */
 package org.gradle.internal.component.external.model;
 
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependencyConstraintMetadata;
-import org.gradle.api.artifacts.DependencyConstraintsMetadata;
-import org.gradle.api.artifacts.DirectDependenciesMetadata;
-import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.hash.HashValue;
-import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -96,9 +89,10 @@ public interface MutableModuleComponentResolveMetadata {
      */
     ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier);
 
-    void addDependencyMetadataRule(String variantName, Action<? super DirectDependenciesMetadata> action, Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser);
-    void addDependencyConstraintMetadataRule(String variantName, Action<? super DependencyConstraintsMetadata> action, Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser);
-    void addAttributesRule(String variantName, Action<? super AttributeContainer> action);
-
     ImmutableAttributesFactory getAttributesFactory();
+
+    /**
+     * Returns the metadata rules container for this module
+     */
+    VariantMetadataRules getVariantMetadataRules();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -90,7 +90,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
 
     @Override
     public ImmutableAttributes getAttributes() {
-        return componentMetadataRules.applyVariantAttributeRules(mergeComponentAndVariantAttributes(variant.getAttributes()));
+        return componentMetadataRules.applyVariantAttributeRules(variant, mergeComponentAndVariantAttributes(variant.getAttributes()));
     }
 
     private AttributeContainerInternal mergeComponentAndVariantAttributes(AttributeContainerInternal variantAttributes) {
@@ -140,7 +140,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     @Override
     public List<? extends DependencyMetadata> getDependencies() {
         if (calculatedDependencies == null) {
-            calculatedDependencies = componentMetadataRules.applyDependencyMetadataRules(dependencies);
+            calculatedDependencies = componentMetadataRules.applyDependencyMetadataRules(variant, dependencies);
         }
         return calculatedDependencies;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -81,7 +81,7 @@ public class VariantMetadataRules {
      * of the variant or its attributes.
      * @param <T> the type of the action subject
      */
-    public static class VariantAction<T> implements Action<T>, Spec<VariantMetadata> {
+    public static class VariantAction<T> {
         private final Spec<? super VariantMetadata> spec;
         private final Action<? super T> delegate;
 
@@ -90,15 +90,15 @@ public class VariantMetadataRules {
             this.delegate = delegate;
         }
 
-
-        @Override
-        public void execute(T subject) {
-            delegate.execute(subject);
-        }
-
-        @Override
-        public boolean isSatisfiedBy(VariantMetadata variant) {
-            return spec.isSatisfiedBy(variant);
+        /**
+         * Executes the underlying action if the supplied variant matches the predicate
+         * @param variant the variant metadata, used to check if the rule applies
+         * @param subject the subject of the rule
+         */
+        public void maybeExecute(VariantMetadata variant, T subject) {
+            if (spec.isSatisfiedBy(variant)) {
+                delegate.execute(subject);
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -46,7 +46,6 @@ import org.gradle.internal.component.model.VariantMetadata;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -212,8 +211,8 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public Map<String, VariantMetadataRules> getComponentMetadataRules() {
-        return Collections.emptyMap();
+    public VariantMetadataRules getVariantMetadataRules() {
+        return VariantMetadataRules.noOp();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -27,7 +27,6 @@ import org.gradle.internal.component.external.model.VariantMetadataRules;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -94,5 +93,5 @@ public interface ComponentResolveMetadata {
 
     List<String> getStatusScheme();
 
-    Map<String, VariantMetadataRules> getComponentMetadataRules();
+    VariantMetadataRules getVariantMetadataRules();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -19,14 +19,15 @@ package org.gradle.internal.component.model;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DependencyConstraintsMetadata;
+import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
-import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependenciesMetadataAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintsMetadataAdapter;
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependenciesMetadataAdapter;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.CollectionUtils;
@@ -38,7 +39,7 @@ import java.util.List;
  * A set of rules provided by the build script author
  * (as {@link Action<DirectDependenciesMetadata>} or {@link Action<DependencyConstraintsMetadata>})
  * that are applied on the dependencies defined in variant/configuration metadata. The rules are applied
- * in the {@link #execute(List)} method when the dependencies of a variant are needed during dependency resolution.
+ * in the {@link #execute(VariantMetadata, List)} method when the dependencies of a variant are needed during dependency resolution.
  */
 public class DependencyMetadataRules {
     private static final Spec<ModuleDependencyMetadata> DEPENDENCY_FILTER = new Spec<ModuleDependencyMetadata>() {
@@ -57,8 +58,8 @@ public class DependencyMetadataRules {
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser;
-    private final List<Action<? super DirectDependenciesMetadata>> dependencyActions = Lists.newArrayList();
-    private final List<Action<? super DependencyConstraintsMetadata>> dependencyConstraintActions = Lists.newArrayList();
+    private final List<VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata>> dependencyActions = Lists.newArrayList();
+    private final List<VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata>> dependencyConstraintActions = Lists.newArrayList();
 
     public DependencyMetadataRules(Instantiator instantiator,
                                    NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser,
@@ -68,35 +69,39 @@ public class DependencyMetadataRules {
         this.dependencyConstraintNotationParser = dependencyConstraintNotationParser;
     }
 
-    public void addDependencyAction(Action<? super DirectDependenciesMetadata> action) {
+    public void addDependencyAction(VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> action) {
         dependencyActions.add(action);
     }
 
-    public void addDependencyConstraintAction(Action<? super DependencyConstraintsMetadata> action) {
+    public void addDependencyConstraintAction(VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> action) {
         dependencyConstraintActions.add(action);
     }
 
-    public <T extends ModuleDependencyMetadata> List<T> execute(List<T> dependencies) {
+    public <T extends ModuleDependencyMetadata> List<T> execute(VariantMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>();
-        calculatedDependencies.addAll(executeDependencyRules(dependencies));
-        calculatedDependencies.addAll(executeDependencyConstraintRules(dependencies));
+        calculatedDependencies.addAll(executeDependencyRules(variant, dependencies));
+        calculatedDependencies.addAll(executeDependencyConstraintRules(variant, dependencies));
         return calculatedDependencies;
     }
 
-    private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(List<T> dependencies) {
+    private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
-        for (Action<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
-            dependenciesMetadataAction.execute(instantiator.newInstance(
-                DirectDependenciesMetadataAdapter.class, calculatedDependencies, instantiator, dependencyNotationParser));
+        for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
+            if (dependenciesMetadataAction.isSatisfiedBy(variant)) {
+                dependenciesMetadataAction.execute(instantiator.newInstance(
+                    DirectDependenciesMetadataAdapter.class, calculatedDependencies, instantiator, dependencyNotationParser));
+            }
         }
         return calculatedDependencies;
     }
 
-    private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(List<T> dependencies) {
+    private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(VariantMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
-        for (Action<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
-            dependencyConstraintsMetadataAction.execute(instantiator.newInstance(
-                DependencyConstraintsMetadataAdapter.class, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
+        for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
+            if (dependencyConstraintsMetadataAction.isSatisfiedBy(variant)) {
+                dependencyConstraintsMetadataAction.execute(instantiator.newInstance(
+                    DependencyConstraintsMetadataAdapter.class, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
+            }
         }
         return calculatedDependencies;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -87,10 +87,8 @@ public class DependencyMetadataRules {
     private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
         for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
-            if (dependenciesMetadataAction.isSatisfiedBy(variant)) {
-                dependenciesMetadataAction.execute(instantiator.newInstance(
-                    DirectDependenciesMetadataAdapter.class, calculatedDependencies, instantiator, dependencyNotationParser));
-            }
+            dependenciesMetadataAction.maybeExecute(variant, instantiator.newInstance(
+                DirectDependenciesMetadataAdapter.class, calculatedDependencies, instantiator, dependencyNotationParser));
         }
         return calculatedDependencies;
     }
@@ -98,10 +96,8 @@ public class DependencyMetadataRules {
     private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(VariantMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
         for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
-            if (dependencyConstraintsMetadataAction.isSatisfiedBy(variant)) {
-                dependencyConstraintsMetadataAction.execute(instantiator.newInstance(
-                    DependencyConstraintsMetadataAdapter.class, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
-            }
+            dependencyConstraintsMetadataAction.maybeExecute(variant, instantiator.newInstance(
+                DependencyConstraintsMetadataAdapter.class, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
         }
         return calculatedDependencies;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantAttributesRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantAttributesRules.java
@@ -50,9 +50,7 @@ public class VariantAttributesRules {
             attributes = attributesFactory.mutable(attributes);
         }
         for (VariantMetadataRules.VariantAction<? super AttributeContainer> action : actions) {
-            if (action.isSatisfiedBy(variant)) {
-                action.execute(attributes);
-            }
+            action.maybeExecute(variant, attributes);
         }
         return attributes.asImmutable();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -69,6 +69,6 @@ public class DefaultArtifactSelector implements ArtifactSelector {
 
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts) {
-        return DefaultArtifactSet.singleVariant(component.getComponentId(), component.getId(), Describables.of(component.getComponentId()), artifacts, component.getSource(), ModuleExclusions.excludeNone(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getComponentMetadataRules());
+        return DefaultArtifactSet.singleVariant(component.getComponentId(), component.getId(), Describables.of(component.getComponentId()), artifacts, component.getSource(), ModuleExclusions.excludeNone(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getVariantMetadataRules());
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.DisplayName
+import org.gradle.internal.component.external.model.VariantMetadataRules
 import org.gradle.internal.component.model.VariantMetadata
 import spock.lang.Specification
 
@@ -31,6 +32,8 @@ class DefaultArtifactSetTest extends Specification {
     def exclusions = Stub(ModuleExclusions)
     def schema = Stub(AttributesSchemaInternal)
     def artifactTypeRegistry = Stub(ArtifactTypeRegistry)
+    private final VariantMetadataRules variantMetadataRules = new VariantMetadataRules()
+
 
     def setup() {
         artifactTypeRegistry.mapAttributesFor(_) >> ImmutableAttributes.EMPTY
@@ -41,9 +44,9 @@ class DefaultArtifactSetTest extends Specification {
         def variant2 = Stub(VariantMetadata)
 
         given:
-        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, [:])
-        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, [:])
-        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, [:])
+        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, variantMetadataRules)
+        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, variantMetadataRules)
+        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, variantMetadataRules)
 
         expect:
         artifacts1.select({false}, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
@@ -58,9 +61,9 @@ class DefaultArtifactSetTest extends Specification {
         def selector = Stub(VariantSelector)
 
         given:
-        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, [:])
-        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, [:])
-        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, [:])
+        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, variantMetadataRules)
+        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, variantMetadataRules)
+        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, variantMetadataRules)
 
         selector.select(_) >> resolvedVariant1
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.Action
-import org.gradle.api.GradleException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -101,32 +100,5 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         then:
         noExceptionThrown()
         variantCount * rule.execute(_)
-    }
-
-    def "fails when selecting a variant that does not exist"() {
-        when:
-        adapterOnGradleMetadata.withVariant("doesNotExist", {})
-
-        then:
-        def e = thrown(GradleException)
-        e.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
-    }
-
-    def "fails when selecting a maven scope that does not exist"() {
-        when:
-        adapterOnMavenMetadata.withVariant("doesNotExist", {})
-
-        then:
-        def e = thrown(GradleException)
-        e.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
-    }
-
-    def "fails when selecting an ivy configuration that does not exist"() {
-        when:
-        adapterOnIvyMetadata.withVariant("doesNotExist", {})
-
-        then:
-        def e = thrown(GradleException)
-        e.message == "Variant doesNotExist is not declared for org.test:producer:1.0"
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -20,16 +20,23 @@ import org.gradle.api.Action
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableMavenModuleResolveMetadata
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
+import org.gradle.internal.component.model.ComponentAttributeMatcher
+import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.util.TestUtil
 import spock.lang.Specification
+
+import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class ComponentMetadataDetailsAdapterTest extends Specification {
     private instantiator = DirectInstantiator.INSTANCE
@@ -38,13 +45,14 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
 
     def versionIdentifier = new DefaultModuleVersionIdentifier("org.test", "producer", "1.0")
     def componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
-    def attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
-    def variantDefinedInGradleMetadata
+    def testAttribute = Attribute.of("someAttribute", String)
+    def attributes = TestUtil.attributesFactory().of(testAttribute, "someValue")
+    def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
+    def gradleMetadata
     def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
-
     def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
     def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
 
@@ -53,7 +61,9 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     }
     private gradleComponentMetadata() {
         def metadata = mavenMetadataFactory.create(componentIdentifier)
-        variantDefinedInGradleMetadata = metadata.addVariant("variantDefinedInGradleMetadata", attributes) //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
+        metadata.addVariant("variantDefinedInGradleMetadata1", attributes) //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
+        metadata.addVariant("variantDefinedInGradleMetadata2", TestUtil.attributesFactory().of(testAttribute, "other")) //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
+        gradleMetadata = metadata
         metadata
     }
 
@@ -61,16 +71,51 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         mavenMetadataFactory.create(componentIdentifier)
     }
 
+    def setup() {
+        schema.attribute(testAttribute)
+    }
+
     def "sees variants defined in Gradle metadata"() {
         given:
         def rule = Mock(Action)
 
         when:
-        adapterOnGradleMetadata.withVariant("variantDefinedInGradleMetadata", rule)
+        adapterOnGradleMetadata.withVariant("variantDefinedInGradleMetadata1", rule)
 
         then:
         noExceptionThrown()
         1 * rule.execute(_)
+    }
+
+    def "can execute rule on all variants"() {
+        given:
+        def adapterRule = Mock(Action)
+        def dependenciesRule = Mock(Action)
+        def constraintsRule = Mock(Action)
+        def attributesRule = Mock(Action)
+        when:
+        adapterOnGradleMetadata.allVariants(adapterRule)
+
+        then: "the adapter rule is called once"
+        noExceptionThrown()
+        1 * adapterRule.execute(_) >> {
+            def adapter = it[0]
+            adapter.withDependencies(dependenciesRule)
+            adapter.withDependencyConstraints(constraintsRule)
+            adapter.attributes(attributesRule)
+        }
+        0 * _
+
+        when:
+        resolve(gradleMetadata)
+
+        then: "attributes are used during matching, the rule is applied on all variants"
+        2 * attributesRule.execute(_)
+
+        and: " we only apply the dependencies rule to the selected variant"
+        1 * dependenciesRule.execute(_)
+        1 * constraintsRule.execute(_)
+        0 * _
     }
 
     def "treats ivy configurations as variants"() {
@@ -100,5 +145,16 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         then:
         noExceptionThrown()
         variantCount * rule.execute(_)
+    }
+
+    void resolve(MutableModuleComponentResolveMetadata component) {
+        def immutable = component.asImmutable()
+        def componentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "consumer", "1.0")
+        def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
+        def componentSelector = newSelector(consumerIdentifier.group, consumerIdentifier.name, new DefaultMutableVersionConstraint(consumerIdentifier.version))
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true, false)
+
+        def configuration = consumer.selectConfigurations(attributes, immutable, schema)[0]
+        configuration.dependencies
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -53,6 +53,10 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     @Shared defaultVariant
 
+    protected static <T> VariantMetadataRules.VariantAction<T> variantAction(String variantName, Action<? super T> action) {
+        new VariantMetadataRules.VariantAction<T>({ it.name == variantName }, action)
+    }
+
     abstract boolean addAllDependenciesAsConstraints()
 
     abstract void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName, Action<? super DependenciesMetadata> action)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -35,7 +35,9 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
 
     @Override
     void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName, Action<? super DependenciesMetadata> action) {
-        metadataImplementation.addDependencyConstraintMetadataRule(variantName, action, instantiator, notationParser, constraintNotationParser)
+        metadataImplementation.variantMetadataRules.addDependencyConstraintAction(
+            instantiator, notationParser, constraintNotationParser,
+            variantAction(variantName, action))
     }
 
     def "maven optional dependencies are accessible as dependency constraints"() {
@@ -46,14 +48,14 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
         ])
 
         when:
-        mavenMetadata.addDependencyMetadataRule("default", {
+        mavenMetadata.variantMetadataRules.addDependencyAction(instantiator, notationParser, constraintNotationParser, variantAction("default", {
             assert it.size() == 1
             assert it[0].name == "notOptional"
-        }, instantiator, notationParser, constraintNotationParser)
-        mavenMetadata.addDependencyConstraintMetadataRule("default", {
+        }))
+        mavenMetadata.variantMetadataRules.addDependencyConstraintAction(instantiator, notationParser, constraintNotationParser, variantAction("default", {
             assert it.size() == 1
             assert it[0].name == "optional"
-        }, instantiator, notationParser, constraintNotationParser)
+        }))
 
         then:
         def dependencies = selectTargetConfigurationMetadata(mavenMetadata).dependencies

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DirectDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DirectDependencyMetadataRulesTest.groovy
@@ -26,7 +26,7 @@ class DirectDependencyMetadataRulesTest extends AbstractDependencyMetadataRulesT
     }
 
     @Override
-    void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName, Action<DependenciesMetadata> action) {
-        metadataImplementation.addDependencyMetadataRule(variantName, action, instantiator, notationParser, constraintNotationParser)
+    void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName, Action<? super DependenciesMetadata> action) {
+        metadataImplementation.variantMetadataRules.addDependencyAction(instantiator, notationParser, constraintNotationParser, variantAction(variantName, action))
     }
 }


### PR DESCRIPTION
### Context

This pull request unchecks a couple of boxes on https://github.com/gradle/gradle/issues/3159#issuecomment-353133089 :

- adds documentation on `VariantMetadataAdapter`
- changes how rules are implemented, so that we don't rely on a `Map<String, XXX>` rules where the key is a variant, but rather check if the variant to be mutated matches a predicate

This will let us add rules that work on all variants or variants with a specific attribute set much easier.

