### PR TITLE
Move GnupgSignatoryProvider to internal package

### DIFF
--- a/subprojects/docs/src/docs/userguide/signingPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/signingPlugin.adoc
@@ -87,7 +87,7 @@ The signing plugin supports OpenPGP subkeys out of the box. Just specify a subke
 [[sec:using_gpg_agent]]
 === Using gpg-agent
 
-By default the signing plugin uses a Java-based implementation of PGP for signing. This implementation cannot use the gpg-agent program for managing private keys, though. If you want to use the gpg-agent, you can change the signatory implementation used by the signing plugin to api:org.gradle.plugins.signing.signatory.gnupg.GnupgSignatory[].
+By default the signing plugin uses a Java-based implementation of PGP for signing. This implementation cannot use the gpg-agent program for managing private keys, though. If you want to use the gpg-agent, you can change the signatory implementation used by the signing plugin:
 
 ++++
 <sample id="useGnupg" dir="signing/gnupg-signatory" title="Sign with GnuPG">
@@ -95,7 +95,7 @@ By default the signing plugin uses a Java-based implementation of PGP for signin
 </sample>
 ++++
 
-This tells the signing plugin to use the `GnupgSignatory` instead of the default api:org.gradle.plugins.signing.signatory.pgp.PgpSignatory[]. The `GnupgSignatory` relies on the gpg2 progam to sign the artifacts. Of course, this requires that GnuPG is installed.
+This tells the signing plugin to use the `GnupgSignatory` instead of the default api:org.gradle.plugins.signing.signatory.pgp.PgpSignatory[]. The `GnupgSignatory` relies on the gpg2 program to sign the artifacts. Of course, this requires that GnuPG is installed.
 
 Without any further configuration the `gpg2` (on Windows: `gpg2.exe`) executable found on the `PATH` will be used. The password is supplied by the `gpg-agent` and the default key is used for signing.
 

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -31,7 +31,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.signatory.SignatoryProvider;
-import org.gradle.plugins.signing.signatory.gnupg.GnupgSignatoryProvider;
+import org.gradle.plugins.signing.signatory.internal.gnupg.GnupgSignatoryProvider;
 import org.gradle.plugins.signing.signatory.pgp.PgpSignatoryProvider;
 import org.gradle.plugins.signing.type.DefaultSignatureTypeProvider;
 import org.gradle.plugins.signing.type.SignatureType;

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSettings.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSettings.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.plugins.signing.signatory.gnupg;
+package org.gradle.plugins.signing.signatory.internal.gnupg;
 
 import org.gradle.api.Incubating;
 import org.gradle.internal.os.OperatingSystem;

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSignatory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSignatory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.plugins.signing.signatory.gnupg;
+package org.gradle.plugins.signing.signatory.internal.gnupg;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSignatoryFactory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSignatoryFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.plugins.signing.signatory.gnupg;
+package org.gradle.plugins.signing.signatory.internal.gnupg;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSignatoryProvider.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/GnupgSignatoryProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.plugins.signing.signatory.gnupg;
+package org.gradle.plugins.signing.signatory.internal.gnupg;
 
 import groovy.lang.Closure;
 import org.gradle.api.Incubating;

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/package-info.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/internal/gnupg/package-info.java
@@ -17,4 +17,4 @@
 /**
  * GnuPG CLI signing support.
  */
-package org.gradle.plugins.signing.signatory.gnupg;
+package org.gradle.plugins.signing.signatory.internal.gnupg;


### PR DESCRIPTION
As said in https://github.com/gradle/gradle-private/issues/1059#event-1408054615 , this should be internal.