### PR TITLE
Workaround caching problems with java-gradle-plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,11 +1,3 @@
-
-import org.gradle.api.JavaVersion
-import org.gradle.api.internal.PropertiesUtils
-import org.gradle.kotlin.dsl.*
-import org.gradle.plugin.devel.tasks.GeneratePluginDescriptors
-import java.nio.charset.Charset
-import java.util.*
-
 /*
  * Copyright 2010 the original author or authors.
  *
@@ -21,6 +13,11 @@ import java.util.*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.gradle.api.internal.PropertiesUtils
+import java.nio.charset.Charset
+import java.util.Properties
+
 plugins {
     groovy
     `java-gradle-plugin`


### PR DESCRIPTION
When the java-gradle-plugin is applied, it has too bad side effects for caching:

for tests in buildSrc, the pluginUnderTestMetadata file is added to the test runtime classpath here. This file contains absolute paths.
The properties file written out by GeneratePluginDescriptors contains system dependent line separators, which breaks caching of any custom task between windows and linux.

This PR works around both of these problems until they are fixed in Gradle core.