### PR TITLE
Fix misplaced/mislabeled sample code blocks

### DIFF
--- a/subprojects/docs/src/docs/userguide/announcePlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/announcePlugin.adoc
@@ -30,7 +30,7 @@ The Gradle announce plugin allows you to send custom announcements during a buil
 To use the announce plugin, apply it to your build script:
 
 ++++
-<sample id="useAnnouncePlugin" dir="announce" title="Using the announce plugin">
+<sample id="useAnnouncePlugin" dir="announce" title="Applying the announce plugin">
             <sourcefile file="build.gradle" snippet="use-plugin"/>
         </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/buildLifecycle.adoc
+++ b/subprojects/docs/src/docs/userguide/buildLifecycle.adoc
@@ -99,7 +99,7 @@ The `includeFlat` method takes directory names as an argument. These directories
 The multi-project tree created in the settings file is made up of so called _project descriptors_. You can modify these descriptors in the settings file at any time. To access a descriptor you can do:
 
 ++++
-<sample id="customLayout" dir="userguide/multiproject/customLayout" title="Modification of elements of the project tree">
+<sample id="customLayout" dir="userguide/multiproject/customLayout" title="Lookup of elements of the project tree">
                 <sourcefile file="settings.gradle" snippet="lookup-project"/>
             </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/eclipsePlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/eclipsePlugin.adoc
@@ -293,7 +293,7 @@ The resulting `.classpath` file will only contain Gradle-generated dependency en
 
 The `whenMerged` hook allows to manipulate the fully populated domain objects. Often this is the preferred way to customize Eclipse files. Here is how you would export all the dependencies of an Eclipse project:
 ++++
-<sample id="exportDependencies" dir="eclipse" title="Export Dependencies">
+<sample id="exportDependencies" dir="eclipse" title="Export Classpath Entries">
                         <sourcefile file="build.gradle" snippet="module-when-merged"/>
                     </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -998,7 +998,7 @@ Manifests are merged in the order they are declared by the `from` statement. If 
 You can easily write a manifest to disk.
 
 ++++
-<sample xmlns:xi="http://www.w3.org/2001/XInclude" id="manifest" dir="userguide/tutorial/manifest" title="Separate MANIFEST.MF for a particular archive">
+<sample xmlns:xi="http://www.w3.org/2001/XInclude" id="manifest" dir="userguide/tutorial/manifest" title="Saving a MANIFEST.MF to disk">
                 <sourcefile file="build.gradle" snippet="write"/>
             </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/javaSoftware.adoc
+++ b/subprojects/docs/src/docs/userguide/javaSoftware.adoc
@@ -372,14 +372,16 @@ But trying to compile a component _brokenclient_ that declares a dependency onto
             </sample>
 ++++
 
-On the other hand, if _Person.java_ in _client_ is updated and its API hasn't changed, _client_ will not be recompiled. This is in particular important for incremental builds of large projects, where we can avoid the compilation of dependencies in chain, and then dramatically reduce build duration:
+On the other hand, if _Person.java_ in _client_ is updated and its API hasn't changed, _client_ will not be recompiled.
 
 ++++
-<sample id="apiSpecification-client" dir="javaLibraryPlugin/apispec-support" title="Recompiling the client">
+<sample id="apiSpecification-client" dir="javaLibraryPlugin/apispec-support" title="Making non-API implementation-only change">
                 <sourcefile file="src/main/java/org/gradle/Person.java"/>
                 <output args=":updateMainComponent" ignoreExtraLines="true" hidden="true" outputFile="buildingJavaLibraries-updateSources.out"/>
             </sample>
 ++++
+
+This is in particular important for incremental builds of large projects, where we can avoid the compilation of dependencies in chain, and then dramatically reduce build duration:
 
 ++++
 <sample id="apiSpecification-client" dir="javaLibraryPlugin/apispec" title="Recompiling the client">

--- a/subprojects/docs/src/docs/userguide/nativeSoftware.adoc
+++ b/subprojects/docs/src/docs/userguide/nativeSoftware.adoc
@@ -863,7 +863,7 @@ Due to this mechanism, your CUnit sources may not contain a `main` method since 
 A api:org.gradle.nativeplatform.test.cunit.CUnitTestSuiteSpec[] component has an associated api:org.gradle.nativeplatform.NativeExecutableSpec[] or api:org.gradle.nativeplatform.NativeLibrarySpec[] component. For each api:org.gradle.nativeplatform.NativeBinarySpec[] configured for the main component, a matching api:org.gradle.nativeplatform.test.cunit.CUnitTestSuiteBinarySpec[] will be configured on the test suite component. These test suite binaries can be configured in a similar way to any other binary instance:
 
 ++++
-<sample id="cunitSources" dir="native-binaries/cunit" title="Building CUnit tests">
+<sample id="cunitSources" dir="native-binaries/cunit" title="Configuring CUnit tests">
                 <sourcefile file="build.gradle" snippet="configure-test-binary"/>
             </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/nativeSoftware.adoc
+++ b/subprojects/docs/src/docs/userguide/nativeSoftware.adoc
@@ -863,7 +863,7 @@ Due to this mechanism, your CUnit sources may not contain a `main` method since 
 A api:org.gradle.nativeplatform.test.cunit.CUnitTestSuiteSpec[] component has an associated api:org.gradle.nativeplatform.NativeExecutableSpec[] or api:org.gradle.nativeplatform.NativeLibrarySpec[] component. For each api:org.gradle.nativeplatform.NativeBinarySpec[] configured for the main component, a matching api:org.gradle.nativeplatform.test.cunit.CUnitTestSuiteBinarySpec[] will be configured on the test suite component. These test suite binaries can be configured in a similar way to any other binary instance:
 
 ++++
-<sample id="cunitSources" dir="native-binaries/cunit" title="Registering CUnit tests">
+<sample id="cunitSources" dir="native-binaries/cunit" title="Building CUnit tests">
                 <sourcefile file="build.gradle" snippet="configure-test-binary"/>
             </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/playPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/playPlugin.adoc
@@ -333,7 +333,7 @@ Of course, pay attention to keep Play version and Scala version for the dependen
 You can further configure the default source sets to do things like add new directories, add filters, etc.
 
 ++++
-<sample id="addExtraPlaySourcesets" dir="play/sourcesets" title="Adding extra source sets to a Play application">
+<sample id="addExtraPlaySourcesets" dir="play/sourcesets" title="Configuring extra source sets to a Play application">
     <sourcefile file="build.gradle" snippet="default-sourcesets"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/repositoryTypes.adoc
+++ b/subprojects/docs/src/docs/userguide/repositoryTypes.adoc
@@ -176,7 +176,7 @@ Optionally, a repository with pattern layout can have its `'organisation'` part 
 You can specify credentials for Ivy repositories secured by basic authentication.
 
 ++++
-<sample id="ivyRepository" dir="userguide/artifacts/defineRepository" title="Ivy repository">
+<sample id="ivyRepository" dir="userguide/artifacts/defineRepository" title="Ivy repository with authentication">
     <sourcefile file="build.gradle" snippet="authenticated-ivy-repo"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/softwareModel.adoc
+++ b/subprojects/docs/src/docs/userguide/softwareModel.adoc
@@ -231,7 +231,7 @@ Managed properties can be of any scalar type. In addition, properties can also b
 | Only if read/write
 |
 ++++
-<sample id="basicRuleSourcePlugin" dir="modelRules/basicRuleSourcePlugin" title="a managed set">
+<sample id="basicRuleSourcePlugin" dir="modelRules/basicRuleSourcePlugin" title="a scalar collection">
     <sourcefile file="build.gradle" snippet="property-type-collection-scalar"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/workingWithFiles.adoc
+++ b/subprojects/docs/src/docs/userguide/workingWithFiles.adoc
@@ -128,7 +128,7 @@ Many objects in Gradle have properties which accept a set of input files. For ex
 Usually, there is a method with the same name as the property, which appends to the set of files. Again, this method accepts any of the types supported by the <<sec:file_collections,files()>> method.
 
 ++++
-<sample id="inputFiles" dir="userguide/files/inputFiles" title="Specifying a set of files">
+<sample id="inputFiles" dir="userguide/files/inputFiles" title="Appending a set of files">
     <sourcefile file="build.gradle" snippet="add-input-files"/>
 </sample>
 ++++


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
I was reading https://docs.gradle.org/current/userguide/build_lifecycle.html#sub:modifying_element_of_the_project_tree and noticed that there's a code block missing
> To access a descriptor you can do:
> &lt;missing here>
> Using this descriptor you can change the name, project directory and build file of a project.

My suspicion was that the title of the blocks needs to be unique, because I checked and the snippet exists in `<sourcefile file="settings.gradle" snippet="lookup-project"/>`: https://github.com/gradle/gradle/blob/v4.4.1/subprojects/docs/src/samples/userguide/multiproject/customLayout/settings.gradle#L3-L6
I also noticed that the missing code block is actually there, but in the wrong section (in the one just after).

After some experimentation I figured out that this happens if there are two consecutive `<sample id="a" title="b">`s in the `.adoc` files.

I was in the mood, so ran a few greps to see if this happens elsewhere as well:
```shell
projects/contrib/github-gradle/subprojects/docs/src/docs/userguide>
$ grep --perl-regexp '<sample((?!>).)*$' *.adoc
# yielded no results, i.e. all the `<sample...>` tags are closed on the same line, this helps in simplifying further queries.

$ samples=$(grep --perl-regexp --no-filename '<sample' *.adoc | sed -re 's/^.*?id="([^"]+)".*?title="([^"]+)".*$/\1\t\2/g' | sort)
$ diff <(echo "$samples") <(echo "$samples" | uniq) | grep '<' | cut -c3-
```
Flagged the following as potentially duplicate:

`addExtraPlaySourcesets`: [Adding extra source sets to a Play application](https://docs.gradle.org/4.4.1/userguide/play_plugin.html#configuring_play_sourcesets)
`apiSpecification-client`: [Recompiling the client](https://docs.gradle.org/4.4.1/userguide/java_software.html#apiSpecification-client)
`basicRuleSourcePlugin`: [a managed set](https://docs.gradle.org/4.4.1/userguide/software_model.html#basicRuleSourcePlugin)
`cunitSources`: [Registering CUnit tests](https://docs.gradle.org/4.4.1/userguide/native_software.html#cunitSources)
`customLayout`: [Modification of elements of the project tree](https://docs.gradle.org/4.4.1/userguide/build_lifecycle.html#customLayout)
`exportDependencies`: [Export Dependencies](https://docs.gradle.org/4.4.1/userguide/eclipse_plugin.html#exportDependencies)
`inputFiles`: [Specifying a set of files](https://docs.gradle.org/4.4.1/userguide/working_with_files.html#inputFiles)
`ivyRepository`: [Ivy repository](https://docs.gradle.org/4.4.1/userguide/dependency_management.html#sec:accessing_password_protected_ivy_repositories) (will be renamed to [this](https://docs.gradle.org/current/userguide/repository_types.html#sec:accessing_password_protected_ivy_repositories) in next release)
`manifest`: [Separate MANIFEST.MF for a particular archive](https://docs.gradle.org/4.4.1/userguide/java_plugin.html#manifest)
`useAnnouncePlugin`: [Using the announce plugin](https://docs.gradle.org/4.4.1/userguide/announce_plugin.html#useAnnouncePlugin)
`useJavaGradlePluginPlugin`: [Using the Java Gradle Plugin Development plugin]() -- left it alone, they're the same
`useJavaLibraryPlugin`: [Declaring API and implementation dependencies](https://docs.gradle.org/4.4.1/userguide/java_library_plugin.html#useJavaLibraryPlugin) -- left it alone, they're the same

And indeed some of them were misplaced / mislabeled. Fixed them. While doing so I noticed that there are bigger issues at hand:
 1. `<sample id="` becomes an HTML section which should have a unique ID, but it looks like due to a lot of copy-paste there's roughly 2-3 IDs per file. This means that it's a lot of times impossible to link to a specific paragraph/section/code sample in the userguide, especially on the single page version.
 2. Whatever tool is converting the `<sample` to HTML is probably using a `Map` keyed by `id+title` (solving the first would invalidate this problem).
 3. If these are fixed, any similar regression should fail the build.

Using a slightly modified version of the above commands I found that there are 52 `<sample>` `id`s reused 161 times. Do you have a documentation team to go through these?

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
