### PR TITLE
Further consistency improvements and duplication reduction in the native plugins 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -119,6 +119,8 @@ public abstract class OperatingSystem {
 
     public abstract String getStaticLibraryName(String libraryName);
 
+    public abstract String getStaticLibrarySuffix();
+
     public abstract String getLinkLibrarySuffix();
 
     public abstract String getLinkLibraryName(String libraryPath);
@@ -231,6 +233,11 @@ public abstract class OperatingSystem {
         }
 
         @Override
+        public String getStaticLibrarySuffix() {
+            return ".lib";
+        }
+
+        @Override
         public String getStaticLibraryName(String libraryName) {
             return withExtension(libraryName, ".lib");
         }
@@ -311,6 +318,11 @@ public abstract class OperatingSystem {
         @Override
         public String getLinkLibraryName(String libraryPath) {
             return getSharedLibraryName(libraryPath);
+        }
+
+        @Override
+        public String getStaticLibrarySuffix() {
+            return ".a";
         }
 
         @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
@@ -118,6 +118,7 @@ class OperatingSystemTest extends Specification {
         def os = new OperatingSystem.Windows()
 
         expect:
+        os.staticLibrarySuffix == ".lib"
         os.getStaticLibraryName("a.lib") == "a.lib"
         os.getStaticLibraryName("a.LIB") == "a.LIB"
         os.getStaticLibraryName("a") == "a.lib"
@@ -251,6 +252,7 @@ class OperatingSystemTest extends Specification {
         def os = new OperatingSystem.Unix()
 
         expect:
+        os.staticLibrarySuffix == ".a"
         os.getStaticLibraryName("a.a") == "a.a"
         os.getStaticLibraryName("liba.a") == "liba.a"
         os.getStaticLibraryName("a") == "liba.a"

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleCppProjectIntegrationTest.groovy
@@ -162,7 +162,7 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
         then:
         resultReleaseHello.assertTasksExecuted(':shuffle:compileReleaseCpp', ':shuffle:linkRelease', ':shuffle:stripSymbolsRelease',
             ':card:compileReleaseCpp', ':card:linkRelease', ':card:stripSymbolsRelease',
-            ':deck:compileReleaseCpp', ':deck:linkRelease', ':deck:_xcode___Deck_Release')
+            ':deck:compileReleaseCpp', ':deck:linkRelease', ':deck:stripSymbolsRelease', ':deck:_xcode___Deck_Release')
     }
 
     def "can create xcode project for C++ executable inside composite build"() {
@@ -223,6 +223,6 @@ class XcodeMultipleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpe
             .succeeds()
 
         then:
-        resultReleaseGreeter.assertTasksExecuted(':compileReleaseCpp', ':linkRelease', ':_xcode___Greeter_Release')
+        resultReleaseGreeter.assertTasksExecuted(':compileReleaseCpp', ':linkRelease', ':stripSymbolsRelease', ':_xcode___Greeter_Release')
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleSwiftProjectIntegrationTest.groovy
@@ -158,7 +158,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             .succeeds()
 
         then:
-        resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease',
+        resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease', ':hello:stripSymbolsRelease',
             ':log:stripSymbolsRelease', ':log:compileReleaseSwift', ':log:linkRelease',
             ':hello:_xcode___Hello_Release')
     }
@@ -237,7 +237,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             .succeeds()
 
         then:
-        resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease',
+        resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease', ':hello:stripSymbolsRelease',
             ":cppGreeter:compileReleaseCpp", ":cppGreeter:linkRelease", ":cppGreeter:stripSymbolsRelease",
             ':hello:_xcode___Hello_Release')
     }
@@ -320,7 +320,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             .succeeds()
 
         then:
-        resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease',
+        resultReleaseHello.assertTasksExecuted(':hello:compileReleaseSwift', ':hello:linkRelease', ':hello:stripSymbolsRelease',
             ":cppGreeter:compileReleaseCpp", ":cppGreeter:createRelease",
             ':hello:_xcode___Hello_Release')
     }
@@ -448,7 +448,7 @@ class XcodeMultipleSwiftProjectIntegrationTest extends AbstractXcodeIntegrationS
             .succeeds()
 
         then:
-        resultReleaseGreeter.assertTasksExecuted(':compileReleaseSwift', ':linkRelease', ':_xcode___Greeter_Release')
+        resultReleaseGreeter.assertTasksExecuted(':compileReleaseSwift', ':linkRelease', ':stripSymbolsRelease', ':_xcode___Greeter_Release')
     }
 
     def "can run tests for Swift library within multi-project from xcode"() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.util.TestPrecondition
 
 import static org.gradle.ide.xcode.internal.XcodeUtils.toSpaceSeparatedList
 
+@Requires(TestPrecondition.NOT_WINDOWS)
 class XcodeSingleCppProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
     def "can create xcode project for C++ application"() {
         given:

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleCppProjectIntegrationTest.groovy
@@ -259,8 +259,8 @@ apply plugin: 'cpp-library'
             .succeeds()
 
         then:
-        resultRelease.assertTasksExecuted(':compileReleaseCpp', ':linkRelease', ':_xcode___App_Release')
-        resultRelease.assertTasksNotSkipped(':compileReleaseCpp', ':linkRelease', ':_xcode___App_Release')
+        resultRelease.assertTasksExecuted(':compileReleaseCpp', ':linkRelease', ':stripSymbolsRelease', ':_xcode___App_Release')
+        resultRelease.assertTasksNotSkipped(':compileReleaseCpp', ':linkRelease', ':stripSymbolsRelease', ':_xcode___App_Release')
         releaseBinary.assertExists()
         fixture(releaseBinary).assertHasDebugSymbolsFor(lib.sourceFileNamesWithoutHeaders)
     }
@@ -419,7 +419,7 @@ library.baseName = 'test_lib'
         project.targets[0].productReference.path == sharedLib("output/lib/main/debug/test_lib").absolutePath
         project.targets[0].buildConfigurationList.buildConfigurations.name == [DefaultXcodeProject.BUILD_DEBUG, DefaultXcodeProject.BUILD_RELEASE]
         project.targets[0].buildConfigurationList.buildConfigurations[0].buildSettings.CONFIGURATION_BUILD_DIR == file("output/lib/main/debug").absolutePath
-        project.targets[0].buildConfigurationList.buildConfigurations[1].buildSettings.CONFIGURATION_BUILD_DIR == file("output/lib/main/release").absolutePath
+        project.targets[0].buildConfigurationList.buildConfigurations[1].buildSettings.CONFIGURATION_BUILD_DIR == file("output/lib/main/release/stripped").absolutePath
 
         project.products.children.size() == 1
         project.products.children[0].path == sharedLib("output/lib/main/debug/test_lib").absolutePath

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleSwiftProjectIntegrationTest.groovy
@@ -537,8 +537,8 @@ apply plugin: 'swift-library'
             .succeeds()
 
         then:
-        resultRelease.assertTasksExecuted(':compileReleaseSwift', ':linkRelease', ':_xcode___App_Release')
-        resultRelease.assertTasksNotSkipped(':compileReleaseSwift', ':linkRelease', ':_xcode___App_Release')
+        resultRelease.assertTasksExecuted(':compileReleaseSwift', ':linkRelease', ':stripSymbolsRelease', ':_xcode___App_Release')
+        resultRelease.assertTasksNotSkipped(':compileReleaseSwift', ':linkRelease', ':stripSymbolsRelease', ':_xcode___App_Release')
         releaseBinary.assertExists()
         fixture(releaseBinary).assertHasDebugSymbolsFor(lib.sourceFileNames)
     }
@@ -681,7 +681,7 @@ library.module = 'TestLib'
         project.targets[0].name == 'TestLib'
         project.targets[0].productReference.path == sharedLib("output/lib/main/debug/TestLib").absolutePath
         project.targets[0].buildConfigurationList.buildConfigurations[0].buildSettings.CONFIGURATION_BUILD_DIR == file("output/lib/main/debug").absolutePath
-        project.targets[0].buildConfigurationList.buildConfigurations[1].buildSettings.CONFIGURATION_BUILD_DIR == file("output/lib/main/release").absolutePath
+        project.targets[0].buildConfigurationList.buildConfigurations[1].buildSettings.CONFIGURATION_BUILD_DIR == file("output/lib/main/release/stripped").absolutePath
         project.targets[1].name == '[INDEXING ONLY] TestLib'
         project.products.children.size() == 1
         project.products.children[0].path == sharedLib("output/lib/main/debug/TestLib").absolutePath

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/fixtures/AbstractXcodeIntegrationSpec.groovy
@@ -192,7 +192,7 @@ Actual: ${actual[key]}
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[0].buildSettings)
         assert target.buildConfigurationList.buildConfigurations[0].buildSettings.CONFIGURATION_BUILD_DIR == file("build/lib/main/debug").absolutePath
         assertNotUnitTestBuildSettings(target.buildConfigurationList.buildConfigurations[1].buildSettings)
-        assert target.buildConfigurationList.buildConfigurations[1].buildSettings.CONFIGURATION_BUILD_DIR == file("build/lib/main/release").absolutePath
+        assert target.buildConfigurationList.buildConfigurations[1].buildSettings.CONFIGURATION_BUILD_DIR == file("build/lib/main/release/stripped").absolutePath
     }
 
     void assertTargetIsStaticLibrary(ProjectFile.PBXTarget target, String expectedProductName, String expectedBinaryName = expectedProductName) {

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -242,9 +242,9 @@ public class XcodePlugin extends IdePlugin {
                         } else if (swiftBinary instanceof SwiftExecutable && swiftBinary.isDebuggable() && swiftBinary.isOptimized()) {
                             target.setRelease(((SwiftExecutable) swiftBinary).getDebuggerExecutableFile(), PBXTarget.ProductType.TOOL);
                         } else if (swiftBinary instanceof SwiftSharedLibrary && swiftBinary.isDebuggable() && !swiftBinary.isOptimized()) {
-                            target.setDebug(((SwiftSharedLibrary) swiftBinary).getLinkTask().get().getBinaryFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
+                            target.setDebug(((SwiftSharedLibrary) swiftBinary).getRuntimeFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
                         } else if (swiftBinary instanceof SwiftSharedLibrary && swiftBinary.isDebuggable() && swiftBinary.isOptimized()) {
-                            target.setRelease(((SwiftSharedLibrary) swiftBinary).getLinkTask().get().getBinaryFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
+                            target.setRelease(((SwiftSharedLibrary) swiftBinary).getRuntimeFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
                         } else if (swiftBinary instanceof SwiftStaticLibrary && swiftBinary.isDebuggable() && !swiftBinary.isOptimized()) {
                             target.setDebug(((SwiftStaticLibrary) swiftBinary).getLinkFile(), PBXTarget.ProductType.STATIC_LIBRARY);
                         } else if (swiftBinary instanceof SwiftStaticLibrary && swiftBinary.isDebuggable() && swiftBinary.isOptimized()) {
@@ -297,13 +297,13 @@ public class XcodePlugin extends IdePlugin {
                     @Override
                     public void execute(CppBinary cppBinary) {
                         if (cppBinary instanceof CppExecutable && cppBinary.isDebuggable() && !cppBinary.isOptimized()) {
-                            target.setDebug(((CppExecutable) cppBinary).getLinkTask().get().getBinaryFile(), PBXTarget.ProductType.TOOL);
+                            target.setDebug(((CppExecutable) cppBinary).getDebuggerExecutableFile(), PBXTarget.ProductType.TOOL);
                         } else if (cppBinary instanceof CppExecutable && cppBinary.isDebuggable() && cppBinary.isOptimized()) {
-                            target.setRelease(((CppExecutable) cppBinary).getLinkTask().get().getBinaryFile(), PBXTarget.ProductType.TOOL);
+                            target.setRelease(((CppExecutable) cppBinary).getDebuggerExecutableFile(), PBXTarget.ProductType.TOOL);
                         } else if (cppBinary instanceof CppSharedLibrary && cppBinary.isDebuggable() && !cppBinary.isOptimized()) {
-                            target.setDebug(((CppSharedLibrary) cppBinary).getLinkTask().get().getBinaryFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
+                            target.setDebug(((CppSharedLibrary) cppBinary).getRuntimeFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
                         } else if (cppBinary instanceof CppSharedLibrary && cppBinary.isDebuggable() && cppBinary.isOptimized()) {
-                            target.setRelease(((CppSharedLibrary) cppBinary).getLinkTask().get().getBinaryFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
+                            target.setRelease(((CppSharedLibrary) cppBinary).getRuntimeFile(), PBXTarget.ProductType.DYNAMIC_LIBRARY);
                         } else if (cppBinary instanceof CppStaticLibrary && cppBinary.isDebuggable() && !cppBinary.isOptimized()) {
                             target.setDebug(((CppStaticLibrary) cppBinary).getLinkFile(), PBXTarget.ProductType.STATIC_LIBRARY);
                         } else if (cppBinary instanceof CppStaticLibrary && cppBinary.isDebuggable() && cppBinary.isOptimized()) {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -221,7 +221,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppInstalledToolCh
         executable.exec().out == app.expectedOutput
     }
 
-    def "uses the basename to calculate the coords"() {
+    def "uses the basename to calculate the coordinates"() {
         def app = new CppAppWithLibrary()
 
         given:

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -623,7 +623,11 @@ dependencies { implementation 'some.group:greeter:1.2' }
         run("installDebug")
 
         then:
-        installation(consumer.file("build/install/main/debug")).exec().out == app.withFeatureDisabled().expectedOutput
+        def debugInstall = installation(consumer.file("build/install/main/debug"))
+        debugInstall.exec().out == app.withFeatureDisabled().expectedOutput
+        debugInstall.assertIncludesLibraries("greeting")
+        def debugLib = sharedLibrary(producer.file("build/lib/main/debug/greeting"))
+        sharedLibrary(consumer.file("build/install/main/debug/lib/greeting")).file.assertIsCopyOf(debugLib.file)
 
         when:
         executer.inDirectory(consumer)
@@ -631,6 +635,11 @@ dependencies { implementation 'some.group:greeter:1.2' }
 
         then:
         installation(consumer.file("build/install/main/release")).exec().out == app.withFeatureEnabled().expectedOutput
+        def releaseInstall = installation(consumer.file("build/install/main/release"))
+        releaseInstall.exec().out == app.withFeatureEnabled().expectedOutput
+        releaseInstall.assertIncludesLibraries("greeting")
+        def releaseLib = sharedLibrary(producer.file("build/lib/main/release/greeting"))
+        sharedLibrary(consumer.file("build/install/main/release/lib/greeting")).file.assertIsCopyOf(releaseLib.strippedRuntimeFile)
     }
 
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.nativeplatform.fixtures.app.CppLib
+import org.gradle.test.fixtures.archive.ZipTestFixture
+import org.gradle.test.fixtures.maven.MavenFileRepository
+
+
+class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractCppInstalledToolChainIntegrationTest implements CppTaskNames {
+    def "can publish the binaries and headers of a library to a Maven repository"() {
+        def lib = new CppLib()
+        assert !lib.publicHeaders.files.empty
+        assert !lib.privateHeaders.files.empty
+
+        given:
+        buildFile << """
+            apply plugin: 'cpp-library'
+            apply plugin: 'maven-publish'
+            
+            group = 'some.group'
+            version = '1.2'
+            library {
+                baseName = 'test'
+                linkage = [Linkage.STATIC, Linkage.SHARED]
+            }
+            publishing {
+                repositories { maven { url 'repo' } }
+            }
+"""
+        lib.writeToProject(testDirectory)
+
+        when:
+        run('publish')
+
+        then:
+        result.assertTasksExecuted(
+            ':compileDebugSharedCpp', ':linkDebugShared',
+            ':compileReleaseSharedCpp', ':linkReleaseShared', ':stripSymbolsReleaseShared',
+            ':compileDebugStaticCpp', ':createDebugStatic',
+            ':compileReleaseStaticCpp', ':createReleaseStatic',
+            ":generatePomFileForDebugSharedPublication",
+            ":generateMetadataFileForDebugSharedPublication",
+            ":publishDebugSharedPublicationToMavenRepository",
+            ":generatePomFileForDebugStaticPublication",
+            ":generateMetadataFileForDebugStaticPublication",
+            ":publishDebugStaticPublicationToMavenRepository",
+            ":cppHeaders",
+            ":generatePomFileForMainPublication",
+            ":generateMetadataFileForMainPublication",
+            ":publishMainPublicationToMavenRepository",
+            ":generatePomFileForReleaseSharedPublication",
+            ":generateMetadataFileForReleaseSharedPublication",
+            ":publishReleaseSharedPublicationToMavenRepository",
+            ":generatePomFileForReleaseStaticPublication",
+            ":generateMetadataFileForReleaseStaticPublication",
+            ":publishReleaseStaticPublicationToMavenRepository",
+            ":publish"
+        )
+
+        def headersZip = file("build/headers/cpp-api-headers.zip")
+        new ZipTestFixture(headersZip).hasDescendants(lib.publicHeaders.files*.name)
+
+        def repo = new MavenFileRepository(file("repo"))
+
+        def main = repo.module('some.group', 'test', '1.2')
+        main.assertPublished()
+        main.assertArtifactsPublished("test-1.2-cpp-api-headers.zip", "test-1.2.pom", "test-1.2.module")
+        main.artifactFile(classifier: 'cpp-api-headers', type: 'zip').assertIsCopyOf(headersZip)
+
+        main.parsedPom.scopes.isEmpty()
+
+        def mainMetadata = main.parsedModuleMetadata
+        mainMetadata.variants.size() == 9
+        def api = mainMetadata.variant("api")
+        api.dependencies.empty
+        api.files.size() == 1
+        api.files[0].name == 'cpp-api-headers.zip'
+        api.files[0].url == 'test-1.2-cpp-api-headers.zip'
+        mainMetadata.variant("debugShared-link").availableAt.coords == "some.group:test_debug_shared:1.2"
+        mainMetadata.variant("debugShared-runtime").availableAt.coords == "some.group:test_debug_shared:1.2"
+        mainMetadata.variant("debugStatic-link").availableAt.coords == "some.group:test_debug_static:1.2"
+        mainMetadata.variant("debugStatic-runtime").availableAt.coords == "some.group:test_debug_static:1.2"
+        mainMetadata.variant("releaseShared-link").availableAt.coords == "some.group:test_release_shared:1.2"
+        mainMetadata.variant("releaseShared-runtime").availableAt.coords == "some.group:test_release_shared:1.2"
+        mainMetadata.variant("releaseStatic-link").availableAt.coords == "some.group:test_release_static:1.2"
+        mainMetadata.variant("releaseStatic-runtime").availableAt.coords == "some.group:test_release_static:1.2"
+
+        def debugShared = repo.module('some.group', 'test_debug_shared', '1.2')
+        debugShared.assertPublished()
+        debugShared.assertArtifactsPublished(withSharedLibrarySuffix("test_debug_shared-1.2"), withLinkLibrarySuffix("test_debug_shared-1.2"), "test_debug_shared-1.2.pom", "test_debug_shared-1.2.module")
+        debugShared.artifactFile(type: sharedLibraryExtension).assertIsCopyOf(sharedLibrary("build/lib/main/debug/shared/test").file)
+        debugShared.artifactFile(type: linkLibrarySuffix).assertIsCopyOf(sharedLibrary("build/lib/main/debug/shared/test").linkFile)
+
+        debugShared.parsedPom.scopes.isEmpty()
+
+        def debugSharedMetadata = debugShared.parsedModuleMetadata
+        debugSharedMetadata.variants.size() == 2
+        debugSharedMetadata.variant('debugShared-link')
+        debugSharedMetadata.variant('debugShared-runtime')
+
+        def debugStatic = repo.module('some.group', 'test_debug_static', '1.2')
+        debugStatic.assertPublished()
+        debugStatic.assertArtifactsPublished(withStaticLibrarySuffix("test_debug_static-1.2"), "test_debug_static-1.2.pom", "test_debug_static-1.2.module")
+        debugStatic.artifactFile(type: staticLibraryExtension).assertIsCopyOf(staticLibrary("build/lib/main/debug/static/test").file)
+
+        debugStatic.parsedPom.scopes.isEmpty()
+
+        def debugStaticMetadata = debugStatic.parsedModuleMetadata
+        debugStaticMetadata.variants.size() == 2
+        debugStaticMetadata.variant('debugStatic-link')
+        debugStaticMetadata.variant('debugStatic-runtime')
+
+        def releaseShared = repo.module('some.group', 'test_release_shared', '1.2')
+        releaseShared.assertPublished()
+        releaseShared.assertArtifactsPublished(withSharedLibrarySuffix("test_release_shared-1.2"), withLinkLibrarySuffix("test_release_shared-1.2"), "test_release_shared-1.2.pom", "test_release_shared-1.2.module")
+        releaseShared.artifactFile(type: sharedLibraryExtension).assertIsCopyOf(sharedLibrary("build/lib/main/release/shared/test").strippedRuntimeFile)
+        releaseShared.artifactFile(type: linkLibrarySuffix).assertIsCopyOf(sharedLibrary("build/lib/main/release/shared/test").strippedLinkFile)
+
+        releaseShared.parsedPom.scopes.isEmpty()
+
+        def releaseSharedMetadata = releaseShared.parsedModuleMetadata
+        releaseSharedMetadata.variants.size() == 2
+        releaseSharedMetadata.variant('releaseShared-link')
+        releaseSharedMetadata.variant('releaseShared-runtime')
+
+        def releaseStatic = repo.module('some.group', 'test_release_static', '1.2')
+        releaseStatic.assertPublished()
+        releaseStatic.assertArtifactsPublished(withStaticLibrarySuffix("test_release_static-1.2"), "test_release_static-1.2.pom", "test_release_static-1.2.module")
+        releaseStatic.artifactFile(type: staticLibraryExtension).assertIsCopyOf(staticLibrary("build/lib/main/release/static/test").file)
+
+        releaseStatic.parsedPom.scopes.isEmpty()
+
+        def releaseStaticMetadata = releaseStatic.parsedModuleMetadata
+        releaseStaticMetadata.variants.size() == 2
+        releaseStaticMetadata.variant('releaseStatic-link')
+        releaseStaticMetadata.variant('releaseStatic-runtime')
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithStaticLinkagePublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithStaticLinkagePublishingIntegrationTest.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.nativeplatform.fixtures.app.CppLib
+import org.gradle.test.fixtures.archive.ZipTestFixture
+import org.gradle.test.fixtures.maven.MavenFileRepository
+
+
+class CppLibraryWithStaticLinkagePublishingIntegrationTest extends AbstractCppInstalledToolChainIntegrationTest implements CppTaskNames {
+    def "can publish the binaries and headers of a library to a Maven repository"() {
+        def lib = new CppLib()
+        assert !lib.publicHeaders.files.empty
+        assert !lib.privateHeaders.files.empty
+
+        given:
+        buildFile << """
+            apply plugin: 'cpp-library'
+            apply plugin: 'maven-publish'
+            
+            group = 'some.group'
+            version = '1.2'
+            library {
+                baseName = 'test'
+                linkage = [Linkage.STATIC]
+            }
+            publishing {
+                repositories { maven { url 'repo' } }
+            }
+"""
+        lib.writeToProject(testDirectory)
+
+        when:
+        run('publish')
+
+        then:
+        result.assertTasksExecuted(
+            compileAndStaticLinkTasks(debug),
+            compileAndStaticLinkTasks(release),
+            ":generatePomFileForDebugPublication",
+            ":generateMetadataFileForDebugPublication",
+            ":publishDebugPublicationToMavenRepository",
+            ":cppHeaders",
+            ":generatePomFileForMainPublication",
+            ":generateMetadataFileForMainPublication",
+            ":publishMainPublicationToMavenRepository",
+            ":generatePomFileForReleasePublication",
+            ":generateMetadataFileForReleasePublication",
+            ":publishReleasePublicationToMavenRepository",
+            ":publish"
+        )
+
+        def headersZip = file("build/headers/cpp-api-headers.zip")
+        new ZipTestFixture(headersZip).hasDescendants(lib.publicHeaders.files*.name)
+
+        def repo = new MavenFileRepository(file("repo"))
+
+        def main = repo.module('some.group', 'test', '1.2')
+        main.assertPublished()
+        main.assertArtifactsPublished("test-1.2-cpp-api-headers.zip", "test-1.2.pom", "test-1.2.module")
+        main.artifactFile(classifier: 'cpp-api-headers', type: 'zip').assertIsCopyOf(headersZip)
+
+        main.parsedPom.scopes.isEmpty()
+
+        def mainMetadata = main.parsedModuleMetadata
+        mainMetadata.variants.size() == 5
+        def api = mainMetadata.variant("api")
+        api.dependencies.empty
+        api.files.size() == 1
+        api.files[0].name == 'cpp-api-headers.zip'
+        api.files[0].url == 'test-1.2-cpp-api-headers.zip'
+        mainMetadata.variant("debug-link").availableAt.coords == "some.group:test_debug:1.2"
+        mainMetadata.variant("debug-runtime").availableAt.coords == "some.group:test_debug:1.2"
+        mainMetadata.variant("release-link").availableAt.coords == "some.group:test_release:1.2"
+        mainMetadata.variant("release-runtime").availableAt.coords == "some.group:test_release:1.2"
+
+        def debug = repo.module('some.group', 'test_debug', '1.2')
+        debug.assertPublished()
+        debug.assertArtifactsPublished(withStaticLibrarySuffix("test_debug-1.2"), "test_debug-1.2.pom", "test_debug-1.2.module")
+        debug.artifactFile(type: staticLibraryExtension).assertIsCopyOf(staticLibrary("build/lib/main/debug/test").file)
+
+        debug.parsedPom.scopes.isEmpty()
+
+        def debugMetadata = debug.parsedModuleMetadata
+        debugMetadata.variants.size() == 2
+        def debugLink = debugMetadata.variant('debug-link')
+        debugLink.dependencies.empty
+        debugLink.files.size() == 1
+        debugLink.files[0].name == staticLibraryName('test')
+        debugLink.files[0].url == withStaticLibrarySuffix("test_debug-1.2")
+        def debugRuntime = debugMetadata.variant('debug-runtime')
+        debugRuntime.dependencies.empty
+        debugRuntime.files.empty
+
+        def release = repo.module('some.group', 'test_release', '1.2')
+        release.assertPublished()
+        release.assertArtifactsPublished(withStaticLibrarySuffix("test_release-1.2"), "test_release-1.2.pom", "test_release-1.2.module")
+        release.artifactFile(type: staticLibraryExtension).assertIsCopyOf(staticLibrary("build/lib/main/release/test").file)
+
+        release.parsedPom.scopes.isEmpty()
+
+        def releaseMetadata = release.parsedModuleMetadata
+        releaseMetadata.variants.size() == 2
+        def releaseLink = releaseMetadata.variant('release-link')
+        releaseLink.dependencies.empty
+        releaseLink.files.size() == 1
+        releaseLink.files[0].name == staticLibraryName('test')
+        releaseLink.files[0].url == withStaticLibrarySuffix("test_release-1.2")
+        def releaseRuntime = releaseMetadata.variant('release-runtime')
+        releaseRuntime.dependencies.empty
+        releaseRuntime.files.empty
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryLinkageIntegrationTest.groovy
@@ -64,6 +64,35 @@ class CppStaticLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
         staticLibrary('build/lib/main/debug/foo').assertExists()
     }
 
+    def "can create debug and release variants of library"() {
+        def library = new CppLib()
+        buildFile << """
+            apply plugin: 'cpp-library'
+
+            library {
+                linkage = [Linkage.STATIC]
+            }
+        """
+        settingsFile << """
+            rootProject.name = 'foo'
+        """
+        library.writeToProject(testDirectory)
+
+        when:
+        succeeds('assembleRelease')
+
+        then:
+        result.assertTasksExecuted(':compileReleaseCpp', ':createRelease', ':assembleRelease')
+        staticLibrary('build/lib/main/release/foo').assertExists()
+
+        when:
+        succeeds('assembleDebug')
+
+        then:
+        result.assertTasksExecuted(':compileDebugCpp', ':createDebug', ':assembleDebug')
+        staticLibrary('build/lib/main/debug/foo').assertExists()
+    }
+
     def "can use link file as task dependency"() {
         given:
         settingsFile << "rootProject.name = 'hello'"

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
@@ -75,7 +75,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
-    def "can build release variant of library"() {
+    def "can build debug and release variants of library"() {
         given:
         def lib = new SwiftLib()
         settingsFile << "rootProject.name = '${lib.projectName}'"
@@ -87,13 +87,21 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
          """
 
         when:
+        succeeds "assembleDebug"
+
+        then:
+        result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assembleDebug")
+        file("build/modules/main/debug/${lib.moduleName}.swiftmodule").assertIsFile()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
+
+        when:
         succeeds "assembleRelease"
 
         then:
         result.assertTasksExecuted(":compileReleaseSwift", ":linkRelease", ":extractSymbolsRelease", ":stripSymbolsRelease", ":assembleRelease")
         file("build/modules/main/release/${lib.moduleName}.swiftmodule").assertIsFile()
-        sharedLibrary("build/lib/main/release/${lib.moduleName}" ).assertExists()
-        sharedLibrary("build/lib/main/release/${lib.moduleName}" ).assertHasStrippedDebugSymbolsFor(lib.sourceFileNames)
+        sharedLibrary("build/lib/main/release/${lib.moduleName}").assertExists()
+        sharedLibrary("build/lib/main/release/${lib.moduleName}").assertHasStrippedDebugSymbolsFor(lib.sourceFileNames)
     }
 
     def "can use link file as task dependency"() {
@@ -114,7 +122,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         expect:
         succeeds "assembleLinkDebug"
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assembleLinkDebug")
-        sharedLibrary("build/lib/main/debug/${lib.moduleName}" ).assertExists()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
     def "can use runtime file as task dependency"() {
@@ -135,7 +143,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         expect:
         succeeds "assembleRuntimeDebug"
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assembleRuntimeDebug")
-        sharedLibrary("build/lib/main/debug/${lib.moduleName}" ).assertExists()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
     def "can use objects as task dependency"() {
@@ -157,7 +165,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         succeeds "compileDebug"
         result.assertTasksExecuted(":compileDebugSwift", ":compileDebug")
         objectFiles(lib)*.assertExists()
-        sharedLibrary("build/lib/main/debug/${lib.moduleName}" ).assertDoesNotExist()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertDoesNotExist()
     }
 
     def "build logic can change source layout convention"() {
@@ -179,7 +187,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         expect:
         succeeds "assemble"
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assemble")
-        sharedLibrary("build/lib/main/debug/${lib.moduleName}" ).assertExists()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
     def "build logic can add individual source files"() {
@@ -204,7 +212,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         expect:
         succeeds "assemble"
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assemble")
-        sharedLibrary("build/lib/main/debug/${lib.moduleName}" ).assertExists()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
     def "build logic can change buildDir"() {
@@ -269,7 +277,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
         succeeds "assemble"
         result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":assemble")
         file("build/modules/main/debug/${lib.moduleName}.swiftmodule").assertExists()
-        sharedLibrary("build/lib/main/debug/${lib.moduleName}" ).assertExists()
+        sharedLibrary("build/lib/main/debug/${lib.moduleName}").assertExists()
     }
 
     def "can compile and link against another library"() {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftStaticLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftStaticLibraryLinkageIntegrationTest.groovy
@@ -64,6 +64,35 @@ class SwiftStaticLibraryLinkageIntegrationTest extends AbstractSwiftIntegrationT
         staticLibrary('build/lib/main/debug/Foo').assertExists()
     }
 
+    def "can create debug and release variants"() {
+        def library = new SwiftLib()
+        buildFile << """
+            apply plugin: 'swift-library'
+
+            library {
+                linkage = [Linkage.STATIC]
+            }
+        """
+        settingsFile << """
+            rootProject.name = 'foo'
+        """
+        library.writeToProject(testDirectory)
+
+        when:
+        succeeds('assembleDebug')
+
+        then:
+        result.assertTasksExecuted(':compileDebugSwift', ':createDebug', ':assembleDebug')
+        staticLibrary('build/lib/main/debug/Foo').assertExists()
+
+        when:
+        succeeds('assembleRelease')
+
+        then:
+        result.assertTasksExecuted(':compileReleaseSwift', ':createRelease', ':assembleRelease')
+        staticLibrary('build/lib/main/release/Foo').assertExists()
+    }
+
     def "can use link file as task dependency"() {
         given:
         def lib = new SwiftLib()

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
@@ -35,8 +35,7 @@ import java.util.Set;
 @Incubating
 public interface BinaryCollection<T extends SoftwareComponent> {
     /**
-     * Returns a {@link BinaryProvider} that contains the single binary matching the specified type and specification. The binary will be in the finalized state.
-     * The provider can be used to apply configuration to the element before it is finalized.
+     * Returns a {@link BinaryProvider} that contains the single binary matching the specified type and specification. The binary will be in the finalized state. The provider can be used to apply configuration to the element before it is finalized.
      *
      * <p>Querying the return value will fail when there is not exactly one matching binary.
      *
@@ -48,8 +47,7 @@ public interface BinaryCollection<T extends SoftwareComponent> {
     <S> BinaryProvider<S> get(Class<S> type, Spec<? super S> spec);
 
     /**
-     * Returns a {@link BinaryProvider} that contains the single binary with the given name. The binary will be in the finalized state.
-     * The provider can be used to apply configuration to the element before it is finalized.
+     * Returns a {@link BinaryProvider} that contains the single binary with the given name. The binary will be in the finalized state. The provider can be used to apply configuration to the element before it is finalized.
      *
      * <p>Querying the return value will fail when there is not exactly one matching binary.
      *
@@ -59,8 +57,7 @@ public interface BinaryCollection<T extends SoftwareComponent> {
     BinaryProvider<T> getByName(String name);
 
     /**
-     * Returns a {@link Provider} that contains the single binary matching the given specification. The binary will be in the finalized state.
-     * The provider can be used to apply configuration to the element before it is finalized.
+     * Returns a {@link Provider} that contains the single binary matching the given specification. The binary will be in the finalized state. The provider can be used to apply configuration to the element before it is finalized.
      *
      * <p>Querying the return value will fail when there is not exactly one matching binary.
      *
@@ -70,25 +67,49 @@ public interface BinaryCollection<T extends SoftwareComponent> {
     BinaryProvider<T> get(Spec<? super T> spec);
 
     /**
-     * Registers an action to execute when an element becomes known. The action is executed for those elements that are required. Fails if any element has already been finalized.
+     * Registers an action to execute when an element becomes known. The action is only executed for those elements that are required. Fails if any element has already been finalized.
      *
      * @param action The action to execute for each element becomes known.
      */
     void whenElementKnown(Action<? super T> action);
 
     /**
-     * Registers an action to execute when an element is finalized. The action is executed for those elements that are required. Fails if any element has already been finalized.
+     * Registers an action to execute when an element of the given type becomes known. The action is only executed for those elements that are required. Fails if any element has already been finalized.
+     *
+     * @param type The type of element to select.
+     * @param action The action to execute for each element becomes known.
+     */
+    <S> void whenElementKnown(Class<S> type, Action<? super S> action);
+
+    /**
+     * Registers an action to execute when an element is finalized. The action is only executed for those elements that are required. Fails if any element has already been finalized.
      *
      * @param action The action to execute for each element when finalized.
      */
     void whenElementFinalized(Action<? super T> action);
 
     /**
-     * Registers an action to execute to configure each elements in the collection. The action is executed for those elements that are required. Fails if any element has already been finalized.
+     * Registers an action to execute when an element of the given type is finalized. The action is only executed for those elements that are required. Fails if any element has already been finalized.
+     *
+     * @param type The type of element to select.
+     * @param action The action to execute for each element when finalized.
+     */
+    <S> void whenElementFinalized(Class<S> type, Action<? super S> action);
+
+    /**
+     * Registers an action to execute to configure each element in the collection. The action is only executed for those elements that are required. Fails if any element has already been finalized.
      *
      * @param action The action to execute on each element for configuration.
      */
     void configureEach(Action<? super T> action);
+
+    /**
+     * Registers an action to execute to configure each element of the given type in the collection. The action is only executed for those elements that are required. Fails if any element has already been finalized.
+     *
+     * @param type The type of element to select.
+     * @param action The action to execute on each element for configuration.
+     */
+    <S> void configureEach(Class<S> type, Action<? super S> action);
 
     /**
      * Returns the set of binaries from this collection. Elements are in a finalized state.

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * @since 4.5
  */
 @Incubating
-public interface BinaryContainer<T extends SoftwareComponent> {
+public interface BinaryCollection<T extends SoftwareComponent> {
     /**
      * Returns a {@link BinaryProvider} that contains the single binary matching the specified type and specification. The binary will be in the finalized state.
      * The provider can be used to apply configuration to the element before it is finalized.

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryContainer.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryContainer.java
@@ -33,9 +33,9 @@ import java.util.Set;
  * @since 4.5
  */
 @Incubating
-public interface NativeBinaryContainer<T extends SoftwareComponent> {
+public interface BinaryContainer<T extends SoftwareComponent> {
     /**
-     * Returns a {@link NativeBinaryProvider} that contains the single binary matching the specified type and specification. The binary will be in the finalized state.
+     * Returns a {@link BinaryProvider} that contains the single binary matching the specified type and specification. The binary will be in the finalized state.
      * The provider can be used to apply configuration to the element before it is finalized.
      *
      * <p>Querying the return value will fail when there is not exactly one matching binary.
@@ -45,10 +45,10 @@ public interface NativeBinaryContainer<T extends SoftwareComponent> {
      * @param <S> type of the binary to return
      * @return a binary from the collection in a finalized state
      */
-    <S> NativeBinaryProvider<S> get(Class<S> type, Spec<? super S> spec);
+    <S> BinaryProvider<S> get(Class<S> type, Spec<? super S> spec);
 
     /**
-     * Returns a {@link NativeBinaryProvider} that contains the single binary with the given name. The binary will be in the finalized state.
+     * Returns a {@link BinaryProvider} that contains the single binary with the given name. The binary will be in the finalized state.
      * The provider can be used to apply configuration to the element before it is finalized.
      *
      * <p>Querying the return value will fail when there is not exactly one matching binary.
@@ -56,7 +56,7 @@ public interface NativeBinaryContainer<T extends SoftwareComponent> {
      * @param name The name of the binary
      * @return a binary from the collection in a finalized state
      */
-    NativeBinaryProvider<T> getByName(String name);
+    BinaryProvider<T> getByName(String name);
 
     /**
      * Returns a {@link Provider} that contains the single binary matching the given specification. The binary will be in the finalized state.
@@ -67,7 +67,7 @@ public interface NativeBinaryContainer<T extends SoftwareComponent> {
      * @param spec specification to satisfy. The spec is applied to each binary prior to configuration.
      * @return a binary from the collection in a finalized state
      */
-    NativeBinaryProvider<T> get(Spec<? super T> spec);
+    BinaryProvider<T> get(Spec<? super T> spec);
 
     /**
      * Registers an action to execute when an element becomes known. The action is executed for those elements that are required. Fails if any element has already been finalized.

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryProvider.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryProvider.java
@@ -16,22 +16,20 @@
 
 package org.gradle.language;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 
 /**
- * Represents a component whose output requires installation prior to execution.
+ * Represents a binary that is created and configured as required.
  *
  * @since 4.5
+ * @param <T> The type of binary.
  */
 @Incubating
-public interface ComponentWithInstallation extends SoftwareComponent {
+public interface BinaryProvider<T> extends Provider<T> {
     /**
-     * Returns the installation directory for this component.
-     *
-     * @since 4.5
+     * Registers an action to execute to configure the binary. The action is executed when the element is required.
      */
-    Provider<Directory> getInstallDirectory();
+    void configure(Action<? super T> action);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithBinaries.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithBinaries.java
@@ -29,5 +29,5 @@ public interface ComponentWithBinaries extends SoftwareComponent {
     /**
      * Returns the binaries of this component.
      */
-    NativeBinaryContainer<? extends SoftwareComponent> getBinaries();
+    BinaryContainer<? extends SoftwareComponent> getBinaries();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithBinaries.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithBinaries.java
@@ -29,5 +29,5 @@ public interface ComponentWithBinaries extends SoftwareComponent {
     /**
      * Returns the binaries of this component.
      */
-    BinaryContainer<? extends SoftwareComponent> getBinaries();
+    BinaryCollection<? extends SoftwareComponent> getBinaries();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithOutputs.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithOutputs.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradle.language.nativeplatform;
+package org.gradle.language;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.provider.Provider;
+import org.gradle.api.file.FileCollection;
 
 /**
- * Represents a native component whose output includes a file to be used at link time.
+ * Represents a component with output files.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithLinkFile extends SoftwareComponent {
-    /**
-     * Returns the link file of this component.
-     */
-    Provider<RegularFile> getLinkFile();
+public interface ComponentWithOutputs extends SoftwareComponent {
+    FileCollection getOutputs();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -43,18 +43,6 @@ public interface CppBinary extends ComponentWithObjectFiles {
     Attribute<Boolean> OPTIMIZED_ATTRIBUTE = Attribute.of("org.gradle.native.optimized", Boolean.class);
 
     /**
-     * Returns true if this binary has debugging enabled.
-     */
-    boolean isDebuggable();
-
-    /**
-     * Returns true if this binary is optimized.
-     *
-     * @since 4.5
-     */
-    boolean isOptimized();
-
-    /**
      * Returns the C++ source files of this binary.
      */
     FileCollection getCppSource();

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -18,11 +18,10 @@ package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.tasks.CppCompile;
-import org.gradle.nativeplatform.toolchain.NativeToolChain;
+import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 
 /**
  * A binary built from C++ source and linked from the resulting object files.
@@ -30,7 +29,7 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
  * @since 4.2
  */
 @Incubating
-public interface CppBinary extends SoftwareComponent {
+public interface CppBinary extends ComponentWithObjectFiles {
     /**
      * The dependency resolution attribute use to indicate whether a binary is debuggable or not.
      */
@@ -42,11 +41,6 @@ public interface CppBinary extends SoftwareComponent {
      * @since 4.5
      */
     Attribute<Boolean> OPTIMIZED_ATTRIBUTE = Attribute.of("org.gradle.native.optimized", Boolean.class);
-
-    /**
-     * Returns the base name of the binary. This is used to calculate output file names.
-     */
-    Provider<String> getBaseName();
 
     /**
      * Returns true if this binary has debugging enabled.
@@ -81,25 +75,9 @@ public interface CppBinary extends SoftwareComponent {
     FileCollection getRuntimeLibraries();
 
     /**
-     * Returns the object files created for this binary.
-     *
-     * @since 4.4
-     */
-    FileCollection getObjects();
-
-    /**
-     * Returns the target platform for this binary.
-     *
-     * @since 4.5
+     * {@inheritDoc}
      */
     CppPlatform getTargetPlatform();
-
-    /**
-     * Returns the tool chain for this binary.
-     *
-     * @since 4.5
-     */
-    NativeToolChain getToolChain();
 
     /**
      * Returns the compile task for this binary.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.tasks.CppCompile;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
+import org.gradle.nativeplatform.Linkage;
 
 /**
  * A binary built from C++ source and linked from the resulting object files.
@@ -41,6 +42,13 @@ public interface CppBinary extends ComponentWithObjectFiles {
      * @since 4.5
      */
     Attribute<Boolean> OPTIMIZED_ATTRIBUTE = Attribute.of("org.gradle.native.optimized", Boolean.class);
+
+    /**
+     * The dependency resolution attribute use to indicate which linkage a binary uses.
+     *
+     * @since 4.5
+     */
+    Attribute<Linkage> LINKAGE_ATTRIBUTE = Attribute.of("org.gradle.native.linkage", Linkage.class);
 
     /**
      * Returns the C++ source files of this binary.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -76,6 +76,8 @@ public interface CppBinary extends ComponentWithObjectFiles {
 
     /**
      * {@inheritDoc}
+     *
+     * @since 4.5
      */
     CppPlatform getTargetPlatform();
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -43,9 +43,8 @@ public interface CppBinary extends SoftwareComponent {
      */
     Attribute<Boolean> OPTIMIZED_ATTRIBUTE = Attribute.of("org.gradle.native.optimized", Boolean.class);
 
-
     /**
-     * Returns the base name of the binary.
+     * Returns the base name of the binary. This is used to calculate output file names.
      */
     Provider<String> getBaseName();
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
@@ -24,7 +24,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
 import org.gradle.language.ComponentWithBinaries;
-import org.gradle.language.BinaryContainer;
+import org.gradle.language.BinaryCollection;
 
 /**
  * Configuration for a C++ component, such as a library or executable, defining the source files and private header directories that make up the component. Private headers are those that are visible only to the source files of the component.
@@ -91,5 +91,5 @@ public interface CppComponent extends ComponentWithBinaries {
      *
      * @since 4.5
      */
-    BinaryContainer<? extends CppBinary> getBinaries();
+    BinaryCollection<? extends CppBinary> getBinaries();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
@@ -24,7 +24,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
 import org.gradle.language.ComponentWithBinaries;
-import org.gradle.language.NativeBinaryContainer;
+import org.gradle.language.BinaryContainer;
 
 /**
  * Configuration for a C++ component, such as a library or executable, defining the source files and private header directories that make up the component. Private headers are those that are visible only to the source files of the component.
@@ -91,5 +91,5 @@ public interface CppComponent extends ComponentWithBinaries {
      *
      * @since 4.5
      */
-    NativeBinaryContainer<? extends CppBinary> getBinaries();
+    BinaryContainer<? extends CppBinary> getBinaries();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
@@ -19,7 +19,7 @@ package org.gradle.language.cpp;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.ComponentWithInstallation;
+import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
@@ -17,12 +17,9 @@
 package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithExecutable;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
-import org.gradle.nativeplatform.tasks.AbstractLinkTask;
-import org.gradle.nativeplatform.tasks.InstallExecutable;
 
 /**
  * An executable built from C++ source.
@@ -30,25 +27,5 @@ import org.gradle.nativeplatform.tasks.InstallExecutable;
  * @since 4.2
  */
 @Incubating
-public interface CppExecutable extends CppBinary, ComponentWithInstallation, ComponentWithOutputs {
-    /**
-     * Returns the executable file for this binary.
-     *
-     * @since 4.4
-     */
-    Provider<RegularFile> getExecutableFile();
-
-    /**
-     * Returns the link task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<? extends AbstractLinkTask> getLinkTask();
-
-    /**
-     * Returns the link task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<InstallExecutable> getInstallTask();
+public interface CppExecutable extends CppBinary, ComponentWithExecutable, ComponentWithInstallation, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
@@ -19,6 +19,7 @@ package org.gradle.language.cpp;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
@@ -29,7 +30,7 @@ import org.gradle.nativeplatform.tasks.InstallExecutable;
  * @since 4.2
  */
 @Incubating
-public interface CppExecutable extends CppBinary, ComponentWithInstallation {
+public interface CppExecutable extends CppBinary, ComponentWithInstallation, ComponentWithOutputs {
     /**
      * Returns the executable file for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
@@ -17,6 +17,8 @@
 package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithExecutable;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
@@ -28,4 +30,10 @@ import org.gradle.language.nativeplatform.ComponentWithInstallation;
  */
 @Incubating
 public interface CppExecutable extends CppBinary, ComponentWithExecutable, ComponentWithInstallation, ComponentWithOutputs {
+    /**
+     * Returns the executable file to use with a debugger for this binary.
+     *
+     * @since 4.5
+     */
+    Provider<RegularFile> getDebuggerExecutableFile();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppSharedLibrary.java
@@ -17,11 +17,8 @@
 package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithLinkFile;
-import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
-import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
 
 /**
  * A shared library built from C++ source.
@@ -29,11 +26,5 @@ import org.gradle.nativeplatform.tasks.AbstractLinkTask;
  * @since 4.2
  */
 @Incubating
-public interface CppSharedLibrary extends CppBinary, ComponentWithLinkFile, ComponentWithRuntimeFile, ComponentWithOutputs {
-    /**
-     * Returns the link task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<? extends AbstractLinkTask> getLinkTask();
+public interface CppSharedLibrary extends CppBinary, ComponentWithSharedLibrary, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppSharedLibrary.java
@@ -18,6 +18,7 @@ package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkFile;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
@@ -28,7 +29,7 @@ import org.gradle.nativeplatform.tasks.AbstractLinkTask;
  * @since 4.2
  */
 @Incubating
-public interface CppSharedLibrary extends CppBinary, ComponentWithLinkFile, ComponentWithRuntimeFile {
+public interface CppSharedLibrary extends CppBinary, ComponentWithLinkFile, ComponentWithRuntimeFile, ComponentWithOutputs {
     /**
      * Returns the link task for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
@@ -17,10 +17,8 @@
 package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithLinkFile;
-import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
+import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
 
 /**
  * A static library built from C++ source.
@@ -28,11 +26,5 @@ import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
  * @since 4.5
  */
 @Incubating
-public interface CppStaticLibrary extends CppBinary, ComponentWithLinkFile, ComponentWithOutputs {
-    /**
-     * Returns the create static library task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<CreateStaticLibrary> getCreateTask();
+public interface CppStaticLibrary extends CppBinary, ComponentWithStaticLibrary, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
@@ -18,7 +18,7 @@ package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.ComponentWithLinkFile;
+import org.gradle.language.nativeplatform.ComponentWithLinkFile;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 
 /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
@@ -18,6 +18,8 @@ package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
 import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
 
 /**
@@ -26,5 +28,5 @@ import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
  * @since 4.5
  */
 @Incubating
-public interface CppStaticLibrary extends CppBinary, ComponentWithStaticLibrary, ComponentWithOutputs {
+public interface CppStaticLibrary extends CppBinary, ComponentWithStaticLibrary, ComponentWithLinkUsage, ComponentWithRuntimeUsage, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
@@ -18,6 +18,7 @@ package org.gradle.language.cpp;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkFile;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 
@@ -27,7 +28,7 @@ import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
  * @since 4.5
  */
 @Incubating
-public interface CppStaticLibrary extends CppBinary, ComponentWithLinkFile {
+public interface CppStaticLibrary extends CppBinary, ComponentWithLinkFile, ComponentWithOutputs {
     /**
      * Returns the create static library task for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
@@ -24,14 +24,16 @@ import org.gradle.api.provider.Property;
 import org.gradle.language.cpp.CppApplication;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
+import org.gradle.language.nativeplatform.PublicationAwareComponent;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultCppApplication extends DefaultCppComponent implements CppApplication {
+public class DefaultCppApplication extends DefaultCppComponent implements CppApplication, PublicationAwareComponent {
     private final ObjectFactory objectFactory;
     private final Property<CppExecutable> developmentBinary;
+    private final MainExecutableVariant mainVariant = new MainExecutableVariant();
 
     @Inject
     public DefaultCppApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations, ConfigurationContainer configurations) {
@@ -44,6 +46,11 @@ public class DefaultCppApplication extends DefaultCppComponent implements CppApp
         DefaultCppExecutable result = objectFactory.newInstance(DefaultCppExecutable.class, getName() + StringUtils.capitalize(nameSuffix), getBaseName(), debuggable, optimized, getCppSource(), getPrivateHeaderDirs(), getImplementationDependencies(), targetPlatform, toolChain, platformToolProvider);
         getBinaries().add(result);
         return result;
+    }
+
+    @Override
+    public MainExecutableVariant getMainPublication() {
+        return mainVariant;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
@@ -24,7 +24,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.language.cpp.CppApplication;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
-import org.gradle.language.nativeplatform.PublicationAwareComponent;
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.tasks.CppCompile;
+import org.gradle.language.internal.DefaultNativeBinary;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
@@ -45,8 +46,7 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public class DefaultCppBinary implements CppBinary {
-    private final String name;
+public class DefaultCppBinary extends DefaultNativeBinary implements CppBinary {
     private final Provider<String> baseName;
     private final boolean debuggable;
     private final boolean optimized;
@@ -63,7 +63,7 @@ public class DefaultCppBinary implements CppBinary {
     private final Configuration implementation;
 
     public DefaultCppBinary(String name, ProjectLayout projectLayout, ObjectFactory objects, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        this.name = name;
+        super(name);
         this.baseName = baseName;
         this.debuggable = debuggable;
         this.optimized = optimized;
@@ -75,22 +75,22 @@ public class DefaultCppBinary implements CppBinary {
         this.implementation = implementation;
         this.compileTaskProperty = objects.property(CppCompile.class);
 
-        Names names = Names.of(name);
+        Names names = getNames();
 
         // TODO - reduce duplication with Swift binary
-        Configuration includePathConfig = configurations.maybeCreate(names.withPrefix("cppCompile"));
+        Configuration includePathConfig = configurations.create(names.withPrefix("cppCompile"));
         includePathConfig.setCanBeConsumed(false);
         includePathConfig.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API));
         includePathConfig.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
         includePathConfig.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, optimized);
 
-        Configuration nativeLink = configurations.maybeCreate(names.withPrefix("nativeLink"));
+        Configuration nativeLink = configurations.create(names.withPrefix("nativeLink"));
         nativeLink.setCanBeConsumed(false);
         nativeLink.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.NATIVE_LINK));
         nativeLink.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
         nativeLink.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, optimized);
 
-        Configuration nativeRuntime = configurations.maybeCreate(names.withPrefix("nativeRuntime"));
+        Configuration nativeRuntime = configurations.create(names.withPrefix("nativeRuntime"));
         nativeRuntime.setCanBeConsumed(false);
         nativeRuntime.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.NATIVE_RUNTIME));
         nativeRuntime.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
@@ -119,11 +119,6 @@ public class DefaultCppBinary implements CppBinary {
     @Inject
     protected NativeDependencyCache getNativeDependencyCache() {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
@@ -60,6 +60,7 @@ public class DefaultCppBinary implements CppBinary {
     private final PlatformToolProvider platformToolProvider;
     private final Configuration includePathConfiguration;
     private final Property<CppCompile> compileTaskProperty;
+    private final Configuration implementation;
 
     public DefaultCppBinary(String name, ProjectLayout projectLayout, ObjectFactory objects, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         this.name = name;
@@ -71,6 +72,7 @@ public class DefaultCppBinary implements CppBinary {
         this.targetPlatform = targetPlatform;
         this.toolChain = toolChain;
         this.platformToolProvider = platformToolProvider;
+        this.implementation = implementation;
         this.compileTaskProperty = objects.property(CppCompile.class);
 
         Names names = Names.of(name);
@@ -157,6 +159,10 @@ public class DefaultCppBinary implements CppBinary {
     @Override
     public FileCollection getRuntimeLibraries() {
         return runtimeLibraries;
+    }
+
+    public Configuration getImplementationDependencies() {
+        return implementation;
     }
 
     public DirectoryProperty getObjectsDir() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
-import org.gradle.language.internal.DefaultBinaryContainer;
+import org.gradle.language.internal.DefaultBinaryCollection;
 import org.gradle.language.nativeplatform.internal.DefaultNativeComponent;
 import org.gradle.language.nativeplatform.internal.Names;
 
@@ -46,7 +46,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     private final Property<String> baseName;
     private final Names names;
     private final Configuration implementation;
-    private final DefaultBinaryContainer<CppBinary> binaries;
+    private final DefaultBinaryCollection<CppBinary> binaries;
 
     @Inject
     public DefaultCppComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory, ConfigurationContainer configurations) {
@@ -63,7 +63,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
 
-        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryContainer.class, CppBinary.class));
+        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryCollection.class, CppBinary.class));
     }
 
     protected Names getNames() {
@@ -127,7 +127,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     }
 
     @Override
-    public DefaultBinaryContainer<CppBinary> getBinaries() {
+    public DefaultBinaryCollection<CppBinary> getBinaries() {
         return binaries;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -30,6 +30,7 @@ import org.gradle.internal.Cast;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.internal.DefaultBinaryCollection;
+import org.gradle.language.nativeplatform.internal.ComponentWithNames;
 import org.gradle.language.nativeplatform.internal.DefaultNativeComponent;
 import org.gradle.language.nativeplatform.internal.Names;
 
@@ -37,7 +38,7 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
-public abstract class DefaultCppComponent extends DefaultNativeComponent implements CppComponent {
+public abstract class DefaultCppComponent extends DefaultNativeComponent implements CppComponent, ComponentWithNames {
     private final FileCollection cppSource;
     private final String name;
     private final FileOperations fileOperations;
@@ -59,14 +60,15 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         baseName = objectFactory.property(String.class);
 
         names = Names.of(name);
-        implementation = configurations.maybeCreate(names.withSuffix("implementation"));
+        implementation = configurations.create(names.withSuffix("implementation"));
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
 
         binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryCollection.class, CppBinary.class));
     }
 
-    protected Names getNames() {
+    @Override
+    public Names getNames() {
         return names;
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
-import org.gradle.language.internal.DefaultNativeBinaryContainer;
+import org.gradle.language.internal.DefaultBinaryContainer;
 import org.gradle.language.nativeplatform.internal.DefaultNativeComponent;
 import org.gradle.language.nativeplatform.internal.Names;
 
@@ -46,7 +46,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     private final Property<String> baseName;
     private final Names names;
     private final Configuration implementation;
-    private final DefaultNativeBinaryContainer<CppBinary> binaries;
+    private final DefaultBinaryContainer<CppBinary> binaries;
 
     @Inject
     public DefaultCppComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory, ConfigurationContainer configurations) {
@@ -63,7 +63,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
 
-        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultNativeBinaryContainer.class, CppBinary.class));
+        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryContainer.class, CppBinary.class));
     }
 
     protected Names getNames() {
@@ -127,7 +127,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     }
 
     @Override
-    public DefaultNativeBinaryContainer<CppBinary> getBinaries() {
+    public DefaultBinaryContainer<CppBinary> getBinaries() {
         return binaries;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -18,10 +18,12 @@ package org.gradle.language.cpp.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -39,14 +41,21 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     private final DirectoryProperty installationDirectory;
     private final Property<InstallExecutable> installTaskProperty;
     private final Property<AbstractLinkTask> linkTaskProperty;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultCppExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultCppExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.executableFile = projectLayout.fileProperty();
         this.installationDirectory = projectLayout.directoryProperty();
         this.linkTaskProperty = objectFactory.property(AbstractLinkTask.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
+        this.outputs = fileOperations.files();
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
@@ -30,18 +31,22 @@ import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
+import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-public class DefaultCppExecutable extends DefaultCppBinary implements CppExecutable, ConfigurableComponentWithExecutable {
+public class DefaultCppExecutable extends DefaultCppBinary implements CppExecutable, ConfigurableComponentWithExecutable, ConfigurableComponentWithRuntimeUsage {
     private final RegularFileProperty executableFile;
     private final DirectoryProperty installationDirectory;
     private final Property<InstallExecutable> installTaskProperty;
     private final Property<LinkExecutable> linkTaskProperty;
+    private final Property<Configuration> runtimeElementsProperty;
     private final ConfigurableFileCollection outputs;
     private final RegularFileProperty debuggerExecutableFile;
 
@@ -53,6 +58,7 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
         this.installationDirectory = projectLayout.directoryProperty();
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
+        this.runtimeElementsProperty = objectFactory.property(Configuration.class);
         this.outputs = fileOperations.files();
     }
 
@@ -84,5 +90,26 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     @Override
     public RegularFileProperty getDebuggerExecutableFile() {
         return debuggerExecutableFile;
+    }
+
+    @Override
+    public Property<Configuration> getRuntimeElements() {
+        return runtimeElementsProperty;
+    }
+
+    @Override
+    public Provider<RegularFile> getRuntimeFile() {
+        return executableFile;
+    }
+
+    @Nullable
+    @Override
+    public Linkage getLinkage() {
+        return null;
+    }
+
+    @Override
+    public boolean hasRuntimeFile() {
+        return true;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -43,11 +43,13 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     private final Property<InstallExecutable> installTaskProperty;
     private final Property<LinkExecutable> linkTaskProperty;
     private final ConfigurableFileCollection outputs;
+    private final RegularFileProperty debuggerExecutableFile;
 
     @Inject
     public DefaultCppExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.executableFile = projectLayout.fileProperty();
+        this.debuggerExecutableFile = projectLayout.fileProperty();
         this.installationDirectory = projectLayout.directoryProperty();
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
@@ -77,5 +79,10 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     @Override
     public Property<LinkExecutable> getLinkTask() {
         return linkTaskProperty;
+    }
+
+    @Override
+    public RegularFileProperty getDebuggerExecutableFile() {
+        return debuggerExecutableFile;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -29,18 +29,19 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
-import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
+import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultCppExecutable extends DefaultCppBinary implements CppExecutable {
+public class DefaultCppExecutable extends DefaultCppBinary implements CppExecutable, ConfigurableComponentWithExecutable {
     private final RegularFileProperty executableFile;
     private final DirectoryProperty installationDirectory;
     private final Property<InstallExecutable> installTaskProperty;
-    private final Property<AbstractLinkTask> linkTaskProperty;
+    private final Property<LinkExecutable> linkTaskProperty;
     private final ConfigurableFileCollection outputs;
 
     @Inject
@@ -48,7 +49,7 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.executableFile = projectLayout.fileProperty();
         this.installationDirectory = projectLayout.directoryProperty();
-        this.linkTaskProperty = objectFactory.property(AbstractLinkTask.class);
+        this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
         this.outputs = fileOperations.files();
     }
@@ -74,7 +75,7 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     }
 
     @Override
-    public Property<AbstractLinkTask> getLinkTask() {
+    public Property<LinkExecutable> getLinkTask() {
         return linkTaskProperty;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -31,19 +32,22 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppLibrary;
 import org.gradle.language.cpp.CppPlatform;
+import org.gradle.language.nativeplatform.PublicationAwareComponent;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary {
+public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary, PublicationAwareComponent {
     private final ObjectFactory objectFactory;
     private final ConfigurableFileCollection publicHeaders;
     private final FileCollection publicHeadersWithConvention;
     private final LockableSetProperty<Linkage> linkage;
     private final Property<CppBinary> developmentBinary;
     private final Configuration api;
+    private final Configuration apiElements;
+    private final MainLibraryVariant mainVariant;
 
     @Inject
     public DefaultCppLibrary(String name, ObjectFactory objectFactory, FileOperations fileOperations, ConfigurationContainer configurations) {
@@ -56,10 +60,19 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         linkage = new LockableSetProperty<Linkage>(objectFactory.setProperty(Linkage.class));
         linkage.add(Linkage.SHARED);
 
-        api = configurations.maybeCreate(getNames().withSuffix("api"));
+        api = configurations.create(getNames().withSuffix("api"));
         api.setCanBeConsumed(false);
         api.setCanBeResolved(false);
         getImplementationDependencies().extendsFrom(api);
+
+        Usage apiUsage = objectFactory.named(Usage.class, Usage.C_PLUS_PLUS_API);
+
+        apiElements = configurations.create(getNames().withSuffix("cppApiElements"));
+        apiElements.extendsFrom(api);
+        apiElements.setCanBeResolved(false);
+        apiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
+
+        mainVariant = new MainLibraryVariant("api", apiUsage, apiElements);
     }
 
     public DefaultCppSharedLibrary addSharedLibrary(String nameSuffix, boolean debuggable, boolean optimized, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
@@ -77,6 +90,15 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
     @Override
     public Configuration getApiDependencies() {
         return api;
+    }
+
+    public Configuration getApiElements() {
+        return apiElements;
+    }
+
+    @Override
+    public MainLibraryVariant getMainPublication() {
+        return mainVariant;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -32,7 +32,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppLibrary;
 import org.gradle.language.cpp.CppPlatform;
-import org.gradle.language.nativeplatform.PublicationAwareComponent;
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -28,17 +28,23 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppSharedLibrary;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithSharedLibrary;
+import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppSharedLibrary, ConfigurableComponentWithSharedLibrary {
+public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppSharedLibrary, ConfigurableComponentWithSharedLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage {
     private final RegularFileProperty linkFile;
     private final RegularFileProperty runtimeFile;
     private final Property<LinkSharedLibrary> linkTaskProperty;
+    private final Property<Configuration> linkElements;
+    private final Property<Configuration> runtimeElements;
     private final ConfigurableFileCollection outputs;
 
     @Inject
@@ -47,6 +53,8 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
         this.linkFile = projectLayout.fileProperty();
         this.runtimeFile = projectLayout.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
+        this.linkElements = objectFactory.property(Configuration.class);
+        this.runtimeElements = objectFactory.property(Configuration.class);
         this.outputs = fileOperations.files();
     }
 
@@ -68,5 +76,26 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     @Override
     public Property<LinkSharedLibrary> getLinkTask() {
         return linkTaskProperty;
+    }
+
+    @Override
+    public Property<Configuration> getLinkElements() {
+        return linkElements;
+    }
+
+    @Override
+    public Property<Configuration> getRuntimeElements() {
+        return runtimeElements;
+    }
+
+    @Nullable
+    @Override
+    public Linkage getLinkage() {
+        return Linkage.SHARED;
+    }
+
+    @Override
+    public boolean hasRuntimeFile() {
+        return true;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -18,9 +18,11 @@ package org.gradle.language.cpp.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -36,13 +38,20 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     private final RegularFileProperty linkFile;
     private final RegularFileProperty runtimeFile;
     private final Property<AbstractLinkTask> linkTaskProperty;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultCppSharedLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultCppSharedLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.linkFile = projectLayout.fileProperty();
         this.runtimeFile = projectLayout.fileProperty();
         this.linkTaskProperty = objectFactory.property(AbstractLinkTask.class);
+        this.outputs = fileOperations.files();
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -28,13 +28,14 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppSharedLibrary;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithSharedLibrary;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppSharedLibrary {
+public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppSharedLibrary, ConfigurableComponentWithSharedLibrary {
     private final RegularFileProperty linkFile;
     private final RegularFileProperty runtimeFile;
     private final Property<LinkSharedLibrary> linkTaskProperty;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -28,7 +28,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppSharedLibrary;
-import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
@@ -37,7 +37,7 @@ import javax.inject.Inject;
 public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppSharedLibrary {
     private final RegularFileProperty linkFile;
     private final RegularFileProperty runtimeFile;
-    private final Property<AbstractLinkTask> linkTaskProperty;
+    private final Property<LinkSharedLibrary> linkTaskProperty;
     private final ConfigurableFileCollection outputs;
 
     @Inject
@@ -45,7 +45,7 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.linkFile = projectLayout.fileProperty();
         this.runtimeFile = projectLayout.fileProperty();
-        this.linkTaskProperty = objectFactory.property(AbstractLinkTask.class);
+        this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
         this.outputs = fileOperations.files();
     }
 
@@ -65,7 +65,7 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     }
 
     @Override
-    public Property<AbstractLinkTask> getLinkTask() {
+    public Property<LinkSharedLibrary> getLinkTask() {
         return linkTaskProperty;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -28,13 +28,14 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppStaticLibrary;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithStaticLibrary;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStaticLibrary {
+public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStaticLibrary, ConfigurableComponentWithStaticLibrary {
     private final RegularFileProperty linkFile;
     private final Property<CreateStaticLibrary> createTaskProperty;
     private final ConfigurableFileCollection outputs;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -18,9 +18,11 @@ package org.gradle.language.cpp.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -35,12 +37,19 @@ import javax.inject.Inject;
 public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStaticLibrary {
     private final RegularFileProperty linkFile;
     private final Property<CreateStaticLibrary> createTaskProperty;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultCppStaticLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultCppStaticLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.linkFile = projectLayout.fileProperty();
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
+        this.outputs = fileOperations.files();
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -21,23 +21,31 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppStaticLibrary;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithStaticLibrary;
+import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStaticLibrary, ConfigurableComponentWithStaticLibrary {
+public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStaticLibrary, ConfigurableComponentWithStaticLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage {
     private final RegularFileProperty linkFile;
     private final Property<CreateStaticLibrary> createTaskProperty;
+    private final Property<Configuration> linkElements;
+    private final Property<Configuration> runtimeElements;
     private final ConfigurableFileCollection outputs;
 
     @Inject
@@ -45,6 +53,8 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
         super(name, projectLayout, objectFactory, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.linkFile = projectLayout.fileProperty();
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
+        this.linkElements = objectFactory.property(Configuration.class);
+        this.runtimeElements = objectFactory.property(Configuration.class);
         this.outputs = fileOperations.files();
     }
 
@@ -61,5 +71,31 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
     @Override
     public Property<CreateStaticLibrary> getCreateTask() {
         return createTaskProperty;
+    }
+
+    @Override
+    public Property<Configuration> getLinkElements() {
+        return linkElements;
+    }
+
+    @Override
+    public Property<Configuration> getRuntimeElements() {
+        return runtimeElements;
+    }
+
+    @Nullable
+    @Override
+    public Linkage getLinkage() {
+        return Linkage.STATIC;
+    }
+
+    @Override
+    public boolean hasRuntimeFile() {
+        return false;
+    }
+
+    @Override
+    public Provider<RegularFile> getRuntimeFile() {
+        return Providers.notDefined();
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -26,19 +26,19 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class MainLibraryVariant implements ComponentWithVariants, SoftwareComponentInternal {
     private final Set<SoftwareComponent> variants = new HashSet<SoftwareComponent>();
     private final String name;
     private final Usage usage;
-    private final Set<? extends PublishArtifact> artifacts;
+    private final Set<PublishArtifact> artifacts = new LinkedHashSet<PublishArtifact>();
     private final Configuration dependencies;
 
-    public MainLibraryVariant(String name, Usage usage, Set<? extends PublishArtifact> artifacts, Configuration dependencies) {
+    public MainLibraryVariant(String name, Usage usage, Configuration dependencies) {
         this.name = name;
         this.usage = usage;
-        this.artifacts = artifacts;
         this.dependencies = dependencies;
     }
 
@@ -55,6 +55,10 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
     @Override
     public Set<? extends SoftwareComponent> getVariants() {
         return variants;
+    }
+
+    public void addArtifact(PublishArtifact artifact) {
+        artifacts.add(artifact);
     }
 
     /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
@@ -41,9 +41,6 @@ import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 
 import javax.inject.Inject;
 
-import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
-import static org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE;
-
 /**
  * <p>A plugin that produces a native application from C++ source.</p>
  *
@@ -90,25 +87,10 @@ public class CppApplicationPlugin implements Plugin<ProjectInternal> {
                 // Use the debug variant as the development binary
                 application.getDevelopmentBinary().set(debugExecutable);
 
-                // TODO - add lifecycle tasks to assemble each variant
-
                 final Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
 
-                final Configuration debugRuntimeElements = configurations.maybeCreate("debugRuntimeElements");
-                debugRuntimeElements.extendsFrom(application.getImplementationDependencies());
-                debugRuntimeElements.setCanBeResolved(false);
-                debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
-                debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugExecutable.isDebuggable());
-                debugRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugExecutable.isOptimized());
-                debugRuntimeElements.getOutgoing().artifact(debugExecutable.getExecutableFile());
-
-                final Configuration releaseRuntimeElements = configurations.maybeCreate("releaseRuntimeElements");
-                releaseRuntimeElements.extendsFrom(application.getImplementationDependencies());
-                releaseRuntimeElements.setCanBeResolved(false);
-                releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
-                releaseRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseExecutable.isDebuggable());
-                releaseRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseExecutable.isOptimized());
-                releaseRuntimeElements.getOutgoing().artifact(releaseExecutable.getExecutableFile());
+                Configuration debugRuntimeElements = debugExecutable.getRuntimeElements().get();
+                Configuration releaseRuntimeElements = releaseExecutable.getRuntimeElements().get();
 
                 final MainExecutableVariant mainVariant = new MainExecutableVariant();
                 NativeVariant debugVariant = new NativeVariant("debug", runtimeUsage, debugRuntimeElements.getAllArtifacts(), debugRuntimeElements);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -31,17 +31,14 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppSharedLibrary;
-import org.gradle.language.cpp.CppStaticLibrary;
 import org.gradle.language.cpp.internal.DefaultCppBinary;
 import org.gradle.language.cpp.internal.DefaultCppExecutable;
 import org.gradle.language.cpp.internal.DefaultCppSharedLibrary;
-import org.gradle.language.cpp.internal.DefaultCppStaticLibrary;
 import org.gradle.language.cpp.tasks.CppCompile;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.plugins.NativeBasePlugin;
 import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
-import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 import org.gradle.nativeplatform.tasks.ExtractSymbols;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
@@ -222,27 +219,6 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
                     library.getRuntimeFile().set(runtimeFile);
                     library.getOutputs().from(library.getLinkFile());
                     library.getOutputs().from(library.getRuntimeFile());
-                } else if (binary instanceof CppStaticLibrary) {
-                    DefaultCppStaticLibrary library = (DefaultCppStaticLibrary) binary;
-
-                    final PlatformToolProvider toolProvider = library.getPlatformToolProvider();
-
-                    // Add a link task
-                    final CreateStaticLibrary link = tasks.create(names.getTaskName("create"), CreateStaticLibrary.class);
-                    link.source(binary.getObjects());
-                    Provider<RegularFile> runtimeFile = buildDirectory.file(providers.provider(new Callable<String>() {
-                        @Override
-                        public String call() {
-                            return toolProvider.getStaticLibraryName("lib/" + names.getDirName() + binary.getBaseName().get());
-                        }
-                    }));
-                    link.setOutputFile(runtimeFile);
-                    link.setTargetPlatform(currentPlatform);
-                    link.setToolChain(toolChain);
-
-                    library.getLinkFile().set(link.getBinaryFile());
-                    library.getCreateTask().set(link);
-                    library.getOutputs().from(library.getLinkFile());
                 }
             }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -63,7 +63,7 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
         project.getComponents().withType(DefaultCppBinary.class, new Action<DefaultCppBinary>() {
             @Override
             public void execute(final DefaultCppBinary binary) {
-                final Names names = Names.of(binary.getName());
+                final Names names = binary.getNames();
 
                 String language = "cpp";
                 final NativePlatform currentPlatform = binary.getTargetPlatform();

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -24,14 +24,12 @@ import org.gradle.api.Plugin;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
-import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppSharedLibrary;
 import org.gradle.language.cpp.internal.DefaultCppBinary;
 import org.gradle.language.cpp.tasks.CppCompile;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.plugins.NativeBasePlugin;
 import org.gradle.nativeplatform.platform.NativePlatform;
-import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import org.gradle.nativeplatform.toolchain.internal.SystemIncludesAwarePlatformToolProvider;
@@ -84,18 +82,6 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
                 };
 
                 CppCompile compile = tasks.create(names.getCompileTaskName(language), CppCompile.class);
-                configureCompile(compile, binary, currentPlatform, toolChain, systemIncludes);
-                compile.getObjectFileDir().set(buildDirectory.dir("obj/" + names.getDirName()));
-
-                binary.getObjectsDir().set(compile.getObjectFileDir());
-                binary.getCompileTask().set(compile);
-
-                if (binary instanceof CppSharedLibrary) {
-                    compile.setPositionIndependentCode(true);
-                }
-            }
-
-            private void configureCompile(CppCompile compile, CppBinary binary, NativePlatform currentPlatform, NativeToolChain toolChain, Callable<List<File>> systemIncludes) {
                 compile.includes(binary.getCompileIncludePath());
                 compile.includes(systemIncludes);
                 compile.source(binary.getCppSource());
@@ -107,6 +93,16 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
                 }
                 compile.setTargetPlatform(currentPlatform);
                 compile.setToolChain(toolChain);
+                compile.getObjectFileDir().set(buildDirectory.dir("obj/" + names.getDirName()));
+
+                binary.getObjectsDir().set(compile.getObjectFileDir());
+                binary.getCompileTask().set(compile);
+            }
+        });
+        project.getComponents().withType(CppSharedLibrary.class, new Action<CppSharedLibrary>() {
+            @Override
+            public void execute(CppSharedLibrary library) {
+                library.getCompileTask().get().setPositionIndependentCode(true);
             }
         });
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -53,9 +53,6 @@ import java.io.File;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
-import static org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE;
-
 /**
  * <p>A plugin that produces a native library from C++ source.</p>
  *
@@ -134,8 +131,6 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                 });
                 apiElements.getOutgoing().artifact(publicHeaders);
 
-                // TODO - add lifecycle tasks
-                // TODO - extract some common code to setup the configurations
                 if (sharedLibs) {
                     String linkageNameSuffix = staticLibs ? "Shared" : "";
                     CppSharedLibrary debugSharedLibrary = library.addSharedLibrary("debug" + linkageNameSuffix, true, false, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
@@ -145,38 +140,10 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                     library.getDevelopmentBinary().set(debugSharedLibrary);
 
                     // Define the outgoing artifacts
-                    // TODO - move this to the base plugin
-                    final Configuration debugLinkElements = configurations.maybeCreate("debugLinkElements");
-                    debugLinkElements.extendsFrom(implementation);
-                    debugLinkElements.setCanBeResolved(false);
-                    debugLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
-                    debugLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugSharedLibrary.isDebuggable());
-                    debugLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugSharedLibrary.isOptimized());
-                    debugLinkElements.getOutgoing().artifact(debugSharedLibrary.getLinkFile());
-
-                    final Configuration debugRuntimeElements = configurations.maybeCreate("debugRuntimeElements");
-                    debugRuntimeElements.extendsFrom(implementation);
-                    debugRuntimeElements.setCanBeResolved(false);
-                    debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
-                    debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugSharedLibrary.isDebuggable());
-                    debugRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugSharedLibrary.isOptimized());
-                    debugRuntimeElements.getOutgoing().artifact(debugSharedLibrary.getRuntimeFile());
-
-                    final Configuration releaseLinkElements = configurations.maybeCreate("releaseLinkElements");
-                    releaseLinkElements.extendsFrom(implementation);
-                    releaseLinkElements.setCanBeResolved(false);
-                    releaseLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
-                    releaseLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseSharedLibrary.isDebuggable());
-                    releaseLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseSharedLibrary.isOptimized());
-                    releaseLinkElements.getOutgoing().artifact(releaseSharedLibrary.getLinkFile());
-
-                    final Configuration releaseRuntimeElements = configurations.maybeCreate("releaseRuntimeElements");
-                    releaseRuntimeElements.extendsFrom(implementation);
-                    releaseRuntimeElements.setCanBeResolved(false);
-                    releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
-                    releaseRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseSharedLibrary.isDebuggable());
-                    releaseRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseSharedLibrary.isOptimized());
-                    releaseRuntimeElements.getOutgoing().artifact(releaseSharedLibrary.getRuntimeFile());
+                    final Configuration debugLinkElements = debugSharedLibrary.getLinkElements().get();
+                    final Configuration debugRuntimeElements = debugSharedLibrary.getRuntimeElements().get();
+                    final Configuration releaseLinkElements = releaseSharedLibrary.getLinkElements().get();
+                    final Configuration releaseRuntimeElements = releaseSharedLibrary.getRuntimeElements().get();
 
                     project.getPluginManager().withPlugin("maven-publish", new Action<AppliedPlugin>() {
                         @Override
@@ -235,38 +202,6 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                     if (!sharedLibs) {
                         // Use the debug static library as the development binary
                         library.getDevelopmentBinary().set(debugStaticLibrary);
-
-                        // Define the outgoing artifacts
-                        // TODO - move this to the base plugin
-                        final Configuration debugLinkElements = configurations.maybeCreate("debugStaticLinkElements");
-                        debugLinkElements.extendsFrom(implementation);
-                        debugLinkElements.setCanBeResolved(false);
-                        debugLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
-                        debugLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugStaticLibrary.isDebuggable());
-                        debugLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugStaticLibrary.isOptimized());
-                        debugLinkElements.getOutgoing().artifact(debugStaticLibrary.getLinkFile());
-
-                        final Configuration debugRuntimeElements = configurations.maybeCreate("debugStaticRuntimeElements");
-                        debugRuntimeElements.extendsFrom(implementation);
-                        debugRuntimeElements.setCanBeResolved(false);
-                        debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
-                        debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugStaticLibrary.isDebuggable());
-                        debugRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugStaticLibrary.isOptimized());
-
-                        final Configuration releaseLinkElements = configurations.maybeCreate("releaseStaticLinkElements");
-                        releaseLinkElements.extendsFrom(implementation);
-                        releaseLinkElements.setCanBeResolved(false);
-                        releaseLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
-                        releaseLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseStaticLibrary.isDebuggable());
-                        releaseLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseStaticLibrary.isOptimized());
-                        releaseLinkElements.getOutgoing().artifact(releaseStaticLibrary.getLinkFile());
-
-                        final Configuration releaseRuntimeElements = configurations.maybeCreate("releaseStaticRuntimeElements");
-                        releaseRuntimeElements.extendsFrom(implementation);
-                        releaseRuntimeElements.setCanBeResolved(false);
-                        releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
-                        releaseRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseStaticLibrary.isDebuggable());
-                        releaseRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseStaticLibrary.isOptimized());
                     }
                 }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.provider.AbstractProvider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.ImmutableActionSet;
-import org.gradle.language.BinaryContainer;
+import org.gradle.language.BinaryCollection;
 import org.gradle.language.BinaryProvider;
 import org.gradle.util.ConfigureUtil;
 
@@ -37,7 +37,7 @@ import java.util.Set;
 
 // TODO - error messages
 // TODO - display names for this container and the Provider implementations
-public class DefaultBinaryContainer<T extends SoftwareComponent> implements BinaryContainer<T> {
+public class DefaultBinaryCollection<T extends SoftwareComponent> implements BinaryCollection<T> {
     private enum State {
         Collecting, Realizing, Finalized
     }
@@ -52,7 +52,7 @@ public class DefaultBinaryContainer<T extends SoftwareComponent> implements Bina
     private ImmutableActionSet<T> finalizeActions = ImmutableActionSet.empty();
 
     @Inject
-    public DefaultBinaryContainer(Class<T> elementType, ProviderFactory providerFactory) {
+    public DefaultBinaryCollection(Class<T> elementType, ProviderFactory providerFactory) {
         this.elementType = elementType;
         this.providerFactory = providerFactory;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryContainer.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryContainer.java
@@ -24,8 +24,8 @@ import org.gradle.api.internal.provider.AbstractProvider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.ImmutableActionSet;
-import org.gradle.language.NativeBinaryContainer;
-import org.gradle.language.NativeBinaryProvider;
+import org.gradle.language.BinaryContainer;
+import org.gradle.language.BinaryProvider;
 import org.gradle.util.ConfigureUtil;
 
 import javax.annotation.Nullable;
@@ -37,7 +37,7 @@ import java.util.Set;
 
 // TODO - error messages
 // TODO - display names for this container and the Provider implementations
-public class DefaultNativeBinaryContainer<T extends SoftwareComponent> implements NativeBinaryContainer<T> {
+public class DefaultBinaryContainer<T extends SoftwareComponent> implements BinaryContainer<T> {
     private enum State {
         Collecting, Realizing, Finalized
     }
@@ -52,13 +52,13 @@ public class DefaultNativeBinaryContainer<T extends SoftwareComponent> implement
     private ImmutableActionSet<T> finalizeActions = ImmutableActionSet.empty();
 
     @Inject
-    public DefaultNativeBinaryContainer(Class<T> elementType, ProviderFactory providerFactory) {
+    public DefaultBinaryContainer(Class<T> elementType, ProviderFactory providerFactory) {
         this.elementType = elementType;
         this.providerFactory = providerFactory;
     }
 
     @Override
-    public <S> NativeBinaryProvider<S> get(final Class<S> type, final Spec<? super S> spec) {
+    public <S> BinaryProvider<S> get(final Class<S> type, final Spec<? super S> spec) {
         SingleElementProvider<S> provider = new SingleElementProvider<S>(type, spec);
         if (state == State.Collecting) {
             pending.add(provider);
@@ -69,7 +69,7 @@ public class DefaultNativeBinaryContainer<T extends SoftwareComponent> implement
     }
 
     @Override
-    public NativeBinaryProvider<T> getByName(final String name) {
+    public BinaryProvider<T> getByName(final String name) {
         return get(elementType, new Spec<T>() {
             @Override
             public boolean isSatisfiedBy(T element) {
@@ -79,7 +79,7 @@ public class DefaultNativeBinaryContainer<T extends SoftwareComponent> implement
     }
 
     @Override
-    public NativeBinaryProvider<T> get(Spec<? super T> spec) {
+    public BinaryProvider<T> get(Spec<? super T> spec) {
         return get(elementType, spec);
     }
 
@@ -153,7 +153,7 @@ public class DefaultNativeBinaryContainer<T extends SoftwareComponent> implement
         return ImmutableSet.copyOf(elements);
     }
 
-    private class SingleElementProvider<S> extends AbstractProvider<S> implements NativeBinaryProvider<S> {
+    private class SingleElementProvider<S> extends AbstractProvider<S> implements BinaryProvider<S> {
         private final Class<S> type;
         private Spec<? super S> spec;
         private S match;

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultNativeBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultNativeBinary.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.internal;
+
+import org.gradle.language.nativeplatform.internal.ComponentWithNames;
+import org.gradle.language.nativeplatform.internal.Names;
+
+public class DefaultNativeBinary implements ComponentWithNames {
+    private final String name;
+    private final Names names;
+
+    public DefaultNativeBinary(String name) {
+        this.name = name;
+        this.names = Names.of(name);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Names getNames() {
+        return names;
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithExecutable.java
@@ -17,18 +17,30 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
-import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
+import org.gradle.nativeplatform.tasks.LinkExecutable;
 
 /**
- * Represents a component that produces a static library.
+ * Represents a native component that produces an executable.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithStaticLibrary extends ComponentWithLinkFile {
+public interface ComponentWithExecutable extends ComponentWithNativeRuntime {
     /**
-     * Returns the task to create the static library.
+     * Returns the link libraries to use to link the executable. Includes the link libraries of the component's dependencies.
      */
-    Provider<? extends CreateStaticLibrary> getCreateTask();
+    FileCollection getLinkLibraries();
+
+    /**
+     * Returns the executable file to produce.
+     */
+    Provider<RegularFile> getExecutableFile();
+
+    /**
+     * Returns the link task for the executable.
+     */
+    Provider<? extends LinkExecutable> getLinkTask();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
@@ -22,7 +22,7 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 
 /**
- * Represents a component whose output requires installation prior to execution.
+ * Represents a native component that produces an application installation.
  *
  * @since 4.5
  */

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
@@ -18,7 +18,9 @@ package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.tasks.InstallExecutable;
 
 /**
  * Represents a native component that produces an application installation.
@@ -28,9 +30,17 @@ import org.gradle.api.provider.Provider;
 @Incubating
 public interface ComponentWithInstallation extends ComponentWithNativeRuntime {
     /**
-     * Returns the installation directory for this component.
-     *
-     * @since 4.5
+     * Returns the runtime libraries required for the installation. Includes the runtime libraries of the component's dependencies.
+     */
+    FileCollection getRuntimeLibraries();
+
+    /**
+     * Returns the installation directory.
      */
     Provider<Directory> getInstallDirectory();
+
+    /**
+     * Returns the install task.
+     */
+    Provider<? extends InstallExecutable> getInstallTask();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.language;
+package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 
 /**
- * Represents a native component whose output includes a runtime component.
+ * Represents a component whose output requires installation prior to execution.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithRuntimeFile extends SoftwareComponent {
+public interface ComponentWithInstallation extends SoftwareComponent {
     /**
-     * Returns the main output of this component.
+     * Returns the installation directory for this component.
+     *
+     * @since 4.5
      */
-    Provider<RegularFile> getRuntimeFile();
+    Provider<Directory> getInstallDirectory();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package org.gradle.language;
+package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 
 /**
- * Represents a binary that is created and configured as required.
+ * Represents a native component whose output includes a file to be used at link time.
  *
  * @since 4.5
- * @param <T> The type of binary.
  */
 @Incubating
-public interface NativeBinaryProvider<T> extends Provider<T> {
+public interface ComponentWithLinkFile extends SoftwareComponent {
     /**
-     * Registers an action to execute to configure the binary. The action is executed when the element is required.
+     * Returns the main output of this component.
      */
-    void configure(Action<? super T> action);
+    Provider<RegularFile> getLinkFile();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
@@ -22,7 +22,7 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 
 /**
- * Represents a native component whose output includes a file to be used at link time.
+ * Represents a native component that produces a file to be used at link time.
  *
  * @since 4.5
  */

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
@@ -17,7 +17,6 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 
@@ -27,7 +26,7 @@ import org.gradle.api.provider.Provider;
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithLinkFile extends SoftwareComponent {
+public interface ComponentWithLinkFile extends ComponentWithNativeRuntime {
     /**
      * Returns the link file of this component.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkUsage.java
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp;
+package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
-import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
-import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Provider;
 
 /**
- * A shared library built from C++ source.
+ * Represents a native component whose link time file and dependencies are published for consumption by some other project.
  *
- * @since 4.2
+ * @since 4.5
  */
 @Incubating
-public interface CppSharedLibrary extends CppBinary, ComponentWithSharedLibrary, ComponentWithLinkUsage, ComponentWithRuntimeUsage, ComponentWithOutputs {
+public interface ComponentWithLinkUsage extends ComponentWithNativeRuntime {
+    /**
+     * Returns the outgoing link elements of this component.
+     */
+    Provider<Configuration> getLinkElements();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithNativeRuntime.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithNativeRuntime.java
@@ -17,20 +17,30 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.file.Directory;
+import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
 
 /**
- * Represents a native component that produces an application installation.
+ * Represents a component that produces outputs that run on a native platform.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithInstallation extends ComponentWithNativeRuntime {
+public interface ComponentWithNativeRuntime extends SoftwareComponent {
     /**
-     * Returns the installation directory for this component.
-     *
-     * @since 4.5
+     * Returns the base name of this component. This is used to calculate output file names.
      */
-    Provider<Directory> getInstallDirectory();
+    Provider<String> getBaseName();
+
+    /**
+     * Returns the target platform for this component.
+     */
+    NativePlatform getTargetPlatform();
+
+    /**
+     * Returns the tool chain for this component.
+     */
+    NativeToolChain getToolChain();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithNativeRuntime.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithNativeRuntime.java
@@ -35,6 +35,16 @@ public interface ComponentWithNativeRuntime extends SoftwareComponent {
     Provider<String> getBaseName();
 
     /**
+     * Returns true if this component has debugging enabled.
+     */
+    boolean isDebuggable();
+
+    /**
+     * Returns true if this component is optimized.
+     */
+    boolean isOptimized();
+
+    /**
      * Returns the target platform for this component.
      */
     NativePlatform getTargetPlatform();

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithObjectFiles.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithObjectFiles.java
@@ -17,20 +17,17 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.file.Directory;
-import org.gradle.api.provider.Provider;
+import org.gradle.api.file.FileCollection;
 
 /**
- * Represents a native component that produces an application installation.
+ * Represents a component that produces object files.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithInstallation extends ComponentWithNativeRuntime {
+public interface ComponentWithObjectFiles extends ComponentWithNativeRuntime {
     /**
-     * Returns the installation directory for this component.
-     *
-     * @since 4.5
+     * Returns the object files created for this component.
      */
-    Provider<Directory> getInstallDirectory();
+    FileCollection getObjects();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
@@ -29,7 +29,7 @@ import org.gradle.api.provider.Provider;
 @Incubating
 public interface ComponentWithRuntimeFile extends SoftwareComponent {
     /**
-     * Returns the main output of this component.
+     * Returns the runtime file of this component.
      */
     Provider<RegularFile> getRuntimeFile();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
@@ -17,7 +17,6 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 
@@ -27,7 +26,7 @@ import org.gradle.api.provider.Provider;
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithRuntimeFile extends SoftwareComponent {
+public interface ComponentWithRuntimeFile extends ComponentWithNativeRuntime {
     /**
      * Returns the runtime file of this component.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
@@ -14,25 +14,22 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp;
+package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.nativeplatform.ComponentWithLinkFile;
-import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
-import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 
 /**
- * A shared library built from C++ source.
+ * Represents a native component whose output includes a runtime component.
  *
- * @since 4.2
+ * @since 4.5
  */
 @Incubating
-public interface CppSharedLibrary extends CppBinary, ComponentWithLinkFile, ComponentWithRuntimeFile {
+public interface ComponentWithRuntimeFile extends SoftwareComponent {
     /**
-     * Returns the link task for this binary.
-     *
-     * @since 4.5
+     * Returns the main output of this component.
      */
-    Provider<? extends AbstractLinkTask> getLinkTask();
+    Provider<RegularFile> getRuntimeFile();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeUsage.java
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp;
+package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
-import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
-import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Provider;
 
 /**
- * A shared library built from C++ source.
+ * Represents a native component whose runtime file and dependencies are published for consumption by some other project.
  *
- * @since 4.2
+ * @since 4.5
  */
 @Incubating
-public interface CppSharedLibrary extends CppBinary, ComponentWithSharedLibrary, ComponentWithLinkUsage, ComponentWithRuntimeUsage, ComponentWithOutputs {
+public interface ComponentWithRuntimeUsage extends ComponentWithNativeRuntime {
+    /**
+     * Returns the outgoing runtime elements of this component.
+     */
+    Provider<Configuration> getRuntimeElements();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
@@ -17,19 +17,18 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 
 /**
- * Represents a native component that produces a file to be used at runtime.
+ * Represents a native component that produces a shared library.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithRuntimeFile extends SoftwareComponent {
+public interface ComponentWithSharedLibrary extends ComponentWithLinkFile, ComponentWithRuntimeFile {
     /**
-     * Returns the runtime file of this component.
+     * Returns the link task for this binary.
      */
-    Provider<RegularFile> getRuntimeFile();
+    Provider<? extends LinkSharedLibrary> getLinkTask();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
@@ -29,12 +29,12 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 @Incubating
 public interface ComponentWithSharedLibrary extends ComponentWithLinkFile, ComponentWithRuntimeFile {
     /**
-     * Returns the link libraries to use to link this binary. Includes the link libraries of the component's dependencies.
+     * Returns the link libraries to use to link the shared library. Includes the link libraries of the component's dependencies.
      */
     FileCollection getLinkLibraries();
 
     /**
-     * Returns the link task for this binary.
+     * Returns the link task for the shared library.
      */
     Provider<? extends LinkSharedLibrary> getLinkTask();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
@@ -17,6 +17,7 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 
@@ -27,6 +28,11 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
  */
 @Incubating
 public interface ComponentWithSharedLibrary extends ComponentWithLinkFile, ComponentWithRuntimeFile {
+    /**
+     * Returns the link libraries to use to link this binary. Includes the link libraries of the component's dependencies.
+     */
+    FileCollection getLinkLibraries();
+
     /**
      * Returns the link task for this binary.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithStaticLibrary.java
@@ -17,19 +17,18 @@
 package org.gradle.language.nativeplatform;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 
 /**
- * Represents a native component that produces a file to be used at runtime.
+ * Represents a component that produces a static library.
  *
  * @since 4.5
  */
 @Incubating
-public interface ComponentWithRuntimeFile extends SoftwareComponent {
+public interface ComponentWithStaticLibrary extends ComponentWithLinkFile {
     /**
-     * Returns the runtime file of this component.
+     * Returns the create static library task for this binary.
      */
-    Provider<RegularFile> getRuntimeFile();
+    Provider<? extends CreateStaticLibrary> getCreateTask();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/PublicationAwareComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/PublicationAwareComponent.java
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package org.gradle.api.component;
+package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
-
-import java.util.Set;
+import org.gradle.api.component.ComponentWithVariants;
+import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.provider.Provider;
 
 /**
- * Represents a {@link SoftwareComponent} that provides one or more mutually exclusive children, or variants.
- *
- * @since 4.3
+ * This should become public at some point.
  */
-@Incubating
-public interface ComponentWithVariants extends SoftwareComponent {
-    Set<? extends SoftwareComponent> getVariants();
+public interface PublicationAwareComponent extends SoftwareComponent {
+    Provider<String> getBaseName();
+
+    ComponentWithVariants getMainPublication();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ComponentWithNames.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ComponentWithNames.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.nativeplatform.internal;
+
+import org.gradle.api.component.SoftwareComponent;
+
+public interface ComponentWithNames extends SoftwareComponent {
+    Names getNames();
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
@@ -28,6 +28,9 @@ import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+/**
+ * A configurable view of a component that produces an executable and installation. This should become public in some form.
+ */
 public interface ConfigurableComponentWithExecutable extends ComponentWithExecutable, ComponentWithInstallation, ComponentWithObjectFiles, ComponentWithOutputs {
     PlatformToolProvider getPlatformToolProvider();
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
@@ -44,6 +44,8 @@ public interface ConfigurableComponentWithExecutable extends ComponentWithExecut
     @Override
     Property<RegularFile> getExecutableFile();
 
+    Property<RegularFile> getDebuggerExecutableFile();
+
     @Override
     Property<Directory> getInstallDirectory();
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
@@ -26,14 +26,10 @@ import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
-import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 public interface ConfigurableComponentWithExecutable extends ComponentWithExecutable, ComponentWithInstallation, ComponentWithObjectFiles, ComponentWithOutputs {
     PlatformToolProvider getPlatformToolProvider();
-
-    @Override
-    NativeToolChainInternal getToolChain();
 
     @Override
     Property<LinkExecutable> getLinkTask();

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.nativeplatform.internal;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithExecutable;
+import org.gradle.language.nativeplatform.ComponentWithInstallation;
+import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
+import org.gradle.nativeplatform.tasks.InstallExecutable;
+import org.gradle.nativeplatform.tasks.LinkExecutable;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+
+public interface ConfigurableComponentWithExecutable extends ComponentWithExecutable, ComponentWithInstallation, ComponentWithObjectFiles, ComponentWithOutputs {
+    PlatformToolProvider getPlatformToolProvider();
+
+    @Override
+    NativeToolChainInternal getToolChain();
+
+    @Override
+    Property<LinkExecutable> getLinkTask();
+
+    @Override
+    Property<InstallExecutable> getInstallTask();
+
+    @Override
+    Property<RegularFile> getExecutableFile();
+
+    @Override
+    Property<Directory> getInstallDirectory();
+
+    @Override
+    ConfigurableFileCollection getOutputs();
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithExecutable.java
@@ -31,7 +31,7 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 /**
  * A configurable view of a component that produces an executable and installation. This should become public in some form.
  */
-public interface ConfigurableComponentWithExecutable extends ComponentWithExecutable, ComponentWithInstallation, ComponentWithObjectFiles, ComponentWithOutputs {
+public interface ConfigurableComponentWithExecutable extends ComponentWithExecutable, ComponentWithInstallation, ComponentWithObjectFiles, ComponentWithOutputs, ComponentWithNames {
     PlatformToolProvider getPlatformToolProvider();
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithLinkUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithLinkUsage.java
@@ -14,19 +14,28 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp;
+package org.gradle.language.nativeplatform.internal;
 
-import org.gradle.api.Incubating;
-import org.gradle.language.ComponentWithOutputs;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
-import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
-import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
+import org.gradle.nativeplatform.Linkage;
+
+import javax.annotation.Nullable;
 
 /**
- * A shared library built from C++ source.
- *
- * @since 4.2
+ * A configurable view of a component that has a link usage. This should become public in some form.
  */
-@Incubating
-public interface CppSharedLibrary extends CppBinary, ComponentWithSharedLibrary, ComponentWithLinkUsage, ComponentWithRuntimeUsage, ComponentWithOutputs {
+public interface ConfigurableComponentWithLinkUsage extends ComponentWithLinkUsage {
+    Configuration getImplementationDependencies();
+
+    @Nullable
+    Linkage getLinkage();
+
+    @Override
+    Property<Configuration> getLinkElements();
+
+    Provider<RegularFile> getLinkFile();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithLinkUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithLinkUsage.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 /**
  * A configurable view of a component that has a link usage. This should become public in some form.
  */
-public interface ConfigurableComponentWithLinkUsage extends ComponentWithLinkUsage {
+public interface ConfigurableComponentWithLinkUsage extends ComponentWithLinkUsage, ComponentWithNames {
     Configuration getImplementationDependencies();
 
     @Nullable

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithRuntimeUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithRuntimeUsage.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 /**
  * A configurable view of a component that has a runtime usage. This should become public in some form.
  */
-public interface ConfigurableComponentWithRuntimeUsage extends ComponentWithRuntimeUsage {
+public interface ConfigurableComponentWithRuntimeUsage extends ComponentWithRuntimeUsage, ComponentWithNames {
     Configuration getImplementationDependencies();
 
     @Nullable

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithRuntimeUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithRuntimeUsage.java
@@ -14,27 +14,30 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp;
+package org.gradle.language.nativeplatform.internal;
 
-import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithExecutable;
-import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
+import org.gradle.nativeplatform.Linkage;
+
+import javax.annotation.Nullable;
 
 /**
- * An executable built from C++ source.
- *
- * @since 4.2
+ * A configurable view of a component that has a runtime usage. This should become public in some form.
  */
-@Incubating
-public interface CppExecutable extends CppBinary, ComponentWithExecutable, ComponentWithInstallation, ComponentWithOutputs, ComponentWithRuntimeUsage {
-    /**
-     * Returns the executable file to use with a debugger for this executable.
-     *
-     * @since 4.5
-     */
-    Provider<RegularFile> getDebuggerExecutableFile();
+public interface ConfigurableComponentWithRuntimeUsage extends ComponentWithRuntimeUsage {
+    Configuration getImplementationDependencies();
+
+    @Nullable
+    Linkage getLinkage();
+
+    @Override
+    Property<Configuration> getRuntimeElements();
+
+    boolean hasRuntimeFile();
+
+    Provider<RegularFile> getRuntimeFile();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
@@ -25,6 +25,9 @@ import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+/**
+ * A configurable view of a component that produces a shared library. This should become public in some form.
+ */
 public interface ConfigurableComponentWithSharedLibrary extends ComponentWithSharedLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
     PlatformToolProvider getPlatformToolProvider();
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.nativeplatform.internal;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
+import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
+import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+
+public interface ConfigurableComponentWithSharedLibrary extends ComponentWithSharedLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
+    PlatformToolProvider getPlatformToolProvider();
+
+    @Override
+    NativeToolChainInternal getToolChain();
+
+    @Override
+    Property<RegularFile> getLinkFile();
+
+    @Override
+    Property<RegularFile> getRuntimeFile();
+
+    @Override
+    Property<LinkSharedLibrary> getLinkTask();
+
+    @Override
+    ConfigurableFileCollection getOutputs();
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
@@ -28,7 +28,7 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 /**
  * A configurable view of a component that produces a shared library. This should become public in some form.
  */
-public interface ConfigurableComponentWithSharedLibrary extends ComponentWithSharedLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
+public interface ConfigurableComponentWithSharedLibrary extends ComponentWithSharedLibrary, ComponentWithObjectFiles, ComponentWithOutputs, ComponentWithNames {
     PlatformToolProvider getPlatformToolProvider();
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithSharedLibrary.java
@@ -23,14 +23,10 @@ import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
-import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 public interface ConfigurableComponentWithSharedLibrary extends ComponentWithSharedLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
     PlatformToolProvider getPlatformToolProvider();
-
-    @Override
-    NativeToolChainInternal getToolChain();
 
     @Override
     Property<RegularFile> getLinkFile();

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithStaticLibrary.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.nativeplatform.internal;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
+import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
+import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+
+public interface ConfigurableComponentWithStaticLibrary extends ComponentWithStaticLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
+    PlatformToolProvider getPlatformToolProvider();
+
+    @Override
+    Property<RegularFile> getLinkFile();
+
+    @Override
+    Property<CreateStaticLibrary> getCreateTask();
+
+    @Override
+    ConfigurableFileCollection getOutputs();
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithStaticLibrary.java
@@ -28,7 +28,7 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 /**
  * A configurable view of a component that produces a static library. This should become public in some form.
  */
-public interface ConfigurableComponentWithStaticLibrary extends ComponentWithStaticLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
+public interface ConfigurableComponentWithStaticLibrary extends ComponentWithStaticLibrary, ComponentWithObjectFiles, ComponentWithOutputs, ComponentWithNames {
     PlatformToolProvider getPlatformToolProvider();
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/ConfigurableComponentWithStaticLibrary.java
@@ -25,6 +25,9 @@ import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+/**
+ * A configurable view of a component that produces a static library. This should become public in some form.
+ */
 public interface ConfigurableComponentWithStaticLibrary extends ComponentWithStaticLibrary, ComponentWithObjectFiles, ComponentWithOutputs {
     PlatformToolProvider getPlatformToolProvider();
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/PublicationAwareComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/PublicationAwareComponent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.language.nativeplatform;
+package org.gradle.language.nativeplatform.internal;
 
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/package-info.java
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.language;
-
-import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.provider.Provider;
-
 /**
- * Represents a native component whose output includes a file to be used at link time.
- *
- * @since 4.5
+ * Model classes for native languages.
  */
-@Incubating
-public interface ComponentWithLinkFile extends SoftwareComponent {
-    /**
-     * Returns the main output of this component.
-     */
-    Provider<RegularFile> getLinkFile();
-}
+package org.gradle.language.nativeplatform;

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -25,9 +25,9 @@ import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.ComponentWithBinaries;
-import org.gradle.language.ComponentWithInstallation;
-import org.gradle.language.ComponentWithLinkFile;
-import org.gradle.language.ComponentWithRuntimeFile;
+import org.gradle.language.nativeplatform.ComponentWithInstallation;
+import org.gradle.language.nativeplatform.ComponentWithLinkFile;
+import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
 import org.gradle.language.ProductionComponent;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -47,7 +47,6 @@ import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.tasks.StripSymbols;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
-import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import java.util.concurrent.Callable;
@@ -108,7 +107,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
             @Override
             public void execute(final ConfigurableComponentWithExecutable executable) {
                 final Names names = Names.of(executable.getName());
-                NativeToolChainInternal toolChain = executable.getToolChain();
+                NativeToolChain toolChain = executable.getToolChain();
                 NativePlatform targetPlatform = executable.getTargetPlatform();
 
                 // Add a link task
@@ -129,7 +128,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 executable.getLinkTask().set(link);
                 executable.getDebuggerExecutableFile().set(link.getBinaryFile());
 
-                if (executable.isDebuggable() && executable.isOptimized() && toolChain.requiresDebugBinaryStripping()) {
+                if (executable.isDebuggable() && executable.isOptimized() && toolProvider.requiresDebugBinaryStripping()) {
                     Provider<RegularFile> symbolLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                         @Override
                         public String call() {
@@ -171,7 +170,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
             public void execute(final ConfigurableComponentWithSharedLibrary library) {
                 final Names names = Names.of(library.getName());
                 NativePlatform targetPlatform = library.getTargetPlatform();
-                NativeToolChainInternal toolChain = library.getToolChain();
+                NativeToolChain toolChain = library.getToolChain();
 
                 // Add a link task
                 final LinkSharedLibrary link = tasks.create(names.getTaskName("link"), LinkSharedLibrary.class);
@@ -204,7 +203,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                     linkFile = link.getImportLibrary();
                 }
 
-                if (library.isDebuggable() && library.isOptimized() && toolChain.requiresDebugBinaryStripping()) {
+                if (library.isDebuggable() && library.isOptimized() && toolProvider.requiresDebugBinaryStripping()) {
                     Provider<RegularFile> symbolLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                         @Override
                         public String call() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -45,7 +45,7 @@ import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.ProductionComponent;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
-import org.gradle.language.nativeplatform.PublicationAwareComponent;
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -127,6 +127,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 link.setDebuggable(executable.isDebuggable());
 
                 executable.getLinkTask().set(link);
+                executable.getDebuggerExecutableFile().set(link.getBinaryFile());
 
                 if (executable.isDebuggable() && executable.isOptimized() && toolChain.requiresDebugBinaryStripping()) {
                     Provider<RegularFile> symbolLocation = buildDirectory.file(providers.provider(new Callable<String>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -84,6 +84,8 @@ public interface SwiftBinary extends ComponentWithObjectFiles {
 
     /**
      * {@inheritDoc}
+     *
+     * @since 4.5
      */
     SwiftPlatform getTargetPlatform();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -17,28 +17,22 @@
 package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 import org.gradle.language.swift.tasks.SwiftCompile;
-import org.gradle.nativeplatform.toolchain.NativeToolChain;
 
 /**
- * A binary built from Swift source.
+ * A binary built from Swift source and linked from the resulting object files.
  *
  * @since 4.2
  */
 @Incubating
-public interface SwiftBinary extends SoftwareComponent {
+public interface SwiftBinary extends ComponentWithObjectFiles {
     /**
      * Returns the name of the Swift module that this binary defines.
      */
     Provider<String> getModule();
-
-    /**
-     * Returns the base name of the binary. This is used to calculate output file names.
-     */
-    Provider<String> getBaseName();
 
     /**
      * Returns true if this binary has debugging enabled.
@@ -82,13 +76,6 @@ public interface SwiftBinary extends SoftwareComponent {
     FileCollection getRuntimeLibraries();
 
     /**
-     * Returns the object files created for this binary.
-     *
-     * @since 4.4
-     */
-    FileCollection getObjects();
-
-    /**
      * Returns the compile task for this binary.
      *
      * @since 4.5
@@ -96,16 +83,7 @@ public interface SwiftBinary extends SoftwareComponent {
     Provider<SwiftCompile> getCompileTask();
 
     /**
-     * Returns the target platform for this binary.
-     *
-     * @since 4.5
+     * {@inheritDoc}
      */
     SwiftPlatform getTargetPlatform();
-
-    /**
-     * Returns the tool chain for this binary.
-     *
-     * @since 4.5
-     */
-    NativeToolChain getToolChain();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -35,18 +35,6 @@ public interface SwiftBinary extends ComponentWithObjectFiles {
     Provider<String> getModule();
 
     /**
-     * Returns true if this binary has debugging enabled.
-     */
-    boolean isDebuggable();
-
-    /**
-     * Returns true if this binary is optimized.
-     *
-     * @since 4.5
-     */
-    boolean isOptimized();
-
-    /**
      * Returns true if this binary has testing enabled.
      *
      * @since 4.4

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -36,6 +36,11 @@ public interface SwiftBinary extends SoftwareComponent {
     Provider<String> getModule();
 
     /**
+     * Returns the base name of the binary. This is used to calculate output file names.
+     */
+    Provider<String> getBaseName();
+
+    /**
      * Returns true if this binary has debugging enabled.
      */
     boolean isDebuggable();

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
@@ -23,7 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.language.ComponentWithBinaries;
-import org.gradle.language.BinaryContainer;
+import org.gradle.language.BinaryCollection;
 
 /**
  * Configuration for a Swift component, such as a library or executable, defining the source files that make up the component plus other settings.
@@ -63,7 +63,7 @@ public interface SwiftComponent extends ComponentWithBinaries {
      *
      * @since 4.5
      */
-    BinaryContainer<? extends SwiftBinary> getBinaries();
+    BinaryCollection<? extends SwiftBinary> getBinaries();
 
     /**
      * Returns the implementation dependencies of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
@@ -23,7 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.language.ComponentWithBinaries;
-import org.gradle.language.NativeBinaryContainer;
+import org.gradle.language.BinaryContainer;
 
 /**
  * Configuration for a Swift component, such as a library or executable, defining the source files that make up the component plus other settings.
@@ -63,7 +63,7 @@ public interface SwiftComponent extends ComponentWithBinaries {
      *
      * @since 4.5
      */
-    NativeBinaryContainer<? extends SwiftBinary> getBinaries();
+    BinaryContainer<? extends SwiftBinary> getBinaries();
 
     /**
      * Returns the implementation dependencies of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
@@ -20,9 +20,8 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithExecutable;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
-import org.gradle.nativeplatform.tasks.InstallExecutable;
-import org.gradle.nativeplatform.tasks.LinkExecutable;
 
 /**
  * An executable built from Swift source.
@@ -30,35 +29,7 @@ import org.gradle.nativeplatform.tasks.LinkExecutable;
  * @since 4.2
  */
 @Incubating
-public interface SwiftExecutable extends SwiftBinary, ComponentWithInstallation, ComponentWithOutputs {
-    /**
-     * Returns the executable file for this binary.
-     *
-     * @since 4.4
-     */
-    Provider<RegularFile> getExecutableFile();
-
-    /**
-     * Returns the script for running this binary.
-     *
-     * @since 4.4
-     */
-    Provider<RegularFile> getRunScriptFile();
-
-    /**
-     * Returns the link task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<LinkExecutable> getLinkTask();
-
-    /**
-     * Returns the install task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<InstallExecutable> getInstallTask();
-
+public interface SwiftExecutable extends SwiftBinary, ComponentWithExecutable, ComponentWithInstallation, ComponentWithOutputs {
     /**
      * Returns the executable file to use with a debugger for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
@@ -19,7 +19,7 @@ package org.gradle.language.swift;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.ComponentWithInstallation;
+import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
@@ -19,6 +19,7 @@ package org.gradle.language.swift;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
@@ -29,7 +30,7 @@ import org.gradle.nativeplatform.tasks.LinkExecutable;
  * @since 4.2
  */
 @Incubating
-public interface SwiftExecutable extends SwiftBinary, ComponentWithInstallation {
+public interface SwiftExecutable extends SwiftBinary, ComponentWithInstallation, ComponentWithOutputs {
     /**
      * Returns the executable file for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
@@ -17,11 +17,8 @@
 package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithLinkFile;
-import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
-import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
+import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
 
 /**
  * A shared library built from Swift source.
@@ -29,11 +26,5 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
  * @since 4.2
  */
 @Incubating
-public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithLinkFile, ComponentWithRuntimeFile, ComponentWithOutputs {
-    /**
-     * Returns the link task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<LinkSharedLibrary> getLinkTask();
+public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithSharedLibrary,  ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
@@ -18,6 +18,8 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
 
 /**
@@ -26,5 +28,5 @@ import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
  * @since 4.2
  */
 @Incubating
-public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithSharedLibrary,  ComponentWithOutputs {
+public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithSharedLibrary, ComponentWithRuntimeUsage, ComponentWithLinkUsage, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
@@ -18,6 +18,7 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkFile;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
@@ -28,7 +29,7 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
  * @since 4.2
  */
 @Incubating
-public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithLinkFile, ComponentWithRuntimeFile {
+public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithLinkFile, ComponentWithRuntimeFile, ComponentWithOutputs {
     /**
      * Returns the link task for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
@@ -18,8 +18,8 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.ComponentWithLinkFile;
-import org.gradle.language.ComponentWithRuntimeFile;
+import org.gradle.language.nativeplatform.ComponentWithLinkFile;
+import org.gradle.language.nativeplatform.ComponentWithRuntimeFile;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 
 /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
@@ -17,10 +17,8 @@
 package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
-import org.gradle.language.nativeplatform.ComponentWithLinkFile;
-import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
+import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
 
 /**
  * A static library built from Swift source.
@@ -28,11 +26,5 @@ import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
  * @since 4.5
  */
 @Incubating
-public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithLinkFile, ComponentWithOutputs {
-    /**
-     * Returns the create static library task for this binary.
-     *
-     * @since 4.5
-     */
-    Provider<CreateStaticLibrary> getCreateTask();
+public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithStaticLibrary, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
@@ -18,6 +18,7 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkFile;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 
@@ -27,7 +28,7 @@ import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
  * @since 4.5
  */
 @Incubating
-public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithLinkFile {
+public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithLinkFile, ComponentWithOutputs {
     /**
      * Returns the create static library task for this binary.
      *

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
@@ -18,7 +18,7 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.ComponentWithLinkFile;
+import org.gradle.language.nativeplatform.ComponentWithLinkFile;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 
 /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
@@ -18,6 +18,8 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.language.ComponentWithOutputs;
+import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
 
 /**
@@ -26,5 +28,5 @@ import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
  * @since 4.5
  */
 @Incubating
-public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithStaticLibrary, ComponentWithOutputs {
+public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithStaticLibrary, ComponentWithRuntimeUsage, ComponentWithLinkUsage, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -72,6 +72,7 @@ public class DefaultSwiftBinary implements SwiftBinary {
     private final NativeToolChainInternal toolChain;
     private final PlatformToolProvider platformToolProvider;
     private final Configuration importPathConfiguration;
+    private final Configuration implementation;
 
     public DefaultSwiftBinary(String name, ProjectLayout projectLayout, final ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         this.name = name;
@@ -85,6 +86,7 @@ public class DefaultSwiftBinary implements SwiftBinary {
         this.compileTaskProperty = objectFactory.property(SwiftCompile.class);
         this.targetPlatform = targetPlatform;
         this.toolChain = toolChain;
+        this.implementation = implementation;
         this.platformToolProvider = platformToolProvider;
 
         Names names = Names.of(name);
@@ -200,6 +202,10 @@ public class DefaultSwiftBinary implements SwiftBinary {
 
     public PlatformToolProvider getPlatformToolProvider() {
         return platformToolProvider;
+    }
+
+    public Configuration getImplementationDependencies() {
+        return implementation;
     }
 
     @Inject

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -127,6 +127,11 @@ public class DefaultSwiftBinary implements SwiftBinary {
     }
 
     @Override
+    public Provider<String> getBaseName() {
+        return module;
+    }
+
+    @Override
     public boolean isDebuggable() {
         return debuggable;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.Cast;
-import org.gradle.language.internal.DefaultBinaryContainer;
+import org.gradle.language.internal.DefaultBinaryCollection;
 import org.gradle.language.nativeplatform.internal.DefaultNativeComponent;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.swift.SwiftBinary;
@@ -32,7 +32,7 @@ import org.gradle.language.swift.SwiftComponent;
 import java.util.Collections;
 
 public abstract class DefaultSwiftComponent extends DefaultNativeComponent implements SwiftComponent {
-    private final DefaultBinaryContainer<SwiftBinary> binaries;
+    private final DefaultBinaryCollection<SwiftBinary> binaries;
     private final FileCollection swiftSource;
     private final Property<String> module;
     private final String name;
@@ -49,7 +49,7 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
         implementation = configurations.maybeCreate(names.withSuffix("implementation"));
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
-        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryContainer.class, SwiftBinary.class));
+        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryCollection.class, SwiftBinary.class));
     }
 
     @Override
@@ -77,7 +77,7 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
     }
 
     @Override
-    public DefaultBinaryContainer<SwiftBinary> getBinaries() {
+    public DefaultBinaryCollection<SwiftBinary> getBinaries() {
         return binaries;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.Cast;
-import org.gradle.language.internal.DefaultNativeBinaryContainer;
+import org.gradle.language.internal.DefaultBinaryContainer;
 import org.gradle.language.nativeplatform.internal.DefaultNativeComponent;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.swift.SwiftBinary;
@@ -32,7 +32,7 @@ import org.gradle.language.swift.SwiftComponent;
 import java.util.Collections;
 
 public abstract class DefaultSwiftComponent extends DefaultNativeComponent implements SwiftComponent {
-    private final DefaultNativeBinaryContainer<SwiftBinary> binaries;
+    private final DefaultBinaryContainer<SwiftBinary> binaries;
     private final FileCollection swiftSource;
     private final Property<String> module;
     private final String name;
@@ -49,7 +49,7 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
         implementation = configurations.maybeCreate(names.withSuffix("implementation"));
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
-        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultNativeBinaryContainer.class, SwiftBinary.class));
+        binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryContainer.class, SwiftBinary.class));
     }
 
     @Override
@@ -77,7 +77,7 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
     }
 
     @Override
-    public DefaultNativeBinaryContainer<SwiftBinary> getBinaries() {
+    public DefaultBinaryContainer<SwiftBinary> getBinaries() {
         return binaries;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
@@ -24,6 +24,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.Cast;
 import org.gradle.language.internal.DefaultBinaryCollection;
+import org.gradle.language.nativeplatform.internal.ComponentWithNames;
 import org.gradle.language.nativeplatform.internal.DefaultNativeComponent;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.swift.SwiftBinary;
@@ -31,7 +32,7 @@ import org.gradle.language.swift.SwiftComponent;
 
 import java.util.Collections;
 
-public abstract class DefaultSwiftComponent extends DefaultNativeComponent implements SwiftComponent {
+public abstract class DefaultSwiftComponent extends DefaultNativeComponent implements SwiftComponent, ComponentWithNames {
     private final DefaultBinaryCollection<SwiftBinary> binaries;
     private final FileCollection swiftSource;
     private final Property<String> module;
@@ -46,7 +47,7 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
         module = objectFactory.property(String.class);
 
         names = Names.of(name);
-        implementation = configurations.maybeCreate(names.withSuffix("implementation"));
+        implementation = configurations.create(names.withSuffix("implementation"));
         implementation.setCanBeConsumed(false);
         implementation.setCanBeResolved(false);
         binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryCollection.class, SwiftBinary.class));
@@ -57,7 +58,8 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
         return name;
     }
 
-    protected Names getNames() {
+    @Override
+    public Names getNames() {
         return names;
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.language.swift.SwiftExecutable;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
@@ -37,10 +38,9 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftExecutable {
+public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftExecutable, ConfigurableComponentWithExecutable {
     private final RegularFileProperty executableFile;
     private final DirectoryProperty installDirectory;
-    private final RegularFileProperty runScriptFile;
     private final Property<LinkExecutable> linkTaskProperty;
     private final Property<InstallExecutable> installTaskProperty;
     private final RegularFileProperty debuggerExecutableFile;
@@ -51,7 +51,6 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.executableFile = projectLayout.fileProperty();
         this.installDirectory = projectLayout.directoryProperty();
-        this.runScriptFile = projectLayout.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
         this.debuggerExecutableFile = projectLayout.fileProperty();
@@ -71,11 +70,6 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     @Override
     public DirectoryProperty getInstallDirectory() {
         return installDirectory;
-    }
-
-    @Override
-    public RegularFileProperty getRunScriptFile() {
-        return runScriptFile;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -22,7 +22,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
@@ -83,7 +82,7 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     }
 
     @Override
-    public Property<RegularFile> getDebuggerExecutableFile() {
+    public RegularFileProperty getDebuggerExecutableFile() {
         return debuggerExecutableFile;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -18,11 +18,13 @@ package org.gradle.language.swift.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -42,9 +44,10 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     private final Property<LinkExecutable> linkTaskProperty;
     private final Property<InstallExecutable> installTaskProperty;
     private final RegularFileProperty debuggerExecutableFile;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultSwiftExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultSwiftExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.executableFile = projectLayout.fileProperty();
         this.installDirectory = projectLayout.directoryProperty();
@@ -52,6 +55,12 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
         this.debuggerExecutableFile = projectLayout.fileProperty();
+        this.outputs = fileOperations.files();
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftLibrary.java
@@ -51,7 +51,7 @@ public class DefaultSwiftLibrary extends DefaultSwiftComponent implements SwiftL
         linkage = new LockableSetProperty<Linkage>(objectFactory.setProperty(Linkage.class));
         linkage.add(Linkage.SHARED);
 
-        api = configurations.maybeCreate(getNames().withSuffix("api"));
+        api = configurations.create(getNames().withSuffix("api"));
         api.setCanBeConsumed(false);
         api.setCanBeResolved(false);
         getImplementationDependencies().extendsFrom(api);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -26,19 +26,25 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithSharedLibrary;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.SwiftSharedLibrary;
+import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements SwiftSharedLibrary, ConfigurableComponentWithSharedLibrary {
+public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements SwiftSharedLibrary, ConfigurableComponentWithSharedLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage {
     private final RegularFileProperty linkFile;
     private final RegularFileProperty runtimeFile;
     private final Property<LinkSharedLibrary> linkTaskProperty;
+    private final Property<Configuration> linkElements;
+    private final Property<Configuration> runtimeElements;
     private final ConfigurableFileCollection outputs;
 
     @Inject
@@ -47,6 +53,8 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
         this.linkFile = projectLayout.fileProperty();
         this.runtimeFile = projectLayout.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
+        this.linkElements = objectFactory.property(Configuration.class);
+        this.runtimeElements = objectFactory.property(Configuration.class);
         this.outputs = fileOperations.files();
     }
 
@@ -68,5 +76,26 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
     @Override
     public Property<LinkSharedLibrary> getLinkTask() {
         return linkTaskProperty;
+    }
+
+    @Override
+    public Property<Configuration> getLinkElements() {
+        return linkElements;
+    }
+
+    @Override
+    public Property<Configuration> getRuntimeElements() {
+        return runtimeElements;
+    }
+
+    @Nullable
+    @Override
+    public Linkage getLinkage() {
+        return Linkage.SHARED;
+    }
+
+    @Override
+    public boolean hasRuntimeFile() {
+        return true;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -21,12 +21,12 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithSharedLibrary;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.SwiftSharedLibrary;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
@@ -35,7 +35,8 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements SwiftSharedLibrary {
+public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements SwiftSharedLibrary, ConfigurableComponentWithSharedLibrary {
+    private final RegularFileProperty linkFile;
     private final RegularFileProperty runtimeFile;
     private final Property<LinkSharedLibrary> linkTaskProperty;
     private final ConfigurableFileCollection outputs;
@@ -43,6 +44,7 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
     @Inject
     public DefaultSwiftSharedLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+        this.linkFile = projectLayout.fileProperty();
         this.runtimeFile = projectLayout.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
         this.outputs = fileOperations.files();
@@ -54,8 +56,8 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
     }
 
     @Override
-    public Provider<RegularFile> getLinkFile() {
-        return runtimeFile;
+    public RegularFileProperty getLinkFile() {
+        return linkFile;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -18,10 +18,12 @@ package org.gradle.language.swift.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -36,12 +38,19 @@ import javax.inject.Inject;
 public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements SwiftSharedLibrary {
     private final RegularFileProperty runtimeFile;
     private final Property<LinkSharedLibrary> linkTaskProperty;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultSwiftSharedLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultSwiftSharedLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.runtimeFile = projectLayout.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
+        this.outputs = fileOperations.files();
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithStaticLibrary;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.SwiftStaticLibrary;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
@@ -34,7 +35,7 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements SwiftStaticLibrary {
+public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements SwiftStaticLibrary, ConfigurableComponentWithStaticLibrary {
     private final RegularFileProperty linkFile;
     private final Property<CreateStaticLibrary> createTaskProperty;
     private final ConfigurableFileCollection outputs;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -18,9 +18,11 @@ package org.gradle.language.swift.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -35,12 +37,19 @@ import javax.inject.Inject;
 public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements SwiftStaticLibrary {
     private final RegularFileProperty linkFile;
     private final Property<CreateStaticLibrary> createTaskProperty;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultSwiftStaticLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultSwiftStaticLibrary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.linkFile = projectLayout.fileProperty();
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
+        this.outputs = fileOperations.files();
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -21,23 +21,31 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithStaticLibrary;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.SwiftStaticLibrary;
+import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements SwiftStaticLibrary, ConfigurableComponentWithStaticLibrary {
+public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements SwiftStaticLibrary, ConfigurableComponentWithStaticLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage {
     private final RegularFileProperty linkFile;
     private final Property<CreateStaticLibrary> createTaskProperty;
+    private final Property<Configuration> linkElements;
+    private final Property<Configuration> runtimeElements;
     private final ConfigurableFileCollection outputs;
 
     @Inject
@@ -45,6 +53,8 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.linkFile = projectLayout.fileProperty();
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
+        this.linkElements = objectFactory.property(Configuration.class);
+        this.runtimeElements = objectFactory.property(Configuration.class);
         this.outputs = fileOperations.files();
     }
 
@@ -61,5 +71,31 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
     @Override
     public Property<CreateStaticLibrary> getCreateTask() {
         return createTaskProperty;
+    }
+
+    @Override
+    public Property<Configuration> getLinkElements() {
+        return linkElements;
+    }
+
+    @Override
+    public Property<Configuration> getRuntimeElements() {
+        return runtimeElements;
+    }
+
+    @Nullable
+    @Override
+    public Linkage getLinkage() {
+        return Linkage.STATIC;
+    }
+
+    @Override
+    public boolean hasRuntimeFile() {
+        return false;
+    }
+
+    @Override
+    public Provider<RegularFile> getRuntimeFile() {
+        return Providers.notDefined();
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 import org.gradle.language.swift.SwiftApplication;
@@ -83,7 +82,6 @@ public class SwiftApplicationPlugin implements Plugin<ProjectInternal> {
         project.afterEvaluate(new Action<Project>() {
             @Override
             public void execute(Project project) {
-                TaskContainer tasks = project.getTasks();
                 ObjectFactory objectFactory = project.getObjects();
 
                 ToolChainSelector.Result<SwiftPlatform> result = toolChainSelector.select(SwiftPlatform.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -50,8 +50,6 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
         project.getPluginManager().apply(NativeBasePlugin.class);
         project.getPluginManager().apply(SwiftCompilerPlugin.class);
 
-        // TODO - Merge with CppBasePlugin to remove code duplication
-
         final TaskContainerInternal tasks = project.getTasks();
         final DirectoryProperty buildDirectory = project.getLayout().getBuildDirectory();
         final ProviderFactory providers = project.getProviders();
@@ -93,11 +91,13 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
 
                 binary.getCompileTask().set(compile);
                 binary.getObjectsDir().set(compile.getObjectFileDir());
-
-                if (binary instanceof SwiftSharedLibrary) {
-                    // Specific compiler arguments
-                    compile.getCompilerArgs().add("-parse-as-library");
-                }
+            }
+        });
+        project.getComponents().withType(SwiftSharedLibrary.class, new Action<SwiftSharedLibrary>() {
+            @Override
+            public void execute(SwiftSharedLibrary library) {
+                // Specific compiler arguments
+                library.getCompileTask().get().getCompilerArgs().add("-parse-as-library");
             }
         });
         project.getComponents().withType(SwiftStaticLibrary.class, new Action<SwiftStaticLibrary>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -120,7 +120,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     Provider<RegularFile> exeLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                         @Override
                         public String call() {
-                            return toolProvider.getExecutableName("exe/" + names.getDirName() + binary.getModule().get());
+                            return toolProvider.getExecutableName("exe/" + names.getDirName() + binary.getBaseName().get());
                         }
                     }));
                     link.setOutputFile(exeLocation);
@@ -133,13 +133,13 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                         Provider<RegularFile> symbolLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                             @Override
                             public String call() {
-                                return toolProvider.getExecutableSymbolFileName("exe/" + names.getDirName() + "stripped/" + binary.getModule().get());
+                                return toolProvider.getExecutableSymbolFileName("exe/" + names.getDirName() + "stripped/" + binary.getBaseName().get());
                             }
                         }));
                         Provider<RegularFile> strippedLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                             @Override
                             public String call() {
-                                return toolProvider.getExecutableName("exe/" + names.getDirName() + "stripped/"+ binary.getModule().get());
+                                return toolProvider.getExecutableName("exe/" + names.getDirName() + "stripped/"+ binary.getBaseName().get());
                             }
                         }));
                         StripSymbols stripSymbols = stripSymbols(link, names, tasks, toolChain, currentPlatform, strippedLocation);
@@ -179,7 +179,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     Provider<RegularFile> runtimeFile = buildDirectory.file(providers.provider(new Callable<String>() {
                         @Override
                         public String call() {
-                            return toolProvider.getSharedLibraryName("lib/" + names.getDirName() + binary.getModule().get());
+                            return toolProvider.getSharedLibraryName("lib/" + names.getDirName() + binary.getBaseName().get());
                         }
                     }));
                     link.setOutputFile(runtimeFile);
@@ -191,13 +191,13 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                         Provider<RegularFile> symbolLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                             @Override
                             public String call() {
-                                return toolProvider.getLibrarySymbolFileName("lib/" + names.getDirName() + "stripped/" + binary.getModule().get());
+                                return toolProvider.getLibrarySymbolFileName("lib/" + names.getDirName() + "stripped/" + binary.getBaseName().get());
                             }
                         }));
                         Provider<RegularFile> strippedLocation = buildDirectory.file(providers.provider(new Callable<String>() {
                             @Override
                             public String call() {
-                                return toolProvider.getSharedLibraryName("lib/" + names.getDirName() + "stripped/"+ binary.getModule().get());
+                                return toolProvider.getSharedLibraryName("lib/" + names.getDirName() + "stripped/"+ binary.getBaseName().get());
                             }
                         }));
                         StripSymbols stripSymbols = stripSymbols(link, names, tasks, toolChain, currentPlatform, strippedLocation);
@@ -224,7 +224,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     Provider<RegularFile> runtimeFile = buildDirectory.file(providers.provider(new Callable<String>() {
                         @Override
                         public String call() {
-                            return toolProvider.getStaticLibraryName("lib/" + names.getDirName() + binary.getModule().get());
+                            return toolProvider.getStaticLibraryName("lib/" + names.getDirName() + binary.getBaseName().get());
                         }
                     }));
                     link.setOutputFile(runtimeFile);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -37,11 +37,9 @@ import org.gradle.language.swift.SwiftStaticLibrary;
 import org.gradle.language.swift.internal.DefaultSwiftBinary;
 import org.gradle.language.swift.internal.DefaultSwiftExecutable;
 import org.gradle.language.swift.internal.DefaultSwiftSharedLibrary;
-import org.gradle.language.swift.internal.DefaultSwiftStaticLibrary;
 import org.gradle.language.swift.tasks.SwiftCompile;
 import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
-import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 import org.gradle.nativeplatform.tasks.ExtractSymbols;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
 import org.gradle.nativeplatform.tasks.LinkExecutable;
@@ -211,29 +209,8 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                     library.getOutputs().from(library.getLinkFile());
                     library.getOutputs().from(library.getRuntimeFile());
                 } else if (binary instanceof SwiftStaticLibrary) {
-                    DefaultSwiftStaticLibrary library = (DefaultSwiftStaticLibrary) binary;
-
                     // Specific compiler arguments
                     compile.getCompilerArgs().add("-parse-as-library");
-
-                    // Add a link task
-                    final CreateStaticLibrary link = tasks.create(names.getTaskName("create"), CreateStaticLibrary.class);
-                    link.source(binary.getObjects());
-                    // TODO - need to set soname
-                    final PlatformToolProvider toolProvider = library.getPlatformToolProvider();
-                    Provider<RegularFile> runtimeFile = buildDirectory.file(providers.provider(new Callable<String>() {
-                        @Override
-                        public String call() {
-                            return toolProvider.getStaticLibraryName("lib/" + names.getDirName() + binary.getBaseName().get());
-                        }
-                    }));
-                    link.setOutputFile(runtimeFile);
-                    link.setTargetPlatform(currentPlatform);
-                    link.setToolChain(toolChain);
-
-                    library.getLinkFile().set(link.getBinaryFile());
-                    library.getCreateTask().set(link);
-                    library.getOutputs().from(library.getLinkFile());
                 }
             }
         });

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -59,7 +59,7 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
         project.getComponents().withType(DefaultSwiftBinary.class, new Action<DefaultSwiftBinary>() {
             @Override
             public void execute(final DefaultSwiftBinary binary) {
-                final Names names = Names.of(binary.getName());
+                final Names names = binary.getNames();
                 SwiftCompile compile = tasks.create(names.getCompileTaskName("swift"), SwiftCompile.class);
                 compile.getModules().from(binary.getCompileModules());
                 compile.getSource().from(binary.getSwiftSource());

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 import org.gradle.language.swift.SwiftComponent;
@@ -67,7 +66,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(SwiftBasePlugin.class);
 
-        final TaskContainer tasks = project.getTasks();
         final ConfigurationContainer configurations = project.getConfigurations();
         final ObjectFactory objectFactory = project.getObjects();
 
@@ -106,7 +104,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                     // TODO - extract some common code to setup the configurations
                     // TODO - extract common code with C++ plugins
 
-                    Configuration implementation = library.getImplementationDependencies();
                     Configuration api = library.getApiDependencies();
 
                     Configuration debugApiElements = configurations.maybeCreate("debugSwiftApiElements");
@@ -117,23 +114,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                     debugApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugSharedLibrary.isOptimized());
                     debugApiElements.getOutgoing().artifact(compileDebug.getModuleFile());
 
-                    Configuration debugLinkElements = configurations.maybeCreate("debugLinkElements");
-                    debugLinkElements.extendsFrom(implementation);
-                    debugLinkElements.setCanBeResolved(false);
-                    debugLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
-                    debugLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugSharedLibrary.isDebuggable());
-                    debugLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugSharedLibrary.isOptimized());
-                    debugLinkElements.getOutgoing().artifact(debugSharedLibrary.getLinkFile());
-
-                    Configuration debugRuntimeElements = configurations.maybeCreate("debugRuntimeElements");
-                    debugRuntimeElements.extendsFrom(implementation);
-                    debugRuntimeElements.setCanBeResolved(false);
-                    debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));
-                    debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugSharedLibrary.isDebuggable());
-                    debugRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugSharedLibrary.isOptimized());
-                    // TODO - should distinguish between link-time and runtime files
-                    debugRuntimeElements.getOutgoing().artifact(debugSharedLibrary.getRuntimeFile());
-
                     Configuration releaseApiElements = configurations.maybeCreate("releaseSwiftApiElements");
                     releaseApiElements.extendsFrom(api);
                     releaseApiElements.setCanBeResolved(false);
@@ -141,23 +121,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                     releaseApiElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseSharedLibrary.isDebuggable());
                     releaseApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseSharedLibrary.isOptimized());
                     releaseApiElements.getOutgoing().artifact(compileRelease.getModuleFile());
-
-                    Configuration releaseLinkElements = configurations.maybeCreate("releaseLinkElements");
-                    releaseLinkElements.extendsFrom(implementation);
-                    releaseLinkElements.setCanBeResolved(false);
-                    releaseLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
-                    releaseLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseSharedLibrary.isDebuggable());
-                    releaseLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseSharedLibrary.isOptimized());
-                    releaseLinkElements.getOutgoing().artifact(releaseSharedLibrary.getLinkFile());
-
-                    Configuration releaseRuntimeElements = configurations.maybeCreate("releaseRuntimeElements");
-                    releaseRuntimeElements.extendsFrom(implementation);
-                    releaseRuntimeElements.setCanBeResolved(false);
-                    releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));
-                    releaseRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseSharedLibrary.isDebuggable());
-                    releaseRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseSharedLibrary.isOptimized());
-                    // TODO - should distinguish between link-time and runtime files
-                    releaseRuntimeElements.getOutgoing().artifact(releaseSharedLibrary.getRuntimeFile());
                 }
 
                 SwiftStaticLibrary debugStaticLibrary = null;
@@ -171,7 +134,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                         SwiftCompile compileDebug = debugStaticLibrary.getCompileTask().get();
                         SwiftCompile compileRelease = releaseStaticLibrary.getCompileTask().get();
 
-                        Configuration implementation = library.getImplementationDependencies();
                         Configuration api = library.getApiDependencies();
 
                         Configuration debugApiElements = configurations.maybeCreate("debugStaticSwiftApiElements");
@@ -182,21 +144,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                         debugApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugStaticLibrary.isOptimized());
                         debugApiElements.getOutgoing().artifact(compileDebug.getModuleFile());
 
-                        Configuration debugLinkElements = configurations.maybeCreate("debugStaticLinkElements");
-                        debugLinkElements.extendsFrom(implementation);
-                        debugLinkElements.setCanBeResolved(false);
-                        debugLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
-                        debugLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugStaticLibrary.isDebuggable());
-                        debugLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugStaticLibrary.isOptimized());
-                        debugLinkElements.getOutgoing().artifact(debugStaticLibrary.getLinkFile());
-
-                        Configuration debugRuntimeElements = configurations.maybeCreate("debugStaticRuntimeElements");
-                        debugRuntimeElements.extendsFrom(implementation);
-                        debugRuntimeElements.setCanBeResolved(false);
-                        debugRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));
-                        debugRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugStaticLibrary.isDebuggable());
-                        debugRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugStaticLibrary.isOptimized());
-
                         Configuration releaseApiElements = configurations.maybeCreate("releaseStaticSwiftApiElements");
                         releaseApiElements.extendsFrom(api);
                         releaseApiElements.setCanBeResolved(false);
@@ -204,21 +151,6 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                         releaseApiElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseStaticLibrary.isDebuggable());
                         releaseApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseStaticLibrary.isOptimized());
                         releaseApiElements.getOutgoing().artifact(compileRelease.getModuleFile());
-
-                        Configuration releaseLinkElements = configurations.maybeCreate("releaseStaticLinkElements");
-                        releaseLinkElements.extendsFrom(implementation);
-                        releaseLinkElements.setCanBeResolved(false);
-                        releaseLinkElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
-                        releaseLinkElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseStaticLibrary.isDebuggable());
-                        releaseLinkElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseStaticLibrary.isOptimized());
-                        releaseLinkElements.getOutgoing().artifact(releaseStaticLibrary.getLinkFile());
-
-                        Configuration releaseRuntimeElements = configurations.maybeCreate("releaseStaticRuntimeElements");
-                        releaseRuntimeElements.extendsFrom(implementation);
-                        releaseRuntimeElements.setCanBeResolved(false);
-                        releaseRuntimeElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));
-                        releaseRuntimeElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseStaticLibrary.isDebuggable());
-                        releaseRuntimeElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseStaticLibrary.isOptimized());
                     }
                 }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -106,7 +106,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 
                     Configuration api = library.getApiDependencies();
 
-                    Configuration debugApiElements = configurations.maybeCreate("debugSwiftApiElements");
+                    Configuration debugApiElements = configurations.create("debugSwiftApiElements");
                     debugApiElements.extendsFrom(api);
                     debugApiElements.setCanBeResolved(false);
                     debugApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
@@ -114,7 +114,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                     debugApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugSharedLibrary.isOptimized());
                     debugApiElements.getOutgoing().artifact(compileDebug.getModuleFile());
 
-                    Configuration releaseApiElements = configurations.maybeCreate("releaseSwiftApiElements");
+                    Configuration releaseApiElements = configurations.create("releaseSwiftApiElements");
                     releaseApiElements.extendsFrom(api);
                     releaseApiElements.setCanBeResolved(false);
                     releaseApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
@@ -136,7 +136,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
 
                         Configuration api = library.getApiDependencies();
 
-                        Configuration debugApiElements = configurations.maybeCreate("debugStaticSwiftApiElements");
+                        Configuration debugApiElements = configurations.create("debugStaticSwiftApiElements");
                         debugApiElements.extendsFrom(api);
                         debugApiElements.setCanBeResolved(false);
                         debugApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
@@ -144,7 +144,7 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                         debugApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugStaticLibrary.isOptimized());
                         debugApiElements.getOutgoing().artifact(compileDebug.getModuleFile());
 
-                        Configuration releaseApiElements = configurations.maybeCreate("releaseStaticSwiftApiElements");
+                        Configuration releaseApiElements = configurations.create("releaseStaticSwiftApiElements");
                         releaseApiElements.extendsFrom(api);
                         releaseApiElements.setCanBeResolved(false);
                         releaseApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
@@ -28,10 +28,14 @@ class DefaultCppApplicationTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
+    def application = new DefaultCppApplication("main", project.objects, project, project.configurations)
+
+    def "has a main publication"() {
+        expect:
+        application.mainPublication
+    }
 
     def "can add an executable"() {
-        def application = new DefaultCppApplication("main", project.objects, project, project.configurations)
-
         expect:
         def exe = application.addExecutable("debug", true, false, Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
         exe.name == 'mainDebug'

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
@@ -36,7 +36,7 @@ class DefaultCppComponentTest extends Specification {
     DefaultCppComponent component
 
     def setup() {
-        _ * configurations.maybeCreate("implementation") >> implementation
+        _ * configurations.create("implementation") >> implementation
         component = new TestComponent("main", fileOperations, objectFactory, configurations)
     }
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
@@ -41,6 +41,16 @@ class DefaultCppLibraryTest extends Specification {
         library.apiDependencies == project.configurations.api
     }
 
+    def "has api elements configuration"() {
+        expect:
+        library.apiElements == project.configurations.cppApiElements
+    }
+
+    def "has main publication"() {
+        expect:
+        library.mainPublication
+    }
+
     def "uses convention for public headers when nothing specified"() {
         def d = tmpDir.file("src/main/public")
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.language.cpp.internal.DefaultCppBinary
 import org.gradle.language.cpp.internal.DefaultCppExecutable
 import org.gradle.language.cpp.internal.DefaultCppSharedLibrary
 import org.gradle.language.cpp.tasks.CppCompile
+import org.gradle.language.nativeplatform.internal.Names
 import org.gradle.nativeplatform.platform.internal.DefaultOperatingSystem
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal
 import org.gradle.nativeplatform.tasks.InstallExecutable
@@ -43,6 +44,7 @@ class CppBasePluginTest extends Specification {
     def "adds compile task for binary"() {
         def binary = Stub(DefaultCppBinary)
         binary.name >> name
+        binary.names >> Names.of(name)
         binary.targetPlatform >> Stub(CppPlatformInternal)
 
         when:
@@ -68,6 +70,7 @@ class CppBasePluginTest extends Specification {
         def executable = Stub(DefaultCppExecutable)
         def executableFile = project.layout.fileProperty()
         executable.name >> name
+        executable.names >> Names.of(name)
         executable.baseName >> baseName
         executable.getExecutableFile() >> executableFile
         executable.targetPlatform >> Stub(CppPlatformInternal)
@@ -100,6 +103,7 @@ class CppBasePluginTest extends Specification {
         baseName.set("test_lib")
         def library = Stub(DefaultCppSharedLibrary)
         library.name >> name
+        library.names >> Names.of(name)
         library.baseName >> baseName
         library.targetPlatform >> Stub(CppPlatformInternal)
         library.platformToolProvider >> new TestPlatformToolProvider()

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.cpp.plugins
 
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.cpp.CppPlatform
 import org.gradle.language.cpp.internal.DefaultCppBinary
@@ -71,6 +72,7 @@ class CppBasePluginTest extends Specification {
         executable.getExecutableFile() >> executableFile
         executable.targetPlatform >> Stub(CppPlatformInternal)
         executable.platformToolProvider >> new TestPlatformToolProvider()
+        executable.implementationDependencies >> Stub(ConfigurationInternal)
 
         when:
         project.pluginManager.apply(CppBasePlugin)
@@ -101,6 +103,7 @@ class CppBasePluginTest extends Specification {
         library.baseName >> baseName
         library.targetPlatform >> Stub(CppPlatformInternal)
         library.platformToolProvider >> new TestPlatformToolProvider()
+        library.implementationDependencies >> Stub(ConfigurationInternal)
 
         when:
         project.pluginManager.apply(CppBasePlugin)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryCollectionTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryCollectionTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.language.internal
 import org.gradle.api.Action
 import org.gradle.api.internal.provider.DefaultProviderFactory
 import org.gradle.api.specs.Spec
+import org.gradle.language.cpp.CppBinary
 import org.gradle.language.swift.SwiftBinary
 import org.gradle.language.swift.SwiftSharedLibrary
 import spock.lang.Specification
@@ -137,6 +138,42 @@ class DefaultBinaryCollectionTest extends Specification {
 
         then:
         1 * finalized.execute(binary1)
+        1 * finalized.execute(binary2)
+        0 * known._
+        0 * configure._
+        0 * finalized._
+    }
+
+    def "runs actions on element of given type when collection is realized"() {
+        def known = Mock(Action)
+        def configure = Mock(Action)
+        def finalized = Mock(Action)
+        def binary1 = Stub(CppBinary)
+        def binary2 = Stub(SwiftBinary)
+
+        when:
+        container.whenElementFinalized(SwiftBinary, finalized)
+        container.configureEach(SwiftBinary, configure)
+        container.whenElementKnown(SwiftBinary, known)
+        container.add(binary1)
+        container.add(binary2)
+
+        then:
+        1 * known.execute(binary2)
+        0 * known._
+        0 * configure._
+        0 * finalized._
+
+        when:
+        container.realizeNow()
+
+        then:
+        1 * configure.execute(binary2)
+        0 * known._
+        0 * configure._
+        0 * finalized._
+
+        then:
         1 * finalized.execute(binary2)
         0 * known._
         0 * configure._

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryCollectionTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryCollectionTest.groovy
@@ -23,8 +23,8 @@ import org.gradle.language.swift.SwiftBinary
 import org.gradle.language.swift.SwiftSharedLibrary
 import spock.lang.Specification
 
-class DefaultBinaryContainerTest extends Specification {
-    def container = new DefaultBinaryContainer(SwiftBinary, new DefaultProviderFactory())
+class DefaultBinaryCollectionTest extends Specification {
+    def container = new DefaultBinaryCollection(SwiftBinary, new DefaultProviderFactory())
 
     def "can query elements when realized"() {
         def binary1 = Stub(SwiftBinary)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryContainerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryContainerTest.groovy
@@ -23,8 +23,8 @@ import org.gradle.language.swift.SwiftBinary
 import org.gradle.language.swift.SwiftSharedLibrary
 import spock.lang.Specification
 
-class DefaultNativeBinaryContainerTest extends Specification {
-    def container = new DefaultNativeBinaryContainer(SwiftBinary, new DefaultProviderFactory())
+class DefaultBinaryContainerTest extends Specification {
+    def container = new DefaultBinaryContainer(SwiftBinary, new DefaultProviderFactory())
 
     def "can query elements when realized"() {
         def binary1 = Stub(SwiftBinary)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -25,11 +25,11 @@ import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.TaskDependencyMatchers
 import org.gradle.language.ComponentWithBinaries
-import org.gradle.language.ComponentWithInstallation
-import org.gradle.language.ComponentWithLinkFile
-import org.gradle.language.ComponentWithRuntimeFile
+import org.gradle.language.nativeplatform.ComponentWithInstallation
+import org.gradle.language.nativeplatform.ComponentWithLinkFile
+import org.gradle.language.nativeplatform.ComponentWithRuntimeFile
 import org.gradle.language.ProductionComponent
-import org.gradle.language.internal.DefaultNativeBinaryContainer
+import org.gradle.language.internal.DefaultBinaryContainer
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
@@ -47,7 +47,7 @@ class NativeBasePluginTest extends Specification {
         def b2 = Stub(SoftwareComponent)
         b2.name >> "b2"
         def component = Stub(ComponentWithBinaries)
-        def binaries = new DefaultNativeBinaryContainer(SoftwareComponent, null)
+        def binaries = new DefaultBinaryContainer(SoftwareComponent, null)
         component.binaries >> binaries
 
         given:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -34,7 +34,7 @@ import org.gradle.language.ComponentWithBinaries
 import org.gradle.language.ComponentWithOutputs
 import org.gradle.language.ProductionComponent
 import org.gradle.language.internal.DefaultBinaryCollection
-import org.gradle.language.nativeplatform.PublicationAwareComponent
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -268,6 +268,7 @@ class NativeBasePluginTest extends Specification {
         toolProvider.getExecutableName(_) >> { String p -> p + ".exe" }
 
         def exeFileProp = project.objects.property(RegularFile)
+        def debugExeFileProp = project.objects.property(RegularFile)
         def linkTaskProp = project.objects.property(LinkExecutable)
         def installDirProp = project.objects.property(Directory)
         def installTaskProp = project.objects.property(InstallExecutable)
@@ -279,6 +280,7 @@ class NativeBasePluginTest extends Specification {
         executable.platformToolProvider >> toolProvider
         executable.baseName >> Providers.of("test_app")
         executable.executableFile >> exeFileProp
+        executable.debuggerExecutableFile >> debugExeFileProp
         executable.linkTask >> linkTaskProp
         executable.installDirectory >> installDirProp
         executable.installTask >> installTaskProp
@@ -306,6 +308,7 @@ class NativeBasePluginTest extends Specification {
 
         and:
         exeFileProp.get().asFile == linkTask.binaryFile.get().asFile
+        debugExeFileProp.get().asFile == linkTask.binaryFile.get().asFile
         linkTaskProp.get() == linkTask
 
         and:
@@ -319,6 +322,7 @@ class NativeBasePluginTest extends Specification {
         toolProvider.getExecutableSymbolFileName(_) >> { String p -> p + ".exe.pdb" }
 
         def exeFileProp = project.objects.property(RegularFile)
+        def debugExeFileProp = project.objects.property(RegularFile)
         def linkTaskProp = project.objects.property(LinkExecutable)
         def installDirProp = project.objects.property(Directory)
         def installTaskProp = project.objects.property(InstallExecutable)
@@ -335,6 +339,7 @@ class NativeBasePluginTest extends Specification {
         executable.platformToolProvider >> toolProvider
         executable.baseName >> Providers.of("test_app")
         executable.executableFile >> exeFileProp
+        executable.debuggerExecutableFile >> debugExeFileProp
         executable.linkTask >> linkTaskProp
         executable.installDirectory >> installDirProp
         executable.installTask >> installTaskProp
@@ -372,6 +377,7 @@ class NativeBasePluginTest extends Specification {
 
         and:
         exeFileProp.get().asFile == stripTask.outputFile.get().asFile
+        debugExeFileProp.get().asFile == linkTask.binaryFile.get().asFile
         linkTaskProp.get() == linkTask
 
         and:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.language.nativeplatform.ComponentWithInstallation
 import org.gradle.language.nativeplatform.ComponentWithLinkFile
 import org.gradle.language.nativeplatform.ComponentWithRuntimeFile
 import org.gradle.language.ProductionComponent
-import org.gradle.language.internal.DefaultBinaryContainer
+import org.gradle.language.internal.DefaultBinaryCollection
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
@@ -47,7 +47,7 @@ class NativeBasePluginTest extends Specification {
         def b2 = Stub(SoftwareComponent)
         b2.name >> "b2"
         def component = Stub(ComponentWithBinaries)
-        def binaries = new DefaultBinaryContainer(SoftwareComponent, null)
+        def binaries = new DefaultBinaryCollection(SoftwareComponent, null)
         component.binaries >> binaries
 
         given:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -214,19 +214,17 @@ class NativeBasePluginTest extends Specification {
         def toolProvider = Stub(PlatformToolProvider)
         toolProvider.getSharedLibraryName(_) >> { String p -> p + ".dll" }
         toolProvider.getLibrarySymbolFileName(_) >> { String p -> p + ".dll.pdb" }
+        toolProvider.requiresDebugBinaryStripping() >> true
 
         def runtimeFileProp = project.objects.property(RegularFile)
         def linkTaskProp = project.objects.property(LinkSharedLibrary)
-
-        def toolChain = Stub(NativeToolChainInternal)
-        toolChain.requiresDebugBinaryStripping() >> true
 
         def sharedLibrary = Stub(ConfigurableComponentWithSharedLibrary)
         sharedLibrary.name >> "windowsDebug"
         sharedLibrary.debuggable >> true
         sharedLibrary.optimized >> true
         sharedLibrary.targetPlatform >> Stub(NativePlatformInternal)
-        sharedLibrary.toolChain >> toolChain
+        sharedLibrary.toolChain >> Stub(NativeToolChainInternal)
         sharedLibrary.platformToolProvider >> toolProvider
         sharedLibrary.baseName >> Providers.of("test_lib")
         sharedLibrary.runtimeFile >> runtimeFileProp
@@ -320,6 +318,7 @@ class NativeBasePluginTest extends Specification {
         def toolProvider = Stub(PlatformToolProvider)
         toolProvider.getExecutableName(_) >> { String p -> p + ".exe" }
         toolProvider.getExecutableSymbolFileName(_) >> { String p -> p + ".exe.pdb" }
+        toolProvider.requiresDebugBinaryStripping() >> true
 
         def exeFileProp = project.objects.property(RegularFile)
         def debugExeFileProp = project.objects.property(RegularFile)
@@ -327,15 +326,12 @@ class NativeBasePluginTest extends Specification {
         def installDirProp = project.objects.property(Directory)
         def installTaskProp = project.objects.property(InstallExecutable)
 
-        def toolChain = Stub(NativeToolChainInternal)
-        toolChain.requiresDebugBinaryStripping() >> true
-
         def executable = Stub(ConfigurableComponentWithExecutable)
         executable.name >> "windowsDebug"
         executable.debuggable >> true
         executable.optimized >> true
         executable.targetPlatform >> Stub(NativePlatformInternal)
-        executable.toolChain >> toolChain
+        executable.toolChain >> Stub(NativeToolChainInternal)
         executable.platformToolProvider >> toolProvider
         executable.baseName >> Providers.of("test_app")
         executable.executableFile >> exeFileProp

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -34,12 +34,14 @@ import org.gradle.language.ComponentWithBinaries
 import org.gradle.language.ComponentWithOutputs
 import org.gradle.language.ProductionComponent
 import org.gradle.language.internal.DefaultBinaryCollection
-import org.gradle.language.nativeplatform.internal.PublicationAwareComponent
+import org.gradle.language.nativeplatform.internal.ComponentWithNames
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithSharedLibrary
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithStaticLibrary
+import org.gradle.language.nativeplatform.internal.Names
+import org.gradle.language.nativeplatform.internal.PublicationAwareComponent
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary
 import org.gradle.nativeplatform.tasks.ExtractSymbols
@@ -154,6 +156,7 @@ class NativeBasePluginTest extends Specification {
 
         def staticLib = Stub(ConfigurableComponentWithStaticLibrary)
         staticLib.name >> "windowsDebug"
+        staticLib.names >> Names.of("windowsDebug")
         staticLib.targetPlatform >> Stub(NativePlatformInternal)
         staticLib.toolChain >> Stub(NativeToolChainInternal)
         staticLib.platformToolProvider >> toolProvider
@@ -184,6 +187,7 @@ class NativeBasePluginTest extends Specification {
 
         def sharedLibrary = Stub(ConfigurableComponentWithSharedLibrary)
         sharedLibrary.name >> "windowsDebug"
+        sharedLibrary.names >> Names.of("windowsDebug")
         sharedLibrary.targetPlatform >> Stub(NativePlatformInternal)
         sharedLibrary.toolChain >> Stub(NativeToolChainInternal)
         sharedLibrary.platformToolProvider >> toolProvider
@@ -216,6 +220,7 @@ class NativeBasePluginTest extends Specification {
 
         def sharedLibrary = Stub(ConfigurableComponentWithSharedLibrary)
         sharedLibrary.name >> "windowsDebug"
+        sharedLibrary.names >> Names.of("windowsDebug")
         sharedLibrary.debuggable >> true
         sharedLibrary.optimized >> true
         sharedLibrary.targetPlatform >> Stub(NativePlatformInternal)
@@ -261,6 +266,7 @@ class NativeBasePluginTest extends Specification {
 
         def executable = Stub(ConfigurableComponentWithExecutable)
         executable.name >> "windowsDebug"
+        executable.names >> Names.of("windowsDebug")
         executable.targetPlatform >> Stub(NativePlatformInternal)
         executable.toolChain >> Stub(NativeToolChainInternal)
         executable.platformToolProvider >> toolProvider
@@ -309,6 +315,7 @@ class NativeBasePluginTest extends Specification {
 
         def executable = Stub(ConfigurableComponentWithExecutable)
         executable.name >> "windowsDebug"
+        executable.names >> Names.of("windowsDebug")
         executable.debuggable >> true
         executable.optimized >> true
         executable.targetPlatform >> Stub(NativePlatformInternal)
@@ -358,6 +365,7 @@ class NativeBasePluginTest extends Specification {
     def "adds outgoing configuration for component with link usage"() {
         def component = Stub(ConfigurableComponentWithLinkUsage)
         component.name >> "debugWindows"
+        component.names >> Names.of("debugWindows")
         component.implementationDependencies >> Stub(ConfigurationInternal)
 
         given:
@@ -371,6 +379,7 @@ class NativeBasePluginTest extends Specification {
     def "adds outgoing configuration for component with runtime usage"() {
         def component = Stub(ConfigurableComponentWithRuntimeUsage)
         component.name >> "debugWindows"
+        component.names >> Names.of("debugWindows")
         component.implementationDependencies >> Stub(ConfigurationInternal)
 
         given:
@@ -436,8 +445,9 @@ class NativeBasePluginTest extends Specification {
 
     private ComponentWithOutputs binary(String name, String taskName) {
         def outputs = fileCollection(taskName)
-        def binary = Stub(ComponentWithOutputs)
+        def binary = Stub(TestBinary)
         binary.name >> name
+        binary.names >> Names.of(name)
         binary.outputs >> outputs
         return binary
     }
@@ -450,6 +460,9 @@ class NativeBasePluginTest extends Specification {
         def outputs = Stub(FileCollection)
         outputs.buildDependencies >> deps
         return outputs
+    }
+
+    interface TestBinary extends ComponentWithOutputs, ComponentWithNames {
     }
 
     interface TestComponent extends ProductionComponent, ComponentWithBinaries {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
@@ -39,9 +39,9 @@ class DefaultSwiftBinaryTest extends Specification {
     DefaultSwiftBinary binary
 
     def setup() {
-        _ * configurations.maybeCreate("swiftCompileDebug") >> compile
-        _ * configurations.maybeCreate("nativeLinkDebug") >> link
-        _ * configurations.maybeCreate("nativeRuntimeDebug") >> runtime
+        _ * configurations.create("swiftCompileDebug") >> compile
+        _ * configurations.create("nativeLinkDebug") >> link
+        _ * configurations.create("nativeRuntimeDebug") >> runtime
 
         binary = new DefaultSwiftBinary("mainDebug", Mock(ProjectLayout), TestUtil.objectFactory(), Stub(Provider), true, false,false, Stub(FileCollection),  configurations, implementation, Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
@@ -36,7 +36,7 @@ class DefaultSwiftComponentTest extends Specification {
     DefaultSwiftComponent component
 
     def setup() {
-        _ * configurations.maybeCreate("implementation") >> implementation
+        _ * configurations.create("implementation") >> implementation
         component = new TestComponent("main", fileOperations, objectFactory, configurations)
     }
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift.plugins
 
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.provider.Providers
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.swift.SwiftPlatform
@@ -101,6 +102,7 @@ class SwiftBasePluginTest extends Specification {
         library.baseName >> Providers.of("test_lib")
         library.targetPlatform >> Stub(SwiftPlatformInternal)
         library.platformToolProvider >> new TestPlatformToolProvider()
+        library.implementationDependencies >> Stub(ConfigurationInternal)
 
         when:
         project.pluginManager.apply(SwiftBasePlugin)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.swift.plugins
 
+import org.gradle.api.internal.provider.Providers
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.language.swift.internal.DefaultSwiftBinary
@@ -63,12 +64,11 @@ class SwiftBasePluginTest extends Specification {
     }
 
     def "adds link and install task for executable"() {
-        def module = project.objects.property(String)
-        module.set("TestApp")
         def executable = Stub(DefaultSwiftExecutable)
         def executableFile = project.layout.fileProperty()
         executable.name >> name
-        executable.module >> module
+        executable.module >> Providers.of("TestApp")
+        executable.baseName >> Providers.of("test_app")
         executable.executableFile >> executableFile
         executable.targetPlatform >> Stub(SwiftPlatformInternal)
         executable.platformToolProvider >> new TestPlatformToolProvider()
@@ -80,7 +80,7 @@ class SwiftBasePluginTest extends Specification {
         then:
         def link = project.tasks[linkTask]
         link instanceof LinkExecutable
-        link.binaryFile.get().asFile == projectDir.file("build/exe/$exeDir" + OperatingSystem.current().getExecutableName("TestApp"))
+        link.binaryFile.get().asFile == projectDir.file("build/exe/$exeDir" + OperatingSystem.current().getExecutableName("test_app"))
 
         def install = project.tasks[installTask]
         install instanceof InstallExecutable
@@ -95,11 +95,10 @@ class SwiftBasePluginTest extends Specification {
     }
 
     def "adds link task for shared library"() {
-        def module = project.objects.property(String)
-        module.set("TestLib")
         def library = Stub(DefaultSwiftSharedLibrary)
         library.name >> name
-        library.module >> module
+        library.module >> Providers.of("TestLib")
+        library.baseName >> Providers.of("test_lib")
         library.targetPlatform >> Stub(SwiftPlatformInternal)
         library.platformToolProvider >> new TestPlatformToolProvider()
 
@@ -110,7 +109,7 @@ class SwiftBasePluginTest extends Specification {
         then:
         def link = project.tasks[taskName]
         link instanceof LinkSharedLibrary
-        link.binaryFile.get().asFile == projectDir.file("build/lib/${libDir}" + OperatingSystem.current().getSharedLibraryName("TestLib"))
+        link.binaryFile.get().asFile == projectDir.file("build/lib/${libDir}" + OperatingSystem.current().getSharedLibraryName("test_lib"))
 
         where:
         name        | taskName        | libDir

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.language.swift.plugins
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.provider.Providers
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.language.nativeplatform.internal.Names
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.language.swift.internal.DefaultSwiftBinary
 import org.gradle.language.swift.internal.DefaultSwiftExecutable
@@ -44,6 +45,7 @@ class SwiftBasePluginTest extends Specification {
     def "adds compile task for component"() {
         def binary = Stub(DefaultSwiftBinary)
         binary.name >> name
+        binary.names >> Names.of(name)
         binary.module >> project.objects.property(String)
         binary.targetPlatform >> Stub(SwiftPlatformInternal)
 
@@ -68,6 +70,7 @@ class SwiftBasePluginTest extends Specification {
         def executable = Stub(DefaultSwiftExecutable)
         def executableFile = project.layout.fileProperty()
         executable.name >> name
+        executable.names >> Names.of(name)
         executable.module >> Providers.of("TestApp")
         executable.baseName >> Providers.of("test_app")
         executable.executableFile >> executableFile
@@ -98,6 +101,7 @@ class SwiftBasePluginTest extends Specification {
     def "adds link task for shared library"() {
         def library = Stub(DefaultSwiftSharedLibrary)
         library.name >> name
+        library.names >> Names.of(name)
         library.module >> Providers.of("TestLib")
         library.baseName >> Providers.of("test_lib")
         library.targetPlatform >> Stub(SwiftPlatformInternal)

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/AbstractPlatformToolProvider.java
@@ -73,6 +73,11 @@ public abstract class AbstractPlatformToolProvider implements PlatformToolProvid
     }
 
     @Override
+    public boolean requiresDebugBinaryStripping() {
+        return true;
+    }
+
+    @Override
     public String getImportLibraryName(String libraryPath) {
         return getSharedLibraryLinkFileName(libraryPath);
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistry.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistry.java
@@ -139,10 +139,5 @@ public class DefaultNativeToolChainRegistry extends DefaultPolymorphicDomainObje
         public String getOutputType() {
             return "unavailable";
         }
-
-        @Override
-        public boolean requiresDebugBinaryStripping() {
-            return false;
-        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeToolChainInternal.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeToolChainInternal.java
@@ -32,11 +32,6 @@ public interface NativeToolChainInternal extends NativeToolChain, ToolChainInter
      */
     String getOutputType();
 
-    /**
-     * Whether or not this tool chain requires a debuggable binary to be stripped or whether the binary is stripped by default.
-     */
-    boolean requiresDebugBinaryStripping();
-
     class Identifier {
         public static String identify(NativeToolChainInternal toolChain, NativePlatformInternal platform) {
             return toolChain.getOutputType() + ":" + platform.getArchitecture().getName() + ":" + platform.getOperatingSystem().getName();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/PlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/PlatformToolProvider.java
@@ -27,6 +27,11 @@ public interface PlatformToolProvider extends ToolProvider {
 
     boolean producesImportLibrary();
 
+    /**
+     * Whether or not this tool chain requires a debuggable binary to be stripped or whether the binary is stripped by default.
+     */
+    boolean requiresDebugBinaryStripping();
+
     String getImportLibraryName(String libraryPath);
 
     String getSharedLibraryLinkFileName(String libraryPath);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/UnavailablePlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/UnavailablePlatformToolProvider.java
@@ -52,6 +52,12 @@ public class UnavailablePlatformToolProvider implements PlatformToolProvider {
     }
 
     @Override
+    public boolean requiresDebugBinaryStripping() {
+        // Doesn't really make sense
+        return true;
+    }
+
+    @Override
     public String getObjectFileExtension() {
         throw failure();
     }
@@ -68,7 +74,8 @@ public class UnavailablePlatformToolProvider implements PlatformToolProvider {
 
     @Override
     public boolean producesImportLibrary() {
-        return targetOperatingSystem.getInternalOs().isWindows();
+        // Doesn't really make sense
+        return targetOperatingSystem.isWindows();
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -140,11 +140,6 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
     }
 
     @Override
-    public boolean requiresDebugBinaryStripping() {
-        return true;
-    }
-
-    @Override
     public PlatformToolProvider select(NativePlatformInternal targetPlatform) {
         PlatformToolProvider toolProvider = toolProviders.get(targetPlatform);
         if (toolProvider == null) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppPlatformToolProvider.java
@@ -87,6 +87,11 @@ class VisualCppPlatformToolProvider extends AbstractPlatformToolProvider impleme
     }
 
     @Override
+    public boolean requiresDebugBinaryStripping() {
+        return false;
+    }
+
+    @Override
     public String getSharedLibraryLinkFileName(String libraryName) {
         return withExtension(getSharedLibraryName(libraryName), ".lib");
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChain.java
@@ -173,11 +173,6 @@ public class VisualCppToolChain extends ExtendableToolChain<VisualCppPlatformToo
         return "Tool chain '" + getName() + "' (" + getTypeName() + ")";
     }
 
-    @Override
-    public boolean requiresDebugBinaryStripping() {
-        return false;
-    }
-
     public boolean isVisualCpp2015() {
         return visualCpp != null && visualCpp.getVersion().getMajor() >= 14;
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftcToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftcToolChain.java
@@ -127,8 +127,4 @@ public class SwiftcToolChain extends ExtendableToolChain<SwiftcPlatformToolChain
         return "Swift Compiler";
     }
 
-    @Override
-    public boolean requiresDebugBinaryStripping() {
-        return true;
-    }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -87,6 +87,18 @@ allprojects { p ->
         return OperatingSystem.current().linkLibrarySuffix.substring(1)
     }
 
+    String staticLibraryName(Object path) {
+        return OperatingSystem.current().getStaticLibraryName(path.toString())
+    }
+
+    String withStaticLibrarySuffix(Object path) {
+        return path + OperatingSystem.current().staticLibrarySuffix
+    }
+
+    String getStaticLibraryExtension() {
+        return OperatingSystem.current().staticLibrarySuffix.substring(1)
+    }
+
     String withSharedLibrarySuffix(Object path) {
         return path + OperatingSystem.current().sharedLibrarySuffix
     }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeInstallationFixture.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeInstallationFixture.groovy
@@ -24,9 +24,6 @@ class NativeInstallationFixture {
     private final TestFile installDir
     private final OperatingSystem os
 
-    NativeInstallationFixture(TestFile installDir) {
-        this(installDir, OperatingSystem.current())
-    }
     NativeInstallationFixture(TestFile installDir, OperatingSystem os) {
         this.installDir = installDir
         this.os = os

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -303,6 +303,9 @@ public class ModuleMetadataFileGenerator {
             } else if (value instanceof Named) {
                 Named named = (Named) value;
                 jsonWriter.value(named.getName());
+            } else if (value instanceof Enum) {
+                Enum<?> enumValue = (Enum<?>) value;
+                jsonWriter.value(enumValue.name());
             } else {
                 throw new IllegalArgumentException(String.format("Cannot write attribute %s with unsupported value %s of type %s.", attribute.getName(), value, value.getClass().getName()));
             }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -444,7 +444,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     }
 
     enum SomeEnum {
-        Value1, Value2
+        VALUE_1, VALUE_2
     }
 
     def "writes file for component with variants with attributes"() {
@@ -456,7 +456,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
-        v1.attributes >> attributes(usage: "compile", debuggable: true, platform: platform, linkage: SomeEnum.Value1)
+        v1.attributes >> attributes(usage: "compile", debuggable: true, platform: platform, linkage: SomeEnum.VALUE_1)
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes()
@@ -486,7 +486,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
       "name": "v1",
       "attributes": {
         "debuggable": true,
-        "linkage": "Value1",
+        "linkage": "VALUE_1",
         "platform": "windows",
         "usage": "compile"
       }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -443,6 +443,10 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 """
     }
 
+    enum SomeEnum {
+        Value1, Value2
+    }
+
     def "writes file for component with variants with attributes"() {
         def writer = new StringWriter()
         def component = Stub(TestComponent)
@@ -452,7 +456,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
-        v1.attributes >> attributes(usage: "compile", debuggable: true, platform: platform)
+        v1.attributes >> attributes(usage: "compile", debuggable: true, platform: platform, linkage: SomeEnum.Value1)
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes()
@@ -482,6 +486,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
       "name": "v1",
       "attributes": {
         "debuggable": true,
+        "linkage": "Value1",
         "platform": "windows",
         "usage": "compile"
       }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/CppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/CppTestExecutable.java
@@ -18,17 +18,19 @@ package org.gradle.nativeplatform.test.cpp;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.CppExecutable;
+import org.gradle.language.cpp.CppBinary;
+import org.gradle.language.nativeplatform.ComponentWithExecutable;
+import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.nativeplatform.test.TestComponent;
 import org.gradle.nativeplatform.test.tasks.RunTestExecutable;
 
 /**
- * A test executable implemented with C++.
+ * A test executable with tests implemented in C++.
  *
  * @since 4.5
  */
 @Incubating
-public interface CppTestExecutable extends CppExecutable, TestComponent {
+public interface CppTestExecutable extends CppBinary, ComponentWithExecutable, ComponentWithInstallation, TestComponent {
     /**
      * {@inheritDoc}
      */

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
@@ -50,12 +51,14 @@ public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTes
     private final Property<LinkExecutable> linkTaskProperty;
     private final Property<RunTestExecutable> runTask;
     private final ConfigurableFileCollection outputs;
+    private final RegularFileProperty debuggerExecutableFile;
 
     @Inject
     public DefaultCppTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objects, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, Provider<CppComponent> testedComponent, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objects, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.testedComponent = testedComponent;
         this.executableFile = projectLayout.fileProperty();
+        this.debuggerExecutableFile = projectLayout.fileProperty();
         this.installationDirectory = projectLayout.directoryProperty();
         this.linkTaskProperty = objects.property(LinkExecutable.class);
         this.installTaskProperty = objects.property(InstallExecutable.class);
@@ -71,6 +74,11 @@ public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTes
     @Override
     public RegularFileProperty getExecutableFile() {
         return executableFile;
+    }
+
+    @Override
+    public Property<RegularFile> getDebuggerExecutableFile() {
+        return debuggerExecutableFile;
     }
 
     @Override

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
@@ -18,16 +18,22 @@ package org.gradle.nativeplatform.test.cpp.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.CppPlatform;
+import org.gradle.language.cpp.internal.DefaultCppBinary;
 import org.gradle.language.cpp.internal.DefaultCppComponent;
-import org.gradle.language.cpp.internal.DefaultCppExecutable;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
+import org.gradle.nativeplatform.tasks.InstallExecutable;
+import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.test.cpp.CppTestExecutable;
 import org.gradle.nativeplatform.test.tasks.RunTestExecutable;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
@@ -36,15 +42,50 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
 
-public class DefaultCppTestExecutable extends DefaultCppExecutable implements CppTestExecutable {
+public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTestExecutable, ConfigurableComponentWithExecutable {
     private final Provider<CppComponent> testedComponent;
+    private final RegularFileProperty executableFile;
+    private final DirectoryProperty installationDirectory;
+    private final Property<InstallExecutable> installTaskProperty;
+    private final Property<LinkExecutable> linkTaskProperty;
     private final Property<RunTestExecutable> runTask;
+    private final ConfigurableFileCollection outputs;
 
     @Inject
     public DefaultCppTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objects, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, Provider<CppComponent> testedComponent, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        super(name, projectLayout, objects, fileOperations, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+        super(name, projectLayout, objects, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.testedComponent = testedComponent;
+        this.executableFile = projectLayout.fileProperty();
+        this.installationDirectory = projectLayout.directoryProperty();
+        this.linkTaskProperty = objects.property(LinkExecutable.class);
+        this.installTaskProperty = objects.property(InstallExecutable.class);
+        this.outputs = fileOperations.files();
         runTask = objects.property(RunTestExecutable.class);
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return outputs;
+    }
+
+    @Override
+    public RegularFileProperty getExecutableFile() {
+        return executableFile;
+    }
+
+    @Override
+    public DirectoryProperty getInstallDirectory() {
+        return installationDirectory;
+    }
+
+    @Override
+    public Property<InstallExecutable> getInstallTask() {
+        return installTaskProperty;
+    }
+
+    @Override
+    public Property<LinkExecutable> getLinkTask() {
+        return linkTaskProperty;
     }
 
     @Override
@@ -62,7 +103,7 @@ public class DefaultCppTestExecutable extends DefaultCppExecutable implements Cp
                 if (tested == null) {
                     return getFileOperations().files();
                 }
-                return ((DefaultCppComponent)tested).getAllHeaderDirs();
+                return ((DefaultCppComponent) tested).getAllHeaderDirs();
             }
         }));
     }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -40,8 +41,8 @@ public class DefaultCppTestExecutable extends DefaultCppExecutable implements Cp
     private final Property<RunTestExecutable> runTask;
 
     @Inject
-    public DefaultCppTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objects, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, Provider<CppComponent> testedComponent, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        super(name, projectLayout, objects, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+    public DefaultCppTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objects, FileOperations fileOperations, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, Provider<CppComponent> testedComponent, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+        super(name, projectLayout, objects, fileOperations, baseName, debuggable, optimized, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.testedComponent = testedComponent;
         runTask = objects.property(RunTestExecutable.class);
     }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
@@ -30,7 +30,6 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.cpp.CppBinary;
-import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.ProductionCppComponent;
 import org.gradle.language.cpp.plugins.CppBasePlugin;
@@ -38,6 +37,7 @@ import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
+import org.gradle.nativeplatform.test.cpp.CppTestExecutable;
 import org.gradle.nativeplatform.test.cpp.CppTestSuite;
 import org.gradle.nativeplatform.test.cpp.internal.DefaultCppTestExecutable;
 import org.gradle.nativeplatform.test.cpp.internal.DefaultCppTestSuite;
@@ -116,9 +116,9 @@ public class CppUnitTestPlugin implements Plugin<ProjectInternal> {
                             }
                         });
                         testTask.setExecutable(installTask.getRunScript());
-                        testTask.dependsOn(testComponent.getTestBinary().map(new Transformer<Provider<Directory>, CppExecutable>() {
+                        testTask.dependsOn(testComponent.getTestBinary().map(new Transformer<Provider<Directory>, CppTestExecutable>() {
                             @Override
-                            public Provider<Directory> transform(CppExecutable cppExecutable) {
+                            public Provider<Directory> transform(CppTestExecutable cppExecutable) {
                                 return cppExecutable.getInstallDirectory();
                             }
                         }));

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBinary.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBinary.java
@@ -35,9 +35,9 @@ public interface SwiftXCTestBinary extends SwiftBinary, TestComponent {
     /**
      * Returns the executable test file for this binary.
      *
-     * @since 4.4
+     * @since 4.5
      */
-    Provider<RegularFile> getExecutableTestFile();
+    Provider<RegularFile> getExecutableFile();
 
     /**
      * Returns the installation directory for this binary.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBundle.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.xctest;
+
+import org.gradle.api.Incubating;
+
+/**
+ * An XCTest executable for tests implemented in Swift.
+ *
+ * @since 4.5
+ */
+@Incubating
+public interface SwiftXCTestBundle extends SwiftXCTestBinary {
+}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBundle.java
@@ -17,6 +17,8 @@
 package org.gradle.nativeplatform.test.xctest;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.Provider;
+import org.gradle.nativeplatform.tasks.LinkMachOBundle;
 
 /**
  * An XCTest executable for tests implemented in Swift.
@@ -25,4 +27,9 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public interface SwiftXCTestBundle extends SwiftXCTestBinary {
+    /**
+     * Returns the link task for this bundle.
+     */
+    @Override
+    Provider<? extends LinkMachOBundle> getLinkTask();
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestExecutable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.xctest;
+
+import org.gradle.api.Incubating;
+
+/**
+ * An XCTest executable for tests implemented in Swift.
+ *
+ * @since 4.5
+ */
+@Incubating
+public interface SwiftXCTestExecutable extends SwiftXCTestBinary {
+}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestExecutable.java
@@ -17,6 +17,8 @@
 package org.gradle.nativeplatform.test.xctest;
 
 import org.gradle.api.Incubating;
+import org.gradle.language.nativeplatform.ComponentWithExecutable;
+import org.gradle.language.nativeplatform.ComponentWithInstallation;
 
 /**
  * An XCTest executable for tests implemented in Swift.
@@ -24,5 +26,5 @@ import org.gradle.api.Incubating;
  * @since 4.5
  */
 @Incubating
-public interface SwiftXCTestExecutable extends SwiftXCTestBinary {
+public interface SwiftXCTestExecutable extends SwiftXCTestBinary, ComponentWithExecutable, ComponentWithInstallation {
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBinary.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBinary.java
@@ -27,7 +27,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.internal.DefaultSwiftBinary;
-import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestBinary;
 import org.gradle.nativeplatform.test.xctest.tasks.XCTest;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
@@ -39,11 +38,10 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
  *
  * Either way, the installation provides a single entry point for executing this binary.
  */
-public class DefaultSwiftXCTestBinary extends DefaultSwiftBinary implements SwiftXCTestBinary {
+public abstract class DefaultSwiftXCTestBinary extends DefaultSwiftBinary implements SwiftXCTestBinary {
     private final RegularFileProperty executableFile;
     private final DirectoryProperty installDirectory;
     private final RegularFileProperty runScriptFile;
-    private final Property<AbstractLinkTask> linkTaskProperty;
     private final Property<XCTest> runTaskProperty;
 
     public DefaultSwiftXCTestBinary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
@@ -51,12 +49,11 @@ public class DefaultSwiftXCTestBinary extends DefaultSwiftBinary implements Swif
         this.executableFile = projectLayout.fileProperty();
         this.installDirectory = projectLayout.directoryProperty();
         this.runScriptFile = projectLayout.fileProperty();
-        this.linkTaskProperty = objectFactory.property(AbstractLinkTask.class);
         this.runTaskProperty = objectFactory.property(XCTest.class);
     }
 
     @Override
-    public RegularFileProperty getExecutableTestFile() {
+    public RegularFileProperty getExecutableFile() {
         return executableFile;
     }
 
@@ -68,11 +65,6 @@ public class DefaultSwiftXCTestBinary extends DefaultSwiftBinary implements Swif
     @Override
     public RegularFileProperty getRunScriptFile() {
         return runScriptFile;
-    }
-
-    @Override
-    public Property<AbstractLinkTask> getLinkTask() {
-        return linkTaskProperty;
     }
 
     @Override

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBinary.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBinary.java
@@ -33,8 +33,6 @@ import org.gradle.nativeplatform.test.xctest.tasks.XCTest;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
-import javax.inject.Inject;
-
 /**
  * Binary of a XCTest suite component.
  * This may be an executable that can be executed directly or a bundle that must be executed through xctest.
@@ -48,7 +46,6 @@ public class DefaultSwiftXCTestBinary extends DefaultSwiftBinary implements Swif
     private final Property<AbstractLinkTask> linkTaskProperty;
     private final Property<XCTest> runTaskProperty;
 
-    @Inject
     public DefaultSwiftXCTestBinary(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
         this.executableFile = projectLayout.fileProperty();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBundle.java
@@ -21,8 +21,10 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.swift.SwiftPlatform;
+import org.gradle.nativeplatform.tasks.LinkMachOBundle;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestBundle;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
@@ -30,8 +32,16 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import javax.inject.Inject;
 
 public class DefaultSwiftXCTestBundle extends DefaultSwiftXCTestBinary implements SwiftXCTestBundle {
+    private final Property<LinkMachOBundle> linkTask;
+
     @Inject
     public DefaultSwiftXCTestBundle(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+        linkTask = objectFactory.property(LinkMachOBundle.class);
+    }
+
+    @Override
+    public Property<LinkMachOBundle> getLinkTask() {
+        return linkTask;
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBundle.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.xctest.internal;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.language.swift.SwiftPlatform;
+import org.gradle.nativeplatform.test.xctest.SwiftXCTestBundle;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+
+import javax.inject.Inject;
+
+public class DefaultSwiftXCTestBundle extends DefaultSwiftXCTestBinary implements SwiftXCTestBundle {
+    @Inject
+    public DefaultSwiftXCTestBundle(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+        super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+    }
+}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
@@ -18,20 +18,57 @@ package org.gradle.nativeplatform.test.xctest.internal;
 
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.language.swift.SwiftPlatform;
+import org.gradle.nativeplatform.tasks.InstallExecutable;
+import org.gradle.nativeplatform.tasks.LinkExecutable;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestExecutable;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 
-public class DefaultSwiftXCTestExecutable extends DefaultSwiftXCTestBinary implements SwiftXCTestExecutable {
+public class DefaultSwiftXCTestExecutable extends DefaultSwiftXCTestBinary implements SwiftXCTestExecutable, ConfigurableComponentWithExecutable {
+    private final Property<LinkExecutable> linkTask;
+    private final Property<InstallExecutable> installTask;
+    private final ConfigurableFileCollection files;
+    private final RegularFileProperty debuggerExecutableFile;
+
     @Inject
-    public DefaultSwiftXCTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+    public DefaultSwiftXCTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, FileOperations fileOperations, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+        debuggerExecutableFile = projectLayout.fileProperty();
+        linkTask = objectFactory.property(LinkExecutable.class);
+        installTask = objectFactory.property(InstallExecutable.class);
+        files = fileOperations.files();
+    }
+
+    @Override
+    public Property<RegularFile> getDebuggerExecutableFile() {
+        return debuggerExecutableFile;
+    }
+
+    @Override
+    public Property<LinkExecutable> getLinkTask() {
+        return linkTask;
+    }
+
+    @Override
+    public Property<InstallExecutable> getInstallTask() {
+        return installTask;
+    }
+
+    @Override
+    public ConfigurableFileCollection getOutputs() {
+        return files;
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.xctest.internal;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.language.swift.SwiftPlatform;
+import org.gradle.nativeplatform.test.xctest.SwiftXCTestExecutable;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+
+import javax.inject.Inject;
+
+public class DefaultSwiftXCTestExecutable extends DefaultSwiftXCTestBinary implements SwiftXCTestExecutable {
+    @Inject
+    public DefaultSwiftXCTestExecutable(String name, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+        super(name, projectLayout, objectFactory, module, debuggable, optimized, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider);
+    }
+}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuite.java
@@ -25,6 +25,8 @@ import org.gradle.language.swift.SwiftComponent;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.internal.DefaultSwiftComponent;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestBinary;
+import org.gradle.nativeplatform.test.xctest.SwiftXCTestBundle;
+import org.gradle.nativeplatform.test.xctest.SwiftXCTestExecutable;
 import org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
@@ -47,8 +49,14 @@ public class DefaultSwiftXCTestSuite extends DefaultSwiftComponent implements Sw
         this.testBinary = objectFactory.property(SwiftXCTestBinary.class);
     }
 
-    public SwiftXCTestBinary addExecutable(String nameSuffix, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        SwiftXCTestBinary result = objectFactory.newInstance(DefaultSwiftXCTestBinary.class, getName() + StringUtils.capitalize(nameSuffix), getModule(), true, false, false, getSwiftSource(), getImplementationDependencies(), targetPlatform, toolChain, platformToolProvider);
+    public SwiftXCTestExecutable addExecutable(String nameSuffix, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+        SwiftXCTestExecutable result = objectFactory.newInstance(DefaultSwiftXCTestExecutable.class, getName() + StringUtils.capitalize(nameSuffix), getModule(), true, false, false, getSwiftSource(), getImplementationDependencies(), targetPlatform, toolChain, platformToolProvider);
+        getBinaries().add(result);
+        return result;
+    }
+
+    public SwiftXCTestBundle addBundle(String nameSuffix, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+        SwiftXCTestBundle result = objectFactory.newInstance(DefaultSwiftXCTestBundle.class, getName() + StringUtils.capitalize(nameSuffix), getModule(), true, false, false, getSwiftSource(), getImplementationDependencies(), targetPlatform, toolChain, platformToolProvider);
         getBinaries().add(result);
         return result;
     }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -123,7 +123,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
     private void configureTestSuiteBuildingTasks(ProjectInternal project, final DefaultSwiftXCTestBinary binary) {
         if (binary instanceof SwiftXCTestBundle) {
             TaskContainer tasks = project.getTasks();
-            final Names names = Names.of(binary.getName());
+            final Names names = binary.getNames();
             SwiftCompile compile = binary.getCompileTask().get();
 
             // TODO - creating a bundle should be done by some general purpose plugin

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -126,6 +126,8 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
             final Names names = Names.of(binary.getName());
             SwiftCompile compile = binary.getCompileTask().get();
 
+            // TODO - creating a bundle should be done by some general purpose plugin
+
             // TODO - make this lazy
             DefaultNativePlatform currentPlatform = new DefaultNativePlatform("current");
             final ModelRegistry modelRegistry = project.getModelRegistry();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -136,7 +136,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
             // Platform specific arguments
             compile.getCompilerArgs().addAll(project.provider(new Callable<List<String>>() {
                 @Override
-                public List<String> call() throws Exception {
+                public List<String> call() {
                     File frameworkDir = new File(sdkPlatformPathLocator.find(), "Developer/Library/Frameworks");
                     return Arrays.asList("-parse-as-library", "-g", "-F" + frameworkDir.getAbsolutePath());
                 }
@@ -146,7 +146,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
             final LinkMachOBundle link = tasks.create(names.getTaskName("link"), LinkMachOBundle.class);
             link.getLinkerArgs().set(project.provider(new Callable<List<String>>() {
                 @Override
-                public List<String> call() throws Exception {
+                public List<String> call() {
                     File frameworkDir = new File(sdkPlatformPathLocator.find(), "Developer/Library/Frameworks");
                     return Lists.newArrayList("-F" + frameworkDir.getAbsolutePath(), "-framework", "XCTest", "-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks", "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../Frameworks");
                 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -170,7 +170,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
         Provider<RegularFile> exeLocation = project.getLayout().getBuildDirectory().file(project.getProviders().provider(new Callable<String>() {
             @Override
             public String call() {
-                return toolProvider.getExecutableName("exe/" + names.getDirName() + binary.getModule().get());
+                return toolProvider.getExecutableName("exe/" + names.getDirName() + binary.getBaseName().get());
             }
         }));
         link.setOutputFile(exeLocation);

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -96,7 +96,13 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
                 ToolChainSelector.Result<SwiftPlatform> result = toolChainSelector.select(SwiftPlatform.class);
 
                 // Create test suite executable
-                DefaultSwiftXCTestBinary binary = (DefaultSwiftXCTestBinary) testSuite.addExecutable("executable", result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                DefaultSwiftXCTestBinary binary;
+                if (result.getTargetPlatform().getOperatingSystem().isMacOsX()) {
+                    binary = (DefaultSwiftXCTestBinary) testSuite.addBundle("executable", result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+
+                } else {
+                    binary = (DefaultSwiftXCTestBinary) testSuite.addExecutable("executable", result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                }
                 testSuite.getTestBinary().set(binary);
 
                 // Create test suite test task

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.nativeplatform.test.cpp.plugins
 
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.language.cpp.CppExecutable
 import org.gradle.language.cpp.plugins.CppApplicationPlugin
 import org.gradle.language.cpp.plugins.CppLibraryPlugin
 import org.gradle.language.cpp.tasks.CppCompile
 import org.gradle.nativeplatform.tasks.InstallExecutable
 import org.gradle.nativeplatform.tasks.LinkExecutable
+import org.gradle.nativeplatform.test.cpp.CppTestExecutable
 import org.gradle.nativeplatform.test.cpp.CppTestSuite
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
@@ -93,10 +93,11 @@ class CppUnitTestPluginTest extends Specification {
 
         and:
         def binaries = project.unitTest.binaries.get()
-        binaries.findAll { it.debuggable && !it.optimized && it instanceof CppExecutable }.size() == 1
+        binaries.size() == 1
+        binaries.findAll { it.debuggable && !it.optimized && it instanceof CppTestExecutable }.size() == 1
 
         and:
-        project.unitTest.testBinary.get() == binaries.find { it.debuggable && !it.optimized && it instanceof CppExecutable }
+        project.unitTest.testBinary.get() == binaries.first()
     }
 
     def "adds compile, link and install tasks"() {

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -36,4 +36,12 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
         def exe = testSuite.addExecutable("Executable", Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
         exe.name == 'testExecutable'
     }
+
+    def "can add a test bundle"() {
+        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects, project.configurations)
+
+        expect:
+        def exe = testSuite.addBundle("Executable", Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
+        exe.name == 'testExecutable'
+    }
 }


### PR DESCRIPTION
This is another bucket of refactorings that continues from #3909:

- The native base plugin takes care of creating the link/install/strip/extract/create tasks for each executable, shared library and static library. The language specific compile tasks are left to the language base plugins. The C++ unit test and XCTest plugins also make use of this rather than duplicating this logic. The XCTest plugin still takes care of a building a bundle, but shouldn't.
- The native base plugin takes care of defining the outgoing link and runtime configurations of each production binary. The API configurations are left to the language library plugins. The incoming configurations are still handled by the language plugins but shouldn't be.
- The native base plugin takes care of defining the Maven publications of the production component. This currently opt-in and only the C++ plugins do so. This should not be opt-in and should apply to any and all components.
- C++ static libraries are published to Maven repositories.
- The native base plugin takes care of creating the assemble task of each binary.
- Changed the modelling to have separate interfaces for production C++ executables, test executables and test bundles.
- Busted up the native component and binary model interfaces into a bunch of smaller, more focussed interfaces.
- Some renames to distinguish between things that apply to components from any domain and things that apply to components from the native domain.


### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
