### PR TITLE
Introduce a SetProperty convenience and use this in the Swift plugins to model library linkages

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/docbook/AssembleDslDocTask.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/docbook/AssembleDslDocTask.groovy
@@ -100,7 +100,7 @@ class AssembleDslDocTask extends DefaultTask {
         ClassMetaDataRepository<ClassMetaData> classRepository = new SimpleClassMetaDataRepository<ClassMetaData>()
         classRepository.load(classMetaDataFile)
         ClassMetaDataRepository<ClassLinkMetaData> linkRepository = new SimpleClassMetaDataRepository<ClassLinkMetaData>()
-        //for every method found in class meta, create a javadoc/groovydoc link
+        //for every method found in class meta, create a javadoc link
         classRepository.each {name, ClassMetaData metaData ->
             linkRepository.put(name, new ClassLinkMetaData(metaData))
         }

--- a/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/links/ClassLinkMetaData.java
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/links/ClassLinkMetaData.java
@@ -39,7 +39,7 @@ public class ClassLinkMetaData implements Serializable, Attachable<ClassLinkMeta
         this.className = classMetaData.getClassName();
         this.simpleName = classMetaData.getSimpleName();
         this.packageName = classMetaData.getPackageName();
-        this.style = classMetaData.isGroovy() ? LinkMetaData.Style.Groovydoc : LinkMetaData.Style.Javadoc;
+        this.style = LinkMetaData.Style.Javadoc;
         for (MethodMetaData method : classMetaData.getDeclaredMethods()) {
             addMethod(method, style);
         }
@@ -81,7 +81,10 @@ public class ClassLinkMetaData implements Serializable, Attachable<ClassLinkMeta
             }
         }
         if (candidates.isEmpty()) {
-            String message = String.format("No method '%s' found for class '%s'.", method, className);
+            String message = String.format("No method '%s' found for class '%s'.\nFound the following methods:", method, className);
+            for (MethodLinkMetaData methodLinkMetaData : methods.values()) {
+                message += "\n  " + methodLinkMetaData;
+            }
             message += "\nThis problem may happen when some apilink from docbook template xmls refers to unknown method."
                     + "\nExample: <apilink class=\"org.gradle.api.Project\" method=\"someMethodThatDoesNotExist\"/>";
             throw new RuntimeException(message);
@@ -139,11 +142,11 @@ public class ClassLinkMetaData implements Serializable, Attachable<ClassLinkMeta
         public String getDisplayName() {
             return signature;
         }
-        
+
         public String getUrlFragment(String className) {
-            return style == LinkMetaData.Style.Dsldoc ? String.format("%s:%s", className, signature) : signature;
+            return style == LinkMetaData.Style.Dsldoc ? String.format("%s:%s", className, signature) : signature.replace('(', '-').replace(')', '-');
         }
-        
+
         @Override
         public String toString() {
             return signature;

--- a/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/links/LinkMetaData.java
+++ b/buildSrc/src/main/groovy/org/gradle/build/docs/dsl/links/LinkMetaData.java
@@ -18,7 +18,7 @@ package org.gradle.build.docs.dsl.links;
 import java.io.Serializable;
 
 public class LinkMetaData implements Serializable {
-    public enum Style { Javadoc, Groovydoc, Dsldoc }
+    public enum Style { Javadoc, Dsldoc }
 
     private final Style style;
     private final String displayName;

--- a/buildSrc/src/test/groovy/org/gradle/build/docs/dsl/links/ClassLinkMetaDataTest.groovy
+++ b/buildSrc/src/test/groovy/org/gradle/build/docs/dsl/links/ClassLinkMetaDataTest.groovy
@@ -43,7 +43,7 @@ class ClassLinkMetaDataTest extends Specification {
         linkMetaData != null
         linkMetaData.style == LinkMetaData.Style.Javadoc
         linkMetaData.displayName == "$SIMPLE_CLASSNAME.${METHOD_NAME}()"
-        linkMetaData.urlFragment == "$METHOD_NAME()"
+        linkMetaData.urlFragment == "$METHOD_NAME--"
 
         when:
         linkMetaData = classLinkMetaData.getMethod("$METHOD_NAME(java.lang.Integer)")
@@ -52,7 +52,7 @@ class ClassLinkMetaDataTest extends Specification {
         linkMetaData != null
         linkMetaData.style == LinkMetaData.Style.Javadoc
         linkMetaData.displayName == "$SIMPLE_CLASSNAME.${METHOD_NAME}(java.lang.Integer)"
-        linkMetaData.urlFragment == "$METHOD_NAME(java.lang.Integer)"
+        linkMetaData.urlFragment == "$METHOD_NAME-java.lang.Integer-"
 
         when:
         linkMetaData = classLinkMetaData.getMethod("$METHOD_NAME(java.lang.Integer, java.lang.String)")
@@ -61,6 +61,6 @@ class ClassLinkMetaDataTest extends Specification {
         linkMetaData != null
         linkMetaData.style == LinkMetaData.Style.Javadoc
         linkMetaData.displayName == "$SIMPLE_CLASSNAME.${METHOD_NAME}(java.lang.Integer, java.lang.String)"
-        linkMetaData.urlFragment == "$METHOD_NAME(java.lang.Integer, java.lang.String)"
+        linkMetaData.urlFragment == "$METHOD_NAME-java.lang.Integer, java.lang.String-"
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -20,9 +20,11 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A factory for creating various kinds of model objects.
@@ -98,4 +100,16 @@ public interface ObjectFactory {
      * @since 4.3
      */
     <T> ListProperty<T> listProperty(Class<T> elementType);
+
+    /**
+     * Creates a {@link SetProperty} implementation to hold a {@link Set} of the given element type. The property with have an empty set as its initial value.
+     *
+     * <p>The implementation will return immutable {@link Set} values from its query methods.</p>
+     *
+     * @param elementType The type of element.
+     * @param <T> The type of element.
+     * @return The property. Never returns null;
+     * @since 4.3
+     */
+    <T> SetProperty<T> setProperty(Class<T> elementType);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -109,7 +109,7 @@ public interface ObjectFactory {
      * @param elementType The type of element.
      * @param <T> The type of element.
      * @return The property. Never returns null;
-     * @since 4.3
+     * @since 4.5
      */
     <T> SetProperty<T> setProperty(Class<T> elementType);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -18,8 +18,10 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
+
 /**
- * Represents a property whose type is a collection of elements of type {@link T}.
+ * Represents a property whose value can be set using multiple elements of type {@link T}, such as a collection property.
  *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors. You can use the factory methods on {@link org.gradle.api.model.ObjectFactory} to create instances of this interface.
  *
@@ -28,6 +30,22 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public interface HasMultipleValues<T> {
+    /**
+     * Sets the value of the property the given value.
+     *
+     * <p>This method can also be used to clear the value of the property, by passing {@code null} as the value.
+     *
+     * @param value The value, can be null.
+     */
+    void set(@Nullable Iterable<? extends T> value);
+
+    /**
+     * Sets the property to have the same value of the given provider. This property will track the value of the provider and query its value each time the value of the property is queried. When the provider has no value, this property will also have no value.
+     *
+     * @param provider Provider
+     */
+    void set(Provider<? extends Iterable<? extends T>> provider);
+
     /**
      * Adds an element to the property value.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Represents a property whose type is a collection of elements of type {@link T}.
+ *
+ * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors. You can use the factory methods on {@link org.gradle.api.model.ObjectFactory} to create instances of this interface.
+ *
+ * @param <T> the type of elements.
+ * @since 4.5
+ */
+@Incubating
+public interface HasMultipleValues<T> {
+    /**
+     * Adds an element to the property value.
+     *
+     * @param element The element
+     * @throws NullPointerException if the specified element is null
+     */
+    void add(T element);
+
+    /**
+     * Adds an element to the property value.
+     *
+     * <p>The given provider will be queried when the value of the property is queried.
+     * The property will have no value when the given provider has no value.
+     *
+     * @param provider Provider
+     */
+    void add(Provider<? extends T> provider);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * <p>The given provider will be queried when the value of the property is queried.
+     * The property will have no value when the given provider has no value.
+     *
+     * @param provider Provider of elements
+     */
+    void addAll(Provider<? extends Iterable<T>> provider);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -29,5 +29,5 @@ import java.util.Set;
  * @since 4.5
  */
 @Incubating
-public interface SetProperty<T> extends Property<Set<T>>, HasMultipleValues<T> {
+public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -18,16 +18,16 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Incubating;
 
-import java.util.List;
+import java.util.Set;
 
 /**
- * Represents a property whose type is a {@link List} of elements of type {@link T}.
+ * Represents a property whose type is a {@link Set} of elements of type {@link T}. Retains iteration order.
  *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created through the factory method {@link org.gradle.api.model.ObjectFactory#listProperty(Class)}.
  *
  * @param <T> the type of elements.
- * @since 4.3
+ * @since 4.5
  */
 @Incubating
-public interface ListProperty<T> extends Property<List<T>>, HasMultipleValues<T> {
+public interface SetProperty<T> extends Property<Set<T>>, HasMultipleValues<T> {
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/provider/ListPropertyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/provider/ListPropertyIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.provider
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-class ListPropertyTaskIntegrationTest extends AbstractIntegrationSpec {
+class ListPropertyIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """
             class MyTask extends DefaultTask {
@@ -38,15 +38,21 @@ class ListPropertyTaskIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    def "can set default value for list property"() {
+    def "can set value for list property from DSL"() {
         buildFile << """
             verify {
-                prop = [ 'a', 'b', 'c' ]
+                prop = ${value}
                 expected = [ 'a', 'b', 'c' ]
             }
         """
         expect:
         succeeds("verify")
+
+        where:
+        value                                      | _
+        "[ 'a', 'b', 'c' ]"                        | _
+        "new LinkedHashSet([ 'a', 'b', 'c' ])"     | _
+        "providers.provider { [ 'a', 'b', 'c' ] }" | _
     }
 
     def "can add to default values"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/provider/ListPropertyTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/provider/ListPropertyTaskIntegrationTest.groovy
@@ -98,28 +98,28 @@ class ListPropertyTaskIntegrationTest extends AbstractIntegrationSpec {
         """
         expect:
         def failure = fails("verify")
-        failure.assertHasCause("Cannot add a null value to a list property.")
+        failure.assertHasCause("Cannot add a null element to a property of type List.")
     }
 
-    def "reasonable message when trying to add a provider providing null to a list property"() {
+    def "has no value when providing null to a list property"() {
         buildFile << """
             verify {
                 prop.add(project.provider { null })
+                expected = null
             }
         """
         expect:
-        def failure = fails("verify")
-        failure.assertHasCause("No value has been specified for this provider.")
+        succeeds("verify")
     }
 
-    def "reasonable message when trying to add a provider providing null list to a list property"() {
+    def "has no value when providing null list to a list property"() {
         buildFile << """
             verify {
                 prop.addAll(project.provider { null })
+                expected = null
             }
         """
         expect:
-        def failure = fails("verify")
-        failure.assertHasCause("No value has been specified for this provider.")
+        succeeds("verify")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Unroll
 import static PropertyStateProjectUnderTest.Language
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 
-class PropertyStateIntegrationTest extends AbstractIntegrationSpec {
+class PropertyIntegrationTest extends AbstractIntegrationSpec {
 
     private final PropertyStateProjectUnderTest projectUnderTest = new PropertyStateProjectUnderTest(testDirectory)
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinScriptIntegrationTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.util.TextUtil.normaliseFileSeparators
 
 @Ignore("Fails on CI for unknown reason")
 @Requires(KOTLIN_SCRIPT)
-class PropertyStateKotlinScriptIntegrationTest extends KotlinScriptIntegrationTest {
+class PropertyKotlinScriptIntegrationTest extends KotlinScriptIntegrationTest {
 
     private final PropertyStateProjectUnderTest projectUnderTest = new PropertyStateProjectUnderTest(testDirectory)
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractClassGenerator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractClassGenerator.java
@@ -26,6 +26,7 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.reflect.ClassDetails;
 import org.gradle.internal.reflect.ClassInspector;
@@ -145,7 +146,7 @@ public abstract class AbstractClassGenerator implements ClassGenerator {
                     continue;
                 }
 
-                if (!property.getters.isEmpty() && Property.class.isAssignableFrom(property.getType())) {
+                if (!property.getters.isEmpty() && (Property.class.isAssignableFrom(property.getType()) || HasMultipleValues.class.isAssignableFrom(property.getType()))) {
                     builder.addPropertySetters(property, property.getters.get(0));
                     continue;
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -19,9 +19,11 @@ package org.gradle.api.internal.model;
 import org.gradle.api.Named;
 import org.gradle.api.internal.provider.DefaultListProperty;
 import org.gradle.api.internal.provider.DefaultProviderFactory;
+import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -54,5 +56,10 @@ public class DefaultObjectFactory implements ObjectFactory {
     @Override
     public <T> ListProperty<T> listProperty(Class<T> elementType) {
         return new DefaultListProperty<T>(elementType);
+    }
+
+    @Override
+    public <T> SetProperty<T> setProperty(Class<T> elementType) {
+        return new DefaultSetProperty<T>(elementType);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -19,6 +19,7 @@ import org.gradle.api.Named;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -36,11 +37,20 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
 
     @Override
     public <T> Property<T> property(Class<T> valueType) {
-        throw new UnsupportedOperationException("Instantiator does not support constructing property objects");
+        return broken();
     }
 
     @Override
     public <T> ListProperty<T> listProperty(Class<T> elementType) {
+        return broken();
+    }
+
+    @Override
+    public <T> SetProperty<T> setProperty(Class<T> elementType) {
+        return broken();
+    }
+
+    private <T> T broken() {
         throw new UnsupportedOperationException("Instantiator does not support constructing property objects");
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.Transformer;
+import org.gradle.api.provider.HasMultipleValues;
+import org.gradle.api.provider.Provider;
+import org.gradle.util.CollectionUtils;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+public abstract class AbstractCollectionProperty<T, C extends Collection<T>> extends AbstractProvider<C> implements PropertyInternal<C>, HasMultipleValues<T> {
+    private static final EmptyCollection EMPTY_COLLECTION = new EmptyCollection();
+    private static final NoValueCollector NO_VALUE_COLLECTOR = new NoValueCollector();
+    private final Class<? extends Collection> collectionType;
+    private Collector<T> value = (Collector<T>) EMPTY_COLLECTION;
+    private List<Collector<T>> collectors = new LinkedList<Collector<T>>();
+
+    AbstractCollectionProperty(Class<? extends Collection> collectionType) {
+        this.collectionType = collectionType;
+    }
+
+    /**
+     * Creates an immutable collection from the given current values of this property.
+     */
+    protected abstract C fromValue(Collection<T> values);
+
+    @Override
+    public void add(final T element) {
+        Preconditions.checkNotNull(element, String.format("Cannot add a null element to a property of type %s.", collectionType.getSimpleName()));
+        collectors.add(new SingleElement<T>(element));
+    }
+
+    @Override
+    public void add(final Provider<? extends T> providerOfElement) {
+        collectors.add(new ElementFromProvider<T>(providerOfElement));
+    }
+
+    @Override
+    public void addAll(final Provider<? extends Iterable<T>> providerOfElements) {
+        collectors.add(new ElementsFromCollectionProvider<T>(providerOfElements));
+    }
+
+    @Nullable
+    @Override
+    public Class<C> getType() {
+        return null;
+    }
+
+    @Override
+    public boolean isPresent() {
+        if (!value.present()) {
+            return false;
+        }
+        for (Collector<T> collector : collectors) {
+            if (!collector.present()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public C get() {
+        List<T> values = new ArrayList<T>(1 + collectors.size());
+        value.collectInto(values);
+        for (Collector<T> collector : collectors) {
+            collector.collectInto(values);
+        }
+        return fromValue(values);
+    }
+
+    @Nullable
+    @Override
+    public C getOrNull() {
+        List<T> values = new ArrayList<T>(1 + collectors.size());
+        if (!value.maybeCollectInto(values)) {
+            return null;
+        }
+        for (Collector<T> collector : collectors) {
+            if (!collector.maybeCollectInto(values)) {
+                return null;
+            }
+        }
+        return fromValue(values);
+    }
+
+    @Override
+    public void setFromAnyValue(Object object) {
+        if (object instanceof Provider) {
+            set((Provider<C>) object);
+        } else {
+            if (object != null && !(collectionType.isInstance(object))) {
+                throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s using an instance of type %s.", collectionType.getName(), object.getClass().getName()));
+            }
+            set((C) object);
+        }
+    }
+
+    @Override
+    public void set(@Nullable final C value) {
+        collectors.clear();
+        if (value == null) {
+            this.value = (Collector<T>) NO_VALUE_COLLECTOR;
+        } else {
+            this.value = new ElementsFromCollection<T, C>(value);
+        }
+    }
+
+    @Override
+    public void set(final Provider<? extends C> provider) {
+        if (provider == null) {
+            throw new IllegalArgumentException("Cannot set the value of a property using a null provider.");
+        }
+        collectors.clear();
+        value = new ElementsFromProvider<T, C>(provider);
+    }
+
+    /**
+     * This could move to the public API.
+     */
+    private interface Collector<T> {
+        boolean present();
+
+        void collectInto(Collection<T> collection);
+
+        boolean maybeCollectInto(Collection<T> collection);
+    }
+
+    @Override
+    public <S> ProviderInternal<S> map(final Transformer<? extends S, ? super C> transformer) {
+        return new AbstractProvider<S>() {
+            @Nullable
+            @Override
+            public Class<S> getType() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public S getOrNull() {
+                Collection<T> value = AbstractCollectionProperty.this.getOrNull();
+                if (value == null) {
+                    return null;
+                }
+                S result = transformer.transform(fromValue(value));
+                if (result == null) {
+                    throw new IllegalStateException(Providers.NULL_TRANSFORMER_RESULT);
+                }
+                return result;
+            }
+        };
+    }
+
+    private static class EmptyCollection implements Collector<Object> {
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<Object> collection) {
+            return true;
+        }
+
+        @Override
+        public void collectInto(Collection<Object> collection) {
+        }
+    }
+
+    private static class SingleElement<T> implements Collector<T> {
+        private final T element;
+
+        SingleElement(T element) {
+            this.element = element;
+        }
+
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public void collectInto(Collection<T> collection) {
+            collection.add(element);
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<T> collection) {
+            collection.add(element);
+            return true;
+        }
+    }
+
+    private static class ElementFromProvider<T> implements Collector<T> {
+        private final Provider<? extends T> providerOfElement;
+
+        ElementFromProvider(Provider<? extends T> providerOfElement) {
+            this.providerOfElement = providerOfElement;
+        }
+
+        @Override
+        public boolean present() {
+            return providerOfElement.isPresent();
+        }
+
+        @Override
+        public void collectInto(Collection<T> collection) {
+            T value = providerOfElement.get();
+            collection.add(value);
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<T> collection) {
+            T value = providerOfElement.getOrNull();
+            if (value == null) {
+                return false;
+            }
+            collection.add(value);
+            return true;
+        }
+    }
+
+    private static class ElementsFromCollectionProvider<T> implements Collector<T> {
+        private final Provider<? extends Iterable<T>> providerOfElements;
+
+        ElementsFromCollectionProvider(Provider<? extends Iterable<T>> providerOfElements) {
+            this.providerOfElements = providerOfElements;
+        }
+
+        @Override
+        public boolean present() {
+            return providerOfElements.isPresent();
+        }
+
+        @Override
+        public void collectInto(Collection<T> collection) {
+            Iterable<T> value = providerOfElements.get();
+            CollectionUtils.addAll(collection, value);
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<T> collection) {
+            Iterable<T> value = providerOfElements.getOrNull();
+            if (value == null) {
+                return false;
+            }
+            CollectionUtils.addAll(collection, value);
+            return true;
+        }
+    }
+
+    private static class ElementsFromCollection<T, C extends Collection<? extends T>> implements Collector<T> {
+        private final C value;
+
+        ElementsFromCollection(C value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public void collectInto(Collection<T> collection) {
+            collection.addAll(value);
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<T> collection) {
+            collection.addAll(value);
+            return true;
+        }
+    }
+
+    private static class ElementsFromProvider<T, C extends Collection<T>> implements Collector<T> {
+        private final Provider<? extends C> provider;
+
+        ElementsFromProvider(Provider<? extends C> provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public boolean present() {
+            return provider.isPresent();
+        }
+
+        @Override
+        public void collectInto(Collection<T> collection) {
+            C value = provider.get();
+            collection.addAll(value);
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<T> collection) {
+            C value = provider.getOrNull();
+            if (value == null) {
+                return false;
+            }
+            collection.addAll(value);
+            return true;
+        }
+    }
+
+    private static class NoValueCollector implements Collector<Object> {
+        @Override
+        public boolean present() {
+            return false;
+        }
+
+        @Override
+        public void collectInto(Collection<Object> collection) {
+            throw new IllegalStateException(Providers.NULL_VALUE);
+        }
+
+        @Override
+        public boolean maybeCollectInto(Collection<Object> collection) {
+            return false;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyInternal.java
@@ -14,20 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.api.provider;
+package org.gradle.api.internal.provider;
 
-import org.gradle.api.Incubating;
+import org.gradle.api.provider.HasMultipleValues;
 
-import java.util.List;
+import java.util.Collection;
 
-/**
- * Represents a property whose type is a {@link List} of elements of type {@link T}.
- *
- * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created through the factory method {@link org.gradle.api.model.ObjectFactory#listProperty(Class)}.
- *
- * @param <T> the type of elements.
- * @since 4.3
- */
-@Incubating
-public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T> {
+public interface CollectionPropertyInternal<T, C extends Collection<T>> extends PropertyInternal, HasMultipleValues<T>, ProviderInternal<C> {
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -16,123 +16,20 @@
 
 package org.gradle.api.internal.provider;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.Transformer;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Provider;
-import org.gradle.internal.Cast;
 
-import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.List;
 
-public class DefaultListProperty<T> implements PropertyInternal<List<T>>, ListProperty<T> {
-    private static final Provider<ImmutableList<Object>> EMPTY_LIST = Providers.of(ImmutableList.of());
-    private Provider<? extends List<T>> provider = Cast.uncheckedCast(EMPTY_LIST);
-
+public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T>> implements ListProperty<T> {
     public DefaultListProperty(Class<T> elementType) {
+        super(List.class);
     }
 
     @Override
-    public void add(final T element) {
-        addAll(Providers.of(ImmutableList.of(
-            Preconditions.checkNotNull(element, "Cannot add a null value to a list property."))));
+    protected List<T> fromValue(Collection<T> values) {
+        return ImmutableList.copyOf(values);
     }
 
-    @Override
-    public void add(final Provider<? extends T> providerOfElement) {
-        addAll(providerOfElement.map(new Transformer<Iterable<T>, T>() {
-            @Override
-            public Iterable<T> transform(T t) {
-                return ImmutableList.of(t);
-            }
-        }));
-    }
-
-    @Override
-    public void addAll(final Provider<? extends Iterable<T>> providerOfElements) {
-        provider = provider.map(new Transformer<List<T>, List<T>>() {
-            @Override
-            public List<T> transform(List<T> ts) {
-                return ImmutableList.<T>builder()
-                    .addAll(ts)
-                    .addAll(providerOfElements.get())
-                    .build();
-            }
-        });
-    }
-
-    @Nullable
-    @Override
-    public Class<List<T>> getType() {
-        return null;
-    }
-
-    @Override
-    public boolean isPresent() {
-        return provider.isPresent();
-    }
-
-    @Override
-    public List<T> get() {
-        return ImmutableList.copyOf(provider.get());
-    }
-
-    @Nullable
-    @Override
-    public List<T> getOrNull() {
-        return getOrElse(null);
-    }
-
-    @Override
-    public List<T> getOrElse(List<T> defaultValue) {
-        List<T> list = provider.getOrNull();
-        if (list == null) {
-            return defaultValue;
-        }
-        return ImmutableList.copyOf(list);
-    }
-
-    @Override
-    public void setFromAnyValue(Object object) {
-        if (object instanceof Provider) {
-            set((Provider<List<T>>) object);
-        } else {
-            if (object != null && !(object instanceof List)) {
-                throw new IllegalArgumentException(String.format("Cannot set the value of a property of type %s using an instance of type %s.", List.class.getName(), object.getClass().getName()));
-            }
-            set((List<T>) object);
-        }
-    }
-
-    @Override
-    public void set(@Nullable List<T> value) {
-        if (value == null) {
-            this.provider = Providers.notDefined();
-            return;
-        }
-        this.provider = Providers.of(value);
-    }
-
-    @Override
-    public void set(Provider<? extends List<T>> provider) {
-        if (provider == null) {
-            throw new IllegalArgumentException("Cannot set the value of a property using a null provider.");
-        }
-        this.provider = provider;
-    }
-
-    @Override
-    public <S> ProviderInternal<S> map(final Transformer<? extends S, ? super List<T>> transformer) {
-        return new TransformBackedProvider<S, List<T>>(transformer, this) {
-            @Override
-            protected S map(List<T> v) {
-                S result = super.map(v);
-                if (result instanceof List) {
-                    return (S) ImmutableList.copyOf((List<T>) result);
-                }
-                return result;
-            }
-        };
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
@@ -17,12 +17,13 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
+import org.gradle.api.provider.PropertyState;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 
-public class DefaultPropertyState<T> implements PropertyInternal<T> {
+public class DefaultPropertyState<T> implements PropertyInternal, PropertyState<T>, ProviderInternal<T> {
     private final Class<T> type;
     private Provider<? extends T> provider = Providers.notDefined();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.api.provider;
+package org.gradle.api.internal.provider;
 
-import org.gradle.api.Incubating;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.provider.SetProperty;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Set;
 
-/**
- * Represents a property whose type is a {@link List} of elements of type {@link T}.
- *
- * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created through the factory method {@link org.gradle.api.model.ObjectFactory#listProperty(Class)}.
- *
- * @param <T> the type of elements.
- * @since 4.3
- */
-@Incubating
-public interface ListProperty<T> extends Property<List<T>>, HasMultipleValues<T> {
+public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>> implements SetProperty<T> {
+    public DefaultSetProperty(Class<T> elementType) {
+        super(Set.class);
+    }
+
+    @Override
+    protected Set<T> fromValue(Collection<T> values) {
+        return ImmutableSet.copyOf(values);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableCollectionProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableCollectionProperty.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Internal;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public abstract class LockableCollectionProperty<T, C extends Collection<T>> extends AbstractProvider<C> implements CollectionPropertyInternal<T, C> {
+    private CollectionPropertyInternal<T, C> delegate;
+    private boolean locked;
+    private C value;
+
+    public LockableCollectionProperty(CollectionPropertyInternal<T, C> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Nullable
+    @Override
+    public Class<C> getType() {
+        return null;
+    }
+
+    public void lockNow() {
+        locked = true;
+        C currentValue = delegate.getOrNull();
+        value = currentValue == null ? null : immutableCopy(currentValue);
+        delegate = null;
+    }
+
+    protected abstract C immutableCopy(C value);
+
+    private void assertNotLocked() {
+        if (locked) {
+            throw new IllegalStateException("This property is locked and cannot be changed.");
+        }
+    }
+
+    @Override
+    public void setFromAnyValue(Object object) {
+        assertNotLocked();
+        delegate.setFromAnyValue(object);
+    }
+
+    @Override
+    public void add(T element) {
+        assertNotLocked();
+        delegate.add(element);
+    }
+
+    @Override
+    public void add(Provider<? extends T> provider) {
+        assertNotLocked();
+        delegate.add(provider);
+    }
+
+    @Override
+    public void addAll(Provider<? extends Iterable<T>> provider) {
+        assertNotLocked();
+        delegate.addAll(provider);
+    }
+
+    @Override
+    public void set(@Nullable Iterable<? extends T> value) {
+        assertNotLocked();
+        delegate.set(value);
+    }
+
+    @Override
+    public void set(Provider<? extends Iterable<? extends T>> provider) {
+        assertNotLocked();
+        delegate.set(provider);
+    }
+
+    @Override
+    @Nullable
+    @Internal
+    public C getOrNull() {
+        return locked ? value : delegate.getOrNull();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableListProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableListProperty.java
@@ -16,80 +16,18 @@
 
 package org.gradle.api.internal.provider;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
-public class LockableListProperty<T> extends AbstractProvider<List<T>> implements ListProperty<T>, PropertyInternal<List<T>> {
-    private ListProperty<T> delegate;
-    private boolean locked;
-    private List<T> value;
-
+public class LockableListProperty<T> extends LockableCollectionProperty<T, List<T>> implements ListProperty<T> {
     public LockableListProperty(ListProperty<T> delegate) {
-        this.delegate = delegate;
-    }
-
-    @Nullable
-    @Override
-    public Class<List<T>> getType() {
-        return null;
-    }
-
-    public void lockNow() {
-        locked = true;
-        value = delegate.getOrNull();
-        delegate = null;
-    }
-
-    private void assertNotLocked() {
-        if (locked) {
-            throw new IllegalStateException("This property is locked and cannot be changed.");
-        }
+        super((CollectionPropertyInternal<T, List<T>>) delegate);
     }
 
     @Override
-    public void setFromAnyValue(Object object) {
-        assertNotLocked();
-        ((PropertyInternal<?>) delegate).setFromAnyValue(object);
-    }
-
-    @Override
-    public void add(T element) {
-        assertNotLocked();
-        delegate.add(element);
-    }
-
-    @Override
-    public void add(Provider<? extends T> provider) {
-        assertNotLocked();
-        delegate.add(provider);
-    }
-
-    @Override
-    public void addAll(Provider<? extends Iterable<T>> provider) {
-        assertNotLocked();
-        delegate.addAll(provider);
-    }
-
-    @Override
-    public void set(@Nullable List<T> value) {
-        assertNotLocked();
-        delegate.set(value);
-    }
-
-    @Override
-    public void set(Provider<? extends List<T>> provider) {
-        assertNotLocked();
-        delegate.set(provider);
-    }
-
-    @Override
-    @Nullable
-    @Internal
-    public List<T> getOrNull() {
-        return locked ? value : delegate.getOrNull();
+    protected List<T> immutableCopy(List<T> value) {
+        return ImmutableList.copyOf(value);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableSetProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableSetProperty.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.api.provider;
+package org.gradle.api.internal.provider;
 
-import org.gradle.api.Incubating;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.provider.SetProperty;
 
-import java.util.List;
+import java.util.Set;
 
-/**
- * Represents a property whose type is a {@link List} of elements of type {@link T}.
- *
- * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created through the factory method {@link org.gradle.api.model.ObjectFactory#listProperty(Class)}.
- *
- * @param <T> the type of elements.
- * @since 4.3
- */
-@Incubating
-public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T> {
+public class LockableSetProperty<T> extends LockableCollectionProperty<T, Set<T>> implements SetProperty<T> {
+    public LockableSetProperty(SetProperty<T> delegate) {
+        super((CollectionPropertyInternal<T, Set<T>>) delegate);
+    }
+
+    @Override
+    protected Set<T> immutableCopy(Set<T> value) {
+        return ImmutableSet.copyOf(value);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/PropertyInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/PropertyInternal.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.provider.PropertyState;
-
-public interface PropertyInternal<T> extends PropertyState<T>, ProviderInternal<T> {
+public interface PropertyInternal {
     /**
      * Sets the property's value from some arbitrary object. Used from the Groovy DSL.
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -19,20 +19,20 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 
-class TransformBackedProvider<S, T> extends AbstractMappingProvider<S, T> {
-    private final Transformer<? extends S, ? super T> transformer;
+class TransformBackedProvider<OUT, IN> extends AbstractMappingProvider<OUT, IN> {
+    private final Transformer<? extends OUT, ? super IN> transformer;
 
-    public TransformBackedProvider(Transformer<? extends S, ? super T> transformer, Provider<? extends T> provider) {
+    public TransformBackedProvider(Transformer<? extends OUT, ? super IN> transformer, Provider<? extends IN> provider) {
         super(null, provider);
         this.transformer = transformer;
     }
 
     @Override
-    protected S map(T v) {
-        S s = transformer.transform(v);
-        if (s == null) {
+    protected OUT map(IN v) {
+        OUT result = transformer.transform(v);
+        if (result == null) {
             throw new IllegalStateException(Providers.NULL_TRANSFORMER_RESULT);
         }
-        return s;
+        return result;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -37,4 +37,11 @@ class DefaultObjectFactoryTest extends Specification {
         property.get() == []
     }
 
+    def "can create a Set property"() {
+        expect:
+        def property = factory.setProperty(String)
+        property.present
+        property.get() == [] as Set
+    }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/AbstractProviderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/AbstractProviderTest.groovy
@@ -17,10 +17,31 @@
 package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
-import spock.lang.Specification
 
-class AbstractProviderTest extends Specification {
+class AbstractProviderTest extends ProviderSpec<String> {
     TestProvider provider = new TestProvider()
+
+    @Override
+    TestProvider providerWithNoValue() {
+        return new TestProvider()
+    }
+
+    @Override
+    TestProvider providerWithValue(String value) {
+        def p = new TestProvider()
+        p.value = value
+        return p
+    }
+
+    @Override
+    String someOtherValue() {
+        "s1"
+    }
+
+    @Override
+    String someValue() {
+        "s2"
+    }
 
     def "is present when value is not null"() {
         expect:
@@ -33,24 +54,6 @@ class AbstractProviderTest extends Specification {
         expect:
         provider.getOrNull() == null
         provider.getOrElse("s2") == "s2"
-    }
-
-    def "cannot query when value is null"() {
-        when:
-        provider.get()
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == 'No value has been specified for this provider.'
-    }
-
-    def "can query with default when value is not null"() {
-        provider.value("s1")
-
-        expect:
-        provider.get() == "s1"
-        provider.getOrNull() == "s1"
-        provider.getOrElse("s2") == "s1"
     }
 
     def "mapped provider is live"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import com.google.common.collect.ImmutableCollection
+import org.gradle.api.Transformer
+import org.gradle.api.provider.Provider
+import spock.lang.Unroll
+
+abstract class CollectionPropertySpec<C extends Collection<String>> extends PropertySpec<C> {
+    def property = property()
+
+    protected void assertValueIs(Collection<String> expected) {
+        def actual = property.get()
+        assert actual instanceof ImmutableCollection
+        assert immutableCollectionType.isInstance(actual)
+        assert actual == toImmutable(expected)
+        assert property.present
+    }
+
+    protected abstract C toImmutable(Collection<String> values)
+
+    protected abstract C toMutable(Collection<String> values)
+
+    protected abstract Class<? extends ImmutableCollection<?>> getImmutableCollectionType()
+
+    def "defaults to empty collection"() {
+        expect:
+        property.present
+        property.get() as List == []
+        property.getOrNull() as List == []
+        property.getOrElse(someValue()) as List == []
+    }
+
+    def "can set value to empty collection"() {
+        expect:
+        property.set(toMutable([]))
+        assertValueIs([])
+    }
+
+    def "returns immutable copy of value"() {
+        expect:
+        property.set(toMutable(["abc"]))
+        assertValueIs(["abc"])
+    }
+
+    def "queries initial value for every call to get()"() {
+        expect:
+        def initialValue = toMutable(["abc"])
+        property.set(initialValue)
+        assertValueIs(["abc"])
+        initialValue.add("added")
+        assertValueIs(["abc", "added"])
+    }
+
+    def "queries underlying provider for every call to get()"() {
+        def provider = Stub(ProviderInternal)
+        provider.get() >>> [["123"], ["abc"]]
+        provider.present >> true
+
+        expect:
+        property.set(provider)
+        assertValueIs(["123"])
+        assertValueIs(["abc"])
+    }
+
+    def "mapped provider is presented with immutable copy of value"() {
+        given:
+        property.set(toMutable(["abc"]))
+        def provider = property.map(new Transformer() {
+            def transform(def value) {
+                assert immutableCollectionType.isInstance(value)
+                assert value == toImmutable(["abc"])
+                return toMutable(["123"])
+            }
+        })
+
+        expect:
+        def actual = provider.get()
+        actual == toMutable(["123"])
+    }
+
+    def "can add values to property with all methods"() {
+        expect:
+        property.add("abc")
+        assertValueIs(["abc"])
+
+        property.add(Providers.of("def"))
+        assertValueIs(["abc", "def"])
+
+        property.addAll(Providers.of(["hij"]))
+        assertValueIs(["abc", "def", "hij"])
+
+        property.add("klm")
+        assertValueIs(["abc", "def", "hij", "klm"])
+
+        property.add(Providers.of("nop"))
+        assertValueIs(["abc", "def", "hij", "klm", "nop"])
+    }
+
+    def "can add values to property with initial value"() {
+        property.set(toMutable(["123"]))
+
+        expect:
+        property.add("abc")
+        assertValueIs(["123", "abc"])
+
+        property.add(Providers.of("def"))
+        assertValueIs(["123", "abc", "def"])
+
+        property.addAll(Providers.of(["hij"]))
+        assertValueIs(["123", "abc", "def", "hij"])
+
+        property.add("klm")
+        assertValueIs(["123", "abc", "def", "hij", "klm"])
+
+        property.add(Providers.of("nop"))
+        assertValueIs(["123", "abc", "def", "hij", "klm", "nop"])
+    }
+
+    def "appends value during `add` to property"() {
+        expect:
+        property.add("123")
+        property.add("456")
+        assertValueIs(["123", "456"])
+    }
+
+    def "appends value from provider during `add` to property"() {
+        expect:
+        property.add(Providers.of("123"))
+        property.add(Providers.of("456"))
+        assertValueIs(["123", "456"])
+    }
+
+    @Unroll
+    def "appends values from provider during `addAll` to property"() {
+        expect:
+        property.addAll(value)
+        assertValueIs(expectedValue)
+
+        where:
+        value                               | expectedValue
+        Providers.of([])                    | []
+        Providers.of(["aaa"])               | ["aaa"]
+        Providers.of(["aaa", "bbb", "ccc"]) | ["aaa", "bbb", "ccc"]
+    }
+
+    def "providers only called once per query"() {
+        def addProvider = Mock(Provider)
+        def addAllProvider = Mock(Provider)
+
+        given:
+        property.add(addProvider)
+        property.addAll(addAllProvider)
+
+        when:
+        property.present
+
+        then:
+        1 * addProvider.present >> true
+        1 * addAllProvider.present >> true
+        0 * _
+
+        when:
+        property.get()
+
+        then:
+        1 * addProvider.get() >> "123"
+        1 * addAllProvider.get() >> ["abc"]
+        0 * _
+
+        when:
+        property.getOrNull()
+
+        then:
+        1 * addProvider.getOrNull() >> "123"
+        1 * addAllProvider.getOrNull() >> ["abc"]
+        0 * _
+    }
+
+    def "property has no value when set to null and other values appended"() {
+        given:
+        property.set(null)
+        property.add("123")
+        property.add(Providers.of("456"))
+        property.addAll(Providers.of(["789"]))
+
+        expect:
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(toMutable(["other"])) == toMutable(["other"])
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == Providers.NULL_VALUE
+    }
+
+    def "property has no value when set to provider with no value and other values appended"() {
+        given:
+        property.set(Providers.notDefined())
+        property.add("123")
+        property.add(Providers.of("456"))
+        property.addAll(Providers.of(["789"]))
+
+        expect:
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(toMutable(["other"])) == toMutable(["other"])
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == Providers.NULL_VALUE
+    }
+
+    def "property has no value when adding an element provider with no value"() {
+        given:
+        property.set(toMutable(["123"]))
+        property.add("456")
+        property.add(Providers.notDefined())
+
+        expect:
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(toMutable(["other"])) == toMutable(["other"])
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == Providers.NULL_VALUE
+    }
+
+    def "property has no value when adding an collection provider with no value"() {
+        given:
+        property.set(toMutable(["123"]))
+        property.add("456")
+        property.addAll(Providers.notDefined())
+
+        expect:
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(toMutable(["other"])) == toMutable(["other"])
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == Providers.NULL_VALUE
+    }
+
+    def "can set null value to remove any added values"() {
+        property.add("abc")
+        property.add(Providers.of("def"))
+        property.addAll(Providers.of(["hij"]))
+
+        expect:
+        property.set(null)
+
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(someValue()) == someValue()
+        property.getOrElse(null) == null
+    }
+
+    def "can set value to override added values"() {
+        property.add("abc")
+        property.add(Providers.of("def"))
+        property.addAll(Providers.of(["hij"]))
+
+        expect:
+        property.set(toMutable(["123", "456"]))
+        assertValueIs(["123", "456"])
+    }
+
+    def "throws NullPointerException when provider returns list with null to property"() {
+        when:
+        property.addAll(Providers.of([null]))
+        property.get()
+
+        then:
+        def ex = thrown(NullPointerException)
+    }
+
+    def "throws NullPointerException when adding a null value to the property"() {
+        when:
+        property.add(null)
+
+        then:
+        def ex = thrown(NullPointerException)
+        ex.message == "Cannot add a null element to a property of type ${type().simpleName}."
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
@@ -16,11 +16,10 @@
 
 package org.gradle.api.internal.provider
 
+import com.google.common.collect.ImmutableCollection
 import com.google.common.collect.ImmutableList
-import org.gradle.api.Transformer
-import spock.lang.Unroll
 
-class DefaultListPropertyTest extends PropertySpec<List<String>> {
+class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
     @Override
     DefaultListProperty<String> property() {
         return new DefaultListProperty<String>(String)
@@ -41,6 +40,21 @@ class DefaultListPropertyTest extends PropertySpec<List<String>> {
         return ["value2"]
     }
 
+    @Override
+    protected Class<? extends ImmutableCollection<?>> getImmutableCollectionType() {
+        return ImmutableList.class
+    }
+
+    @Override
+    protected List<String> toImmutable(Collection<String> values) {
+        return ImmutableList.copyOf(values)
+    }
+
+    @Override
+    protected List<String> toMutable(Collection<String> values) {
+        return new ArrayList<String>(values)
+    }
+
     def property = property()
 
     def "defaults to empty list"() {
@@ -51,190 +65,4 @@ class DefaultListPropertyTest extends PropertySpec<List<String>> {
         property.getOrElse(["abc"]) == []
     }
 
-    def "returns immutable copy of value"() {
-        expect:
-        property.set(["abc"])
-        assertValueIs(["abc"])
-    }
-
-    def "queries initial value for every call to get()"() {
-        expect:
-        def initialValue = ["abc"]
-        property.set(initialValue)
-        assertValueIs(["abc"])
-        initialValue.add("added")
-        assertValueIs(["abc", "added"])
-    }
-
-    def "queries underlying provider for every call to get()"() {
-        def provider = Stub(ProviderInternal)
-        provider.get() >>> [["123"], ["abc"]]
-        provider.present >> true
-
-        expect:
-        property.set(provider)
-        assertValueIs(["123"])
-        assertValueIs(["abc"])
-    }
-
-    def "mapped provider returns immutable copy of result"() {
-        given:
-        property.set(["abc"])
-        def provider = property.map(new Transformer<List<String>, List<String>>() {
-            @Override
-            List<String> transform(List<String> value) {
-                assert value instanceof ImmutableList
-                assert value == ["abc"]
-                return ["123"]
-            }
-        })
-
-        expect:
-        def actual = provider.get()
-        actual instanceof ImmutableList
-        actual == ["123"]
-    }
-
-    def "can add values to property with all methods"() {
-        expect:
-        property.add("abc")
-        assertValueIs(["abc"])
-
-        property.add(Providers.of("def"))
-        assertValueIs(["abc", "def"])
-
-        property.addAll(Providers.of(["hij"]))
-        assertValueIs(["abc", "def", "hij"])
-
-        property.add("klm")
-        assertValueIs(["abc", "def", "hij", "klm"])
-
-        property.add(Providers.of("nop"))
-        assertValueIs(["abc", "def", "hij", "klm", "nop"])
-    }
-
-    def "can add values to property with initial value"() {
-        property.set(["123"])
-
-        expect:
-        property.add("abc")
-        assertValueIs(["123", "abc"])
-
-        property.add(Providers.of("def"))
-        assertValueIs(["123", "abc", "def"])
-
-        property.addAll(Providers.of(["hij"]))
-        assertValueIs(["123", "abc", "def", "hij"])
-
-        property.add("klm")
-        assertValueIs(["123", "abc", "def", "hij", "klm"])
-
-        property.add(Providers.of("nop"))
-        assertValueIs(["123", "abc", "def", "hij", "klm", "nop"])
-    }
-
-    def "appends value during `add` to property"() {
-        expect:
-        property.add("123")
-        assertValueIs(["123"])
-    }
-
-    def "appends value from provider during `add` to property"() {
-        expect:
-        property.add(Providers.of("123"))
-        assertValueIs(["123"])
-    }
-
-    @Unroll
-    def "appends values from provider during `addAll` to property"() {
-        expect:
-        property.addAll(value)
-        assertValueIs(expectedValue)
-
-        where:
-        value                               | expectedValue
-        Providers.of([])                    | []
-        Providers.of(["aaa"])               | ["aaa"]
-        Providers.of(["aaa", "bbb", "ccc"]) | ["aaa", "bbb", "ccc"]
-    }
-
-    def "providers only called once per property.get()"() {
-        def addProvider = Spy(DefaultProvider, constructorArgs: [{ "123" }])
-        def addAllProvider = Spy(DefaultProvider, constructorArgs: [{ ["abc"] }])
-
-        when:
-        property.add(addProvider)
-        property.addAll(addAllProvider)
-        assertValueIs(["123", "abc"])
-
-        then:
-        1 * addProvider.get()
-        1 * addAllProvider.get()
-    }
-
-    def "can set null value to remove any added values"() {
-        property.add("abc")
-        property.add(Providers.of("def"))
-        property.addAll(Providers.of(["hij"]))
-
-        expect:
-        property.set(null)
-
-        !property.present
-        property.getOrNull() == null
-        property.getOrElse(someValue()) == someValue()
-        property.getOrElse(null) == null
-    }
-
-    def "can set value to override added values"() {
-        property.add("abc")
-        property.add(Providers.of("def"))
-        property.addAll(Providers.of(["hij"]))
-
-        expect:
-        property.set(["123", "456"])
-        assertValueIs(["123", "456"])
-    }
-
-    def "throws IllegalStateException when list property has no value"() {
-        when:
-        property.set(null)
-        property.get()
-        then:
-        def ex = thrown(IllegalStateException)
-        ex.message == Providers.NULL_VALUE
-
-        when:
-        property.addAll(Providers.of(["123"]))
-        property.get()
-        then:
-        ex = thrown(IllegalStateException)
-        ex.message == Providers.NULL_VALUE
-    }
-
-    def "throws NullPointerException when provider returns list with null to property"() {
-        when:
-        property.addAll(Providers.of([null]))
-        property.get()
-
-        then:
-        def ex = thrown(NullPointerException)
-        ex.message == null
-    }
-
-    def "throws NullPointerException when adding a null value to the property"() {
-        when:
-        property.add(null)
-
-        then:
-        def ex = thrown(NullPointerException)
-        ex.message == "Cannot add a null value to a list property."
-    }
-
-    private void assertValueIs(List<String> expected) {
-        def actual = property.get()
-        assert actual instanceof ImmutableList
-        assert actual == expected
-        assert property.present
-    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
@@ -31,16 +31,6 @@ class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
     }
 
     @Override
-    List<String> someValue() {
-        return ["value"]
-    }
-
-    @Override
-    List<String> someOtherValue() {
-        return ["value2"]
-    }
-
-    @Override
     protected Class<? extends ImmutableCollection<?>> getImmutableCollectionType() {
         return ImmutableList.class
     }
@@ -54,8 +44,6 @@ class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
     protected List<String> toMutable(Collection<String> values) {
         return new ArrayList<String>(values)
     }
-
-    def property = property()
 
     def "defaults to empty list"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
@@ -18,12 +18,25 @@ package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
 import org.gradle.api.provider.PropertyState
+import org.gradle.api.provider.Provider
 import spock.lang.Unroll
 
 class DefaultPropertyStateTest extends PropertySpec<String> {
     @Override
     DefaultPropertyState<String> property() {
         return new DefaultPropertyState<String>(String)
+    }
+
+    @Override
+    Provider<String> providerWithNoValue() {
+        return property()
+    }
+
+    @Override
+    Provider<String> providerWithValue(String value) {
+        def p = property()
+        p.set(value)
+        return p
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderTest.groovy
@@ -17,10 +17,28 @@
 package org.gradle.api.internal.provider
 
 import org.gradle.api.provider.Provider
-import spock.lang.Specification
 import spock.lang.Unroll
 
-class DefaultProviderTest extends Specification {
+class DefaultProviderTest extends ProviderSpec<String> {
+    @Override
+    Provider<String> providerWithNoValue() {
+        return new DefaultProvider<String>({ null })
+    }
+
+    @Override
+    Provider<String> providerWithValue(String value) {
+        return new DefaultProvider<String>({ value })
+    }
+
+    @Override
+    String someValue() {
+        return "s1"
+    }
+
+    @Override
+    String someOtherValue() {
+        return "s2"
+    }
 
     @Unroll
     def "can compare string representation with other instance returning value #value"() {
@@ -64,22 +82,6 @@ class DefaultProviderTest extends Specification {
 
         then:
         value
-    }
-
-    def "returns value or null for get or null method"() {
-        when:
-        def provider = createProvider()
-
-        then:
-        !provider.isPresent()
-        provider.getOrNull() == null
-
-        when:
-        provider = createProvider(true)
-
-        then:
-        provider.isPresent()
-        provider.getOrNull()
     }
 
     def "rethrows exception if value calculation throws exception"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
@@ -31,16 +31,6 @@ class DefaultSetPropertyTest extends CollectionPropertySpec<Set<String>> {
     }
 
     @Override
-    Set<String> someValue() {
-        return ["value"]
-    }
-
-    @Override
-    Set<String> someOtherValue() {
-        return ["value2"]
-    }
-
-    @Override
     protected Class<? extends ImmutableCollection<?>> getImmutableCollectionType() {
         return ImmutableSet.class
     }
@@ -54,8 +44,6 @@ class DefaultSetPropertyTest extends CollectionPropertySpec<Set<String>> {
     protected Set<String> toMutable(Collection<String> values) {
         return new LinkedHashSet<String>(values)
     }
-
-    def property = property()
 
     def "defaults to empty set"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import com.google.common.collect.ImmutableCollection
+import com.google.common.collect.ImmutableSet
+
+class DefaultSetPropertyTest extends CollectionPropertySpec<Set<String>> {
+    @Override
+    DefaultSetProperty<String> property() {
+        return new DefaultSetProperty<String>(String)
+    }
+
+    @Override
+    Class<Set<String>> type() {
+        return Set
+    }
+
+    @Override
+    Set<String> someValue() {
+        return ["value"]
+    }
+
+    @Override
+    Set<String> someOtherValue() {
+        return ["value2"]
+    }
+
+    @Override
+    protected Class<? extends ImmutableCollection<?>> getImmutableCollectionType() {
+        return ImmutableSet.class
+    }
+
+    @Override
+    protected Set<String> toImmutable(Collection<String> values) {
+        return ImmutableSet.copyOf(values)
+    }
+
+    @Override
+    protected Set<String> toMutable(Collection<String> values) {
+        return new LinkedHashSet<String>(values)
+    }
+
+    def property = property()
+
+    def "defaults to empty set"() {
+        expect:
+        property.present
+        property.get() == ImmutableSet.of()
+        property.getOrNull() == ImmutableSet.of()
+        property.getOrElse(["abc"] as Set) == ImmutableSet.of()
+    }
+
+    def "retains iteration order of added elements"() {
+        given:
+        property.set(["123"] as Set)
+        property.add("abc")
+        property.addAll(Providers.of(["123", "abc", "123", "456"]))
+        property.add("123")
+        property.add("def")
+
+        expect:
+        property.get() as List == ["123", "abc", "456", "def"]
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/LockableCollectionPropertySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/LockableCollectionPropertySpec.groovy
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.Transformer
+import org.gradle.api.provider.Provider
+import spock.lang.Specification
+
+abstract class LockableCollectionPropertySpec<C extends Collection<String>> extends Specification {
+    abstract CollectionPropertyInternal<String, C> target()
+    abstract LockableCollectionProperty<String, C> property(CollectionPropertyInternal<String, C> target)
+    abstract C toMutable(Collection<String> values)
+    abstract C toImmutable(Collection<String> values)
+
+    CollectionPropertyInternal<String, C> target = target()
+    LockableCollectionProperty<String, C> property = property(target)
+
+    def "delegates to original property before property is locked"() {
+        when:
+        property.add("123")
+
+        then:
+        1 * target.add("123")
+
+        when:
+        def result = property.get()
+
+        then:
+        result == toMutable(["abc"])
+        1 * target.getOrNull() >> toMutable(["abc"])
+
+        when:
+        def present = property.present
+
+        then:
+        !present
+        1 * target.getOrNull() >> null
+
+        when:
+        def transformer = Stub(Transformer)
+        transformer.transform(toMutable(["abc"])) >> "123"
+        transformer.transform(toMutable(["bcd"])) >> "456"
+        def mapped = property.map(transformer)
+        def result1 = mapped.get()
+        def result2 = mapped.get()
+
+        then:
+        result1 == "123"
+        result2 == "456"
+        1 * target.getOrNull() >> toMutable(["abc"])
+        1 * target.getOrNull() >> toMutable(["bcd"])
+    }
+
+    def "cannot add element after property is locked"() {
+        given:
+        property.lockNow()
+
+        when:
+        property.add("broken")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'This property is locked and cannot be changed.'
+
+        and:
+        0 * target._
+    }
+
+    def "cannot add element provider after property is locked"() {
+        given:
+        property.lockNow()
+
+        when:
+        property.add(Stub(Provider))
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'This property is locked and cannot be changed.'
+
+        and:
+        0 * target._
+    }
+
+    def "cannot add elements provider after property is locked"() {
+        given:
+        property.lockNow()
+
+        when:
+        property.addAll(Stub(Provider))
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'This property is locked and cannot be changed.'
+
+        and:
+        0 * target._
+    }
+
+    def "cannot set elements after property is locked"() {
+        given:
+        property.lockNow()
+
+        when:
+        property.set(["broken"])
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'This property is locked and cannot be changed.'
+
+        and:
+        0 * target._
+    }
+
+    def "cannot set element provider after property is locked"() {
+        given:
+        property.lockNow()
+
+        when:
+        property.set(Stub(Provider))
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'This property is locked and cannot be changed.'
+
+        and:
+        0 * target._
+    }
+
+    def "cannot set from any value after property is locked"() {
+        given:
+        property.lockNow()
+
+        when:
+        property.setFromAnyValue(123)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'This property is locked and cannot be changed.'
+
+        and:
+        0 * target._
+    }
+
+    def "changes from original property are not visible after property is locked"() {
+        def value = toMutable(["123"])
+
+        when:
+        property.lockNow()
+
+        then:
+        1 * target.getOrNull() >> value
+        0 * target._
+
+        when:
+        value.add("more")
+        def result1 = property.get()
+        def result2 = property.getOrNull()
+        def result3 = property.getOrElse(toMutable(["broken"]))
+
+        then:
+        result1 == toImmutable(["123"])
+        result2 == toImmutable(["123"])
+        result3 == toImmutable(["123"])
+
+        and:
+        0 * target._
+    }
+
+    def "changes from original property are not visible after property is locked and property had no value"() {
+        when:
+        property.lockNow()
+
+        then:
+        1 * target.getOrNull() >> null
+        0 * target._
+
+        when:
+        def result1 = property.present
+        def result2 = property.getOrNull()
+
+        then:
+        !result1
+        result2 == null
+
+        and:
+        0 * target._
+    }
+
+    def "changes from original property are not visible through a mapped provider after property is locked"() {
+        def value = toMutable(["123"])
+
+        when:
+        def transformer = Mock(Transformer)
+        def mapped = property.map(transformer)
+        property.lockNow()
+
+        then:
+        1 * target.getOrNull() >> value
+        0 * target._
+
+        when:
+        value.add("more")
+        def result1 = mapped.get()
+        def result2 = mapped.getOrNull()
+        def result3 = mapped.getOrElse(200)
+
+        then:
+        result1 == 45
+        result2 == 46
+        result3 == 47
+
+        and:
+        1 * transformer.transform(toImmutable(["123"])) >> 45
+        1 * transformer.transform(toImmutable(["123"])) >> 46
+        1 * transformer.transform(toImmutable(["123"])) >> 47
+        0 * target._
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/LockableSetPropertyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/LockableSetPropertyTest.groovy
@@ -16,29 +16,29 @@
 
 package org.gradle.api.internal.provider
 
-import com.google.common.collect.ImmutableList
-import org.gradle.api.provider.ListProperty
+import com.google.common.collect.ImmutableSet
+import org.gradle.api.provider.SetProperty
 
-class LockableListPropertyTest extends LockableCollectionPropertySpec<List<String>> {
+class LockableSetPropertyTest extends LockableCollectionPropertySpec<Set<String>> {
     @Override
-    CollectionPropertyInternal<String, List<String>> target() {
+    CollectionPropertyInternal<String, Set<String>> target() {
         return Mock(TestProperty)
     }
 
     @Override
-    LockableCollectionProperty<String, List<String>> property(CollectionPropertyInternal<String, List<String>> target) {
-        return new LockableListProperty<String>(target)
+    LockableCollectionProperty<String, Set<String>> property(CollectionPropertyInternal<String, Set<String>> target) {
+        return new LockableSetProperty<String>(target)
     }
 
     @Override
-    List<String> toMutable(Collection<String> values) {
-        return new ArrayList<String>(values)
+    Set<String> toMutable(Collection<String> values) {
+        return new LinkedHashSet<String>(values)
     }
 
     @Override
-    List<String> toImmutable(Collection<String> values) {
-        return ImmutableList.copyOf(values)
+    Set<String> toImmutable(Collection<String> values) {
+        return ImmutableSet.copyOf(values)
     }
 
-    interface TestProperty extends CollectionPropertyInternal<String, List<String>>, ListProperty<String> {}
+    interface TestProperty extends CollectionPropertyInternal<String, Set<String>>, SetProperty<String> {}
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -227,6 +227,35 @@ abstract class PropertySpec<T> extends Specification {
         0 * _
     }
 
+    def "transformation is provided with the current value of the property each time the value is queried"() {
+        def transformer = Mock(Transformer)
+        def property = property()
+
+        when:
+        def provider = property.map(transformer)
+
+        then:
+        0 * _
+
+        when:
+        property.set(someValue())
+        def r1 = provider.get()
+
+        then:
+        r1 == 123
+        1 * transformer.transform(someValue()) >> 123
+        0 * _
+
+        when:
+        property.set(someOtherValue())
+        def r2 = provider.get()
+
+        then:
+        r2 == 456
+        1 * transformer.transform(someOtherValue()) >> 456
+        0 * _
+    }
+
     def "can map value to some other type"() {
         def transformer = Mock(Transformer)
         def property = property()
@@ -255,7 +284,7 @@ abstract class PropertySpec<T> extends Specification {
         0 * _
     }
 
-    def "mapped provider has no value when property has no value"() {
+    def "mapped provider has no value when property has no value and transformer is not invoked"() {
         def transformer = Mock(Transformer)
         def property = property()
         property.set(null)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -17,11 +17,11 @@
 package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import spock.lang.Specification
 
-abstract class PropertySpec<T> extends Specification {
-    abstract PropertyInternal<T> property()
+abstract class PropertySpec<T> extends ProviderSpec<T> {
+    abstract Property<T> property()
 
     abstract T someValue()
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.provider.Provider
+import spock.lang.Specification
+
+abstract class ProviderSpec<T> extends Specification {
+    abstract Provider<T> providerWithValue(T value)
+
+    abstract Provider<T> providerWithNoValue()
+
+    abstract T someValue()
+
+    abstract T someOtherValue()
+
+    def "can query value when it has as value"() {
+        given:
+        def provider = providerWithValue(someValue())
+
+        expect:
+        provider.present
+        provider.get() == someValue()
+        provider.getOrNull() == someValue()
+        provider.getOrElse(someOtherValue()) == someValue()
+    }
+
+    def "cannot query value when it has none"() {
+        given:
+        def provider = providerWithNoValue()
+
+        expect:
+        !provider.present
+        provider.getOrNull() == null
+        provider.getOrElse(someValue()) == someValue()
+
+        when:
+        provider.get()
+
+        then:
+        def t = thrown(IllegalStateException)
+        t.message == "No value has been specified for this provider."
+    }
+
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -158,6 +158,12 @@ existed in a different case and would adjust the given file accordingly. This le
 
 The `Project.file()` method will now ignore case and only normalize redundant segments like `/../`. It will not touch the file system.
 
+### ListProperty no longer extends Property
+
+TBD - `ListProperty` now extends `HasMultipleValues` and `Provider` instead of `Property`. The `Property` interface represents a property whose incoming and outgoing types are the same. However, a `List` can be assembled from any `Iterable` rather than just any `List` and this new arrangement reflects this, allowing a `ListProperty<T>` to be set using any `Iterable<T>`. This also applies to the DSL, where the Groovy DSL will allow any `Iterable` to be used to set the value.
+
+The new `SetProperty` type also follows this pattern.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -28,6 +28,10 @@ Think of every feature section as a mini blog post.
 
 In this release, the Gradle team added a new chapter in the user guide documenting the [Provider API](userguide/lazy_configuration.html).
 
+### Provider API improvements
+
+A convenience for dealing with sets has been added. TBD - link to API
+
 ### Faster C/C++ compilation and builds
 
 #### Build Cache Support

--- a/subprojects/docs/src/docs/userguide/lazyConfiguration.adoc
+++ b/subprojects/docs/src/docs/userguide/lazyConfiguration.adoc
@@ -144,7 +144,7 @@ In this section, we are going to explore lazy collections. They work exactly lik
 * For `List` values the interface is called api:org.gradle.api.provider.ListProperty[]. You can create a new `ListProperty` using api:org.gradle.api.model.ObjectFactory#listProperty(java.lang.Class)[] and specifying the element's type.
 * For `Set` values the interface is called api:org.gradle.api.provider.SetProperty[]. You can create a new `SetProperty` using api:org.gradle.api.model.ObjectFactory#setProperty(java.lang.Class)[] and specifying the element's type.
 
-This type of property allows you to overwrite the entire collection value with api:org.gradle.api.provider.Property#set(org.gradle.api.provider.Provider)[] or add new elements through the various `add` methods:
+This type of property allows you to overwrite the entire collection value with api:org.gradle.api.provider.HasMultipleValues#set(java.lang.Iterable)[] and api:org.gradle.api.provider.HasMultipleValues#set(org.gradle.api.provider.Provider)[] or add new elements through the various `add` methods:
 
 * api:org.gradle.api.provider.HasMultipleValues#add(T)[]: Add a single concrete element to the collection
 * api:org.gradle.api.provider.HasMultipleValues#add(org.gradle.api.provider.Provider)[]: Add a lazily evaluated element to the collection

--- a/subprojects/docs/src/docs/userguide/lazyConfiguration.adoc
+++ b/subprojects/docs/src/docs/userguide/lazyConfiguration.adoc
@@ -15,7 +15,7 @@
 [[lazy_configuration]]
 == Lazy Configuration
 
-As a build grows in complexity, knowing when and where a particular value is configured can become difficult to reason about. Gradle provides several ways to manage this complexity with lazy configuration.
+As a build grows in complexity, knowing when and where a particular value is configured can become difficult to reason about. Gradle provides several ways to manage this complexity using _lazy configuration_.
 
 [[sec:lazy_properties]]
 === Lazy properties
@@ -41,7 +41,8 @@ Gradle represents lazy properties with two interfaces:
 * api:org.gradle.api.provider.Property[] are properties that can be queried and overwritten.
 ** Properties with these types are configurable.
 ** `Property` implements the `Provider` interface.
-** The method api:org.gradle.api.provider.Property#set(T)[] provides a value for the property, overwriting whatever value may have been present.
+** The method api:org.gradle.api.provider.Property#set(T)[] specifies a value for the property, overwriting whatever value may have been present.
+** The method api:org.gradle.api.provider.Property#set(org.gradle.api.provider.Provider)[] specifies a `Provider` for the value for the property, overwriting whatever value may have been present. This allows you to wire together `Provider` and `Property` instances before the values are configured.
 ** A `Property` can be created by the factory method api:org.gradle.api.model.ObjectFactory#property(java.lang.Class)[].
 
 Neither of these types nor their subtypes are intended to be implemented by a build script or plugin author.  Gradle provides several factory methods to create instances of these types. See the <<lazy_configuration_reference,Quick Reference>> for all of the types and factories available.
@@ -57,7 +58,7 @@ The following demonstrates a task with a read-only property and a configurable p
 </sample>
 ++++
 
-The `Greeting` task has a `Property<String>` for the mutable part of the message and a `Provider` for the modified, read-only, message.
+The `Greeting` task has a `Property<String>` for the mutable part of the message and a `Provider<String>` for the calculated, read-only, message.
 
 [NOTE]
 ====
@@ -138,15 +139,18 @@ Another thing to note is the absence of any explicit task dependency. Properties
 [[sec:working_with_collection]]
 === Working with collection Providers
 
-In this section, we are going to explore lazy collections. They work exactly like any other `Provider` and, just like `FileSystemLocation` providers, they have additional modeling around them. They are implemented as a strongly typed model called api:org.gradle.api.provider.ListProperty[]. You can create a new `ListProperty` using api:org.gradle.api.model.ObjectFactory#listProperty(java.lang.Class)[] and specifying the element's type.
+In this section, we are going to explore lazy collections. They work exactly like any other `Provider` and, just like `FileSystemLocation` providers, they have additional modeling around them. There are two provider interfaces available, one for `List` values and another for `Set` values:
 
-This type of property allows you to overwrite the entire list with api:org.gradle.api.provider.Property#set(org.gradle.api.provider.Provider)[] or add new elements through the various `add` methods:
+* For `List` values the interface is called api:org.gradle.api.provider.ListProperty[]. You can create a new `ListProperty` using api:org.gradle.api.model.ObjectFactory#listProperty(java.lang.Class)[] and specifying the element's type.
+* For `Set` values the interface is called api:org.gradle.api.provider.SetProperty[]. You can create a new `SetProperty` using api:org.gradle.api.model.ObjectFactory#setProperty(java.lang.Class)[] and specifying the element's type.
 
-* api:org.gradle.api.provider.ListProperty#add(T)[]: Add a single concrete element to the list
-* api:org.gradle.api.provider.ListProperty#add(org.gradle.api.provider.Provider)[]: Add a lazily evaluated element to the list
-* api:org.gradle.api.provider.ListProperty#addAll(org.gradle.api.provider.Provider)[]: Add a lazily evaluated list of elements to the list
+This type of property allows you to overwrite the entire collection value with api:org.gradle.api.provider.Property#set(org.gradle.api.provider.Provider)[] or add new elements through the various `add` methods:
 
-Just like every `Provider`, the list is evaluated when api:org.gradle.api.provider.Provider#get()[] is called. The following example show the api:org.gradle.api.provider.ListProperty[] in action:
+* api:org.gradle.api.provider.HasMultipleValues#add(T)[]: Add a single concrete element to the collection
+* api:org.gradle.api.provider.HasMultipleValues#add(org.gradle.api.provider.Provider)[]: Add a lazily evaluated element to the collection
+* api:org.gradle.api.provider.HasMultipleValues#addAll(org.gradle.api.provider.Provider)[]: Add a lazily evaluated collection of elements to the list
+
+Just like every `Provider`, the collection is calculated when api:org.gradle.api.provider.Provider#get()[] is called. The following example show the api:org.gradle.api.provider.ListProperty[] in action:
 
 ++++
 <sample id="listProperty" dir="providers/listProperty" title="List property">
@@ -224,6 +228,11 @@ The Provider API is <<feature_lifecycle,incubating>>. Please create new issues a
 |api:org.gradle.api.provider.Provider[]<List<T>>
 |api:org.gradle.api.provider.ListProperty[]
 |* api:org.gradle.api.model.ObjectFactory#listProperty(java.lang.Class)[]
+
+|Set of any type
+|api:org.gradle.api.provider.Provider[]<Set<T>>
+|api:org.gradle.api.provider.SetProperty[]
+|* api:org.gradle.api.model.ObjectFactory#setProperty(java.lang.Class)[]
 
 |Any other type
 |api:org.gradle.api.provider.Provider[]<T>

--- a/subprojects/docs/src/samples/providers/propertyAndProvider/build.gradle
+++ b/subprojects/docs/src/samples/providers/propertyAndProvider/build.gradle
@@ -3,9 +3,9 @@ class Greeting extends DefaultTask {
     @Input
     final Property<String> message = project.objects.property(String)
 
-    // Read-only property
+    // Read-only property calculated from the message
     @Internal
-    final Provider<String> fullMessage = project.provider { message.get() + " from Gradle" }
+    final Provider<String> fullMessage = message.map { it + " from Gradle" }
 
     @TaskAction
     void printMessage() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftLibrary.java
@@ -18,7 +18,7 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.nativeplatform.Linkage;
 
 /**
@@ -40,5 +40,5 @@ public interface SwiftLibrary extends SwiftComponent {
      *
      * @since 4.5
      */
-    ListProperty<Linkage> getLinkage();
+    SetProperty<Linkage> getLinkage();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftLibrary.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.internal.provider.LockableListProperty;
+import org.gradle.api.internal.provider.LockableSetProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.language.swift.SwiftBinary;
@@ -39,7 +39,7 @@ public class DefaultSwiftLibrary extends DefaultSwiftComponent implements SwiftL
     private final Configuration api;
     private final ProjectLayout projectLayout;
     private final ObjectFactory objectFactory;
-    private final LockableListProperty<Linkage> linkage;
+    private final LockableSetProperty<Linkage> linkage;
     private final ConfigurationContainer configurations;
     private final Property<SwiftBinary> developmentBinary;
 
@@ -51,7 +51,7 @@ public class DefaultSwiftLibrary extends DefaultSwiftComponent implements SwiftL
         this.configurations = configurations;
         this.developmentBinary = objectFactory.property(SwiftBinary.class);
 
-        linkage = new LockableListProperty<Linkage>(objectFactory.listProperty(Linkage.class));
+        linkage = new LockableSetProperty<Linkage>(objectFactory.setProperty(Linkage.class));
         linkage.add(Linkage.SHARED);
 
         api = configurations.maybeCreate(getNames().withSuffix("api"));
@@ -83,7 +83,7 @@ public class DefaultSwiftLibrary extends DefaultSwiftComponent implements SwiftL
     }
 
     @Override
-    public LockableListProperty<Linkage> getLinkage() {
+    public LockableSetProperty<Linkage> getLinkage() {
         return linkage;
     }
 }


### PR DESCRIPTION
This change introduces a `SetProperty<T>` similar in purpose as `ListProperty<T>`. It makes some breaking changes to `ListProperty` to allow the property value to be set using any `Iterable<T>` rather than only from `List<T>`, and `SetProperty` follows the same pattern.

The new type is used in the Swift library plugin to model the linkages of a library using a set rather than list of linkage values.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
