### PR TITLE
Always honour DSL-defined dependency constraints

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -83,8 +83,12 @@ class TestUtil {
         return NamedObjectInstantiator.INSTANCE
     }
 
-    static ExperimentalFeatures experimentalFeatures() {
-        return new ExperimentalFeatures()
+    static ExperimentalFeatures experimentalFeatures(boolean enabled = false) {
+        def experimentalFeatures = new ExperimentalFeatures()
+        if (enabled) {
+            experimentalFeatures.enable()
+        }
+        return experimentalFeatures
     }
 
     static TestUtil create(File rootDir) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -16,17 +16,16 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
 /**
  * This is a variation of {@link PublishedDependencyConstraintsIntegrationTest} that tests dependency constraints
  * declared in the build script (instead of published)
  */
 class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
-    private final ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "conf").expectDefaultConfiguration('runtime')
+    private final ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "conf")
 
     def setup() {
-        ExperimentalFeaturesFixture.enable(settingsFile)
         settingsFile << "rootProject.name = 'test'"
         resolve.prepare()
         buildFile << """
@@ -37,36 +36,6 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 conf
             }
         """
-    }
-
-    void "dependency constraint is ignored when feature not enabled"() {
-        given:
-        // Do not enable feature
-        settingsFile.text = """
-            rootProject.name = 'test'
-        """
-        resolve.expectDefaultConfiguration('default')
-        mavenRepo.module("org", "foo", '1.0').publish()
-        mavenRepo.module("org", "foo", '1.1').publish()
-
-        buildFile << """
-            dependencies {
-                conf 'org:foo:1.0'
-                constraints {
-                    conf 'org:foo:1.1'
-                }
-            }
-        """
-
-        when:
-        run 'checkDeps'
-
-        then:
-        resolve.expectGraph {
-            root(":", ":test:") {
-                module("org:foo:1.0")
-            }
-        }
     }
 
     void "dependency constraint is not included in resolution without a hard dependency"() {
@@ -380,7 +349,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1:runtime").byConflictResolution()
+                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution()
                 edge("org:included:1.0", "project :included", "org:included:1.0") {
                     noArtifacts()
                     module("org:foo:1.1:runtime")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -126,12 +126,7 @@ public class DependencyGraphBuilder {
         final List<EdgeState> dependenciesMissingLocalMetadata = Lists.newArrayList();
         final Map<ModuleVersionIdentifier, ComponentIdentifier> componentIdentifierCache = Maps.newHashMap();
 
-        final PendingDependenciesHandler pendingDependenciesHandler;
-        if (experimentalFeatures.isEnabled()) {
-            pendingDependenciesHandler = new DefaultPendingDependenciesHandler(componentSelectorConverter, dependencySubstitutionApplicator);
-        } else {
-            pendingDependenciesHandler = PendingDependenciesHandler.IGNORE;
-        }
+        final PendingDependenciesHandler pendingDependenciesHandler = new DefaultPendingDependenciesHandler(componentSelectorConverter, dependencySubstitutionApplicator);
 
         while (resolveState.peek() != null || conflictHandler.hasConflicts()) {
             if (resolveState.peek() != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesHandler.java
@@ -16,8 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 public interface PendingDependenciesHandler {
-    PendingDependenciesHandler IGNORE = new IgnorePendingDependenciesHandler();
-
     Visitor start(boolean isOptionalConfiguration);
 
     interface Visitor {
@@ -25,29 +23,4 @@ public interface PendingDependenciesHandler {
 
         void complete();
     }
-
-    class IgnorePendingDependenciesHandler implements PendingDependenciesHandler {
-        @Override
-        public Visitor start(boolean isOptionalConfiguration) {
-            return new IgnorePendingDependenciesVisitor(isOptionalConfiguration);
-        }
-
-        static class IgnorePendingDependenciesVisitor implements PendingDependenciesHandler.Visitor {
-            private final boolean isOptionalConfiguration;
-
-            IgnorePendingDependenciesVisitor(boolean isOptionalConfiguration) {
-                this.isOptionalConfiguration = isOptionalConfiguration;
-            }
-
-            @Override
-            public boolean maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState) {
-                return !isOptionalConfiguration && dependencyState.getDependencyMetadata().isPending();
-            }
-
-            @Override
-            public void complete() {
-            }
-        }
-   }
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -140,7 +140,15 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
                 && dependencyScope != MavenScope.System;
         }
 
+        if (dependency.isOptional() && ignoreOptionalDependencies()) {
+            return false;
+        }
+
         return hierarchy.contains(dependencyScope.name().toLowerCase());
+    }
+
+    private boolean ignoreOptionalDependencies() {
+        return !experimentalFeatures.isEnabled();
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -29,9 +29,12 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstra
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.api.specs.Spec
+import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
+import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.testing.internal.util.Specification
 import org.gradle.util.TestUtil
@@ -49,17 +52,18 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     @Shared attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     @Shared schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())
-    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures(true))
     @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     @Shared defaultVariant
 
     protected static <T> VariantMetadataRules.VariantAction<T> variantAction(String variantName, Action<? super T> action) {
-        new VariantMetadataRules.VariantAction<T>({ it.name == variantName }, action)
+        Spec<VariantResolveMetadata> spec = variantName ? { it.name == variantName } as Spec<VariantResolveMetadata> : Specs.satisfyAll()
+        new VariantMetadataRules.VariantAction<T>(spec, action)
     }
 
     abstract boolean addAllDependenciesAsConstraints()
 
-    abstract void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName, Action<? super DependenciesMetadata> action)
+    abstract void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName = null, Action<? super DependenciesMetadata> action)
 
     boolean supportedInMetadata(String metadata) {
         !addAllDependenciesAsConstraints() || metadata != "ivy" //ivy does not support dependency constraints or optional dependencies
@@ -102,7 +106,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def rule = Mock(Action)
 
         when:
-        doAddDependencyMetadataRule(metadataImplementation, "default", rule)
+        doAddDependencyMetadataRule(metadataImplementation, rule)
         def metadata = metadataImplementation.asImmutable()
 
         then:
@@ -223,7 +227,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         }
 
         when:
-        doAddDependencyMetadataRule(metadataImplementation, "default", rule)
+        doAddDependencyMetadataRule(metadataImplementation, rule)
         def dependencies = selectTargetConfigurationMetadata(metadataImplementation).dependencies
 
         then:
@@ -245,7 +249,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         }
 
         when:
-        doAddDependencyMetadataRule(metadataImplementation, "default", rule)
+        doAddDependencyMetadataRule(metadataImplementation, rule)
         def dependencies = selectTargetConfigurationMetadata(metadataImplementation).dependencies
 
         then:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.TestUtil
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRulesTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures(true))
 
     @Override
     boolean addAllDependenciesAsConstraints() {


### PR DESCRIPTION
When a dependency constraint is defined in the DSL the user has
explicitly opted-in to this feature, and should not require the
experimental-features flag in order to have them take effect.
This change ensures that DSL-defined contstraints are always honoured,
and instead uses the experimentalFeatures flag to determine if Maven
optional dependencies should be treated as dependency constraints.

Signed-off-by: Daz DeBoer <daz@gradle.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
