### PR TITLE
Support new JDK 10 versioning scheme

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
@@ -62,7 +62,7 @@ public class DefaultJvmVersionDetector implements JvmVersionDetector {
         try {
             String versionStr = reader.readLine();
             while (versionStr != null) {
-                Matcher matcher = Pattern.compile("(?:java|openjdk) version \"(.+?)\"").matcher(versionStr);
+                Matcher matcher = Pattern.compile("(?:java|openjdk) version \"(.+?)\"( \\d{4}-\\d{2}-\\d{2})*").matcher(versionStr);
                 if (matcher.matches()) {
                     return JavaVersion.toVersion(matcher.group(1));
                 }

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
@@ -60,6 +60,14 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
         Java(TM) SE Runtime Environment (build 1.8.0_91-b14)
         Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
         """                     | "1.8"
+        """java version "10-ea"
+Java(TM) SE Runtime Environment 18.3 (build 10-ea+35)
+Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10-ea+35, mixed mode)
+"""                             | "10"
+        """java version "10-ea" 2018-03-20
+Java(TM) SE Runtime Environment 18.3 (build 10-ea+36)
+Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10-ea+36, mixed mode)
+"""                             | "10"
     }
 
     def "fails to parse version number"() {


### PR DESCRIPTION
### Context

Starting with jdk-10+36 a date is added to the version output. The regex for the version parsing take this into consideration. We might want to think about using `.*` instead and ignore whatever changes the make to the versioning scheme after the actual version number to avoid future breakage.

It tried out the change manually with the following build script:

```
task helloWorld {
    doLast {
        println "Hello World!"
    }
}
```

...and the following commands:

```
$ java -version
java version "10-ea" 2018-03-20
Java(TM) SE Runtime Environment 18.3 (build 10-ea+36)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10-ea+36, mixed mode)

$ /Users/bmuschko/dev/tmp/gradle-source/bin/gradle hW
Parallel execution is an incubating feature.

> Task :helloWorld
Hello World!

BUILD SUCCESSFUL in 0s
1 actionable task: 1 executed
```