### PR TITLE
Adapt version detection to JEP-322

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetector.java
@@ -62,7 +62,7 @@ public class DefaultJvmVersionDetector implements JvmVersionDetector {
         try {
             String versionStr = reader.readLine();
             while (versionStr != null) {
-                Matcher matcher = Pattern.compile("(?:java|openjdk) version \"(.+?)\"").matcher(versionStr);
+                Matcher matcher = Pattern.compile("(?:java|openjdk) version \"(.+?)\"( \\d{4}-\\d{2}-\\d{2}( LTS)?)?").matcher(versionStr);
                 if (matcher.matches()) {
                     return JavaVersion.toVersion(matcher.group(1));
                 }

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
@@ -60,6 +60,18 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
         Java(TM) SE Runtime Environment (build 1.8.0_91-b14)
         Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
         """                     | "1.8"
+        """java version "9.0.1"
+        Java(TM) SE Runtime Environment (build 9.0.1+11)
+        Java HotSpot(TM) 64-Bit Server VM (build 9.0.1+11, mixed mode)
+        """                     | "9.0.1"
+        """java version "10-ea"
+        Java(TM) SE Runtime Environment 18.3 (build 10-ea+35)
+        Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10-ea+35, mixed mode)
+        """                     | "10"
+        """java version "10-ea" 2018-03-20
+        Java(TM) SE Runtime Environment 18.3 (build 10-ea+36)
+        Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10-ea+36, mixed mode)
+        """                     | "10"
     }
 
     def "fails to parse version number"() {


### PR DESCRIPTION
JEP-322 is a modification to the Java versioning scheme to accommodate the time-based release model that the JDK is moving to. Starting with JDK 10-ea build 36, the changes from this version scheme are in play and the version dection logic now breaks because of the addition of the  java.version.date to the version output. This commit adjusts for that. Additionally, future LTS releases of the JDK will contain an appended " LTS" as well, so this commit adjuts for that too.

Signed-off-by: Jason Tedor <jason@tedor.me>

Closes #3849