### PR TITLE
Support injecting null parameters in Worker API

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DependencyInjectingInstantiator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DependencyInjectingInstantiator.java
@@ -106,6 +106,9 @@ public class DependencyInjectingInstantiator implements Instantiator {
             if (pos < parameters.length && targetType.isInstance(parameters[pos])) {
                 resolvedParameters[i] = parameters[pos];
                 pos++;
+            } else if (pos < parameters.length && parameters[pos] instanceof NullReference) {
+                resolvedParameters[i] = null;
+                pos++;
             } else {
                 resolvedParameters[i] = services.get(constructor.getGenericParameterTypes()[i]);
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/NullReference.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/NullReference.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import java.io.Serializable;
+
+/**
+ * Used to represent a {@code null} reference as a type. This is useful when doing transformations
+ * on parameter types when some parameters may be unreadable due to being {@code null}. It can act
+ * as a placeholder for a {@code null} reference.
+ * <p>
+ * This is used by the Worker API to communicate to the {@link DependencyInjectingInstantiator}
+ * of when a {@code null} reference should be used in place of a constructor parameter.
+ */
+public final class NullReference implements Serializable {
+    private static final NullReference INSTANCE = new NullReference();
+
+    /**
+     * Do not allow public construction.
+     */
+    private NullReference() {
+    }
+
+    /**
+     * Returns the single {@link NullReference} instance maintained by the class.
+     *
+     * @return Singleton instance.
+     */
+    public static NullReference get() {
+        return INSTANCE;
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DependencyInjectingInstantiatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DependencyInjectingInstantiatorTest.groovy
@@ -53,6 +53,18 @@ class DependencyInjectingInstantiatorTest extends Specification {
         result.param2 == 12
     }
 
+    def "injects NullReference parameters into constructor to set nulls"() {
+        given:
+        classGenerator.generate(_) >> { Class<?> c -> c }
+
+        when:
+        def result = instantiator.newInstance(HasInjectConstructor, NullReference.get(), NullReference.get())
+
+        then:
+        result.param1 == null
+        result.param2 == null
+    }
+
     def "injects missing parameters from provided service registry"() {
         given:
         classGenerator.generate(_) >> { Class<?> c -> c }


### PR DESCRIPTION
### Context
See gradle/gradle#2405.

Users working with Worker API should be able to set parameters in their workers to `null`. Currently, doing this produces an NPE.

The solution in this PR is to use `NullReference` (a new internal class) to model a `null` reference and have `DependencyInjectingInstantiator` interpret this class such that it assigns `null` to the corresponding constructor parameter. The logic for this can be extended to recognize explicit `null`s passed into `DependencyInjectingInstantiator.newInstance`, but I wasn't sure if this would be desirable and it isn't necessary to fix the issue relating to the Worker API specifically.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
