### PR TITLE
Widen docs content on wide screens

### DIFF
--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -130,10 +130,22 @@ h4, h5, h6 {
 }
 
 p {
-    font-size: 1.0625rem;
+    font-size: 1rem;
     line-height: 1.6;
     margin-bottom: 1.25rem;
     text-rendering: optimizeLegibility;
+}
+
+@media (min-width: 1200px) {
+    p {
+        font-size: 1.0625rem;
+    }
+}
+
+@media (min-width: 1400px) {
+    p {
+        font-size: 1.125rem;
+    }
 }
 
 dt {
@@ -248,7 +260,7 @@ blockquote p:last-child {
 }
 
 .content, .text-container {
-    width: 45rem;
+    width: 60rem;
 }
 
 .content-container {
@@ -291,7 +303,7 @@ code, pre {
 }
 
 *:not(pre) > code {
-    font-size: 0.9375rem;
+    font-size: 0.9375em;
     letter-spacing: 0;
     padding: 0.1em 0.5ex;
     text-rendering: optimizeSpeed;
@@ -481,8 +493,6 @@ h3.releaseinfo {
 .site-header__navigation {
     display: flex;
     flex-direction: column;
-    max-width: 1200px;
-    margin: 0 auto;
 }
 
 .site-header__navigation-header {
@@ -494,7 +504,7 @@ h3.releaseinfo {
 
 .site-header__navigation-collapsible {
     flex: 1 1 auto;
-    height: 404px;
+    height: 304px;
     overflow: visible;
     transition: height 0.3s ease;
 }
@@ -637,10 +647,6 @@ h3.releaseinfo {
         flex-direction: row;
     }
 
-    .site-header__navigation-header {
-        margin-left: 0;
-    }
-
     .site-header__navigation-button {
         display: none;
     }
@@ -747,7 +753,7 @@ h3.releaseinfo {
     margin-top: 1.5em;
 }
 
-@media screen and (min-width: 720px) {
+@media screen and (min-width: 45rem) {
     .main-content {
         display: flex;
         justify-content: center;
@@ -755,31 +761,30 @@ h3.releaseinfo {
 }
 
 /* User guide navigation appears for desktops */
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 64rem) {
     .main-content {
         padding-top: 75px;
     }
 
     .docs-navigation {
         display: block;
-        flex: 0 1 auto;
-        width: 220px;
+        flex: 0 0 auto;
+        width: 13.75rem;
     }
 
     .chapter, .book {
-        flex: 0 1 720px;
+        flex: 0 0 45rem;
         margin: 0 20px;
-        min-height: 600px;
     }
 }
 
 /* Fixed intra-chapter navigation for desktops */
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 75rem) {
     .chapter .toc {
         position: fixed;
         left: calc(50% + 380px);
         top: 50px;
-        width: 220px;
+        width: 13.75rem;
         padding-top: 15px;
         font-size: 1rem;
         background-color: #F7F7F8;
@@ -821,12 +826,34 @@ h3.releaseinfo {
     }
 
     .docs-navigation {
-        flex-basis: 220px;
+        flex-basis: 13.75rem;
     }
 
     /* Sneaky way to make room for TOC */
     .secondary-navigation {
-        flex: 0 1 220px;
+        flex: 0 0 13.75rem;
+    }
+}
+
+@media screen and (min-width: 84.375rem) {
+    .chapter .toc {
+        left: calc(50% + 26.25rem);
+    }
+
+    .chapter, .book {
+        flex-basis: 50rem;
+        max-width: 50rem;
+    }
+}
+
+@media screen and (min-width: 90rem) {
+    .chapter .toc {
+        left: calc(50% + 31.25rem);
+    }
+
+    .chapter, .book {
+        flex-basis: 60rem;
+        max-width: 60rem;
     }
 }
 
@@ -950,7 +977,7 @@ h3.releaseinfo {
 }
 
 .site-footer__subscribe-newsletter {
-    flex: 0 1 auto;
+    flex: 0 0 auto;
 }
 
 .site-footer__subscribe-newsletter p {
@@ -1080,6 +1107,12 @@ h3.releaseinfo {
     .site-footer__copy {
         order: 2;
         text-align: right;
+    }
+}
+
+@media screen and (min-width: 1400px) {
+    .site-footer__navigation {
+        max-width: 90rem;
     }
 }
 


### PR DESCRIPTION
This adds a breakpoint that expands content for DSL reference
and user manual on wide screens.

Content copy is also made smaller and larger to fit smaller and
larger screens.

![responsive-docs](https://user-images.githubusercontent.com/51534/34237400-be437442-e5b9-11e7-88dd-21f280e9f090.gif)

### Context
We got feedback that we should allow a wider content area.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
