### PR TITLE
Configure default javascript repos to provide only artifacts

### DIFF
--- a/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/base/JavaScriptBasePluginIntegrationTest.groovy
+++ b/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/base/JavaScriptBasePluginIntegrationTest.groovy
@@ -16,9 +16,12 @@
 
 package org.gradle.plugins.javascript.base
 
+import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
+import spock.lang.Unroll
 
 import static org.gradle.plugins.javascript.base.JavaScriptBasePluginTestFixtures.addGoogleRepoScript
+import static org.gradle.plugins.javascript.base.JavaScriptBasePluginTestFixtures.addGradlePublicJsRepoScript
 
 class JavaScriptBasePluginIntegrationTest extends WellBehavedPluginTest {
 
@@ -31,8 +34,12 @@ class JavaScriptBasePluginIntegrationTest extends WellBehavedPluginTest {
         applyPlugin()
     }
 
-    def "can download from googles repo"() {
+    @Unroll
+    def "can download from googles repo (experimental=#experimental)"() {
         given:
+        if (experimental) {
+            ExperimentalFeaturesFixture.enable(settingsFile)
+        }
         addGoogleRepoScript(buildFile)
 
         when:
@@ -57,6 +64,46 @@ class JavaScriptBasePluginIntegrationTest extends WellBehavedPluginTest {
         jquery.exists()
         jquery.text.contains("jQuery v1.7.2")
 
+        where:
+        experimental | _
+        true         | _
+        false        | _
+    }
+
+    @Unroll
+    def "can download from gradleJs repo (experimental=#experimental)"() {
+        given:
+        if (experimental) {
+            ExperimentalFeaturesFixture.enable(settingsFile)
+        }
+        addGradlePublicJsRepoScript(buildFile)
+
+        when:
+        buildFile << """
+            configurations {
+                jshint
+            }
+            dependencies {
+                jshint "com.jshint:jshint:r07@js"
+            }
+            task resolve(type: Copy) {
+                from configurations.jshint
+                into "jshint"
+            }
+        """
+
+        then:
+        succeeds "resolve"
+
+        and:
+        def jshint = file("jshint/jshint-r07.js")
+        jshint.exists()
+        jshint.text.contains("JSHint")
+
+        where:
+        experimental | _
+        true         | _
+        false        | _
     }
 
 }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/base/JavaScriptRepositoriesExtension.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/base/JavaScriptRepositoriesExtension.java
@@ -46,6 +46,12 @@ public class JavaScriptRepositoriesExtension {
             public void execute(MavenArtifactRepository repository) {
                 repository.setName("gradleJs");
                 repository.setUrl(GRADLE_PUBLIC_JAVASCRIPT_REPO_URL);
+                repository.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+                    @Override
+                    public void execute(MavenArtifactRepository.MetadataSources metadataSources) {
+                        metadataSources.artifact();
+                    }
+                });
                 action.execute(repository);
             }
         });
@@ -64,6 +70,12 @@ public class JavaScriptRepositoriesExtension {
                     public void execute(IvyPatternRepositoryLayout layout) {
                         layout.artifact("[organization]/[revision]/[module].[ext]");
                         layout.ivy("[organization]/[revision]/[module].xml");
+                    }
+                });
+                repo.metadataSources(new Action<IvyArtifactRepository.MetadataSources>() {
+                    @Override
+                    public void execute(IvyArtifactRepository.MetadataSources metadataSources) {
+                        metadataSources.artifact();
                     }
                 });
                 action.execute(repo);


### PR DESCRIPTION
This introduces the new `metadataSources { artifact() }` to the two repositories the javascript plugin defines.

For the current behaviour, this is a performance improvement, because we do not look for metadata anymore, which is never there.
For the 5.0 (experimental) behavior, this fixes the repos which otherwise do not look for artifacts without metadata anymore.