### PR TITLE
Reorganize content for a better separation between build scan and cmd line

### DIFF
--- a/subprojects/docs/src/docs/userguide/dependencyManagement.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyManagement.adoc
@@ -302,13 +302,19 @@ You can also assign collections or arrays of dependency notations to a configura
 Gradle provides sufficient tooling to navigate large dependency graphs and mitigate situations that can lead to link:https://en.wikipedia.org/wiki/Dependency_hell[dependency hell]. Users can chose to render the full graph of dependencies as well as identify the selection reason and origin for a dependency. The origin of a dependency can be a declared dependency in the build script or a transitive dependency in graph plus their corresponding configuration. Gradle offers both capabilities through visual representation via build scans and as command line tooling.
 
 [[sec:listing_dependencies]]
-==== Listing all dependencies in a project
+==== Listing dependencies in a project
 
-A project can declare one or more dependencies. Gradle can visualize the whole dependency tree for every configuration available in the project with the help of the _dependency report_.
+A project can declare one or more dependencies. Gradle can visualize the whole dependency tree for every configuration available in the project.
 
-Rendering the dependency tree is particularly useful if you'd like identify which dependencies have been resolved at runtime. It also provides you with information about any dependency conflict resolution that occurred in the process and clearly indicates the selected version. The dependency report always contains declared and transitive dependencies.
+Rendering the dependency tree is particularly useful if you'd like to identify which dependencies have been resolved at runtime. It also provides you with information about any dependency conflict resolution that occurred in the process and clearly indicates the selected version. The dependency report always contains declared and transitive dependencies.
 
 Let's say you'd want to create tasks for your project that use the link:https://www.eclipse.org/jgit/[JGit library] to execute SCM operations e.g. to model a release process. You can declare dependencies for any external tooling with the help of a <<sub:scope_of_dependency_configurations,custom configuration>> so that it doesn't doesn't pollute other contexts like the compilation classpath for your production source code.
+
+++++
+<sample id="jgit-dependency" dir="userguide/dependencies/dependenciesReport" title="Declaring the JGit dependency with a custom configuration">
+    <sourcefile file="build.gradle" snippet="dependency-declaration" />
+</sample>
+++++
 
 A link:https://scans.gradle.com/[build scan] can visualize dependencies as a navigable, searchable tree. Additional context information can be rendered by clicking on a specific dependency in the graph.
 
@@ -321,26 +327,29 @@ A link:https://scans.gradle.com/[build scan] can visualize dependencies as a nav
 </figure>
 +++++
 
-To render the dependencies graph from the command line execute the `dependencies` task for the corresponding configuration.
+Every Gradle project provides the task `dependencies` to render the so-called _dependency report_ from the command line. By default the dependency report renders dependencies for all configurations. To pair down on the information provide the optional parameter `--configuration`.
 
 ++++
 <sample id="dependencyReport" dir="userguide/dependencies/dependenciesReport" title="Rendering the dependency report for a custom configuration">
-    <sourcefile file="build.gradle" snippet="dependency-declaration" />
     <output args="-q dependencies --configuration scm"/>
 </sample>
 ++++
 
-The dependencies report rendered as console output provides detailed information about the dependencies available in the graph. Any dependency that could not be resolved is marked with `FAILED` in red color. Dependencies with the same coordinates that can occur multiple times in the graph are omitted and indicated by an asterisk. Dependencies that had to undergo conflict resolution render the requested and selected version separated by a right arrow character.
+The dependencies report provides detailed information about the dependencies available in the graph. Any dependency that could not be resolved is marked with `FAILED` in red color. Dependencies with the same coordinates that can occur multiple times in the graph are omitted and indicated by an asterisk. Dependencies that had to undergo conflict resolution render the requested and selected version separated by a right arrow character.
 
 ==== Identifying which dependency version was selected and why
 
 Large software projects inevitably deal with an increased number of dependencies either through direct or transitive dependencies. The <<sec:listing_dependencies,dependencies report>> provides you with the raw list of dependencies but does not explain _why_ they have been selected or _which_ dependency is responsible for pulling them into the graph.
 
-The _dependency insight report_ can answer both questions. Given a dependency in the dependency graph you can identify the selection reason and track down the origin of the dependency selection. You can think of the dependency insight report as the inverse representation of the dependency report for a given dependency.
+Let's have a look at a concrete example. A project may request two different versions of the same dependency either as direct or transitive dependency. Gradle applies version conflict resolution to ensure that only one version of the dependency exists in the dependency graph. In this example the conflicting dependency is represented by `commons-codec:commons-codec`.
 
-Let's have a look at a concrete example. A project may request two different versions of the same dependency either as direct or transitive dependency. Gradle applies version conflict resolution to ensure that only one version of the dependency exists in the dependency graph. The dependency insight report can tell you the selection reason (conflict resolution) and the origin(s) of the dependency in the graph up to the configuration.
+++++
+<sample id="jgit-dependency-with-conflict" dir="userguide/dependencies/dependencyInsightReport" title="Declaring the JGit dependency and a conflicting dependency">
+    <sourcefile file="build.gradle" snippet="dependency-declaration" />
+</sample>
+++++
 
-The dependency tree in a link:https://scans.gradle.com/[build scan] renders the selection reason as well as the origin of a dependency if you click on a dependency and select the "Required By" tab.
+The dependency tree in a link:https://scans.gradle.com/[build scan] renders the selection reason (conflict resolution) as well as the origin of a dependency if you click on a dependency and select the "Required By" tab.
 
 +++++
 <figure xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -351,11 +360,10 @@ The dependency tree in a link:https://scans.gradle.com/[build scan] renders the 
 </figure>
 +++++
 
-The dependency insight report on the command line can be rendered by executing the `dependencyInsight` task. You have to provide the mandatory parameter `--dependency` to specify the coordinates of the dependency under inspection.
+Every Gradle project provides the task `dependencyInsight` to render the so-called  _dependency insight report_ from the command line. Given a dependency in the dependency graph you can identify the selection reason and track down the origin of the dependency selection. You can think of the dependency insight report as the inverse representation of the dependency report for a given dependency. When executing the task you have to provide the mandatory parameter `--dependency` to specify the coordinates of the dependency under inspection. The parameter `--configuration` is optional but helps with filtering the output.
 
 ++++
 <sample id="dependencyInsightReport" dir="userguide/dependencies/dependencyInsightReport" title="Using the dependency insight report for a given dependency">
-    <sourcefile file="build.gradle" snippet="dependency-declaration" />
     <output args="-q dependencyInsight --dependency commons-codec --configuration scm"/>
 </sample>
 ++++


### PR DESCRIPTION
### Context

See https://github.com/gradle/dotorg-docs/issues/140 for more information.