### PR TITLE
Add access to component attributes in component selection rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.HasAttributes;
 
 import java.util.List;
 
@@ -25,7 +26,7 @@ import java.util.List;
  * a component descriptor (Ivy file, Maven POM).
  */
 @Incubating
-public interface ComponentMetadata {
+public interface ComponentMetadata extends HasAttributes {
     /**
      * Returns the identifier of the component.
      *

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProvider.java
@@ -23,9 +23,11 @@ import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataAdapter;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -161,6 +163,11 @@ public class MetadataProvider {
             @Override
             public List<String> getStatusScheme() {
                 return statusScheme;
+            }
+
+            @Override
+            public AttributeContainer getAttributes() {
+                return ImmutableAttributes.EMPTY;
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataAdapter.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
 import java.util.List;
@@ -42,5 +43,10 @@ public class ComponentMetadataAdapter implements ComponentMetadata {
 
     public List<String> getStatusScheme() {
         return metadata.getStatusScheme();
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return metadata.getAttributes();
     }
 }


### PR DESCRIPTION
This allows the component selection rules to access attributes and reject versions based on
the attribute values.

See https://github.com/gradle/gradle/issues/3159#issuecomment-353133089