### PR TITLE
Always report Checkstyle violations-summary from xml report

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
@@ -56,7 +56,7 @@ abstract class CheckstyleInvoker {
             }
 
             ant.checkstyle(config: config.asFile(), failOnViolation: false,
-                    maxErrors: maxErrors, maxWarnings: maxWarnings, failureProperty: FAILURE_PROPERTY_NAME) {
+                maxErrors: maxErrors, maxWarnings: maxWarnings, failureProperty: FAILURE_PROPERTY_NAME) {
 
                 source.addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
                 classpath.addToAntBuilder(ant, 'classpath')
@@ -98,43 +98,48 @@ abstract class CheckstyleInvoker {
                 GFileUtils.deleteQuietly(xmlDestination)
             }
 
-            def message
-            /*
-             * Ant checkstyle task does not return any metrics, only pass/fail based on thresholds.
-             * If an xml report was produced, report violations metrics.
-             */
-            if (reports.xml.enabled) {
-                try {
-                    def checkstyleReportXmlParser = new XmlParser().parse(reports.xml.destination)
-                    def errorFileCount = checkstyleReportXmlParser.file.error.groupBy { it.parent().@name }.keySet().size()
-                    if (errorFileCount > 0) {
-                        message = baseMessage(reports)
-                        message += "\nCheckstyle files with violations: $errorFileCount"
-                        message += "\nCheckstyle violations by severity: "
-                        message += checkstyleReportXmlParser.file.error.countBy { it.@severity }
-                    }
-                } finally {
-                }
-            }
-
             if (ant.project.properties[FAILURE_PROPERTY_NAME] && !ignoreFailures) {
-                // might not have xml reports
-                message = message ?: baseMessage(reports)
-                throw new GradleException(message)
-            } else if (message) {
-                logger.warn(message);
+                throw new GradleException(getMessage(reports, parseCheckstyleXml(reports)))
+            } else {
+                def reportXml = parseCheckstyleXml(reports)
+                if(violationsExist(reportXml)) {
+                    logger.warn(getMessage(reports, reportXml))
+                }
             }
         }
     }
 
-    private static String baseMessage(CheckstyleReports reports) {
-        def message = "Checkstyle rule violations were found."
+    private static boolean violationsExist(Node reportXml) {
+        return reportXml != null && getErrorFileCount(reportXml) > 0
+    }
+
+    private static parseCheckstyleXml(CheckstyleReports reports) {
+        return reports.xml.enabled ? new XmlParser().parse(reports.xml.destination) : null
+    }
+
+    private static String getMessage(CheckstyleReports reports, Node reportXml) {
+        return "Checkstyle rule violations were found.${getReportUrlMessage(reports)}${getViolationMessage(reportXml)}"
+    }
+
+    private static int getErrorFileCount(Node reportXml) {
+        return reportXml.file.error.groupBy { it.parent().@name }.keySet().size()
+    }
+
+    private static String getReportUrlMessage(CheckstyleReports reports) {
         def report = reports.html.enabled ? reports.html : reports.xml.enabled ? reports.xml : null
-        if (report) {
-            def reportUrl = new ConsoleRenderer().asClickableFileUrl(report.destination)
-            message += " See the report at: $reportUrl"
+        return report ? " See the report at: ${new ConsoleRenderer().asClickableFileUrl(report.destination)}" : "\n"
+    }
+
+    private static String getViolationMessage(Node reportXml) {
+        if (violationsExist(reportXml)) {
+            def errorFileCount = getErrorFileCount(reportXml)
+            def violations = reportXml.file.error.countBy { it.@severity }
+            return """
+                    Checkstyle files with violations: $errorFileCount
+                    Checkstyle violations by severity: ${violations}
+                    """.stripIndent()
         }
-        return message
+        return "\n"
     }
 
     private static boolean isHtmlReportEnabledOnly(CheckstyleReports reports) {


### PR DESCRIPTION
### Context
See discussion in #881, fixes #881.

Two main changes here:

* Checkstyle violations which are tolerated due to thresholds `maxErrors` or `maxWarnings` not being met were not reported prior to this change - the developer is unaware of the Checkstyle violations unless they proactively check the HTML or XML report.  `maxErrors` and `maxWarnings` should be used to allow the build to pass for acceptable counts, but the presence of errors or warnings (or even info-level violations) should be summarised in the build-output, with a link to the reports.  With this change Checkstyle violations-summary is always reported if there are violations, regardless of whether the build is passing or failing.
* If the Checkstyle XML report is generated, it is parsed and a violations summary is always printed if there are any violations recorded - the number of files with violations is reported, together with a summary of violations-by-severity.  If the build is failing this information is in the failure exception cause, otherwise it is logged at warn-level.

**Old/Existing behaviour**

* Checkstyle failed the build: Exception cause contains a link to report.
* Checkstyle would have failed the build but for `ignoreFailures`: Warning logged with a link to report.
* Checkstyle would have failed the build but for `maxErrors` and `maxWarnings` not being met: **Silent**
* Checkstyle produces info-level violations: **Silent**

**New behaviour**

* Any Checkstyle failing build: exception cause contains violations-summary as well as report link.
* Any Checkstyle violations in passing build: violations-summary logged at warn level.

**Example output**

_Failing build_

```
[ant:checkstyle] [ERROR] /<redacted>/gradle/subprojects/code-quality/build/tmp/test files/CheckstylePluginVersionIntegrationTest/analyze_bad_code/ggrk6/src/main/java/org/gradle/class1.java:1:27: Name 'class1' must match pattern '^[A-Z][a-zA-Z0-9]*$'. [TypeName]
[ant:checkstyle] [ERROR] /<redacted>/gradle/subprojects/code-quality/build/tmp/test files/CheckstylePluginVersionIntegrationTest/analyze_bad_code/ggrk6/src/main/groovy/org/gradle/class2.java:1:27: Name 'class2' must match pattern '^[A-Z][a-zA-Z0-9]*$'. [TypeName]

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':checkstyleMain'.
> Checkstyle rule violations were found. See the report at: file:///<redacted>/gradle/subprojects/code-quality/build/tmp/test%20files/CheckstylePluginVersionIntegrationTest/analyze_bad_code/ggrk6/build/reports/checkstyle/main.html
  Checkstyle files with violations: 2
  Checkstyle violations by severity: [error:2]

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':checkstyleMain'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:103)
```

_Passing build_

```
:compileJava
:compileGroovy
:processResources NO-SOURCE
:classes
:checkstyleMain
Checkstyle rule violations were found. See the report at: file:///<redacted>/gradle/subprojects/code-quality/build/tmp/test%20files/CheckstylePluginVersionIntegrationTest/can_ignore_failures/os501/build/reports/checkstyle/main.html
Checkstyle files with violations: 2
Checkstyle violations by severity: [error:2]
:compileTestJava
```
### Tests

Updated integration tests to check for violations-summary-output in both passing and failing builds.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
