### PR TITLE
Add options to opt into advanced pom support and into gradle metadata

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -95,6 +95,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean buildScan;
     private boolean noBuildScan;
     private boolean interactive;
+    private boolean advancedPomSupport;
 
     /**
      * {@inheritDoc}
@@ -849,5 +850,25 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     @Incubating
     public void setInteractive(boolean interactive) {
         this.interactive = interactive;
+    }
+
+    /**
+     * Returns true when optional dependencies, compile/runtime scope separation and BOMs are included in dependency resolution.
+     *
+     * @since 4.5
+     */
+    @Incubating
+    public boolean isAdvancedPomSupport() {
+        return advancedPomSupport;
+    }
+
+    /**
+     * Specified if optional dependencies, compile/runtime scope separation and BOMs are to be included in dependency resolution.
+     *
+     * @since 4.5
+     */
+    @Incubating
+    public void setAdvancedPomSupport(boolean advancedPomSupport) {
+        this.advancedPomSupport = advancedPomSupport;
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -96,6 +96,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean noBuildScan;
     private boolean interactive;
     private boolean advancedPomSupport;
+    private boolean gradleMetadata;
 
     /**
      * {@inheritDoc}
@@ -853,9 +854,9 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     }
 
     /**
-     * Returns true when optional dependencies, compile/runtime scope separation and BOMs are included in dependency resolution.
+     * Returns true if optional dependencies, compile/runtime scope separation and BOMs are included in dependency resolution.
      *
-     * @since 4.5
+     * @since 4.6
      */
     @Incubating
     public boolean isAdvancedPomSupport() {
@@ -863,12 +864,32 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     }
 
     /**
-     * Specified if optional dependencies, compile/runtime scope separation and BOMs are to be included in dependency resolution.
+     * Specifies if optional dependencies, compile/runtime scope separation and BOMs are to be included in dependency resolution.
      *
-     * @since 4.5
+     * @since 4.6
      */
     @Incubating
     public void setAdvancedPomSupport(boolean advancedPomSupport) {
         this.advancedPomSupport = advancedPomSupport;
+    }
+
+    /**
+     * Returns true if gradle metadata should be use as preferred format for resolving and publishing dependencies.
+     *
+     * @since 4.6
+     */
+    @Incubating
+    public boolean isGradleMetadata() {
+        return gradleMetadata;
+    }
+
+    /**
+     * Specifies if gradle metadata should be use as preferred format for resolving and publishing dependencies.
+     *
+     * @since 4.6
+     */
+    @Incubating
+    public void setGradleMetadata(boolean gradleMetadata) {
+        this.gradleMetadata = gradleMetadata;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ExperimentalFeatures.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ExperimentalFeatures.java
@@ -15,19 +15,16 @@
  */
 package org.gradle.api.internal;
 
+import org.gradle.StartParameter;
+
 public class ExperimentalFeatures {
-    private static final String ENABLE_EXPERIMENTAL_FEATURES = "org.gradle.internal.experimentalFeatures";
-    private boolean enabled;
+    private StartParameterInternal startParameter;
 
-    public ExperimentalFeatures() {
-        enabled = System.getProperty(ENABLE_EXPERIMENTAL_FEATURES) != null;
-    }
-
-    public void enable() {
-        enabled = true;
+    public ExperimentalFeatures(StartParameter startParameter) {
+        this.startParameter = (StartParameterInternal) startParameter;
     }
 
     public boolean isEnabled() {
-        return enabled;
+        return startParameter.isExperimental();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ExperimentalFeatures.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ExperimentalFeatures.java
@@ -24,7 +24,11 @@ public class ExperimentalFeatures {
         this.startParameter = (StartParameterInternal) startParameter;
     }
 
-    public boolean isEnabled() {
+    public boolean isAdvancedPomSupportEnabled() {
+        return startParameter.isAdvancedPomSupport();
+    }
+
+    public boolean isExperimentalEnabled() {
         return startParameter.isExperimental();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -17,10 +17,10 @@ package org.gradle.api.internal;
 
 import org.gradle.StartParameter;
 
-public class ExperimentalFeatures {
+public class FeaturePreviews {
     private StartParameterInternal startParameter;
 
-    public ExperimentalFeatures(StartParameter startParameter) {
+    public FeaturePreviews(StartParameter startParameter) {
         this.startParameter = (StartParameterInternal) startParameter;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -18,17 +18,17 @@ package org.gradle.api.internal;
 import org.gradle.StartParameter;
 
 public class FeaturePreviews {
-    private StartParameterInternal startParameter;
+    private StartParameter startParameter;
 
     public FeaturePreviews(StartParameter startParameter) {
-        this.startParameter = (StartParameterInternal) startParameter;
+        this.startParameter = startParameter;
     }
 
     public boolean isAdvancedPomSupportEnabled() {
         return startParameter.isAdvancedPomSupport();
     }
 
-    public boolean isExperimentalEnabled() {
-        return startParameter.isExperimental();
+    public boolean isGradleMetadataEnabled() {
+        return startParameter.isGradleMetadata();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -126,6 +126,4 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
     Path findIdentityPath();
 
     void setIdentityPath(Path path);
-
-    ExperimentalFeatures getExperimentalFeatures();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 public class StartParameterInternal extends StartParameter implements Deprecatable {
     private final Deprecatable deprecationHandler = new LoggingDeprecatable();
+    private boolean experimental;
 
     @Override
     public StartParameter newInstance() {
@@ -47,5 +48,13 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
     @Override
     public void checkDeprecation() {
         deprecationHandler.checkDeprecation();
+    }
+
+    public void setExperimental(boolean experimental) {
+        this.experimental = experimental;
+    }
+
+    public boolean isExperimental() {
+        return experimental;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 public class StartParameterInternal extends StartParameter implements Deprecatable {
     private final Deprecatable deprecationHandler = new LoggingDeprecatable();
-    private boolean experimental;
 
     @Override
     public StartParameter newInstance() {
@@ -48,13 +47,5 @@ public class StartParameterInternal extends StartParameter implements Deprecatab
     @Override
     public void checkDeprecation() {
         deprecationHandler.checkDeprecation();
-    }
-
-    public void setExperimental(boolean experimental) {
-        this.experimental = experimental;
-    }
-
-    public boolean isExperimental() {
-        return experimental;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -299,7 +299,7 @@ public class StartParameterBuildOptions {
         public static final String GRADLE_PROPERTY = "org.gradle.advancedpomsupport";
 
         public AdvancedPomSupportOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("advanced-pom-support", "Enables support for optional dependencies, compile/runtime scope separation and BOMs.", "Disables support for optional dependencies, compile/runtime scope separation and BOMs").incubating());
+            super(GRADLE_PROPERTY);
         }
 
         @Override
@@ -312,7 +312,7 @@ public class StartParameterBuildOptions {
         public static final String GRADLE_PROPERTY = "org.gradle.gradlemetadata";
 
         public GradleMetadataOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("gradle-metadata", "Enables the gradle metadata format for resolving and publishing dependencies.", "Disables the gradle metadata format for resolving and publishing dependencies.").incubating());
+            super(GRADLE_PROPERTY);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -58,7 +58,7 @@ public class StartParameterBuildOptions {
         options.add(new BuildCacheOption());
         options.add(new BuildScanOption());
         options.add(new AdvancedPomSupportOption());
-        options.add(new ExperimentalOption());
+        options.add(new GradleMetadataOption());
         StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
 
@@ -308,16 +308,16 @@ public class StartParameterBuildOptions {
         }
     }
 
-    public static class ExperimentalOption extends BooleanBuildOption<StartParameterInternal> {
-        public static final String GRADLE_PROPERTY = "org.gradle.experimental";
+    public static class GradleMetadataOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String GRADLE_PROPERTY = "org.gradle.gradlemetadata";
 
-        public ExperimentalOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("experimental", "Enables experimental features.", "Disables experimental features.").internal());
+        public GradleMetadataOption() {
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("gradle-metadata", "Enables the gradle metadata format for resolving and publishing dependencies.", "Disables the gradle metadata format for resolving and publishing dependencies.").incubating());
         }
 
         @Override
         public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
-            settings.setExperimental(value);
+            settings.setGradleMetadata(value);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -57,6 +57,7 @@ public class StartParameterBuildOptions {
         options.add(new ConfigureOnDemandOption());
         options.add(new BuildCacheOption());
         options.add(new BuildScanOption());
+        options.add(new AdvancedPomSupportOption());
         options.add(new ExperimentalOption());
         StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
@@ -291,6 +292,19 @@ public class StartParameterBuildOptions {
             } else {
                 settings.setNoBuildScan(true);
             }
+        }
+    }
+
+    public static class AdvancedPomSupportOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String GRADLE_PROPERTY = "org.gradle.advancedpomsupport";
+
+        public AdvancedPomSupportOption() {
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("advanced-pom-support", "Enables support for optional dependencies, compile/runtime scope separation and BOMs.", "Disables support for optional dependencies, compile/runtime scope separation and BOMs").incubating());
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
+            settings.setAdvancedPomSupport(value);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -57,6 +57,7 @@ public class StartParameterBuildOptions {
         options.add(new ConfigureOnDemandOption());
         options.add(new BuildCacheOption());
         options.add(new BuildScanOption());
+        options.add(new ExperimentalOption());
         StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
 
@@ -290,6 +291,19 @@ public class StartParameterBuildOptions {
             } else {
                 settings.setNoBuildScan(true);
             }
+        }
+    }
+
+    public static class ExperimentalOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String GRADLE_PROPERTY = "org.gradle.experimental";
+
+        public ExperimentalOption() {
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("experimental", "Enables experimental features.", "Disables experimental features.").internal());
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
+            settings.setExperimental(value);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -18,7 +18,7 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.BuildScopeFileTimeStampInspector;
@@ -251,8 +251,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return BuildStartedTime.startingAt(Math.min(currentTime, buildRequestMetaData.getStartTime()));
     }
 
-    ExperimentalFeatures createExperimentalFeatures(StartParameter startParameter) {
-        return new ExperimentalFeatures(startParameter);
+    FeaturePreviews createExperimentalFeatures(StartParameter startParameter) {
+        return new FeaturePreviews(startParameter);
     }
 
     CleanupActionFactory createCleanupActionFactory(BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -251,8 +251,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return BuildStartedTime.startingAt(Math.min(currentTime, buildRequestMetaData.getStartTime()));
     }
 
-    ExperimentalFeatures createExperimentalFeatures() {
-        return new ExperimentalFeatures();
+    ExperimentalFeatures createExperimentalFeatures(StartParameter startParameter) {
+        return new ExperimentalFeatures(startParameter);
     }
 
     CleanupActionFactory createCleanupActionFactory(BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -27,7 +27,6 @@ import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.Settings;
-import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.file.FileResolver;
@@ -145,11 +144,6 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             throw new IllegalStateException("Identity path already set");
         }
         identityPath = path;
-    }
-
-    @Override
-    public ExperimentalFeatures getExperimentalFeatures() {
-        return services.get(ExperimentalFeatures.class);
     }
 
     @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -19,7 +19,7 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.api.Task
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.DefaultInstantiatorFactory
-import org.gradle.api.internal.ExperimentalFeatures
+import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
@@ -84,11 +84,11 @@ class TestUtil {
         return NamedObjectInstantiator.INSTANCE
     }
 
-    static ExperimentalFeatures experimentalFeatures(boolean advancedPomSupportEnabled = false, boolean experimentalEnabled = false) {
+    static FeaturePreviews featurePreviews(boolean advancedPomSupportEnabled = false, boolean experimentalEnabled = false) {
         def startParameter = new StartParameterInternal()
         startParameter.setAdvancedPomSupport(advancedPomSupportEnabled)
         startParameter.setExperimental(experimentalEnabled)
-        return new ExperimentalFeatures(startParameter)
+        return new FeaturePreviews(startParameter)
     }
 
     static TestUtil create(File rootDir) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -84,10 +84,10 @@ class TestUtil {
         return NamedObjectInstantiator.INSTANCE
     }
 
-    static FeaturePreviews featurePreviews(boolean advancedPomSupportEnabled = false, boolean experimentalEnabled = false) {
+    static FeaturePreviews featurePreviews(boolean advancedPomSupportEnabled = false, boolean gradleMetadataEnabled = false) {
         def startParameter = new StartParameterInternal()
-        startParameter.setAdvancedPomSupport(advancedPomSupportEnabled)
-        startParameter.setExperimental(experimentalEnabled)
+        startParameter.advancedPomSupport = advancedPomSupportEnabled
+        startParameter.gradleMetadata = gradleMetadataEnabled
         return new FeaturePreviews(startParameter)
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.DefaultInstantiatorFactory
 import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.InstantiatorFactory
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
@@ -84,11 +85,11 @@ class TestUtil {
     }
 
     static ExperimentalFeatures experimentalFeatures(boolean enabled = false) {
-        def experimentalFeatures = new ExperimentalFeatures()
+        def startParameter = new StartParameterInternal()
         if (enabled) {
-            experimentalFeatures.enable()
+            startParameter.setExperimental(true)
         }
-        return experimentalFeatures
+        return new ExperimentalFeatures(startParameter)
     }
 
     static TestUtil create(File rootDir) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -84,11 +84,10 @@ class TestUtil {
         return NamedObjectInstantiator.INSTANCE
     }
 
-    static ExperimentalFeatures experimentalFeatures(boolean enabled = false) {
+    static ExperimentalFeatures experimentalFeatures(boolean advancedPomSupportEnabled = false, boolean experimentalEnabled = false) {
         def startParameter = new StartParameterInternal()
-        if (enabled) {
-            startParameter.setExperimental(true)
-        }
+        startParameter.setAdvancedPomSupport(advancedPomSupportEnabled)
+        startParameter.setExperimental(experimentalEnabled)
         return new ExperimentalFeatures(startParameter)
     }
 

--- a/subprojects/dependency-management/preview-features.adoc
+++ b/subprojects/dependency-management/preview-features.adoc
@@ -1,28 +1,35 @@
-# Gradle 5.0 preview features
+# Gradle 5.0 Feature Previews
 
 ## Enhanced support for Maven repositories
 
-Because these improvements change the resolution result for certain Gradle `Configuration` instances, we consider them to be "potentially breaking changes". As such, these improvements are _opt-in_ for the Gradle 4.x stream of releases, but we expect to make them the default in Gradle 5.0.
+These improvements can change the resolution result for certain Gradle configurations. Thus we consider them to be _potentially breaking changes_. As such, these improvements are opt-in for the Gradle 4.x stream of releases, but are scheduled to become the default in Gradle 5.0.
 
-### Dependency constraints from Maven POM files
+[NOTE]
+Activate this feature in Gradle 4.6+ by setting `org.gralde.advancedpomsupport=true` in _gradle.properties_ or calling Gradle with
+`--advanced-pom-support`
 
-With the introduction of 'dependency constraints', Gradle can now provide a better experience for consumers of Maven repositories. There is not a clear 1:1 mapping between dependency constraints and Maven POM features, but there are some cases where it makes sense for Gradle to map a Maven POM feature to a dependency constraint. 
+### Maven `optional` dependencies
 
-#### Maven `optional` dependencies
+Whenever a POM file contains a dependency declaration with `<optional>true</optional>`, Gradle will create a _dependency constraint_. This constraint will produce the expected result for an optional dependency: if the dependency module is brought in by another, non-optional, dependency declaration, then the constraint will apply when choosing the version for that dependency (e.g., if the optional dependency defines a higher version, that one is chosen).
 
-Whenever a POM file contains a dependency with `<optional>true</optional>`, Gradle 5.0 will create a _dependency constraint_ for that dependency. This constraint will produce the expected result for an optional dependency: if the dependency module is brought into the graph by another edge, then the constraint will apply when choosing the version for that dependency.
+### Maven BOM files and `<dependencyManagement>`
 
-#### Maven BOM files and `<dependencyManagement>`
+Gradle now provides support for "Maven BOM" files, which are effectively POM files that use `<dependencyManagement>` to control the dependency versions of direct and transitive dependencies. The BOM support in Gradle works similar to the use of `<scope>import</scope>` when depending on a BOM in Maven, but is done via a regular dependency declaration on the BOM:
 
-Gradle now provides support for a "Maven BOM" file, which is effectively a POM file that uses `<dependencyManagement>` to control the dependency versions for another project. Since Gradle has no concept of a "parent POM" file, support for Maven BOM is similar to the use of `<scope>import</scope>` when depending on a BOM in Maven, but is done via a regular dependency declaration.
+```
+dependencies {
+  implementation 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE'
+}
+```
 
-When Gradle discovers a dependency on a Maven BOM file, all dependencies declared in the `<dependencyManagement>` block are treated as Gradle _dependency constraints_. This means that any `<dependencyManagement>` versions defined in the BOM file can impact the resolved graph. Gradle treats any POM file with `<packaging>pom</packaging>` as a potential BOM file: if a dependency resolves to a Maven module with `pom` packaging, then a _dependency constraint_ will be produced for every dependency declared in a `dependencyManagement` block. 
+When Gradle discovers a dependency on a Maven BOM file, all dependencies declared in the `<dependencyManagement>` block are treated as Gradle _dependency constraints_. This means that any `<dependencyManagement>` versions defined in the BOM file can impact the resolved graph. Gradle treats any POM file with `<packaging>pom</packaging>` as BOM file: if a dependency resolves to a Maven module with `pom` packaging, then a _dependency constraint_ will be produced for every dependency declared in a `dependencyManagement` block.
 
 Note one major difference between the handling of BOM files in Maven and Gradle: a dependency on a BOM is just a regular dependency, and can be published and resolved transitively just like any other dependency. This is different from Maven, where a BOM is _imported_ into the build, and downstream consumers do not automatically benefit from the dependency constraints defined. For example, if project A depends on project B, and project B _imports_ the BOM for project C, then a dependency declared in project A will not use the versions defined in project C.
 
 ### Runtime scoped dependencies are not included in Java compile classpath
 
-Since v1.0, Gradle has been included `runtime` scoped dependencies in the Java compile classpath. While this often works fine, it has a number of drawbacks:
+Since Gradle 1.0, `runtime` scoped dependencies have been included in the Java compile classpath. While this often works fine, it has a number of drawbacks:
+
 - It's easy to publish a compile-time dependency with `runtime` scope, causing issues for non-Gradle consumers
 - The compile classpath is much larger than it needs to be, slowing down compilation
 - The compile classpath includes `runtime` files that do not impact compilation, resulting in unnecessary re-compilation when these files change.
@@ -32,14 +39,30 @@ With Gradle 5.0, we intend to change this behaviour. A Maven POM will be conside
 ## New Gradle `.module` metadata format
 
 In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a new module metadata format, that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
-This new metadata format is under active development, so we have made it _opt-in_ for the Gradle 4.x stream.
 
-Issues with enabling it by default in Gradle 4.x:
+The new metadata format is still under active development. The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md[here]. Currently there are the following issues with enabling it in Gradle 4.x:
+
 - We do not yet guarantee backward or forward compatibility for the metadata file format. Thus, resolution may change when upgrading Gradle, if a metadata file is published with an old format.
 - An additional request is required for Maven and Ivy repositories to check for the new metadata file.
 
-## Gradle does not search for `.jar` file when POM/Ivy file is missing
+[NOTE]
+Activate this feature in Gradle 4.6+ by setting `org.gralde.gradlemetadata=true` in _gradle.properties_ or calling Gradle with
+`--gradle-metadata`
 
-A regular `maven` or `ivy` module will be defined by the presence of a `pom` or `ivy.xml` file. However, Gradle will also search for a `.jar` file in these repositories, in the off chance that the module was "published" without any metadata file. If the jar file is discovered, it's considered to be a module with no dependencies.
+### Publishing `.module` metadata files
 
-This behaviour will no longer be the default in Gradle 5.0, reducing the number of network requests and working in a less surprising manner. It will be possible to opt-in to these "artifact only modules" by configuring the `metadataSources` for a repository.
+If this feature preview is activated, the _maven-publish_ and _ivy-publlish_ plugins automatically publish a `.module` file in addition to the `pom`/`iny.xml` metadata file. If these modules are consumed by Gradle, _dependency constraints_ and _version constraints_, for examples strict versions, are preserved. By still publishing the traditional metadata formats, compatibility with Maven and Ivy is still ensured as much as possible.
+
+The `.module` files are used to automatically publish the `api` and `runtime` variants of  Java libraries. These variants are honoured during dependency resolution. Additional publishing features will be added in the future which will allow for the publication of additional variants.
+
+### Consuming `.module` metadata files
+
+If this feature preview is activated, Gradle automatically searches for a `.module` file for each dependency in a Maven or Ivy repository. If the file is found, it is preferred over the `pom`/`ivy.xml` file.
+
+If a `.module` file is found, _dependency constraints_ and _version constraints_ of the dependency are consumed from that file and are honored during dependency resolution.
+
+### Gradle does not search for `.jar` file when metadata files are missing
+
+With this feature preview, Gradle expects a `.module` or a  `.pom`/`ivy.xml` file for each regular Maven or Ivy module. Previously, Gradle also searched for a `.jar` file in repositories in the absence of any metadata file. This was to cover the unusual case that the module was published without any metadata file. If the jar file was discovered, it was considered to be a module with no dependencies.
+
+This behaviour is no longer active with this feature preview and will no longer be the default in Gradle 5.0. This reduces the number of network requests and makes module discovery less magical. It is still possible to opt into support for such _artifact only modules_ by configuring the `metadataSources` for a repository.

--- a/subprojects/dependency-management/preview-features.adoc
+++ b/subprojects/dependency-management/preview-features.adoc
@@ -5,8 +5,7 @@
 These improvements can change the resolution result for certain Gradle configurations. Thus we consider them to be _potentially breaking changes_. As such, these improvements are opt-in for the Gradle 4.x stream of releases, but are scheduled to become the default in Gradle 5.0.
 
 [NOTE]
-Activate this feature in Gradle 4.6+ by setting `org.gralde.advancedpomsupport=true` in _gradle.properties_ or calling Gradle with
-`--advanced-pom-support`
+Activate this feature in Gradle 4.6+ by setting `org.gradle.advancedpomsupport=true` in _gradle.properties_.
 
 ### Maven `optional` dependencies
 
@@ -46,8 +45,7 @@ The new metadata format is still under active development. The latest version of
 - An additional request is required for Maven and Ivy repositories to check for the new metadata file.
 
 [NOTE]
-Activate this feature in Gradle 4.6+ by setting `org.gralde.gradlemetadata=true` in _gradle.properties_ or calling Gradle with
-`--gradle-metadata`
+Activate this feature in Gradle 4.6+ by setting `org.gralde.gradlemetadata=true` in _gradle.properties_.
 
 ### Publishing `.module` metadata files
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -26,9 +26,7 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
     void "dependency constraint is ignored when feature is not enabled"() {
         given:
         // Do not enable feature
-        settingsFile.text = """
-            rootProject.name = 'test'
-        """
+        propertiesFile.text = ''
 
         repository {
             'org:foo:1.0'()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.publish.RemoteRepositorySpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.HttpRepository
@@ -197,7 +197,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         given:
         setupRepositories(REPO_TYPES)
         if (testVariant.contains('+experimental')) {
-            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+            FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         }
         setupModuleChain(chain)
 
@@ -241,7 +241,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def "explicit compile configuration selection works for a chain of pure maven dependencies (experimental=#experimental)"() {
         given:
         if (experimental) {
-            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+            FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         }
         def modules = ['mavenCompile1', 'mavenCompile2', 'mavenCompile3']
         setupRepositories(modules)
@@ -318,7 +318,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     @Unroll
     def "with experimental resolve behavior, explicit #conf configuration selection still works for maven dependencies"() {
         given:
-        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+        FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         def modules = ['maven', 'mavenCompile1', 'maven-gradle', 'mavenCompile2']
         setupRepositories(modules)
         setupModuleChain(modules)
@@ -363,7 +363,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def "explicit configuration selection in ivy modules is supported=#supported if targeting a #target module (experimental=#experimental)"() {
         given:
         if (experimental) {
-            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+            FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         }
         String targetRepoName = supported? "$target-select" : target //use a different name if selection is supported to not follow the default expectations defined in leaksRuntime()
         setupRepositories([targetRepoName, 'ivy'])

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -197,7 +197,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         given:
         setupRepositories(REPO_TYPES)
         if (testVariant.contains('+experimental')) {
-            ExperimentalFeaturesFixture.enable(propertiesFile)
+            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         }
         setupModuleChain(chain)
 
@@ -241,7 +241,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def "explicit compile configuration selection works for a chain of pure maven dependencies (experimental=#experimental)"() {
         given:
         if (experimental) {
-            ExperimentalFeaturesFixture.enable(propertiesFile)
+            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         }
         def modules = ['mavenCompile1', 'mavenCompile2', 'mavenCompile3']
         setupRepositories(modules)
@@ -318,7 +318,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     @Unroll
     def "with experimental resolve behavior, explicit #conf configuration selection still works for maven dependencies"() {
         given:
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         def modules = ['maven', 'mavenCompile1', 'maven-gradle', 'mavenCompile2']
         setupRepositories(modules)
         setupModuleChain(modules)
@@ -363,7 +363,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def "explicit configuration selection in ivy modules is supported=#supported if targeting a #target module (experimental=#experimental)"() {
         given:
         if (experimental) {
-            ExperimentalFeaturesFixture.enable(propertiesFile)
+            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         }
         String targetRepoName = supported? "$target-select" : target //use a different name if selection is supported to not follow the default expectations defined in leaksRuntime()
         setupRepositories([targetRepoName, 'ivy'])

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -197,7 +197,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         given:
         setupRepositories(REPO_TYPES)
         if (testVariant.contains('+experimental')) {
-            ExperimentalFeaturesFixture.enable(settingsFile)
+            ExperimentalFeaturesFixture.enable(propertiesFile)
         }
         setupModuleChain(chain)
 
@@ -241,7 +241,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def "explicit compile configuration selection works for a chain of pure maven dependencies (experimental=#experimental)"() {
         given:
         if (experimental) {
-            ExperimentalFeaturesFixture.enable(settingsFile)
+            ExperimentalFeaturesFixture.enable(propertiesFile)
         }
         def modules = ['mavenCompile1', 'mavenCompile2', 'mavenCompile3']
         setupRepositories(modules)
@@ -318,7 +318,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     @Unroll
     def "with experimental resolve behavior, explicit #conf configuration selection still works for maven dependencies"() {
         given:
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         def modules = ['maven', 'mavenCompile1', 'maven-gradle', 'mavenCompile2']
         setupRepositories(modules)
         setupModuleChain(modules)
@@ -363,7 +363,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
     def "explicit configuration selection in ivy modules is supported=#supported if targeting a #target module (experimental=#experimental)"() {
         given:
         if (experimental) {
-            ExperimentalFeaturesFixture.enable(settingsFile)
+            ExperimentalFeaturesFixture.enable(propertiesFile)
         }
         String targetRepoName = supported? "$target-select" : target //use a different name if selection is supported to not follow the default expectations defined in leaksRuntime()
         setupRepositories([targetRepoName, 'ivy'])

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -28,7 +28,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
 
     def setup() {
         resolve.prepare()
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         settingsFile << "rootProject.name = 'testproject'"
         buildFile << """
             repositories { maven { url "${mavenHttpRepo.uri}" } }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -28,7 +28,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
 
     def setup() {
         resolve.prepare()
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         settingsFile << "rootProject.name = 'testproject'"
         buildFile << """
             repositories { maven { url "${mavenHttpRepo.uri}" } }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
 
@@ -28,7 +28,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
 
     def setup() {
         resolve.prepare()
-        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+        FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         settingsFile << "rootProject.name = 'testproject'"
         buildFile << """
             repositories { maven { url "${mavenHttpRepo.uri}" } }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser.FORMAT_VERSION
@@ -27,7 +27,7 @@ class MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest extends Ab
 
     def setup() {
         resolve.prepare()
-        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableExperimental(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -27,7 +27,7 @@ class MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest extends Ab
 
     def setup() {
         resolve.prepare()
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -27,7 +27,7 @@ class MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest extends Ab
 
     def setup() {
         resolve.prepare()
-        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableGradleMetadata(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -27,7 +27,7 @@ class MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest extends Ab
 
     def setup() {
         resolve.prepare()
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -30,7 +30,7 @@ class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends A
         resolve.prepare()
         server.start()
 
-        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableGradleMetadata(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
 
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -30,7 +30,7 @@ class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends A
         resolve.prepare()
         server.start()
 
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
 
     }
@@ -117,7 +117,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2:runtime")
+                module("test:a:1.2")
             }
         }
 
@@ -128,7 +128,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2:runtime")
+                module("test:a:1.2")
             }
         }
 
@@ -144,7 +144,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2:runtime")
+                module("test:a:1.2")
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -30,7 +30,7 @@ class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends A
         resolve.prepare()
         server.start()
 
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
 
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
@@ -30,7 +30,7 @@ class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends A
         resolve.prepare()
         server.start()
 
-        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableExperimental(propertiesFile)
         settingsFile << "rootProject.name = 'test'"
 
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -25,7 +25,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.DomainObjectContext;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
@@ -151,7 +151,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                           ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                           InstantiatorFactory instantiatorFactory,
                                                           FileResourceRepository fileResourceRepository,
-                                                          ExperimentalFeatures experimentalFeatures,
+                                                          FeaturePreviews featurePreviews,
                                                           MavenMutableModuleMetadataFactory metadataFactory,
                                                           IvyMutableModuleMetadataFactory ivyMetadataFactory) {
             return new DefaultBaseRepositoryFactory(
@@ -168,7 +168,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 moduleIdentifierFactory,
                 instantiatorFactory,
                 fileResourceRepository,
-                experimentalFeatures,
+                featurePreviews,
                 metadataFactory,
                 ivyMetadataFactory);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts;
 import com.google.common.collect.Sets;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.ClassPathRegistry;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.component.DefaultComponentIdentifierFactory;
@@ -187,8 +187,8 @@ class DependencyManagementBuildScopeServices {
 
     MavenMutableModuleMetadataFactory createMutableMavenMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                                         ImmutableAttributesFactory attributesFactory,
-                                                                        ExperimentalFeatures experimentalFeatures) {
-        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, NamedObjectInstantiator.INSTANCE, experimentalFeatures);
+                                                                        FeaturePreviews featurePreviews) {
+        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, NamedObjectInstantiator.INSTANCE, featurePreviews);
     }
 
     IvyMutableModuleMetadataFactory createMutableIvyMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {
@@ -316,7 +316,7 @@ class DependencyManagementBuildScopeServices {
                                                                 ModuleExclusions moduleExclusions,
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 ComponentSelectorConverter componentSelectorConverter,
-                                                                ExperimentalFeatures experimentalFeatures,
+                                                                FeaturePreviews featurePreviews,
                                                                 ImmutableAttributesFactory attributesFactory) {
         return new DefaultArtifactDependencyResolver(
             buildOperationExecutor,
@@ -326,7 +326,7 @@ class DependencyManagementBuildScopeServices {
             versionComparator,
             moduleExclusions,
             componentSelectorConverter,
-            experimentalFeatures,
+            featurePreviews,
             attributesFactory);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
@@ -66,10 +66,10 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     private final ModuleExclusions moduleExclusions;
     private final BuildOperationExecutor buildOperationExecutor;
     private final ComponentSelectorConverter componentSelectorConverter;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory attributesFactory;
 
-    public DefaultArtifactDependencyResolver(BuildOperationExecutor buildOperationExecutor, List<ResolverProviderFactory> resolverFactories, ResolveIvyFactory ivyFactory, DependencyDescriptorFactory dependencyDescriptorFactory, VersionComparator versionComparator, ModuleExclusions moduleExclusions, ComponentSelectorConverter componentSelectorConverter, ExperimentalFeatures experimentalFeatures, ImmutableAttributesFactory attributesFactory) {
+    public DefaultArtifactDependencyResolver(BuildOperationExecutor buildOperationExecutor, List<ResolverProviderFactory> resolverFactories, ResolveIvyFactory ivyFactory, DependencyDescriptorFactory dependencyDescriptorFactory, VersionComparator versionComparator, ModuleExclusions moduleExclusions, ComponentSelectorConverter componentSelectorConverter, FeaturePreviews featurePreviews, ImmutableAttributesFactory attributesFactory) {
         this.resolverFactories = resolverFactories;
         this.ivyFactory = ivyFactory;
         this.dependencyDescriptorFactory = dependencyDescriptorFactory;
@@ -77,7 +77,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         this.moduleExclusions = moduleExclusions;
         this.buildOperationExecutor = buildOperationExecutor;
         this.componentSelectorConverter = componentSelectorConverter;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
         this.attributesFactory = attributesFactory;
     }
 
@@ -103,7 +103,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         ResolveContextToComponentResolver requestResolver = createResolveContextConverter();
         ConflictHandler conflictHandler = createConflictHandler(resolutionStrategy, globalRules);
 
-        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, globalRules.getModuleMetadataProcessor().getModuleReplacements(), applicator, componentSelectorConverter, experimentalFeatures, attributesFactory);
+        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, globalRules.getModuleMetadataProcessor().getModuleReplacements(), applicator, componentSelectorConverter, featurePreviews, attributesFactory);
     }
 
     private ComponentResolversChain createResolvers(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, ArtifactTypeRegistry artifactTypeRegistry) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -23,7 +23,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
@@ -73,7 +73,7 @@ public class DependencyGraphBuilder {
     private final ModuleReplacementsData moduleReplacementsData;
     private final ComponentSelectorConverter componentSelectorConverter;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory attributesFactory;
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
@@ -83,7 +83,7 @@ public class DependencyGraphBuilder {
                                   ModuleExclusions moduleExclusions,
                                   BuildOperationExecutor buildOperationExecutor, ModuleReplacementsData moduleReplacementsData,
                                   DependencySubstitutionApplicator dependencySubstitutionApplicator, ComponentSelectorConverter componentSelectorConverter,
-                                  ExperimentalFeatures experimentalFeatures,
+                                  FeaturePreviews featurePreviews,
                                   ImmutableAttributesFactory attributesFactory) {
         this.idResolver = componentIdResolver;
         this.metaDataResolver = componentMetaDataResolver;
@@ -96,7 +96,7 @@ public class DependencyGraphBuilder {
         this.moduleReplacementsData = moduleReplacementsData;
         this.dependencySubstitutionApplicator = dependencySubstitutionApplicator;
         this.componentSelectorConverter = componentSelectorConverter;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
         this.attributesFactory = attributesFactory;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -66,7 +66,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final InstantiatorFactory instantiatorFactory;
     private final FileResourceRepository fileResourceRepository;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
     private final MavenMutableModuleMetadataFactory mavenMetadataFactory;
     private final IvyMutableModuleMetadataFactory ivyMetadataFactory;
 
@@ -83,7 +83,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
                                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                         InstantiatorFactory instantiatorFactory,
                                         FileResourceRepository fileResourceRepository,
-                                        ExperimentalFeatures experimentalFeatures,
+                                        FeaturePreviews featurePreviews,
                                         MavenMutableModuleMetadataFactory mavenMetadataFactory,
                                         IvyMutableModuleMetadataFactory ivyMetadataFactory) {
         this.localMavenRepositoryLocator = localMavenRepositoryLocator;
@@ -100,7 +100,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.instantiatorFactory = instantiatorFactory;
         this.fileResourceRepository = fileResourceRepository;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
         this.mavenMetadataFactory = mavenMetadataFactory;
         this.ivyMetadataFactory = ivyMetadataFactory;
     }
@@ -117,7 +117,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     }
 
     public MavenArtifactRepository createMavenLocalRepository() {
-        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), moduleIdentifierFactory, fileResourceRepository, experimentalFeatures, mavenMetadataFactory);
+        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), moduleIdentifierFactory, fileResourceRepository, featurePreviews, mavenMetadataFactory);
         File localMavenRepository = localMavenRepositoryLocator.getLocalMavenRepository();
         mavenRepository.setUrl(localMavenRepository);
         return mavenRepository;
@@ -142,15 +142,15 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     }
 
     public IvyArtifactRepository createIvyRepository() {
-        return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, externalResourcesFileStore, createAuthenticationContainer(), ivyContextManager, moduleIdentifierFactory, instantiatorFactory, fileResourceRepository, metadataParser, experimentalFeatures, ivyMetadataFactory);
+        return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, externalResourcesFileStore, createAuthenticationContainer(), ivyContextManager, moduleIdentifierFactory, instantiatorFactory, fileResourceRepository, metadataParser, featurePreviews, ivyMetadataFactory);
     }
 
     public MavenArtifactRepository createMavenRepository() {
-        return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), moduleIdentifierFactory, externalResourcesFileStore, fileResourceRepository, experimentalFeatures, mavenMetadataFactory);
+        return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), moduleIdentifierFactory, externalResourcesFileStore, fileResourceRepository, featurePreviews, mavenMetadataFactory);
     }
 
     public MavenArtifactRepository createMavenRepository(Transformer<String, MavenArtifactRepository> describer) {
-        return instantiator.newInstance(DefaultMavenArtifactRepository.class, describer, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), moduleIdentifierFactory, externalResourcesFileStore, fileResourceRepository, experimentalFeatures, mavenMetadataFactory);
+        return instantiator.newInstance(DefaultMavenArtifactRepository.class, describer, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), moduleIdentifierFactory, externalResourcesFileStore, fileResourceRepository, featurePreviews, mavenMetadataFactory);
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -348,7 +348,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
 
         void setDefaults(FeaturePreviews featurePreviews) {
             ivyDescriptor();
-            if (featurePreviews.isExperimentalEnabled()) {
+            if (featurePreviews.isGradleMetadataEnabled()) {
                 gradleMetadata();
             } else {
                 artifact();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.repositories.IvyArtifactRepositoryMetaDataProvid
 import org.gradle.api.artifacts.repositories.RepositoryLayout;
 import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor;
 import org.gradle.api.internal.DefaultActionConfiguration;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
@@ -112,7 +112,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
                                         InstantiatorFactory instantiatorFactory,
                                         FileResourceRepository fileResourceRepository,
                                         ModuleMetadataParser moduleMetadataParser,
-                                        ExperimentalFeatures experimentalFeatures,
+                                        FeaturePreviews featurePreviews,
                                         IvyMutableModuleMetadataFactory metadataFactory) {
         super(instantiatorFactory.decorate(), authenticationContainer);
         this.fileResolver = fileResolver;
@@ -130,7 +130,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         this.metaDataProvider = new MetaDataProvider();
         this.instantiator = instantiatorFactory.decorate();
         this.ivyContextManager = ivyContextManager;
-        this.metadataSources.setDefaults(experimentalFeatures);
+        this.metadataSources.setDefaults(featurePreviews);
     }
 
     @Override
@@ -346,9 +346,9 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         boolean ivyDescriptor;
         boolean artifact;
 
-        void setDefaults(ExperimentalFeatures experimentalFeatures) {
+        void setDefaults(FeaturePreviews featurePreviews) {
             ivyDescriptor();
-            if (experimentalFeatures.isExperimentalEnabled()) {
+            if (featurePreviews.isExperimentalEnabled()) {
                 gradleMetadata();
             } else {
                 artifact();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -348,7 +348,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
 
         void setDefaults(ExperimentalFeatures experimentalFeatures) {
             ivyDescriptor();
-            if (experimentalFeatures.isEnabled()) {
+            if (experimentalFeatures.isExperimentalEnabled()) {
                 gradleMetadata();
             } else {
                 artifact();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -22,7 +22,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
@@ -89,10 +89,10 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                           FileStore<String> resourcesFileStore,
                                           FileResourceRepository fileResourceRepository,
-                                          ExperimentalFeatures experimentalFeatures, MavenMutableModuleMetadataFactory metadataFactory) {
+                                          FeaturePreviews featurePreviews, MavenMutableModuleMetadataFactory metadataFactory) {
         this(new DefaultDescriber(), fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory,
             artifactFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory,
-            resourcesFileStore, fileResourceRepository, experimentalFeatures, metadataFactory);
+            resourcesFileStore, fileResourceRepository, featurePreviews, metadataFactory);
     }
 
     public DefaultMavenArtifactRepository(Transformer<String, MavenArtifactRepository> describer,
@@ -106,7 +106,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                           FileStore<String> resourcesFileStore,
                                           FileResourceRepository fileResourceRepository,
-                                          ExperimentalFeatures experimentalFeatures,
+                                          FeaturePreviews featurePreviews,
                                           MavenMutableModuleMetadataFactory metadataFactory) {
         super(instantiatorFactory.decorate(), authenticationContainer);
         this.describer = describer;
@@ -120,7 +120,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         this.resourcesFileStore = resourcesFileStore;
         this.fileResourceRepository = fileResourceRepository;
         this.metadataFactory = metadataFactory;
-        this.metadataSources.setDefaults(experimentalFeatures);
+        this.metadataSources.setDefaults(featurePreviews);
     }
 
     @Override
@@ -256,9 +256,9 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         boolean mavenPom;
         boolean artifact;
 
-        void setDefaults(ExperimentalFeatures experimentalFeatures) {
+        void setDefaults(FeaturePreviews featurePreviews) {
             mavenPom();
-            if (experimentalFeatures.isExperimentalEnabled()) {
+            if (featurePreviews.isExperimentalEnabled()) {
                 gradleMetadata();
             } else {
                 artifact();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -258,7 +258,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
         void setDefaults(FeaturePreviews featurePreviews) {
             mavenPom();
-            if (featurePreviews.isExperimentalEnabled()) {
+            if (featurePreviews.isGradleMetadataEnabled()) {
                 gradleMetadata();
             } else {
                 artifact();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -258,7 +258,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
         void setDefaults(ExperimentalFeatures experimentalFeatures) {
             mavenPom();
-            if (experimentalFeatures.isEnabled()) {
+            if (experimentalFeatures.isExperimentalEnabled()) {
                 gradleMetadata();
             } else {
                 artifact();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.repositories;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
@@ -57,9 +57,9 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
                                                AuthenticationContainer authenticationContainer,
                                                ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                FileResourceRepository fileResourceRepository,
-                                               ExperimentalFeatures experimentalFeatures,
+                                               FeaturePreviews featurePreviews,
                                                MavenMutableModuleMetadataFactory metadataFactory) {
-        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, null, fileResourceRepository, experimentalFeatures, metadataFactory);
+        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, null, fileResourceRepository, featurePreviews, metadataFactory);
         this.moduleIdentifierFactory = moduleIdentifierFactory;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -33,21 +33,21 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
 
     public MavenMutableModuleMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                              ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
-                                             ExperimentalFeatures experimentalFeatures) {
+                                             FeaturePreviews featurePreviews) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.attributesFactory = attributesFactory;
         this.objectInstantiator = objectInstantiator;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
     }
 
     @Override
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, experimentalFeatures.isAdvancedPomSupportEnabled());
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, featurePreviews.isAdvancedPomSupportEnabled());
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
@@ -63,6 +63,6 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
 
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from, List<MavenDependencyDescriptor> dependencies) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, experimentalFeatures.isAdvancedPomSupportEnabled());
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, featurePreviews.isAdvancedPomSupportEnabled());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -47,7 +47,7 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
     @Override
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, experimentalFeatures);
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, experimentalFeatures.isAdvancedPomSupportEnabled());
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
@@ -63,6 +63,6 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
 
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from, List<MavenDependencyDescriptor> dependencies) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, experimentalFeatures);
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, experimentalFeatures.isAdvancedPomSupportEnabled());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -45,9 +44,9 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     // We need to work with the 'String' version of the usage attribute, since this is expected for all providers by the `PreferJavaRuntimeVariant` schema
     private static final Attribute<String> USAGE_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
 
+    private final boolean advancedPomSupportEnabled;
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
-    private final ExperimentalFeatures experimentalFeatures;
 
     private final ImmutableList<MavenDependencyDescriptor> dependencies;
     private final String packaging;
@@ -56,9 +55,9 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     private ImmutableList<? extends ConfigurationMetadata> derivedVariants;
 
-    DefaultMavenModuleResolveMetadata(DefaultMutableMavenModuleResolveMetadata metadata, ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, ExperimentalFeatures experimentalFeatures) {
+    DefaultMavenModuleResolveMetadata(DefaultMutableMavenModuleResolveMetadata metadata, ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, boolean advancedPomSupportEnabled) {
         super(metadata);
-        this.experimentalFeatures = experimentalFeatures;
+        this.advancedPomSupportEnabled = advancedPomSupportEnabled;
         this.attributesFactory = attributesFactory;
         this.objectInstantiator = objectInstantiator;
         packaging = metadata.getPackaging();
@@ -69,7 +68,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     private DefaultMavenModuleResolveMetadata(DefaultMavenModuleResolveMetadata metadata, ModuleSource source) {
         super(metadata, source);
-        this.experimentalFeatures = metadata.experimentalFeatures;
+        this.advancedPomSupportEnabled = metadata.advancedPomSupportEnabled;
         this.attributesFactory = metadata.attributesFactory;
         this.objectInstantiator = metadata.objectInstantiator;
         packaging = metadata.packaging;
@@ -148,7 +147,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     }
 
     private boolean ignoreOptionalDependencies() {
-        return !experimentalFeatures.isEnabled();
+        return !advancedPomSupportEnabled;
     }
 
     @Override
@@ -158,7 +157,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
 
     @Override
     public MutableMavenModuleResolveMetadata asMutable() {
-        return new DefaultMutableMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, experimentalFeatures);
+        return new DefaultMutableMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, advancedPomSupportEnabled);
     }
 
     public String getPackaging() {
@@ -178,7 +177,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     }
 
     private boolean isJavaLibrary() {
-        return experimentalFeatures.isEnabled() && (isKnownJarPackaging() || isPomPackaging());
+        return advancedPomSupportEnabled && (isKnownJarPackaging() || isPomPackaging());
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.ExperimentalFeatures;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
@@ -36,7 +35,7 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
 
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final boolean advancedPomSupportEnabled;
 
     private String packaging = "jar";
     private boolean relocated;
@@ -45,17 +44,17 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
 
     public DefaultMutableMavenModuleResolveMetadata(ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, Collection<MavenDependencyDescriptor> dependencies,
                                                     ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
-                                                    ExperimentalFeatures experimentalFeatures) {
+                                                    boolean advancedPomSupportEnabled) {
         super(attributesFactory, id, componentIdentifier);
         this.dependencies = ImmutableList.copyOf(dependencies);
         this.attributesFactory = attributesFactory;
         this.objectInstantiator = objectInstantiator;
-        this.experimentalFeatures = experimentalFeatures;
+        this.advancedPomSupportEnabled = advancedPomSupportEnabled;
     }
 
     DefaultMutableMavenModuleResolveMetadata(MavenModuleResolveMetadata metadata,
                                              ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
-                                             ExperimentalFeatures experimentalFeatures) {
+                                             boolean advancedPomSupportEnabled) {
         super(metadata);
         this.packaging = metadata.getPackaging();
         this.relocated = metadata.isRelocated();
@@ -63,12 +62,12 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
         this.dependencies = metadata.getDependencies();
         this.attributesFactory = attributesFactory;
         this.objectInstantiator = objectInstantiator;
-        this.experimentalFeatures = experimentalFeatures;
+        this.advancedPomSupportEnabled = advancedPomSupportEnabled;
     }
 
     @Override
     public MavenModuleResolveMetadata asImmutable() {
-        return new DefaultMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, experimentalFeatures);
+        return new DefaultMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, advancedPomSupportEnabled);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -53,7 +53,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
     RuleActionAdapter<ComponentMetadataDetails> adapter = Mock(RuleActionAdapter)
     def mockedHandler = new DefaultComponentMetadataHandler(DirectInstantiator.INSTANCE, adapter, moduleIdentifierFactory)
     def ruleAction = Stub(RuleAction)
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
     def "does nothing when no rules registered"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -42,7 +42,7 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     final FileResourceRepository fileRepository = TestFiles.fileRepository()
     final GradlePomModuleDescriptorParser parser = new GradlePomModuleDescriptorParser(new DefaultVersionSelectorScheme(), moduleIdentifierFactory, fileRepository, mavenMetadataFactory)
     final parseContext = Mock(DescriptorParseContext)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -48,7 +48,7 @@ import spock.lang.Unroll
 class ModuleMetadataSerializerTest extends Specification {
 
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    private final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    private final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     private final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
     private final ModuleMetadataSerializer serializer = moduleMetadataSerializer()
     private GradlePomModuleDescriptorParser pomModuleDescriptorParser = pomParser()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -40,7 +40,7 @@ class ModuleMetadataStoreTest extends Specification {
     ModuleComponentIdentifier moduleComponentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "testArtifact", "1.0")
     ModuleMetadataSerializer serializer = Mock()
     ModuleMetadataStore store = new ModuleMetadataStore(pathKeyFileStore, serializer, moduleIdentifierFactory)
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     def "getModuleDescriptorFile returns null for not cached descriptors"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
@@ -107,7 +106,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, new ExperimentalFeatures(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.experimentalFeatures(), TestUtil.attributesFactory())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -554,7 +553,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, new ExperimentalFeatures(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.experimentalFeatures(), TestUtil.attributesFactory())
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -106,7 +106,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.experimentalFeatures(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -553,7 +553,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.experimentalFeatures(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
@@ -57,7 +56,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
         localMavenRepoLocator, fileResolver, transportFactory, locallyAvailableResourceFinder,
         artifactIdentifierFileStore, externalResourceFileStore, pomParser, metadataParser, authenticationSchemeRegistry, ivyContextManager, moduleIdentifierFactory,
-        TestUtil.instantiatorFactory(), Mock(FileResourceRepository), new ExperimentalFeatures(), mavenMetadataFactory, ivyMetadataFactory
+        TestUtil.instantiatorFactory(), Mock(FileResourceRepository), TestUtil.experimentalFeatures(), mavenMetadataFactory, ivyMetadataFactory
     )
 
     def testCreateFlatDirResolver() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -50,13 +50,13 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ivyContextManager = Mock(IvyContextManager)
     final AuthenticationSchemeRegistry authenticationSchemeRegistry = new DefaultAuthenticationSchemeRegistry()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
 
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
         localMavenRepoLocator, fileResolver, transportFactory, locallyAvailableResourceFinder,
         artifactIdentifierFileStore, externalResourceFileStore, pomParser, metadataParser, authenticationSchemeRegistry, ivyContextManager, moduleIdentifierFactory,
-        TestUtil.instantiatorFactory(), Mock(FileResourceRepository), TestUtil.experimentalFeatures(), mavenMetadataFactory, ivyMetadataFactory
+        TestUtil.instantiatorFactory(), Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory, ivyMetadataFactory
     )
 
     def testCreateFlatDirResolver() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -55,7 +55,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
-    final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.experimentalFeatures(), metadataFactory)
+    final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory)
 
     def "default values"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ComponentMetadataSupplier
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
@@ -56,7 +55,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
-    final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, new ExperimentalFeatures(), metadataFactory)
+    final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.experimentalFeatures(), metadataFactory)
 
     def "default values"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
@@ -48,7 +47,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
-        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), new ExperimentalFeatures(), mavenMetadataFactory)
+        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), TestUtil.experimentalFeatures(), mavenMetadataFactory)
 
     def "creates local repository"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -44,10 +44,10 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final ModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
-        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), TestUtil.experimentalFeatures(), mavenMetadataFactory)
+        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory)
 
     def "creates local repository"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -41,7 +41,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final ModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(resolver,
         transportFactory,
@@ -53,7 +53,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
         authenticationContainer,
         moduleIdentifierFactory,
         Mock(FileResourceRepository),
-        TestUtil.experimentalFeatures(),
+        TestUtil.featurePreviews(),
         mavenMetadataFactory
     )
     final ProgressLoggerFactory progressLoggerFactory = Mock()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
@@ -54,7 +53,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
         authenticationContainer,
         moduleIdentifierFactory,
         Mock(FileResourceRepository),
-        new ExperimentalFeatures(),
+        TestUtil.experimentalFeatures(),
         mavenMetadataFactory
     )
     final ProgressLoggerFactory progressLoggerFactory = Mock()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -49,7 +49,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def attributes = TestUtil.attributesFactory().of(testAttribute, "someValue")
     def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     def gradleMetadata
     def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -52,7 +52,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     @Shared attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     @Shared schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())
-    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures(true))
+    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews(true))
     @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     @Shared defaultVariant
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -34,7 +34,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 
 class DefaultMavenModuleResolveMetadataTest extends AbstractModuleComponentResolveMetadataTest {
 
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     @Override
     ModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Usage
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -133,12 +132,10 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractModuleComponentResol
     }
 
     @Unroll
-    def "recognises java library for packaging=#packaging and experimental=#experimental"() {
+    def "recognises java library for packaging=#packaging and advancedPomSupport=#advancedPomSupport"() {
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
-        def experimentalFeatures = Mock(ExperimentalFeatures)
-        experimentalFeatures.enabled >> experimental
-        def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], TestUtil.attributesFactory(), TestUtil.objectInstantiator(), experimentalFeatures)
+        def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], TestUtil.attributesFactory(), TestUtil.objectInstantiator(), advancedPomSupport)
         metadata.packaging = packaging
 
         when:
@@ -160,15 +157,15 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractModuleComponentResol
         }
 
         where:
-        packaging      | experimental | isJavaLibrary
-        "pom"          | false        | false
-        "jar"          | false        | false
-        "maven-plugin" | false        | false
-        "war"          | false        | false
-        "pom"          | true         | true
-        "jar"          | true         | true
-        "maven-plugin" | true         | true
-        "war"          | true         | false
+        packaging      | advancedPomSupport | isJavaLibrary
+        "pom"          | false              | false
+        "jar"          | false              | false
+        "maven-plugin" | false              | false
+        "war"          | false              | false
+        "pom"          | true               | true
+        "jar"          | true               | true
+        "maven-plugin" | true               | true
+        "war"          | true               | false
     }
 
     def dependency(String org, String module, String version, String scope) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.internal.hash.HashValue
 import org.gradle.util.TestUtil
 
 class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModuleComponentResolveMetadataTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     @Override
     AbstractMutableModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List<DependencyMetadata> dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.TestUtil
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRulesTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.experimentalFeatures(true))
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews(true))
 
     @Override
     boolean addAllDependenciesAsConstraints() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.publish.RemoteRepositorySpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -126,8 +126,8 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         resolve.expectDefaultConfiguration(usesJavaLibraryVariants() ? "runtime" : "default")
         settingsFile << "rootProject.name = '$rootProjectName'"
         if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
-            ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
+            FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
+            FeaturePreviewsFixture.enableExperimental(propertiesFile)
         }
         resolve.prepare()
         buildFile << """

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -127,7 +127,7 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         settingsFile << "rootProject.name = '$rootProjectName'"
         if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
             FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
-            FeaturePreviewsFixture.enableExperimental(propertiesFile)
+            FeaturePreviewsFixture.enableGradleMetadata(propertiesFile)
         }
         resolve.prepare()
         buildFile << """

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -126,7 +126,7 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         resolve.expectDefaultConfiguration(usesJavaLibraryVariants() ? "runtime" : "default")
         settingsFile << "rootProject.name = '$rootProjectName'"
         if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-            ExperimentalFeaturesFixture.enable(settingsFile)
+            ExperimentalFeaturesFixture.enable(propertiesFile)
         }
         resolve.prepare()
         buildFile << """

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -126,7 +126,8 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         resolve.expectDefaultConfiguration(usesJavaLibraryVariants() ? "runtime" : "default")
         settingsFile << "rootProject.name = '$rootProjectName'"
         if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-            ExperimentalFeaturesFixture.enable(propertiesFile)
+            ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+            ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
         }
         resolve.prepare()
         buildFile << """

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,14 +6,13 @@ Here are the new features introduced in this Gradle release.
 
 Gradle now supports [additional features for modules with POM metadata](https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/preview-features.adoc). This includes support for _optional dependencies_, _BOM import_ and _compile/runtime scope separation_. 
 
-_Note:_ This is a _Gradle 5.0 feature preview_, which means it is a potentially breaking change that will be activated by default in Gradle 5.0. It can be turned on in Gradle 4.6+ by setting `org.gralde.advancedpomsupport=true` in _gradle.properties_ or calling Gradle with `--advanced-pom-support`.
+_Note:_ This is a _Gradle 5.0 feature preview_, which means it is a potentially breaking change that will be activated by default in Gradle 5.0. It can be turned on in Gradle 4.6+ by setting `org.gradle.advancedpomsupport=true` in _gradle.properties_.
 
 ### New Gradle `.module` metadata format (preview)
 
 In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a [new module metadata format](https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/preview-features.adoc), that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
 
-The new metadata format is still under active development, but it can already be used in its current state in Gradle 4.6+ by setting `org.gralde.gradlemetadata=true` in _gradle.properties_ or calling Gradle with
-`--gradle-metadata`.
+The new metadata format is still under active development, but it can already be used in its current state in Gradle 4.6+ by setting `org.gralde.gradlemetadata=true` in _gradle.properties_.
 
 <!--
 ### Example new and noteworthy

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -2,9 +2,18 @@
 
 Here are the new features introduced in this Gradle release.
 
-<!--
-IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
-Add-->
+### Advanced POM support (preview)
+
+Gradle now supports [additional features for modules with POM metadata](https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/preview-features.adoc). This includes support for _optional dependencies_, _BOM import_ and _compile/runtime scope separation_. 
+
+_Note:_ This is a _Gradle 5.0 feature preview_, which means it is a potentially breaking change that will be activated by default in Gradle 5.0. It can be turned on in Gradle 4.6+ by setting `org.gralde.advancedpomsupport=true` in _gradle.properties_ or calling Gradle with `--advanced-pom-support`.
+
+### New Gradle `.module` metadata format (preview)
+
+In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a [new module metadata format](https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/preview-features.adoc), that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
+
+The new metadata format is still under active development, but it can already be used in its current state in Gradle 4.6+ by setting `org.gralde.gradlemetadata=true` in _gradle.properties_ or calling Gradle with
+`--gradle-metadata`.
 
 <!--
 ### Example new and noteworthy

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -88,6 +88,10 @@ class AbstractIntegrationSpec extends Specification {
         testDirectory.file('settings.gradle')
     }
 
+    protected TestFile getPropertiesFile() {
+        testDirectory.file('gradle.properties')
+    }
+
     def singleProjectBuild(String projectName, @DelegatesTo(BuildTestFile) Closure cl = {}) {
         buildTestFixture.singleProjectBuild(projectName, cl)
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExperimentalFeaturesFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExperimentalFeaturesFixture.groovy
@@ -17,9 +17,16 @@
 package org.gradle.integtests.fixtures
 
 class ExperimentalFeaturesFixture {
-    static void enable(File file) {
+
+    static void enableExperimental(File file) {
         file << """
 org.gradle.experimental=true
+"""
+    }
+
+    static void enableAdvancedPomSupport(File file) {
+        file << """
+org.gradle.advancedpomsupport=true
 """
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExperimentalFeaturesFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExperimentalFeaturesFixture.groovy
@@ -19,7 +19,7 @@ package org.gradle.integtests.fixtures
 class ExperimentalFeaturesFixture {
     static void enable(File file) {
         file << """
-            gradle.experimentalFeatures.enable()
+org.gradle.experimental=true
 """
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.fixtures
 
-class ExperimentalFeaturesFixture {
+class FeaturePreviewsFixture {
 
     static void enableExperimental(File file) {
         file << """

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -18,9 +18,9 @@ package org.gradle.integtests.fixtures
 
 class FeaturePreviewsFixture {
 
-    static void enableExperimental(File file) {
+    static void enableGradleMetadata(File file) {
         file << """
-org.gradle.experimental=true
+org.gradle.gradlemetadata=true
 """
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
@@ -32,7 +32,7 @@ trait GradleMetadataAwarePublishingSpec {
     void prepare() {
         executer.beforeExecute {
             if (publishModuleMetadata) {
-                withArgument("--experimental")
+                withArgument("--gradle-metadata")
             }
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
@@ -32,7 +32,7 @@ trait GradleMetadataAwarePublishingSpec {
     void prepare() {
         executer.beforeExecute {
             if (publishModuleMetadata) {
-                withArgument("-Dorg.gradle.internal.experimentalFeatures")
+                withArgument("--experimental")
             }
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleMetadataAwarePublishingSpec.groovy
@@ -32,7 +32,7 @@ trait GradleMetadataAwarePublishingSpec {
     void prepare() {
         executer.beforeExecute {
             if (publishModuleMetadata) {
-                withArgument("--gradle-metadata")
+                withArgument("-Dorg.gradle.gradlemetadata=true")
             }
         }
     }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -31,7 +31,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -85,7 +85,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final DefaultIvyDependencySet ivyDependencies;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final ImmutableAttributesFactory immutableAttributesFactory;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
     private FileCollection ivyDescriptorFile;
     private FileCollection gradleModuleDescriptorFile;
     private SoftwareComponentInternal component;
@@ -94,13 +94,13 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     public DefaultIvyPublication(
         String name, Instantiator instantiator, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
         ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-        ImmutableAttributesFactory immutableAttributesFactory, ExperimentalFeatures experimentalFeatures) {
+        ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews) {
         this.name = name;
         this.publicationIdentity = publicationIdentity;
         this.projectDependencyResolver = projectDependencyResolver;
         configurations = instantiator.newInstance(DefaultIvyConfigurationContainer.class, instantiator);
         this.immutableAttributesFactory = immutableAttributesFactory;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
         ivyArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory);
         ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class);
         descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this);
@@ -290,7 +290,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             // Always publish `ComponentWithVariants`
             return true;
         }
-        return experimentalFeatures.isExperimentalEnabled();
+        return featurePreviews.isExperimentalEnabled();
     }
 
     private static File assertDescriptorFile(FileCollection ref) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -290,7 +290,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             // Always publish `ComponentWithVariants`
             return true;
         }
-        return featurePreviews.isExperimentalEnabled();
+        return featurePreviews.isGradleMetadataEnabled();
     }
 
     private static File assertDescriptorFile(FileCollection ref) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -290,7 +290,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             // Always publish `ComponentWithVariants`
             return true;
         }
-        return experimentalFeatures.isEnabled();
+        return experimentalFeatures.isExperimentalEnabled();
     }
 
     private static File assertDescriptorFile(FileCollection ref) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -25,7 +25,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -74,19 +74,19 @@ public class IvyPublishPlugin implements Plugin<Project> {
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final FileCollectionFactory fileCollectionFactory;
     private final ImmutableAttributesFactory immutableAttributesFactory;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
 
     @Inject
     public IvyPublishPlugin(Instantiator instantiator, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver,
                             ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-                            ImmutableAttributesFactory immutableAttributesFactory, ExperimentalFeatures experimentalFeatures) {
+                            ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews) {
         this.instantiator = instantiator;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.fileResolver = fileResolver;
         this.projectDependencyResolver = projectDependencyResolver;
         this.fileCollectionFactory = fileCollectionFactory;
         this.immutableAttributesFactory = immutableAttributesFactory;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
     }
 
     public void apply(final Project project) {
@@ -189,7 +189,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
             return instantiator.newInstance(
                 DefaultIvyPublication.class,
-                name, instantiator, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, experimentalFeatures
+                name, instantiator, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, featurePreviews
             );
         }
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -53,7 +53,7 @@ class DefaultIvyPublicationTest extends Specification {
     def notationParser = Mock(NotationParser)
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
     def attributesFactory = TestUtil.attributesFactory()
-    def experimentalFeatures = TestUtil.experimentalFeatures()
+    def featurePreviews = TestUtil.featurePreviews()
 
     File ivyDescriptorFile
     File moduleDescriptorFile
@@ -281,7 +281,7 @@ class DefaultIvyPublicationTest extends Specification {
             projectDependencyResolver,
             TestFiles.fileCollectionFactory(),
             attributesFactory,
-            experimentalFeatures
+            featurePreviews
         )
         publication.setIvyDescriptorFile(new SimpleFileCollection(ivyDescriptorFile))
         publication.setGradleModuleDescriptorFile(new SimpleFileCollection(moduleDescriptorFile))

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.ClassGeneratorBackedInstantiator
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.component.SoftwareComponentInternal
@@ -54,7 +53,7 @@ class DefaultIvyPublicationTest extends Specification {
     def notationParser = Mock(NotationParser)
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
     def attributesFactory = TestUtil.attributesFactory()
-    def experimentalFeatures = new ExperimentalFeatures()
+    def experimentalFeatures = TestUtil.experimentalFeatures()
 
     File ivyDescriptorFile
     File moduleDescriptorFile

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
 
         String attributes = params.variant == null ?
             "" :

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -53,7 +53,8 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
+        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
 
         String attributes = params.variant == null ?
             "" :

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.publish.ivy
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.test.fixtures.ArtifactResolutionExpectationSpec
 import org.gradle.test.fixtures.GradleMetadataAwarePublishingSpec
@@ -53,8 +53,8 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
-        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
 
         String attributes = params.variant == null ?
             "" :

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableGradleMetadata(propertiesFile)
         FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
 
         String attributes = params.variant == null ?

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -28,7 +28,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractInstalledToolChain
 
     def setup() {
         when:
-        FeaturePreviewsFixture.enableExperimental(consumer.file("gradle.properties"))
+        FeaturePreviewsFixture.enableGradleMetadata(consumer.file("gradle.properties"))
         consumer.file("build.gradle") << """
             repositories {
                 maven { 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -28,7 +28,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractInstalledToolChain
 
     def setup() {
         when:
-        ExperimentalFeaturesFixture.enable(consumer.file("gradle.properties"))
+        ExperimentalFeaturesFixture.enableExperimental(consumer.file("gradle.properties"))
         consumer.file("build.gradle") << """
             repositories {
                 maven { 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -28,7 +28,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractInstalledToolChain
 
     def setup() {
         when:
-        ExperimentalFeaturesFixture.enable(consumer.file("settings.gradle"))
+        ExperimentalFeaturesFixture.enable(consumer.file("gradle.properties"))
         consumer.file("build.gradle") << """
             repositories {
                 maven { 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppApp
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrary
@@ -28,7 +28,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractInstalledToolChain
 
     def setup() {
         when:
-        ExperimentalFeaturesFixture.enableExperimental(consumer.file("gradle.properties"))
+        FeaturePreviewsFixture.enableExperimental(consumer.file("gradle.properties"))
         consumer.file("build.gradle") << """
             repositories {
                 maven { 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -22,7 +22,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.language.cpp.CppSharedLibrary;
@@ -58,7 +57,7 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
         final DirectoryProperty buildDirectory = project.getLayout().getBuildDirectory();
 
         // Enable the use of Gradle metadata. This is a temporary opt-in switch until available by default
-        ((StartParameterInternal) project.getGradle().getStartParameter()).setExperimental(true);
+        project.getGradle().getStartParameter().setGradleMetadata(true);
 
         // Create the tasks for each C++ binary that is registered
         project.getComponents().withType(DefaultCppBinary.class, new Action<DefaultCppBinary>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.language.cpp.CppSharedLibrary;
@@ -57,7 +58,7 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
         final DirectoryProperty buildDirectory = project.getLayout().getBuildDirectory();
 
         // Enable the use of Gradle metadata. This is a temporary opt-in switch until available by default
-        project.getGradle().getExperimentalFeatures().enable();
+        ((StartParameterInternal) project.getGradle().getStartParameter()).setExperimental(true);
 
         // Create the tasks for each C++ binary that is registered
         project.getComponents().withType(DefaultCppBinary.class, new Action<DefaultCppBinary>() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
@@ -47,7 +47,7 @@ class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest
         disableModuleMetadataPublishing()
 
         // Instead enable via property
-        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableGradleMetadata(propertiesFile)
 
         createBuildScripts("""
             publishing {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
@@ -47,7 +47,7 @@ class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest
         disableModuleMetadataPublishing()
 
         // Instead enable via property
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
 
         createBuildScripts("""
             publishing {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
@@ -42,12 +42,12 @@ class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest
         publishedModule.parsedModuleMetadata.variants.isEmpty()
     }
 
-    def "can enable module metadata publishing via init script"() {
-        // Don't enable via system property
+    def "can enable module metadata publishing via property"() {
+        // Don't enable via command line argument
         disableModuleMetadataPublishing()
 
-        // Instead enable via DSL
-        ExperimentalFeaturesFixture.enable(file("init.gradle"))
+        // Instead enable via property
+        ExperimentalFeaturesFixture.enable(propertiesFile)
 
         createBuildScripts("""
             publishing {
@@ -61,7 +61,6 @@ class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest
 
 
         when:
-        executer.withArguments("-I", "init.gradle")
         run "publish"
 
         then:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 
 class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest {
@@ -47,7 +47,7 @@ class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest
         disableModuleMetadataPublishing()
 
         // Instead enable via property
-        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableExperimental(propertiesFile)
 
         createBuildScripts("""
             publishing {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -383,7 +383,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             // Always publish `ComponentWithVariants`
             return true;
         }
-        return experimentalFeatures.isEnabled();
+        return experimentalFeatures.isExperimentalEnabled();
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -34,7 +34,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MavenVersionUtils;
@@ -101,7 +101,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final Set<MavenDependency> runtimeDependencyConstraints = new LinkedHashSet<MavenDependency>();
     private final Set<MavenDependency> apiDependencyConstraints = new LinkedHashSet<MavenDependency>();
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private FileCollection pomFile;
     private FileCollection moduleMetadataFile;
@@ -112,7 +112,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     public DefaultMavenPublication(
         String name, MavenProjectIdentity projectIdentity, NotationParser<Object, MavenArtifact> mavenArtifactParser, Instantiator instantiator,
         ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-        ExperimentalFeatures experimentalFeatures,
+        FeaturePreviews featurePreviews,
         ImmutableAttributesFactory immutableAttributesFactory) {
         this.name = name;
         this.projectDependencyResolver = projectDependencyResolver;
@@ -120,7 +120,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         this.immutableAttributesFactory = immutableAttributesFactory;
         mavenArtifacts = instantiator.newInstance(DefaultMavenArtifactSet.class, name, mavenArtifactParser, fileCollectionFactory);
         pom = instantiator.newInstance(DefaultMavenPom.class, this);
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
     }
 
     public String getName() {
@@ -383,7 +383,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             // Always publish `ComponentWithVariants`
             return true;
         }
-        return experimentalFeatures.isExperimentalEnabled();
+        return featurePreviews.isExperimentalEnabled();
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -383,7 +383,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             // Always publish `ComponentWithVariants`
             return true;
         }
-        return featurePreviews.isExperimentalEnabled();
+        return featurePreviews.isGradleMetadataEnabled();
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -24,7 +24,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.ExperimentalFeatures;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -76,19 +76,19 @@ public class MavenPublishPlugin implements Plugin<Project> {
     private final FileResolver fileResolver;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final FileCollectionFactory fileCollectionFactory;
-    private final ExperimentalFeatures experimentalFeatures;
+    private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory immutableAttributesFactory;
 
     @Inject
     public MavenPublishPlugin(Instantiator instantiator, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver,
                               ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-                              ExperimentalFeatures experimentalFeatures, ImmutableAttributesFactory immutableAttributesFactory) {
+                              FeaturePreviews featurePreviews, ImmutableAttributesFactory immutableAttributesFactory) {
         this.instantiator = instantiator;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.fileResolver = fileResolver;
         this.projectDependencyResolver = projectDependencyResolver;
         this.fileCollectionFactory = fileCollectionFactory;
-        this.experimentalFeatures = experimentalFeatures;
+        this.featurePreviews = featurePreviews;
         this.immutableAttributesFactory = immutableAttributesFactory;
     }
 
@@ -220,7 +220,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
 
             return instantiator.newInstance(
                     DefaultMavenPublication.class,
-                    name, projectIdentity, artifactNotationParser, instantiator, projectDependencyResolver, fileCollectionFactory, experimentalFeatures, immutableAttributesFactory
+                    name, projectIdentity, artifactNotationParser, instantiator, projectDependencyResolver, fileCollectionFactory, featurePreviews, immutableAttributesFactory
             );
         }
     }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -393,7 +393,7 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def createPublication() {
-        def publication = new DefaultMavenPublication("pub-name", module, notationParser, DirectInstantiator.INSTANCE, projectDependencyResolver, TestFiles.fileCollectionFactory(), TestUtil.experimentalFeatures(), TestUtil.attributesFactory())
+        def publication = new DefaultMavenPublication("pub-name", module, notationParser, DirectInstantiator.INSTANCE, projectDependencyResolver, TestFiles.fileCollectionFactory(), TestUtil.featurePreviews(), TestUtil.attributesFactory())
         publication.setPomFile(new SimpleFileCollection(pomFile))
         publication.setGradleModuleMetadataFile(new SimpleFileCollection(gradleMetadataFile))
         return publication;

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
-import org.gradle.api.internal.ExperimentalFeatures
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
@@ -394,7 +393,7 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def createPublication() {
-        def publication = new DefaultMavenPublication("pub-name", module, notationParser, DirectInstantiator.INSTANCE, projectDependencyResolver, TestFiles.fileCollectionFactory(), new ExperimentalFeatures(), TestUtil.attributesFactory())
+        def publication = new DefaultMavenPublication("pub-name", module, notationParser, DirectInstantiator.INSTANCE, projectDependencyResolver, TestFiles.fileCollectionFactory(), TestUtil.experimentalFeatures(), TestUtil.attributesFactory())
         publication.setPomFile(new SimpleFileCollection(pomFile))
         publication.setGradleModuleMetadataFile(new SimpleFileCollection(gradleMetadataFile))
         return publication;

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -68,7 +68,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         def attributes = params.variant == null ?
             "" :
             """ 

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.integtests.fixtures.publish.maven
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.test.fixtures.ArtifactResolutionExpectationSpec
 import org.gradle.test.fixtures.GradleMetadataAwarePublishingSpec
@@ -68,8 +68,8 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
-        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         def attributes = params.variant == null ?
             "" :
             """ 

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -68,7 +68,8 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableExperimental(propertiesFile)
+        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         def attributes = params.variant == null ?
             "" :
             """ 

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -68,7 +68,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
     private def doResolveArtifacts(ResolveParams params) {
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
-        FeaturePreviewsFixture.enableExperimental(propertiesFile)
+        FeaturePreviewsFixture.enableGradleMetadata(propertiesFile)
         FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         def attributes = params.variant == null ?
             "" :

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.java
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 
 class JavaLibraryConsumptionIntegrationTest extends AbstractIntegrationSpec {
 
     def "runtime dependencies from maven modules do not leak into compile classpath"() {
         given:
-        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
+        FeaturePreviewsFixture.enableAdvancedPomSupport(propertiesFile)
         buildFile << """
             apply plugin: 'java-library'
             ${jcenterRepository()}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
@@ -23,7 +23,7 @@ class JavaLibraryConsumptionIntegrationTest extends AbstractIntegrationSpec {
 
     def "runtime dependencies from maven modules do not leak into compile classpath"() {
         given:
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableAdvancedPomSupport(propertiesFile)
         buildFile << """
             apply plugin: 'java-library'
             ${jcenterRepository()}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
@@ -23,7 +23,7 @@ class JavaLibraryConsumptionIntegrationTest extends AbstractIntegrationSpec {
 
     def "runtime dependencies from maven modules do not leak into compile classpath"() {
         given:
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         buildFile << """
             apply plugin: 'java-library'
             ${jcenterRepository()}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -33,7 +33,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
         settingsFile << """
             rootProject.name = 'springbootproject'
         """
-        ExperimentalFeaturesFixture.enable(settingsFile)
+        ExperimentalFeaturesFixture.enable(propertiesFile)
         def buildScript = """
             plugins {
                 id "java"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.ExperimentalFeaturesFixture
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
@@ -33,7 +33,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
         settingsFile << """
             rootProject.name = 'springbootproject'
         """
-        ExperimentalFeaturesFixture.enableAdvancedPomSupport(testProjectDir.newFile('gradle.properties'))
+        FeaturePreviewsFixture.enableAdvancedPomSupport(testProjectDir.newFile('gradle.properties'))
         def buildScript = """
             plugins {
                 id "java"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -33,7 +33,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
         settingsFile << """
             rootProject.name = 'springbootproject'
         """
-        ExperimentalFeaturesFixture.enable(propertiesFile)
+        ExperimentalFeaturesFixture.enableAdvancedPomSupport(testProjectDir.newFile('gradle.properties'))
         def buildScript = """
             plugins {
                 id "java"

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.integtests.tooling.fixture
 
-import org.gradle.StartParameter
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.initialization.DefaultBuildRequestMetaData
 import org.gradle.initialization.GradleLauncherFactory
@@ -89,7 +89,7 @@ class ToolingApiDistributionResolver {
                 .parent(NativeServicesTestFixture.getInstance())
                 .provider(new GlobalScopeServices(false))
                 .build()
-        def startParameter = new StartParameter()
+        def startParameter = new StartParameterInternal()
         startParameter.gradleUserHomeDir = new IntegrationTestBuildContext().gradleUserHomeDir
         def userHomeScopeServiceRegistry = globalRegistry.get(GradleUserHomeScopeServiceRegistry)
         def gradleUserHomeServices = userHomeScopeServiceRegistry.getServicesFor(startParameter.gradleUserHomeDir)


### PR DESCRIPTION
See: #3945
 
Note: the first two commits turn the existing _experimental_ flag into an option. Which is then superseded by the two new options in the other commits.

Note: This **depends on #3870** to be merged first (that should resolve the conflicts this PR currently has with master).
  