### PR TITLE
`PomReader` parse active pom profiles is error!

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -683,7 +683,16 @@ public class PomReader implements PomParent {
      */
     private boolean isActivationPropertyActivated(Element propertyElement) {
         String propertyName = getFirstChildText(propertyElement, "name");
-        return propertyName.startsWith("!");
+        String propertyValue = getFirstChildText(propertyElement, "value");
+        if(propertyName != null && propertyName.length() > 0 ){
+            String systemPropertyValue = System.getProperty(propertyName);
+            if(propertyValue == null){
+                return systemPropertyValue == propertyValue;
+            }else{
+                return propertyValue.equals(systemPropertyValue);
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
https://github.com/gradle/gradle/blob/022de6f9e371785a31a5001df84138b45650f516/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java#L684-L687

https://github.com/gradle/gradle/blob/022de6f9e371785a31a5001df84138b45650f516/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java#L646-L652

Maven to activate this profile if  the property customProperty is start with "!".
But [Maven documentation](http://books.sonatype.com/mvnref-book/reference/profiles-sect-activation.html#profiles-sect-activation-config)  say:

>The property element tells Maven to activate this profile if the property customProperty is set to the value xxx

Signed-off-by: 王宁 <childe.wangning@gmail.com>

