### PR TITLE
Validate the name of a dependency artifact defined in the build script

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -99,8 +99,9 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
 
     @Override
     public DependencyArtifact artifact(Action<? super DependencyArtifact> configureAction) {
-        DependencyArtifact artifact = new DefaultDependencyArtifact();
+        DefaultDependencyArtifact artifact = new DefaultDependencyArtifact();
         configureAction.execute(artifact);
+        artifact.validate();
         artifacts.add(artifact);
         return artifact;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyArtifact.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.DependencyArtifact;
 
 public class DefaultDependencyArtifact implements DependencyArtifact {
@@ -33,6 +34,13 @@ public class DefaultDependencyArtifact implements DependencyArtifact {
         this.extension = extension;
         this.classifier = classifier;
         this.url = url;
+        validate();
+    }
+
+    protected void validate() {
+        if (this.name == null) {
+            throw new InvalidUserDataException("Artifact name must not be null!");
+        }
     }
 
     public String getName() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependencySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependencySpec.groovy
@@ -59,6 +59,18 @@ abstract class AbstractModuleDependencySpec extends Specification {
         e.message == "Name must not be null!"
     }
 
+    def "cannot request artifact with null name"() {
+        when:
+        def dep = createDependency("group", "name", "version")
+        dep.artifact {
+            classifier = 'test'
+        }
+
+        then:
+        def e = thrown InvalidUserDataException
+        e.message == "Artifact name must not be null!"
+    }
+
     void "can exclude dependencies"() {
         def excludeArgs1 = WrapUtil.toMap("group", "aGroup")
         def excludeArgs2 = WrapUtil.toMap("module", "aModule")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
@@ -176,6 +176,23 @@ dependencies {
         }
     }
 
+    def "throws readable error if an artifact name is missing"() {
+        given:
+        buildFile << """
+dependencies {
+    conf ("org.gradle:test:1.45") {
+        artifact {
+            classifier = 'classifier'
+        }
+    }
+}
+"""
+
+        expect:
+        fails "checkDep"
+        failure.assertHasCause("Artifact name must not be null!")
+    }
+
     @RequiredFeatures(
         // only available with Maven metadata: Gradle metadata does not support "optional"
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")


### PR DESCRIPTION
Throw a proper error if the name is missing. This is similar to the error we throw if a user attempts to create a dependency without name.

Before, an NPE was thrown as the name was assumed to be never null.