### PR TITLE
Add integration test exposing Issue #3873

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
@@ -38,10 +38,11 @@ import java.lang.reflect.InvocationTargetException
  */
 class BuildOperationNotificationsFixture {
 
+    public static final String FIXTURE_SCRIPT_NAME = "injectBuildOpFixture.gradle"
     private final File initScript
 
     BuildOperationNotificationsFixture(GradleExecuter executer, TestDirectoryProvider projectDir) {
-        this.initScript = projectDir.testDirectory.file("injectBuildOpFixture.gradle")
+        this.initScript = projectDir.testDirectory.file(FIXTURE_SCRIPT_NAME)
         this.initScript.text = injectNotificationListenerBuildLogic()
         executer.beforeExecute {
             it.usingInitScript(this.initScript)


### PR DESCRIPTION
- Adds a testcase exposing https://github.com/gradle/gradle/issues/3873
- Changes ApplyScriptPluginBuildOperationIntegrationTest to use BuildOperationNotificationsFixture
to ensure consuming data from build scan works as expected.
