### PR TITLE
Consolidate how `status` is implemented internally

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -48,7 +49,6 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final ModuleComponentIdentifier componentIdentifier;
     private final boolean changing;
     private final boolean missing;
-    private final String status;
     private final List<String> statusScheme;
     @Nullable
     private final ModuleSource moduleSource;
@@ -67,7 +67,6 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         this.moduleVersionIdentifier = metadata.getId();
         changing = metadata.isChanging();
         missing = metadata.isMissing();
-        status = metadata.getStatus();
         statusScheme = metadata.getStatusScheme();
         moduleSource = metadata.getSource();
         configurationDefinitions = metadata.getConfigurationDefinitions();
@@ -78,7 +77,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         variants = metadata.getVariants();
     }
 
-    private ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
+    private static ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
         return ((AttributeContainerInternal) metadata.getAttributes()).asImmutable();
     }
 
@@ -91,7 +90,6 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         this.moduleVersionIdentifier = metadata.getId();
         changing = metadata.changing;
         missing = metadata.missing;
-        status = metadata.status;
         statusScheme = metadata.statusScheme;
         moduleSource = source;
         configurationDefinitions = metadata.configurationDefinitions;
@@ -200,7 +198,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
     @Override
     public String getStatus() {
-        return status;
+        return attributes.getAttribute(ProjectInternal.STATUS_ATTRIBUTE);
     }
 
     @Override
@@ -282,7 +280,6 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             && missing == that.missing
             && Objects.equal(moduleVersionIdentifier, that.moduleVersionIdentifier)
             && Objects.equal(componentIdentifier, that.componentIdentifier)
-            && Objects.equal(status, that.status)
             && Objects.equal(statusScheme, that.statusScheme)
             && Objects.equal(moduleSource, that.moduleSource)
             && Objects.equal(configurationDefinitions, that.configurationDefinitions)
@@ -298,7 +295,6 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             componentIdentifier,
             changing,
             missing,
-            status,
             statusScheme,
             moduleSource,
             configurationDefinitions,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -62,7 +62,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final Map<String, DefaultConfigurationMetadata> configurations = Maps.newHashMap();
     private ImmutableList<? extends ConfigurationMetadata> graphVariants;
 
-    protected AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
+    AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
         this.componentIdentifier = metadata.getComponentId();
         this.moduleVersionIdentifier = metadata.getId();
         changing = metadata.isChanging();
@@ -79,18 +79,14 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     private ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
-        AttributeContainer attributes = metadata.getAttributes();
-        if (attributes == null) {
-            attributes = ImmutableAttributes.EMPTY;
-        }
-        return ((AttributeContainerInternal) attributes).asImmutable();
+        return ((AttributeContainerInternal) metadata.getAttributes()).asImmutable();
     }
 
 
     /**
      * Creates a copy of the given metadata
      */
-    protected AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, @Nullable ModuleSource source) {
+    AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, @Nullable ModuleSource source) {
         this.componentIdentifier = metadata.getComponentId();
         this.moduleVersionIdentifier = metadata.getId();
         changing = metadata.changing;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.DependencyMetadata
@@ -348,12 +348,13 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
     }
 
     def attributes(Map<String, String> values) {
-        def attrs = ImmutableAttributes.EMPTY
+        def attrs = TestUtil.attributesFactory().mutable()
+        attrs.attribute(ProjectInternal.STATUS_ATTRIBUTE, 'integration')
         if (values) {
             values.each { String key, String value ->
-                attrs = TestUtil.attributesFactory().concat(attrs, Attribute.of(key, String), value)
+                attrs.attribute(Attribute.of(key, String), value)
             }
         }
-        return attrs
+        return attrs.asImmutable()
     }
 }


### PR DESCRIPTION
### Context

This pull request fixes a review comment in https://github.com/gradle/gradle/issues/3159#issuecomment-353133089 by backing the `status` as a real attribute. Before it was _viewable_ as an attribute, not stored as such.

There are possible performance implications with this implementation, let's wait for the build to be green before merging.
