### PR TITLE
Internal `VariantMetadata` renames

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -33,11 +33,11 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSource;
-import org.gradle.internal.component.model.VariantMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
 
@@ -59,14 +59,14 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
         this.schema = schema;
     }
 
-    public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, Set<? extends VariantMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules variantMetadataRules) {
+    public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules variantMetadataRules) {
         if (variants.size() == 1) {
-            VariantMetadata variantMetadata = variants.iterator().next();
+            VariantResolveMetadata variantMetadata = variants.iterator().next();
             ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, variantMetadataRules);
             return new SingleVariantAttributeSet(componentIdentifier, schema, resolvedVariant);
         }
         ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builder();
-        for (VariantMetadata variant : variants) {
+        for (VariantResolveMetadata variant : variants) {
             ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, variantMetadataRules);
             result.add(resolvedVariant);
         }
@@ -74,12 +74,12 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     }
 
     public static ArtifactSet singleVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, DisplayName displayName, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSource moduleSource, ModuleExclusion exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules componentMetadataRules) {
-        VariantMetadata variantMetadata = new DefaultVariantMetadata(displayName, ImmutableAttributes.EMPTY, ImmutableList.copyOf(artifacts));
+        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(displayName, ImmutableAttributes.EMPTY, ImmutableList.copyOf(artifacts));
         ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, componentMetadataRules);
         return new SingleVariantAttributeSet(componentIdentifier, schema, resolvedVariant);
     }
 
-    private static ResolvedVariant toResolvedVariant(VariantMetadata variant, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules componentMetadataRules) {
+    private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, VariantMetadataRules componentMetadataRules) {
         List<? extends ComponentArtifactMetadata> artifacts = variant.getArtifacts();
         ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -109,7 +110,7 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     }
 
 
-    private static class VariantNameSpec implements Spec<org.gradle.internal.component.model.VariantMetadata> {
+    private static class VariantNameSpec implements Spec<VariantResolveMetadata> {
         private final String name;
 
         private VariantNameSpec(String name) {
@@ -117,7 +118,7 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
         }
 
         @Override
-        public boolean isSatisfiedBy(org.gradle.internal.component.model.VariantMetadata element) {
+        public boolean isSatisfiedBy(VariantResolveMetadata element) {
             return name.equals(element.getName());
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
@@ -26,6 +26,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -36,13 +37,13 @@ import org.gradle.internal.typeconversion.NotationParser;
  * is responsible for targetting variants subject to a rule.
  */
 public class VariantMetadataAdapter implements VariantMetadata {
-    private final Spec<? super org.gradle.internal.component.model.VariantMetadata> spec;
+    private final Spec<? super VariantResolveMetadata> spec;
     private final MutableModuleComponentResolveMetadata metadata;
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser;
 
-    public VariantMetadataAdapter(Spec<? super org.gradle.internal.component.model.VariantMetadata> spec,
+    public VariantMetadataAdapter(Spec<? super VariantResolveMetadata> spec,
                                   MutableModuleComponentResolveMetadata metadata, Instantiator instantiator,
                                   NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser,
                                   NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
@@ -19,12 +19,12 @@ package org.gradle.api.internal.artifacts.type;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Factory;
-import org.gradle.internal.component.model.VariantMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.io.File;
 
 public interface ArtifactTypeRegistry extends Factory<ArtifactTypeContainer> {
-    ImmutableAttributes mapAttributesFor(VariantMetadata variant);
+    ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant);
 
     ImmutableAttributes mapAttributesFor(File file);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.VariantMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.io.File;
@@ -61,7 +61,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
     }
 
     @Override
-    public ImmutableAttributes mapAttributesFor(VariantMetadata variant) {
+    public ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant) {
         ImmutableAttributes attributes = variant.getAttributes().asImmutable();
 
         // Add attributes to be applied given the extension

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -35,7 +35,7 @@ import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSource;
-import org.gradle.internal.component.model.VariantMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
 
@@ -425,7 +425,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
     }
 
-    protected static class ImmutableVariantImpl implements ComponentVariant, VariantMetadata {
+    protected static class ImmutableVariantImpl implements ComponentVariant, VariantResolveMetadata {
         private final ModuleComponentIdentifier componentId;
         private final String name;
         private final ImmutableAttributes attributes;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -19,14 +19,14 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.component.model.ExcludeMetadata;
-import org.gradle.internal.component.model.VariantMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 
 /**
  * An _immutable_ view of the variant of a component.
  *
- * TODO - this should replace or merge into VariantMetadata, OutgoingVariant, ConfigurationMetadata
+ * TODO - this should replace or merge into VariantResolveMetadata, OutgoingVariant, ConfigurationMetadata
  */
-public interface ComponentVariant extends VariantMetadata {
+public interface ComponentVariant extends VariantResolveMetadata {
     String getName();
 
     ImmutableList<? extends Dependency> getDependencies();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -22,12 +22,12 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.VariantMetadata;
 
 import java.util.Collection;
 import java.util.List;
@@ -37,7 +37,7 @@ import java.util.Set;
  * Effectively immutable implementation of ConfigurationMetadata.
  * Used to represent Ivy and Maven modules in the dependency graph.
  */
-public class DefaultConfigurationMetadata implements ConfigurationMetadata, VariantMetadata {
+public class DefaultConfigurationMetadata implements ConfigurationMetadata, VariantResolveMetadata {
     private final ModuleComponentIdentifier componentId;
     private final String name;
     private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
@@ -141,7 +141,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     }
 
     @Override
-    public Set<? extends VariantMetadata> getVariants() {
+    public Set<? extends VariantResolveMetadata> getVariants() {
         return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts()));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -30,7 +30,7 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.VariantMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -98,7 +98,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     }
 
     @Override
-    public Set<? extends VariantMetadata> getVariants() {
+    public Set<? extends VariantResolveMetadata> getVariants() {
         return ImmutableSet.of(variant);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -25,9 +25,9 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadataRules;
 import org.gradle.internal.component.model.VariantAttributesRules;
-import org.gradle.internal.component.model.VariantMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -37,14 +37,14 @@ public class VariantMetadataRules {
     private DependencyMetadataRules dependencyMetadataRules;
     private VariantAttributesRules variantAttributesRules;
 
-    public ImmutableAttributes applyVariantAttributeRules(VariantMetadata variant, AttributeContainerInternal source) {
+    public ImmutableAttributes applyVariantAttributeRules(VariantResolveMetadata variant, AttributeContainerInternal source) {
         if (variantAttributesRules != null) {
             return variantAttributesRules.execute(variant, source);
         }
         return source.asImmutable();
     }
 
-    public <T extends ModuleDependencyMetadata> List<T> applyDependencyMetadataRules(VariantMetadata variant, List<T> configDependencies) {
+    public <T extends ModuleDependencyMetadata> List<T> applyDependencyMetadataRules(VariantResolveMetadata variant, List<T> configDependencies) {
         if (dependencyMetadataRules != null) {
             return dependencyMetadataRules.execute(variant, configDependencies);
         }
@@ -82,10 +82,10 @@ public class VariantMetadataRules {
      * @param <T> the type of the action subject
      */
     public static class VariantAction<T> {
-        private final Spec<? super VariantMetadata> spec;
+        private final Spec<? super VariantResolveMetadata> spec;
         private final Action<? super T> delegate;
 
-        public VariantAction(Spec<? super VariantMetadata> spec, Action<? super T> delegate) {
+        public VariantAction(Spec<? super VariantResolveMetadata> spec, Action<? super T> delegate) {
             this.spec = spec;
             this.delegate = delegate;
         }
@@ -95,7 +95,7 @@ public class VariantMetadataRules {
          * @param variant the variant metadata, used to check if the rule applies
          * @param subject the subject of the rule
          */
-        public void maybeExecute(VariantMetadata variant, T subject) {
+        public void maybeExecute(VariantResolveMetadata variant, T subject) {
             if (spec.isSatisfiedBy(variant)) {
                 delegate.execute(subject);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -42,7 +43,6 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
-import org.gradle.internal.component.model.VariantMetadata;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -339,7 +339,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         }
 
         @Override
-        public Set<? extends VariantMetadata> getVariants() {
+        public Set<? extends VariantResolveMetadata> getVariants() {
             return allVariants.get(name);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -62,7 +62,7 @@ public interface ConfigurationMetadata extends HasAttributes {
     /**
      * Returns the variants of this configuration. Should include at least one value. Exactly one variant must be selected and the artifacts of that variant used.
      */
-    Set<? extends VariantMetadata> getVariants();
+    Set<? extends VariantResolveMetadata> getVariants();
 
     /**
      * Returns the exclusions to apply to this configuration:

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -21,7 +21,7 @@ import org.gradle.internal.DisplayName;
 
 import java.util.List;
 
-public class DefaultVariantMetadata implements VariantMetadata {
+public class DefaultVariantMetadata implements VariantResolveMetadata {
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final List<? extends ComponentArtifactMetadata> artifacts;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -39,7 +39,7 @@ import java.util.List;
  * A set of rules provided by the build script author
  * (as {@link Action<DirectDependenciesMetadata>} or {@link Action<DependencyConstraintsMetadata>})
  * that are applied on the dependencies defined in variant/configuration metadata. The rules are applied
- * in the {@link #execute(VariantMetadata, List)} method when the dependencies of a variant are needed during dependency resolution.
+ * in the {@link #execute(VariantResolveMetadata, List)} method when the dependencies of a variant are needed during dependency resolution.
  */
 public class DependencyMetadataRules {
     private static final Spec<ModuleDependencyMetadata> DEPENDENCY_FILTER = new Spec<ModuleDependencyMetadata>() {
@@ -77,14 +77,14 @@ public class DependencyMetadataRules {
         dependencyConstraintActions.add(action);
     }
 
-    public <T extends ModuleDependencyMetadata> List<T> execute(VariantMetadata variant, List<T> dependencies) {
+    public <T extends ModuleDependencyMetadata> List<T> execute(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>();
         calculatedDependencies.addAll(executeDependencyRules(variant, dependencies));
         calculatedDependencies.addAll(executeDependencyConstraintRules(variant, dependencies));
         return calculatedDependencies;
     }
 
-    private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantMetadata variant, List<T> dependencies) {
+    private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
         for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
             dependenciesMetadataAction.maybeExecute(variant, instantiator.newInstance(
@@ -93,7 +93,7 @@ public class DependencyMetadataRules {
         return calculatedDependencies;
     }
 
-    private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(VariantMetadata variant, List<T> dependencies) {
+    private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
         for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
             dependencyConstraintsMetadataAction.maybeExecute(variant, instantiator.newInstance(

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantAttributesRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantAttributesRules.java
@@ -29,7 +29,7 @@ import java.util.List;
  * A set of rules provided by the build script author
  * (as {@link Action &lt;? super AttributeContainer&gt;}
  * that are applied on the attributes defined in variant/configuration metadata. The rules are applied
- * in the {@link #execute(VariantMetadata, AttributeContainerInternal)} method when the attributes of a variant are needed during dependency resolution.
+ * in the {@link #execute(VariantResolveMetadata, AttributeContainerInternal)} method when the attributes of a variant are needed during dependency resolution.
  */
 public class VariantAttributesRules {
     private final ImmutableAttributesFactory attributesFactory;
@@ -43,7 +43,7 @@ public class VariantAttributesRules {
         actions.add(action);
     }
 
-    public ImmutableAttributes execute(VariantMetadata variant, AttributeContainerInternal attributes) {
+    public ImmutableAttributes execute(VariantResolveMetadata variant, AttributeContainerInternal attributes) {
         if (attributes == null) {
             attributes = attributesFactory.mutable();
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Metadata for a basic variant of a component, that defines only artifacts and no dependencies.
  */
-public interface VariantMetadata {
+public interface VariantResolveMetadata {
     String getName();
 
     DisplayName asDescribable();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.DisplayName
 import org.gradle.internal.component.external.model.VariantMetadataRules
-import org.gradle.internal.component.model.VariantMetadata
+import org.gradle.internal.component.model.VariantResolveMetadata
 import spock.lang.Specification
 
 class DefaultArtifactSetTest extends Specification {
@@ -40,8 +40,8 @@ class DefaultArtifactSetTest extends Specification {
     }
 
     def "returns empty set when component id does not match spec"() {
-        def variant1 = Stub(VariantMetadata)
-        def variant2 = Stub(VariantMetadata)
+        def variant1 = Stub(VariantResolveMetadata)
+        def variant2 = Stub(VariantResolveMetadata)
 
         given:
         def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, variantMetadataRules)
@@ -55,8 +55,8 @@ class DefaultArtifactSetTest extends Specification {
     }
 
     def "selects artifacts when component id matches spec"() {
-        def variant1 = Stub(VariantMetadata)
-        def variant2 = Stub(VariantMetadata)
+        def variant1 = Stub(VariantResolveMetadata)
+        def variant2 = Stub(VariantResolveMetadata)
         def resolvedVariant1 = Stub(ResolvedArtifactSet)
         def selector = Stub(VariantSelector)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.IvyArtifactName
-import org.gradle.internal.component.model.VariantMetadata
+import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -48,7 +48,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
     def "does not apply any mapping when no artifact types registered"() {
         def attrs = ImmutableAttributes.EMPTY
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
 
         given:
         variant.attributes >> attrs
@@ -59,7 +59,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
     def "does not apply any mapping when variant has no artifacts"() {
         def attrs = ImmutableAttributes.EMPTY
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
 
         given:
         variant.attributes >> attrs
@@ -72,7 +72,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
     def "adds artifactType attribute but does not apply any mapping when no matching artifact type"() {
         def attrs = ImmutableAttributes.EMPTY
         def attrsPlusFormat = concat(attrs, ["artifactType": "jar"])
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 
@@ -92,7 +92,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
     def "applies mapping when no attributes defined for matching type"() {
         def attrs = ImmutableAttributes.EMPTY
         def attrsPlusFormat = concat(attrs, ["artifactType": "jar"])
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 
@@ -112,7 +112,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
     def "applies mapping to matching artifact type"() {
         def attrs = ImmutableAttributes.EMPTY
         def attrsPlusFormat = concat(attrs, ["artifactType": "jar", "custom": "123"])
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 
@@ -131,7 +131,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
     def "does not apply mapping when multiple artifacts with different types"() {
         def attrs = ImmutableAttributes.EMPTY
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
         def artifact1 = Stub(ComponentArtifactMetadata)
         def artifactName1 = Stub(IvyArtifactName)
         def artifact2 = Stub(ComponentArtifactMetadata)
@@ -156,7 +156,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
     def "does not apply mapping when variant already defines some attributes"() {
         def attrs = attributesFactory.of(Attribute.of("attr", String), "value")
-        def variant = Stub(VariantMetadata)
+        def variant = Stub(VariantResolveMetadata)
         def artifact = Stub(ComponentArtifactMetadata)
         def artifactName = Stub(IvyArtifactName)
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.test.fixtures
 
-import org.gradle.test.fixtures.gradle.VariantMetadata
+import org.gradle.test.fixtures.gradle.VariantMetadataSpec
 
 /**
  * Represents a module in a repository.
@@ -35,7 +35,7 @@ interface Module {
     ModuleArtifact getModuleMetadata()
     GradleModuleMetadata getParsedModuleMetadata()
 
-    void withVariant(String name, @DelegatesTo(value=VariantMetadata.class, strategy = Closure.DELEGATE_FIRST) groovy.lang.Closure<?> action)
+    void withVariant(String name, @DelegatesTo(value=VariantMetadataSpec.class, strategy = Closure.DELEGATE_FIRST) groovy.lang.Closure<?> action)
 
     Map<String, String> getAttributes()
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -23,10 +23,10 @@ class GradleFileModuleAdapter {
     private final String group
     private final String module
     private final String version
-    private final List<VariantMetadata> variants
+    private final List<VariantMetadataSpec> variants
     private final Map<String, String> attributes
 
-    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadata> variants, Map<String, String> attributes = [:]) {
+    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadataSpec> variants, Map<String, String> attributes = [:]) {
         this.group = group
         this.module = module
         this.version = version

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -19,19 +19,19 @@ package org.gradle.test.fixtures.gradle
 import groovy.transform.CompileStatic
 
 @CompileStatic
-class VariantMetadata {
+class VariantMetadataSpec {
     String name
     Map<String, String> attributes
     List<DependencySpec> dependencies = []
     List<DependencyConstraintSpec> dependencyConstraints = []
     List<FileSpec> artifacts = []
 
-    VariantMetadata(String name, Map<String, String> attributes = [:]) {
+    VariantMetadataSpec(String name, Map<String, String> attributes = [:]) {
         this.name = name
         this.attributes = attributes
     }
 
-    VariantMetadata(String name, Map<String, String> attributes, List<DependencySpec> dependencies, List<DependencyConstraintSpec> dependencyConstraints, List<FileSpec> artifacts) {
+    VariantMetadataSpec(String name, Map<String, String> attributes, List<DependencySpec> dependencies, List<DependencyConstraintSpec> dependencyConstraints, List<FileSpec> artifacts) {
         this.name = name
         this.attributes = attributes
         this.dependencies = dependencies

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -28,7 +28,7 @@ import org.gradle.test.fixtures.gradle.DependencyConstraintSpec
 import org.gradle.test.fixtures.gradle.DependencySpec
 import org.gradle.test.fixtures.gradle.FileSpec
 import org.gradle.test.fixtures.gradle.GradleFileModuleAdapter
-import org.gradle.test.fixtures.gradle.VariantMetadata
+import org.gradle.test.fixtures.gradle.VariantMetadataSpec
 
 class IvyFileModule extends AbstractModule implements IvyModule {
     final String ivyPattern
@@ -45,7 +45,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     final Map extendsFrom = [:]
     final Map extraAttributes = [:]
     final Map extraInfo = [:]
-    private final List<VariantMetadata> variants = [new VariantMetadata("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API]), new VariantMetadata("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME])]
     String branch = null
     String status = "integration"
     MetadataPublish metadataPublish = MetadataPublish.ALL
@@ -119,15 +119,15 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         return this
     }
 
-    private VariantMetadata createVariant(String variant, Map<String, String> attributes) {
-        def variantMetadata = new VariantMetadata(variant, attributes)
+    private VariantMetadataSpec createVariant(String variant, Map<String, String> attributes) {
+        def variantMetadata = new VariantMetadataSpec(variant, attributes)
         variants.add(variantMetadata)
         configuration(variant) //add variant also as configuration for plain ivy publishing
         return variantMetadata;
     }
 
     @Override
-    void withVariant(String name, @DelegatesTo(value = VariantMetadata, strategy = Closure.DELEGATE_FIRST) Closure<?> action) {
+    void withVariant(String name, @DelegatesTo(value = VariantMetadataSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> action) {
         def variant = variants.find { it.name == name }
         if (variant == null) {
             variant = createVariant(name, [:])
@@ -393,7 +393,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         }
         GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(organisation, module, revision,
             variants.collect { v ->
-                new VariantMetadata(
+                new VariantMetadataSpec(
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -28,7 +28,7 @@ import org.gradle.test.fixtures.gradle.DependencyConstraintSpec
 import org.gradle.test.fixtures.gradle.DependencySpec
 import org.gradle.test.fixtures.gradle.FileSpec
 import org.gradle.test.fixtures.gradle.GradleFileModuleAdapter
-import org.gradle.test.fixtures.gradle.VariantMetadata
+import org.gradle.test.fixtures.gradle.VariantMetadataSpec
 
 import java.text.SimpleDateFormat
 
@@ -44,7 +44,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     String packaging
     int publishCount = 1
     private boolean hasPom = true
-    private final List<VariantMetadata> variants = [new VariantMetadata("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API]), new VariantMetadata("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME])]
     private final List dependencies = []
     private final List artifacts = []
     final updateFormat = new SimpleDateFormat("yyyyMMddHHmmss")
@@ -164,8 +164,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         return this
     }
 
-    private VariantMetadata createVariant(String variant, Map<String, String> attributes) {
-        def variantMetadata = new VariantMetadata(variant, attributes)
+    private VariantMetadataSpec createVariant(String variant, Map<String, String> attributes) {
+        def variantMetadata = new VariantMetadataSpec(variant, attributes)
         variants.add(variantMetadata)
         return variantMetadata;
     }
@@ -191,7 +191,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         return artifacts
     }
 
-    List<VariantMetadata> getVariants() {
+    List<VariantMetadataSpec> getVariants() {
         return variants
     }
 
@@ -428,7 +428,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         }
         GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(groupId, artifactId, version,
             variants.collect { v ->
-                new VariantMetadata(
+                new VariantMetadataSpec(
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
@@ -616,7 +616,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     }
 
     @Override
-    void withVariant(String name, @DelegatesTo(value = VariantMetadata, strategy = Closure.DELEGATE_FIRST) Closure<?> action) {
+    void withVariant(String name, @DelegatesTo(value = VariantMetadataSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> action) {
         def variant = variants.find { it.name == name }
         if (variant == null) {
             variant = createVariant(name, [:])

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -50,8 +50,8 @@ import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.VariantMetadata;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.language.base.internal.resolve.LibraryResolveException;
@@ -173,7 +173,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             }
 
             @Override
-            public ImmutableAttributes mapAttributesFor(VariantMetadata variant) {
+            public ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant) {
                 return variant.getAttributes().asImmutable();
             }
 


### PR DESCRIPTION
This commit fixes a comment from https://github.com/gradle/gradle/issues/3159#issuecomment-353133089 by renaming the internal and test fixtures `VariantMetadata` types to avoid confusion.
