### PR TITLE
Remove `@Nested` on private properties

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -100,7 +100,6 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
 
     private boolean showProgress;
 
-    @Nested
     private final FindBugsReportsInternal reports;
 
     public FindBugs() {
@@ -128,6 +127,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      *
      * @return The reports container
      */
+    @Nested
     public FindBugsReports getReports() {
         return reports;
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -770,7 +770,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * @return The test framework options.
      */
     @Nested
-    // TODO:LPTR This doesn't resolve any of the nested options for the concrete subtypes
     public TestFrameworkOptions getOptions() {
         return getTestFramework().getOptions();
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -770,6 +770,8 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * @return The test framework options.
      */
     @Nested
+    // TestFrameworkOptions currently don't have any annotated properties. We use this nested input to distinguish between testing frameworks.
+    // This works since the actual option class changes when we change the testing framework.
     public TestFrameworkOptions getOptions() {
         return getTestFramework().getOptions();
     }


### PR DESCRIPTION
This was used to obtain the right type. We now use the runtime type
anyway.
