### PR TITLE
License user manual and DSL reference under CC NC-SA 4.0

### DIFF
--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -412,6 +412,10 @@ p .right {
     padding-bottom: 0;
 }
 
+.citetitle {
+    font-style: normal;
+}
+
 table th.border-right {
     border-right: solid #d0d0d0 1px;
 }
@@ -1138,15 +1142,6 @@ h3.releaseinfo {
     width: 224px;
     height: 135px;
     margin: 12px;
-}
-
-.legalnotice {
-    color: #666;
-}
-
-.legalnotice p:first-of-type:before {
-    content: "Copyright Notice: ";
-    font-weight: 500;
 }
 
 .segmentedlist {

--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -347,6 +347,10 @@
 
             <p>We hope you build happiness with Gradle!</p>
 
+            <h2>Licenses</h2>
+
+            <p>Gradle build tool source code is open and licensed under the <a href="https://github.com/gradle/gradle/blob/master/LICENSE">Apache License 2.0</a>.</p>
+
             <xsl:apply-templates mode="book.titlepage.recto.auto.mode" select="bookinfo/legalnotice"/>
         </main>
     </xsl:template>

--- a/subprojects/docs/src/docs/userguide/userguide.xml
+++ b/subprojects/docs/src/docs/userguide/userguide.xml
@@ -21,10 +21,7 @@
             <holder>Hans Dockter, Adam Murdoch</holder>
         </copyright>
         <legalnotice>
-            <para>Copies of this document may be made for your own use and for distribution to others, provided that you
-                do not charge any fee for such copies and further provided that each copy contains this Copyright
-                Notice, whether distributed in print or electronically.
-            </para>
+            <para>Gradle user manual and DSL references are licensed under <ulink url="http://creativecommons.org/licenses/by-nc-sa/4.0/"><citetitle>Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</citetitle></ulink>.</para>
         </legalnotice>
     </bookinfo>
     <!-- NOTE: Asciidoctor file names must match their declared URL paths, camel-cased -->


### PR DESCRIPTION
This is similar to other open source projects, and was chosen
so that users can contribute but not sell Gradle docs available
on the web.

This puts the license at the bottom of the user manual home page. One alternative we could consider is a new page that is linked from the footer or something.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
