### PR TITLE
Allow variant specific dependencies to be declared for C++ and Swift components

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationDependenciesIntegrationTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
+
+class CppApplicationDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest implements CppTaskNames {
+    @Override
+    protected void makeComponentWithLibrary() {
+        buildFile << """
+            apply plugin: 'cpp-application'
+            project(':lib') {
+                apply plugin: 'cpp-library'
+            }
+"""
+        file("lib/src/main/cpp/lib.cpp") << """
+            void lib_func() { }
+"""
+        file("src/main/cpp/app.cpp") << """
+            int main() {
+                return 0;
+            }
+"""
+    }
+
+    @Override
+    protected String getComponentUnderTestDsl() {
+        return "application"
+    }
+
+    @Override
+    protected List<String> getAssembleDebugTasks() {
+        return [':compileDebugCpp', ':linkDebug', ':installDebug']
+    }
+
+    @Override
+    protected List<String> getAssembleReleaseTasks() {
+        return [':compileReleaseCpp', ':linkRelease', ':installRelease'] + extractAndStripSymbolsTasksRelease(toolChain)
+    }
+
+    @Override
+    protected List<String> getLibDebugTasks() {
+        return [':lib:compileDebugCpp', ':lib:linkDebug']
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationDependenciesIntegrationTest.groovy
@@ -28,7 +28,13 @@ class CppApplicationDependenciesIntegrationTest extends AbstractNativeProduction
             }
 """
         file("lib/src/main/cpp/lib.cpp") << """
-            void lib_func() { }
+            #ifdef _WIN32
+            #define EXPORT_FUNC __declspec(dllexport)
+            #else
+            #define EXPORT_FUNC
+            #endif
+            
+            void EXPORT_FUNC lib_func() { }
 """
         file("src/main/cpp/app.cpp") << """
             int main() {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryDependenciesIntegrationTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
+
+class CppLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest implements CppTaskNames {
+    @Override
+    protected void makeComponentWithLibrary() {
+        buildFile << """
+            apply plugin: 'cpp-library'
+            project(':lib') {
+                apply plugin: 'cpp-library'
+            }
+"""
+        file("lib/src/main/cpp/lib.cpp") << """
+            void lib_func() { }
+"""
+        file("src/main/cpp/lib.cpp") << """
+            int main_func() {
+                return 0;
+            }
+"""
+    }
+
+    @Override
+    protected String getComponentUnderTestDsl() {
+        return "library"
+    }
+
+    @Override
+    protected List<String> getAssembleDebugTasks() {
+        return [':compileDebugCpp', ':linkDebug']
+    }
+
+    @Override
+    protected List<String> getAssembleReleaseTasks() {
+        return [':compileReleaseCpp', ':linkRelease'] + extractAndStripSymbolsTasksRelease(toolChain)
+    }
+
+    @Override
+    protected List<String> getLibDebugTasks() {
+        return [':lib:compileDebugCpp', ':lib:linkDebug']
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryDependenciesIntegrationTest.groovy
@@ -28,7 +28,13 @@ class CppLibraryDependenciesIntegrationTest extends AbstractNativeProductionComp
             }
 """
         file("lib/src/main/cpp/lib.cpp") << """
-            void lib_func() { }
+            #ifdef _WIN32
+            #define EXPORT_FUNC __declspec(dllexport)
+            #else
+            #define EXPORT_FUNC
+            #endif
+            
+            void EXPORT_FUNC lib_func() { }
 """
         file("src/main/cpp/lib.cpp") << """
             int main_func() {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryWithBothLinkagePublishingIntegrationTest.groovy
@@ -92,14 +92,14 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
         api.files.size() == 1
         api.files[0].name == 'cpp-api-headers.zip'
         api.files[0].url == 'test-1.2-cpp-api-headers.zip'
-        mainMetadata.variant("debugShared-link").availableAt.coords == "some.group:test_debug_shared:1.2"
-        mainMetadata.variant("debugShared-runtime").availableAt.coords == "some.group:test_debug_shared:1.2"
-        mainMetadata.variant("debugStatic-link").availableAt.coords == "some.group:test_debug_static:1.2"
-        mainMetadata.variant("debugStatic-runtime").availableAt.coords == "some.group:test_debug_static:1.2"
-        mainMetadata.variant("releaseShared-link").availableAt.coords == "some.group:test_release_shared:1.2"
-        mainMetadata.variant("releaseShared-runtime").availableAt.coords == "some.group:test_release_shared:1.2"
-        mainMetadata.variant("releaseStatic-link").availableAt.coords == "some.group:test_release_static:1.2"
-        mainMetadata.variant("releaseStatic-runtime").availableAt.coords == "some.group:test_release_static:1.2"
+        mainMetadata.variant("debug-shared-link").availableAt.coords == "some.group:test_debug_shared:1.2"
+        mainMetadata.variant("debug-shared-runtime").availableAt.coords == "some.group:test_debug_shared:1.2"
+        mainMetadata.variant("debug-static-link").availableAt.coords == "some.group:test_debug_static:1.2"
+        mainMetadata.variant("debug-static-runtime").availableAt.coords == "some.group:test_debug_static:1.2"
+        mainMetadata.variant("release-shared-link").availableAt.coords == "some.group:test_release_shared:1.2"
+        mainMetadata.variant("release-shared-runtime").availableAt.coords == "some.group:test_release_shared:1.2"
+        mainMetadata.variant("release-static-link").availableAt.coords == "some.group:test_release_static:1.2"
+        mainMetadata.variant("release-static-runtime").availableAt.coords == "some.group:test_release_static:1.2"
 
         def debugShared = repo.module('some.group', 'test_debug_shared', '1.2')
         debugShared.assertPublished()
@@ -111,8 +111,8 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
 
         def debugSharedMetadata = debugShared.parsedModuleMetadata
         debugSharedMetadata.variants.size() == 2
-        debugSharedMetadata.variant('debugShared-link')
-        debugSharedMetadata.variant('debugShared-runtime')
+        debugSharedMetadata.variant('debug-shared-link')
+        debugSharedMetadata.variant('debug-shared-runtime')
 
         def debugStatic = repo.module('some.group', 'test_debug_static', '1.2')
         debugStatic.assertPublished()
@@ -123,8 +123,8 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
 
         def debugStaticMetadata = debugStatic.parsedModuleMetadata
         debugStaticMetadata.variants.size() == 2
-        debugStaticMetadata.variant('debugStatic-link')
-        debugStaticMetadata.variant('debugStatic-runtime')
+        debugStaticMetadata.variant('debug-static-link')
+        debugStaticMetadata.variant('debug-static-runtime')
 
         def releaseShared = repo.module('some.group', 'test_release_shared', '1.2')
         releaseShared.assertPublished()
@@ -136,8 +136,8 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
 
         def releaseSharedMetadata = releaseShared.parsedModuleMetadata
         releaseSharedMetadata.variants.size() == 2
-        releaseSharedMetadata.variant('releaseShared-link')
-        releaseSharedMetadata.variant('releaseShared-runtime')
+        releaseSharedMetadata.variant('release-shared-link')
+        releaseSharedMetadata.variant('release-shared-runtime')
 
         def releaseStatic = repo.module('some.group', 'test_release_static', '1.2')
         releaseStatic.assertPublished()
@@ -148,8 +148,8 @@ class CppLibraryWithBothLinkagePublishingIntegrationTest extends AbstractInstall
 
         def releaseStaticMetadata = releaseStatic.parsedModuleMetadata
         releaseStaticMetadata.variants.size() == 2
-        releaseStaticMetadata.variant('releaseStatic-link')
-        releaseStaticMetadata.variant('releaseStatic-runtime')
+        releaseStaticMetadata.variant('release-static-link')
+        releaseStaticMetadata.variant('release-static-runtime')
     }
 
     def "correct variant of published library is selected when resolving"() {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationDependenciesIntegrationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.swift
+
+import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+@Requires(TestPrecondition.SWIFT_SUPPORT)
+class SwiftApplicationDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
+    @Override
+    protected void makeComponentWithLibrary() {
+        buildFile << """
+            apply plugin: 'swift-application'
+            project(':lib') {
+                apply plugin: 'swift-library'
+            }
+"""
+
+        file("src/main/swift/main.swift") << """
+"""
+        file("lib/src/main/swift/Lib.swift") << """
+            class Lib {
+            }
+"""
+    }
+
+    @Override
+    protected String getComponentUnderTestDsl() {
+        return "application"
+    }
+
+    @Override
+    protected List<String> getAssembleDebugTasks() {
+        return [":compileDebugSwift", ":linkDebug", ":installDebug"]
+    }
+
+    @Override
+    protected List<String> getAssembleReleaseTasks() {
+        return [":compileReleaseSwift", ":linkRelease", ":stripSymbolsRelease", ":extractSymbolsRelease", ":installRelease"]
+    }
+
+    @Override
+    protected List<String> getLibDebugTasks() {
+        return [":lib:compileDebugSwift", ":lib:linkDebug"]
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.swift
+
+import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+@Requires(TestPrecondition.SWIFT_SUPPORT)
+class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
+    @Override
+    protected void makeComponentWithLibrary() {
+        buildFile << """
+            apply plugin: 'swift-library'
+            project(':lib') {
+                apply plugin: 'swift-library'
+            }
+"""
+
+        file("src/main/swift/Lib.swift") << """
+            class Lib {
+            }
+"""
+        file("lib/src/main/swift/Lib.swift") << """
+            class Lib {
+            }
+"""
+    }
+
+    @Override
+    protected String getComponentUnderTestDsl() {
+        return "library"
+    }
+
+    @Override
+    protected List<String> getAssembleDebugTasks() {
+        return [":compileDebugSwift", ":linkDebug"]
+    }
+
+    @Override
+    protected List<String> getAssembleReleaseTasks() {
+        return [":compileReleaseSwift", ":linkRelease", ":stripSymbolsRelease", ":extractSymbolsRelease"]
+    }
+
+    @Override
+    protected List<String> getLibDebugTasks() {
+        return [":lib:compileDebugSwift", ":lib:linkDebug"]
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
@@ -74,7 +74,7 @@ public interface BinaryCollection<T extends SoftwareComponent> {
     void whenElementKnown(Action<? super T> action);
 
     /**
-     * Registers an action to execute when an element of the given type becomes known. The action is only executed for those elements that are required. Fails if any element has already been finalized.
+     * Registers an action to execute when an element of the given type becomes known. The action is only executed for those elements that are required. Fails if any matching element has already been finalized.
      *
      * @param type The type of element to select.
      * @param action The action to execute for each element becomes known.
@@ -89,7 +89,7 @@ public interface BinaryCollection<T extends SoftwareComponent> {
     void whenElementFinalized(Action<? super T> action);
 
     /**
-     * Registers an action to execute when an element of the given type is finalized. The action is only executed for those elements that are required. Fails if any element has already been finalized.
+     * Registers an action to execute when an element of the given type is finalized. The action is only executed for those elements that are required. Fails if any matching element has already been finalized.
      *
      * @param type The type of element to select.
      * @param action The action to execute for each element when finalized.
@@ -104,7 +104,7 @@ public interface BinaryCollection<T extends SoftwareComponent> {
     void configureEach(Action<? super T> action);
 
     /**
-     * Registers an action to execute to configure each element of the given type in the collection. The action is only executed for those elements that are required. Fails if any element has already been finalized.
+     * Registers an action to execute to configure each element of the given type in the collection. The action is only executed for those elements that are required. Fails if any matching element has already been finalized.
      *
      * @param type The type of element to select.
      * @param action The action to execute on each element for configuration.

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
@@ -40,7 +40,7 @@ public interface BinaryCollection<T extends SoftwareComponent> {
      * <p>Querying the return value will fail when there is not exactly one matching binary.
      *
      * @param type type to match
-     * @param spec specification to satisfy. The spec is applied to each binary prior to configuration.
+     * @param spec specification to satisfy. The spec is applied to each binary <em>prior</em> to configuration.
      * @param <S> type of the binary to return
      * @return a binary from the collection in a finalized state
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryProvider.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryProvider.java
@@ -29,7 +29,14 @@ import org.gradle.api.provider.Provider;
 @Incubating
 public interface BinaryProvider<T> extends Provider<T> {
     /**
-     * Registers an action to execute to configure the binary. The action is executed when the element is required.
+     * Registers an action to execute to configure the binary. The action is executed only when the element is required.
      */
     void configure(Action<? super T> action);
+
+    /**
+     * Registers an action to execute when the binary has been configured. The action is executed only when the element is required.
+     *
+     * @since 4.6
+     */
+    void whenFinalized(Action<? super T> action);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,18 @@
 package org.gradle.language;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.FileCollection;
 
 /**
- * Represents a component with output files.
+ * Allows the implementation dependencies of a component to be specified.
  *
- * @since 4.5
+ * @since 4.6
  */
 @Incubating
-public interface ComponentWithOutputs extends SoftwareComponent {
+public interface ComponentDependencies {
     /**
-     * Returns the outputs produced for this component.
+     * Adds an implementation dependency to this component.
+     *
+     * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
      */
-    FileCollection getOutputs();
+    void implementation(Object notation);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,24 @@
 
 package org.gradle.language;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.file.FileCollection;
 
 /**
- * Represents a component with output files.
+ * Represents a component with implementation dependencies.
  *
- * @since 4.5
+ * @since 4.6
  */
 @Incubating
-public interface ComponentWithOutputs extends SoftwareComponent {
+public interface ComponentWithDependencies extends SoftwareComponent {
     /**
-     * Returns the outputs produced for this component.
+     * Returns the dependencies of this component.
      */
-    FileCollection getOutputs();
+    ComponentDependencies getDependencies();
+
+    /**
+     * Executes the given action to configure the dependencies of this component.
+     */
+    void dependencies(Action<? super ComponentDependencies> action);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/LibraryDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/LibraryDependencies.java
@@ -17,17 +17,18 @@
 package org.gradle.language;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.component.SoftwareComponent;
 
 /**
- * Represents a component with implementation dependencies.
+ * Allows the API and implementation dependencies of a library to be specified.
  *
  * @since 4.6
  */
 @Incubating
-public interface ComponentWithDependencies extends SoftwareComponent {
+public interface LibraryDependencies extends ComponentDependencies {
     /**
-     * Returns the dependencies of this component.
+     * Adds an API dependency to this library.
+     *
+     * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
      */
-    ComponentDependencies getDependencies();
+    void api(Object notation);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithDependencies;
 import org.gradle.language.cpp.tasks.CppCompile;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 import org.gradle.nativeplatform.Linkage;
@@ -30,7 +31,7 @@ import org.gradle.nativeplatform.Linkage;
  * @since 4.2
  */
 @Incubating
-public interface CppBinary extends ComponentWithObjectFiles {
+public interface CppBinary extends ComponentWithObjectFiles, ComponentWithDependencies {
     /**
      * The dependency resolution attribute use to indicate whether a binary is debuggable or not.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
@@ -25,6 +25,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
 import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.BinaryCollection;
+import org.gradle.language.ComponentWithDependencies;
 
 /**
  * Configuration for a C++ component, such as a library or executable, defining the source files and private header directories that make up the component. Private headers are those that are visible only to the source files of the component.
@@ -36,7 +37,7 @@ import org.gradle.language.BinaryCollection;
  * @since 4.2
  */
 @Incubating
-public interface CppComponent extends ComponentWithBinaries {
+public interface CppComponent extends ComponentWithBinaries, ComponentWithDependencies {
     /**
      * Specifies the base name for this component. This name is used to calculate various output file names. The default value is calculated from the project name.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppLibrary.java
@@ -23,6 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.language.LibraryDependencies;
 import org.gradle.nativeplatform.Linkage;
 
 /**
@@ -57,6 +58,14 @@ public interface CppLibrary extends ProductionCppComponent {
      * @since 4.3
      */
     FileTree getPublicHeaderFiles();
+
+    /**
+     * Returns the dependencies of this library.
+     *
+     * @since 4.6
+     */
+    @Override
+    LibraryDependencies getDependencies();
 
     /**
      * Returns the API dependencies of this library.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
@@ -17,13 +17,16 @@
 package org.gradle.language.cpp.internal;
 
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.language.ComponentDependencies;
 import org.gradle.language.cpp.CppApplication;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
+import org.gradle.language.internal.DefaultComponentDependencies;
 import org.gradle.language.nativeplatform.internal.PublicationAwareComponent;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
@@ -34,18 +37,34 @@ public class DefaultCppApplication extends DefaultCppComponent implements CppApp
     private final ObjectFactory objectFactory;
     private final Property<CppExecutable> developmentBinary;
     private final MainExecutableVariant mainVariant = new MainExecutableVariant();
+    private final DefaultComponentDependencies dependencies;
 
     @Inject
-    public DefaultCppApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations, ConfigurationContainer configurations) {
-        super(name, fileOperations, objectFactory, configurations);
+    public DefaultCppApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations) {
+        super(name, fileOperations, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(CppExecutable.class);
+        this.dependencies = objectFactory.newInstance(DefaultComponentDependencies.class, getNames().withSuffix("implementation"));
     }
 
     public DefaultCppExecutable addExecutable(String nameSuffix, boolean debuggable, boolean optimized, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
         DefaultCppExecutable result = objectFactory.newInstance(DefaultCppExecutable.class, getName() + StringUtils.capitalize(nameSuffix), getBaseName(), debuggable, optimized, getCppSource(), getPrivateHeaderDirs(), getImplementationDependencies(), targetPlatform, toolChain, platformToolProvider);
         getBinaries().add(result);
         return result;
+    }
+
+    @Override
+    public Configuration getImplementationDependencies() {
+        return dependencies.getImplementationDependencies();
+    }
+
+    @Override
+    public ComponentDependencies getDependencies() {
+        return dependencies;
+    }
+
+    public void dependencies(Action<? super ComponentDependencies> action) {
+        action.execute(dependencies);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
@@ -59,7 +59,7 @@ public class DefaultCppBinary extends DefaultNativeBinary implements CppBinary {
     private final Property<CppCompile> compileTaskProperty;
 
     public DefaultCppBinary(String name, ProjectLayout projectLayout, ObjectFactory objects, Provider<String> baseName, boolean debuggable, boolean optimized, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration componentImplementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        super(name, projectLayout, configurations, componentImplementation);
+        super(name, objects, projectLayout, componentImplementation);
         this.baseName = baseName;
         this.debuggable = debuggable;
         this.optimized = optimized;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -17,8 +17,6 @@
 package org.gradle.language.cpp.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -46,11 +44,10 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     private final FileCollection privateHeadersWithConvention;
     private final Property<String> baseName;
     private final Names names;
-    private final Configuration implementation;
     private final DefaultBinaryCollection<CppBinary> binaries;
 
     @Inject
-    public DefaultCppComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory, ConfigurationContainer configurations) {
+    public DefaultCppComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory) {
         super(fileOperations);
         this.name = name;
         this.fileOperations = fileOperations;
@@ -58,12 +55,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         privateHeaders = fileOperations.files();
         privateHeadersWithConvention = createDirView(privateHeaders, "src/" + name + "/headers");
         baseName = objectFactory.property(String.class);
-
         names = Names.of(name);
-        implementation = configurations.create(names.withSuffix("implementation"));
-        implementation.setCanBeConsumed(false);
-        implementation.setCanBeResolved(false);
-
         binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryCollection.class, CppBinary.class));
     }
 
@@ -112,11 +104,6 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     @Override
     public FileCollection getPrivateHeaderDirs() {
         return privateHeadersWithConvention;
-    }
-
-    @Override
-    public Configuration getImplementationDependencies() {
-        return implementation;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariant.java
@@ -24,19 +24,20 @@ import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.language.nativeplatform.internal.Names;
 
 import java.util.Set;
 
 public class NativeVariant implements SoftwareComponentInternal, ComponentWithVariants {
-    private final String name;
     private final Usage linkUsage;
     private final Configuration linkElements;
     private final Usage runtimeUsage;
     private final Set<? extends PublishArtifact> runtimeArtifacts;
     private final Configuration runtimeElementsConfiguration;
+    private final Names names;
 
-    public NativeVariant(String name, Usage usage, Set<? extends PublishArtifact> artifacts, Configuration dependencies) {
-        this.name = name;
+    public NativeVariant(Names names, Usage usage, Set<? extends PublishArtifact> artifacts, Configuration dependencies) {
+        this.names = names;
         this.linkUsage = null;
         this.linkElements = null;
         this.runtimeUsage = usage;
@@ -44,8 +45,8 @@ public class NativeVariant implements SoftwareComponentInternal, ComponentWithVa
         this.runtimeElementsConfiguration = dependencies;
     }
 
-    public NativeVariant(String name, Usage linkUsage, Configuration linkElements, Usage runtimeUsage, Configuration runtimeElements) {
-        this.name = name;
+    public NativeVariant(Names names, Usage linkUsage, Configuration linkElements, Usage runtimeUsage, Configuration runtimeElements) {
+        this.names = names;
         this.linkUsage = linkUsage;
         this.linkElements = linkElements;
         this.runtimeUsage = runtimeUsage;
@@ -55,7 +56,7 @@ public class NativeVariant implements SoftwareComponentInternal, ComponentWithVa
 
     @Override
     public String getName() {
-        return name;
+        return names.getBaseName();
     }
 
     @Override
@@ -66,9 +67,9 @@ public class NativeVariant implements SoftwareComponentInternal, ComponentWithVa
     @Override
     public Set<? extends UsageContext> getUsages() {
         if (linkElements == null) {
-            return ImmutableSet.of(new DefaultUsageContext(name + "-runtime", runtimeUsage, runtimeArtifacts, runtimeElementsConfiguration));
+            return ImmutableSet.of(new DefaultUsageContext(names.getLowerBaseName() + "-runtime", runtimeUsage, runtimeArtifacts, runtimeElementsConfiguration));
         } else {
-            return ImmutableSet.of(new DefaultUsageContext(name + "-link", linkUsage, linkElements.getAllArtifacts(), linkElements), new DefaultUsageContext(name + "-runtime", runtimeUsage, runtimeArtifacts, runtimeElementsConfiguration));
+            return ImmutableSet.of(new DefaultUsageContext(names.getLowerBaseName() + "-link", linkUsage, linkElements.getAllArtifacts(), linkElements), new DefaultUsageContext(names.getLowerBaseName() + "-runtime", runtimeUsage, runtimeArtifacts, runtimeElementsConfiguration));
         }
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.language.cpp.CppApplication;
 import org.gradle.language.cpp.CppExecutable;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.internal.DefaultCppApplication;
+import org.gradle.language.cpp.internal.DefaultCppExecutable;
 import org.gradle.language.cpp.internal.NativeVariant;
 import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
@@ -87,11 +88,11 @@ public class CppApplicationPlugin implements Plugin<ProjectInternal> {
         // TODO - move this to a shared location
 
         final Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
-        application.getBinaries().whenElementKnown(CppExecutable.class, new Action<CppExecutable>() {
+        application.getBinaries().whenElementKnown(DefaultCppExecutable.class, new Action<DefaultCppExecutable>() {
             @Override
-            public void execute(CppExecutable executable) {
+            public void execute(DefaultCppExecutable executable) {
                 Configuration runtimeElements = executable.getRuntimeElements().get();
-                NativeVariant variant = new NativeVariant(executable.getName(), runtimeUsage, runtimeElements.getAllArtifacts(), runtimeElements);
+                NativeVariant variant = new NativeVariant(executable.getNames(), runtimeUsage, runtimeElements.getAllArtifacts(), runtimeElements);
                 application.getMainPublication().addVariant(variant);
             }
         });

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
@@ -74,24 +74,25 @@ public class CppApplicationPlugin implements Plugin<ProjectInternal> {
                 ToolChainSelector.Result<CppPlatform> result = toolChainSelector.select(CppPlatform.class);
 
                 CppExecutable debugExecutable = application.addExecutable("debug", true, false, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
-                CppExecutable releaseExecutable = application.addExecutable("release", true, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                application.addExecutable("release", true, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
 
                 // Use the debug variant as the development binary
                 application.getDevelopmentBinary().set(debugExecutable);
 
-                // Add publications
-
-                final Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
-
-                Configuration debugRuntimeElements = debugExecutable.getRuntimeElements().get();
-                Configuration releaseRuntimeElements = releaseExecutable.getRuntimeElements().get();
-
-                NativeVariant debugVariant = new NativeVariant("debug", runtimeUsage, debugRuntimeElements.getAllArtifacts(), debugRuntimeElements);
-                application.getMainPublication().addVariant(debugVariant);
-                NativeVariant releaseVariant = new NativeVariant("release", runtimeUsage, releaseRuntimeElements.getAllArtifacts(), releaseRuntimeElements);
-                application.getMainPublication().addVariant(releaseVariant);
-
                 application.getBinaries().realizeNow();
+            }
+        });
+
+        // Define publications
+        // TODO - move this to a shared location
+
+        final Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
+        application.getBinaries().whenElementKnown(CppExecutable.class, new Action<CppExecutable>() {
+            @Override
+            public void execute(CppExecutable executable) {
+                Configuration runtimeElements = executable.getRuntimeElements().get();
+                NativeVariant variant = new NativeVariant(executable.getName(), runtimeUsage, runtimeElements.getAllArtifacts(), runtimeElements);
+                application.getMainPublication().addVariant(variant);
             }
         });
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -138,43 +138,47 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                 if (sharedLibs) {
                     String linkageNameSuffix = staticLibs ? "Shared" : "";
                     CppSharedLibrary debugSharedLibrary = library.addSharedLibrary("debug" + linkageNameSuffix, true, false, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
-                    CppSharedLibrary releaseSharedLibrary = library.addSharedLibrary("release" + linkageNameSuffix, true, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                    library.addSharedLibrary("release" + linkageNameSuffix, true, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
 
                     // Use the debug shared library as the development binary
                     library.getDevelopmentBinary().set(debugSharedLibrary);
 
-                    // Define the outgoing artifacts
-                    final Configuration debugLinkElements = debugSharedLibrary.getLinkElements().get();
-                    final Configuration debugRuntimeElements = debugSharedLibrary.getRuntimeElements().get();
-                    final Configuration releaseLinkElements = releaseSharedLibrary.getLinkElements().get();
-                    final Configuration releaseRuntimeElements = releaseSharedLibrary.getRuntimeElements().get();
+                    // Define the outgoing publications
+                    // TODO - move this to a shared location
 
-                    NativeVariant debugVariant = new NativeVariant("debug" + linkageNameSuffix, linkUsage, debugLinkElements, runtimeUsage, debugRuntimeElements);
-                    mainVariant.addVariant(debugVariant);
-                    NativeVariant releaseVariant = new NativeVariant("release" + linkageNameSuffix, linkUsage, releaseLinkElements, runtimeUsage, releaseRuntimeElements);
-                    mainVariant.addVariant(releaseVariant);
+                    library.getBinaries().whenElementKnown(CppSharedLibrary.class, new Action<CppSharedLibrary>() {
+                        @Override
+                        public void execute(CppSharedLibrary library) {
+                            Configuration linkElements = library.getLinkElements().get();
+                            Configuration runtimeElements = library.getRuntimeElements().get();
+                            NativeVariant variant = new NativeVariant(library.getName(), linkUsage, linkElements, runtimeUsage, runtimeElements);
+                            mainVariant.addVariant(variant);
+                        }
+                    });
                 }
 
                 if (staticLibs) {
                     String linkageNameSuffix = sharedLibs ? "Static" : "";
                     CppStaticLibrary debugStaticLibrary = library.addStaticLibrary("debug" + linkageNameSuffix, true, false, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
-                    CppStaticLibrary releaseStaticLibrary = library.addStaticLibrary("release" + linkageNameSuffix, true, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                    library.addStaticLibrary("release" + linkageNameSuffix, true, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
 
                     if (!sharedLibs) {
                         // Use the debug static library as the development binary
                         library.getDevelopmentBinary().set(debugStaticLibrary);
                     }
 
-                    // Define the outgoing artifacts
-                    final Configuration debugLinkElements = debugStaticLibrary.getLinkElements().get();
-                    final Configuration debugRuntimeElements = debugStaticLibrary.getRuntimeElements().get();
-                    final Configuration releaseLinkElements = releaseStaticLibrary.getLinkElements().get();
-                    final Configuration releaseRuntimeElements = releaseStaticLibrary.getRuntimeElements().get();
+                    // Define the outgoing publications
+                    // TODO - move this to a shared location
 
-                    NativeVariant debugVariant = new NativeVariant("debug" + linkageNameSuffix, linkUsage, debugLinkElements, runtimeUsage, debugRuntimeElements);
-                    mainVariant.addVariant(debugVariant);
-                    NativeVariant releaseVariant = new NativeVariant("release" + linkageNameSuffix, linkUsage, releaseLinkElements, runtimeUsage, releaseRuntimeElements);
-                    mainVariant.addVariant(releaseVariant);
+                    library.getBinaries().whenElementKnown(CppStaticLibrary.class, new Action<CppStaticLibrary>() {
+                        @Override
+                        public void execute(CppStaticLibrary library) {
+                            Configuration linkElements = library.getLinkElements().get();
+                            Configuration runtimeElements = library.getRuntimeElements().get();
+                            NativeVariant variant = new NativeVariant(library.getName(), linkUsage, linkElements, runtimeUsage, runtimeElements);
+                            mainVariant.addVariant(variant);
+                        }
+                    });
                 }
 
                 library.getBinaries().realizeNow();

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -37,6 +37,8 @@ import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppSharedLibrary;
 import org.gradle.language.cpp.CppStaticLibrary;
 import org.gradle.language.cpp.internal.DefaultCppLibrary;
+import org.gradle.language.cpp.internal.DefaultCppSharedLibrary;
+import org.gradle.language.cpp.internal.DefaultCppStaticLibrary;
 import org.gradle.language.cpp.internal.MainLibraryVariant;
 import org.gradle.language.cpp.internal.NativeVariant;
 import org.gradle.language.internal.NativeComponentFactory;
@@ -146,12 +148,12 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                     // Define the outgoing publications
                     // TODO - move this to a shared location
 
-                    library.getBinaries().whenElementKnown(CppSharedLibrary.class, new Action<CppSharedLibrary>() {
+                    library.getBinaries().whenElementKnown(DefaultCppSharedLibrary.class, new Action<DefaultCppSharedLibrary>() {
                         @Override
-                        public void execute(CppSharedLibrary library) {
+                        public void execute(DefaultCppSharedLibrary library) {
                             Configuration linkElements = library.getLinkElements().get();
                             Configuration runtimeElements = library.getRuntimeElements().get();
-                            NativeVariant variant = new NativeVariant(library.getName(), linkUsage, linkElements, runtimeUsage, runtimeElements);
+                            NativeVariant variant = new NativeVariant(library.getNames(), linkUsage, linkElements, runtimeUsage, runtimeElements);
                             mainVariant.addVariant(variant);
                         }
                     });
@@ -170,12 +172,12 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                     // Define the outgoing publications
                     // TODO - move this to a shared location
 
-                    library.getBinaries().whenElementKnown(CppStaticLibrary.class, new Action<CppStaticLibrary>() {
+                    library.getBinaries().whenElementKnown(DefaultCppStaticLibrary.class, new Action<DefaultCppStaticLibrary>() {
                         @Override
-                        public void execute(CppStaticLibrary library) {
+                        public void execute(DefaultCppStaticLibrary library) {
                             Configuration linkElements = library.getLinkElements().get();
                             Configuration runtimeElements = library.getRuntimeElements().get();
-                            NativeVariant variant = new NativeVariant(library.getName(), linkUsage, linkElements, runtimeUsage, runtimeElements);
+                            NativeVariant variant = new NativeVariant(library.getNames(), linkUsage, linkElements, runtimeUsage, runtimeElements);
                             mainVariant.addVariant(variant);
                         }
                     });

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
@@ -218,6 +218,18 @@ public class DefaultBinaryCollection<T extends SoftwareComponent> implements Bin
             });
         }
 
+        @Override
+        public void whenFinalized(final Action<? super S> action) {
+            whenElementFinalized(new Action<T>() {
+                @Override
+                public void execute(T t) {
+                    if (match == t) {
+                        action.execute(match);
+                    }
+                }
+            });
+        }
+
         @Nullable
         @Override
         public S getOrNull() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultBinaryCollection.java
@@ -89,9 +89,6 @@ public class DefaultBinaryCollection<T extends SoftwareComponent> implements Bin
             throw new IllegalStateException("Cannot add actions to this collection as it has already been realized.");
         }
         knownActions = knownActions.add(action);
-        for (T element : elements) {
-            action.execute(element);
-        }
     }
 
     @Override
@@ -133,14 +130,20 @@ public class DefaultBinaryCollection<T extends SoftwareComponent> implements Bin
             throw new IllegalStateException("Cannot add an element to this collection as it has already been realized.");
         }
         elements.add(element);
-        knownActions.execute(element);
     }
 
+    /**
+     * Realizes the contents of this collection, running configuration actions and firing notifications. No further elements can be added.
+     */
     public void realizeNow() {
         if (state != State.Collecting) {
             throw new IllegalStateException("Cannot realize this collection as it has already been realized.");
         }
         state = State.Realizing;
+
+        for (T element : elements) {
+            knownActions.execute(element);
+        }
         knownActions = ImmutableActionSet.empty();
 
         for (SingleElementProvider<?> provider : pending) {
@@ -157,7 +160,6 @@ public class DefaultBinaryCollection<T extends SoftwareComponent> implements Bin
             finalizeActions.execute(element);
         }
         finalizeActions = ImmutableActionSet.empty();
-
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultComponentDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultComponentDependencies.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.internal;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.language.ComponentDependencies;
+
+import javax.inject.Inject;
+
+public class DefaultComponentDependencies implements ComponentDependencies {
+    private final Configuration implementation;
+
+    @Inject
+    public DefaultComponentDependencies(ConfigurationContainer configurations, String implementationName) {
+        implementation = configurations.create(implementationName);
+        implementation.setCanBeConsumed(false);
+        implementation.setCanBeResolved(false);
+    }
+
+    public Configuration getImplementationDependencies() {
+        return implementation;
+    }
+
+    @Inject
+    protected DependencyHandler getDependencyHandler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void implementation(Object notation) {
+        implementation.getDependencies().add(getDependencyHandler().create(notation));
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultLibraryDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultLibraryDependencies.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.internal;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.language.LibraryDependencies;
+
+import javax.inject.Inject;
+
+public class DefaultLibraryDependencies extends DefaultComponentDependencies implements LibraryDependencies {
+    private final Configuration apiDependencies;
+
+    @Inject
+    public DefaultLibraryDependencies(ConfigurationContainer configurations, String implementationName, String apiName) {
+        super(configurations, implementationName);
+        apiDependencies = configurations.create(apiName);
+        apiDependencies.setCanBeConsumed(false);
+        apiDependencies.setCanBeResolved(false);
+        getImplementationDependencies().extendsFrom(apiDependencies);
+    }
+
+    public Configuration getApiDependencies() {
+        return apiDependencies;
+    }
+
+    @Override
+    public void api(Object notation) {
+        apiDependencies.getDependencies().add(getDependencyHandler().create(notation));
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Names.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Names.java
@@ -31,6 +31,16 @@ public abstract class Names {
         return new Other(name);
     }
 
+    /**
+     * Camel case formatted base name.
+     */
+    public abstract String getBaseName();
+
+    /**
+     * Lower case formatted base name, with '_' separators
+     */
+    public abstract String getLowerBaseName();
+
     public abstract String withPrefix(String prefix);
 
     public abstract String withSuffix(String suffix);
@@ -43,6 +53,16 @@ public abstract class Names {
     public abstract String getDirName();
 
     private static class Main extends Names {
+        @Override
+        public String getBaseName() {
+            return "main";
+        }
+
+        @Override
+        public String getLowerBaseName() {
+            return "main";
+        }
+
         @Override
         public String getCompileTaskName(String language) {
             return "compile" + StringUtils.capitalize(language);
@@ -71,11 +91,13 @@ public abstract class Names {
 
     private static class Other extends Names {
         private final String baseName;
+        private final String lowerBaseName;
         private final String capitalizedBaseName;
         private final String dirName;
 
         Other(String name) {
             StringBuilder baseName = new StringBuilder();
+            StringBuilder lowerBaseName = new StringBuilder();
             StringBuilder capBaseName = new StringBuilder();
             StringBuilder dirName = new StringBuilder();
             int startLast = 0;
@@ -83,17 +105,28 @@ public abstract class Names {
             for (; i < name.length(); i++) {
                 if (Character.isUpperCase(name.charAt(i))) {
                     if (i > startLast) {
-                        append(name, startLast, i, baseName, capBaseName, dirName);
+                        append(name, startLast, i, baseName, lowerBaseName, capBaseName, dirName);
                     }
                     startLast = i;
                 }
             }
             if (i > startLast) {
-                append(name, startLast, i, baseName, capBaseName, dirName);
+                append(name, startLast, i, baseName, lowerBaseName, capBaseName, dirName);
             }
             this.baseName = baseName.toString();
+            this.lowerBaseName = lowerBaseName.toString();
             this.capitalizedBaseName = capBaseName.toString();
             this.dirName = dirName.toString();
+        }
+
+        @Override
+        public String getBaseName() {
+            return baseName;
+        }
+
+        @Override
+        public String getLowerBaseName() {
+            return lowerBaseName;
         }
 
         @Override
@@ -122,7 +155,7 @@ public abstract class Names {
             return dirName;
         }
 
-        private void append(String name, int start, int end, StringBuilder baseName, StringBuilder capBaseName, StringBuilder dirName) {
+        private void append(String name, int start, int end, StringBuilder baseName, StringBuilder lowerBaseName, StringBuilder capBaseName, StringBuilder dirName) {
             dirName.append(Character.toLowerCase(name.charAt(start)));
             dirName.append(name.substring(start + 1, end));
             dirName.append('/');
@@ -132,7 +165,10 @@ public abstract class Names {
                     baseName.append(name.substring(start + 1, end));
                 } else {
                     baseName.append(name.substring(start, end));
+                    lowerBaseName.append('-');
                 }
+                lowerBaseName.append(Character.toLowerCase(name.charAt(start)));
+                lowerBaseName.append(name.substring(start + 1, end));
                 capBaseName.append(Character.toUpperCase(name.charAt(start)));
                 capBaseName.append(name.substring(start + 1, end));
             }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -18,6 +18,7 @@ package org.gradle.language.swift;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 import org.gradle.language.swift.tasks.SwiftCompile;
@@ -69,6 +70,13 @@ public interface SwiftBinary extends ComponentWithObjectFiles {
      * @since 4.5
      */
     Provider<SwiftCompile> getCompileTask();
+
+    /**
+     * Returns the module file for this binary.
+     *
+     * @since 4.6
+     */
+    Provider<RegularFile> getModuleFile();
 
     /**
      * {@inheritDoc}

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
+import org.gradle.language.ComponentWithDependencies;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
 import org.gradle.language.swift.tasks.SwiftCompile;
 
@@ -29,7 +30,7 @@ import org.gradle.language.swift.tasks.SwiftCompile;
  * @since 4.2
  */
 @Incubating
-public interface SwiftBinary extends ComponentWithObjectFiles {
+public interface SwiftBinary extends ComponentWithObjectFiles, ComponentWithDependencies {
     /**
      * Returns the name of the Swift module that this binary defines.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
@@ -24,6 +24,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.BinaryCollection;
+import org.gradle.language.ComponentWithDependencies;
 
 /**
  * Configuration for a Swift component, such as a library or executable, defining the source files that make up the component plus other settings.
@@ -35,7 +36,7 @@ import org.gradle.language.BinaryCollection;
  * @since 4.2
  */
 @Incubating
-public interface SwiftComponent extends ComponentWithBinaries {
+public interface SwiftComponent extends ComponentWithBinaries, ComponentWithDependencies {
     /**
      * Defines the Swift module for this component. The default value is calculated from the project name.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftLibrary.java
@@ -19,6 +19,7 @@ package org.gradle.language.swift;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.language.LibraryDependencies;
 import org.gradle.nativeplatform.Linkage;
 
 /**
@@ -30,6 +31,14 @@ import org.gradle.nativeplatform.Linkage;
  */
 @Incubating
 public interface SwiftLibrary extends ProductionSwiftComponent {
+    /**
+     * Returns the dependencies of this library.
+     *
+     * @since 4.6
+     */
+    @Override
+    LibraryDependencies getDependencies();
+
     /**
      * Returns the API dependencies of this library.
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftApplication.java
@@ -17,10 +17,13 @@
 package org.gradle.language.swift.internal;
 
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.language.ComponentDependencies;
+import org.gradle.language.internal.DefaultComponentDependencies;
 import org.gradle.language.swift.SwiftApplication;
 import org.gradle.language.swift.SwiftExecutable;
 import org.gradle.language.swift.SwiftPlatform;
@@ -32,12 +35,28 @@ import javax.inject.Inject;
 public class DefaultSwiftApplication extends DefaultSwiftComponent implements SwiftApplication {
     private final ObjectFactory objectFactory;
     private final Property<SwiftExecutable> developmentBinary;
+    private final DefaultComponentDependencies dependencies;
 
     @Inject
-    public DefaultSwiftApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations, ConfigurationContainer configurations) {
-        super(name, fileOperations, objectFactory, configurations);
+    public DefaultSwiftApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations) {
+        super(name, fileOperations, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(SwiftExecutable.class);
+        this.dependencies = objectFactory.newInstance(DefaultComponentDependencies.class, getNames().withSuffix("implementation"));
+    }
+
+    @Override
+    public Configuration getImplementationDependencies() {
+        return dependencies.getImplementationDependencies();
+    }
+
+    @Override
+    public ComponentDependencies getDependencies() {
+        return dependencies;
+    }
+
+    public void dependencies(Action<? super ComponentDependencies> action) {
+        action.execute(dependencies);
     }
 
     public SwiftExecutable addExecutable(String nameSuffix, boolean debuggable, boolean optimized, boolean testable, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
@@ -37,7 +36,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
-import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.language.cpp.internal.NativeDependencyCache;
 import org.gradle.language.internal.DefaultNativeBinary;
 import org.gradle.language.nativeplatform.internal.Names;
@@ -66,49 +64,45 @@ public class DefaultSwiftBinary extends DefaultNativeBinary implements SwiftBina
     private final FileCollection compileModules;
     private final FileCollection linkLibs;
     private final Configuration runtimeLibs;
-    private final DirectoryProperty objectsDir;
     private final RegularFileProperty moduleFile;
     private final Property<SwiftCompile> compileTaskProperty;
     private final SwiftPlatform targetPlatform;
     private final NativeToolChainInternal toolChain;
     private final PlatformToolProvider platformToolProvider;
     private final Configuration importPathConfiguration;
-    private final Configuration implementation;
 
-    public DefaultSwiftBinary(String name, ProjectLayout projectLayout, final ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        super(name);
+    public DefaultSwiftBinary(String name, ProjectLayout projectLayout, final ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration componentImplementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
+        super(name, projectLayout, configurations, componentImplementation);
         this.module = module;
         this.debuggable = debuggable;
         this.optimized = optimized;
         this.testable = testable;
         this.source = source;
-        this.objectsDir = projectLayout.directoryProperty();
         this.moduleFile = projectLayout.fileProperty();
         this.compileTaskProperty = objectFactory.property(SwiftCompile.class);
         this.targetPlatform = targetPlatform;
         this.toolChain = toolChain;
-        this.implementation = implementation;
         this.platformToolProvider = platformToolProvider;
 
         Names names = getNames();
 
         // TODO - reduce duplication with C++ binary
         importPathConfiguration = configurations.create(names.withPrefix("swiftCompile"));
-        importPathConfiguration.extendsFrom(implementation);
+        importPathConfiguration.extendsFrom(getImplementationDependencies());
         importPathConfiguration.setCanBeConsumed(false);
         importPathConfiguration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
         importPathConfiguration.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
         importPathConfiguration.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, optimized);
 
         Configuration nativeLink = configurations.create(names.withPrefix("nativeLink"));
-        nativeLink.extendsFrom(implementation);
+        nativeLink.extendsFrom(getImplementationDependencies());
         nativeLink.setCanBeConsumed(false);
         nativeLink.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_LINK));
         nativeLink.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
         nativeLink.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, optimized);
 
         Configuration nativeRuntime = configurations.create(names.withPrefix("nativeRuntime"));
-        nativeRuntime.extendsFrom(implementation);
+        nativeRuntime.extendsFrom(getImplementationDependencies());
         nativeRuntime.setCanBeConsumed(false);
         nativeRuntime.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME));
         nativeRuntime.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debuggable);
@@ -164,21 +158,12 @@ public class DefaultSwiftBinary extends DefaultNativeBinary implements SwiftBina
         return runtimeLibs;
     }
 
-    public DirectoryProperty getObjectsDir() {
-        return objectsDir;
-    }
-
     public RegularFileProperty getModuleFile() {
         return moduleFile;
     }
 
     public Configuration getImportPathConfiguration() {
         return importPathConfiguration;
-    }
-
-    @Override
-    public FileCollection getObjects() {
-        return objectsDir.getAsFileTree().matching(new PatternSet().include("**/*.obj", "**/*.o"));
     }
 
     @Override
@@ -198,10 +183,6 @@ public class DefaultSwiftBinary extends DefaultNativeBinary implements SwiftBina
 
     public PlatformToolProvider getPlatformToolProvider() {
         return platformToolProvider;
-    }
-
-    public Configuration getImplementationDependencies() {
-        return implementation;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -72,7 +72,7 @@ public class DefaultSwiftBinary extends DefaultNativeBinary implements SwiftBina
     private final Configuration importPathConfiguration;
 
     public DefaultSwiftBinary(String name, ProjectLayout projectLayout, final ObjectFactory objectFactory, Provider<String> module, boolean debuggable, boolean optimized, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration componentImplementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
-        super(name, projectLayout, configurations, componentImplementation);
+        super(name, objectFactory, projectLayout, componentImplementation);
         this.module = module;
         this.debuggable = debuggable;
         this.optimized = optimized;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftComponent.java
@@ -16,8 +16,6 @@
 
 package org.gradle.language.swift.internal;
 
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
@@ -38,18 +36,14 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
     private final Property<String> module;
     private final String name;
     private final Names names;
-    private final Configuration implementation;
 
-    public DefaultSwiftComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory, ConfigurationContainer configurations) {
+    public DefaultSwiftComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory) {
         super(fileOperations);
         this.name = name;
         swiftSource = createSourceView("src/"+ name + "/swift", Collections.singletonList("swift"));
         module = objectFactory.property(String.class);
 
         names = Names.of(name);
-        implementation = configurations.create(names.withSuffix("implementation"));
-        implementation.setCanBeConsumed(false);
-        implementation.setCanBeResolved(false);
         binaries = Cast.uncheckedCast(objectFactory.newInstance(DefaultBinaryCollection.class, SwiftBinary.class));
     }
 
@@ -71,11 +65,6 @@ public abstract class DefaultSwiftComponent extends DefaultNativeComponent imple
     @Override
     public FileCollection getSwiftSource() {
         return swiftSource;
-    }
-
-    @Override
-    public Configuration getImplementationDependencies() {
-        return implementation;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
@@ -27,12 +27,13 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.language.internal.NativeComponentFactory;
+import org.gradle.language.nativeplatform.internal.ComponentWithNames;
+import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 import org.gradle.language.swift.SwiftApplication;
 import org.gradle.language.swift.SwiftExecutable;
 import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.internal.DefaultSwiftApplication;
-import org.gradle.language.swift.tasks.SwiftCompile;
 import org.gradle.util.GUtil;
 
 import javax.inject.Inject;
@@ -82,34 +83,32 @@ public class SwiftApplicationPlugin implements Plugin<ProjectInternal> {
         project.afterEvaluate(new Action<Project>() {
             @Override
             public void execute(Project project) {
-                ObjectFactory objectFactory = project.getObjects();
+                final ObjectFactory objectFactory = project.getObjects();
 
                 ToolChainSelector.Result<SwiftPlatform> result = toolChainSelector.select(SwiftPlatform.class);
 
                 SwiftExecutable debugExecutable = application.addExecutable("debug", true, false, true, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
-                SwiftExecutable releaseExecutable = application.addExecutable("release", true, true, false, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                application.addExecutable("release", true, true, false, result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
 
                 // Add outgoing APIs
-                SwiftCompile compileDebug = debugExecutable.getCompileTask().get();
-                SwiftCompile compileRelease = releaseExecutable.getCompileTask().get();
+                // TODO - remove this
 
-                Configuration implementation = application.getImplementationDependencies();
+                final Configuration implementation = application.getImplementationDependencies();
+                final Usage apiUsage = objectFactory.named(Usage.class, Usage.SWIFT_API);
 
-                Configuration debugApiElements = configurations.maybeCreate("debugSwiftApiElements");
-                debugApiElements.extendsFrom(implementation);
-                debugApiElements.setCanBeResolved(false);
-                debugApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
-                debugApiElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, debugExecutable.isDebuggable());
-                debugApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, debugExecutable.isOptimized());
-                debugApiElements.getOutgoing().artifact(compileDebug.getModuleFile());
-
-                Configuration releaseApiElements = configurations.maybeCreate("releaseSwiftApiElements");
-                releaseApiElements.extendsFrom(implementation);
-                releaseApiElements.setCanBeResolved(false);
-                releaseApiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.SWIFT_API));
-                releaseApiElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, releaseExecutable.isDebuggable());
-                releaseApiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, releaseExecutable.isOptimized());
-                releaseApiElements.getOutgoing().artifact(compileRelease.getModuleFile());
+                application.getBinaries().whenElementKnown(SwiftExecutable.class, new Action<SwiftExecutable>() {
+                    @Override
+                    public void execute(SwiftExecutable executable) {
+                        Names names = ((ComponentWithNames) executable).getNames();
+                        Configuration apiElements = configurations.create(names.withSuffix("SwiftApiElements"));
+                        apiElements.extendsFrom(implementation);
+                        apiElements.setCanBeResolved(false);
+                        apiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
+                        apiElements.getAttributes().attribute(DEBUGGABLE_ATTRIBUTE, executable.isDebuggable());
+                        apiElements.getAttributes().attribute(OPTIMIZED_ATTRIBUTE, executable.isOptimized());
+                        apiElements.getOutgoing().artifact(executable.getModuleFile());
+                    }
+                });
 
                 // Use the debug variant as the development variant
                 application.getDevelopmentBinary().set(debugExecutable);

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
@@ -28,7 +28,12 @@ class DefaultCppApplicationTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
-    def application = new DefaultCppApplication("main", project.objects, project, project.configurations)
+    def application = new DefaultCppApplication("main", project.objects, project)
+
+    def "has implementation dependencies"() {
+        expect:
+        application.implementationDependencies == project.configurations['implementation']
+    }
 
     def "has a main publication"() {
         expect:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppBinaryTest.groovy
@@ -19,23 +19,26 @@ package org.gradle.language.cpp.internal
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.ProjectLayout
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.provider.Provider
 import org.gradle.language.cpp.CppPlatform
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
+import org.junit.Rule
 import spock.lang.Specification
 
-
 class DefaultCppBinaryTest extends Specification {
-    def implementation = Stub(Configuration)
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    def project = TestUtil.createRootProject(tmpDir.testDirectory)
+    def implementation = Stub(ConfigurationInternal)
     def headerDirs = Stub(FileCollection)
     def compile = Stub(Configuration)
     def link = Stub(Configuration)
     def runtime = Stub(Configuration)
     def configurations = Stub(ConfigurationContainer)
-    def projectLayout = Mock(ProjectLayout)
 
     DefaultCppBinary binary
 
@@ -46,7 +49,7 @@ class DefaultCppBinaryTest extends Specification {
         _ * configurations.create("nativeRuntimeDebug") >> runtime
         _ * componentHeaders.plus(_) >> headerDirs
 
-        binary = new DefaultCppBinary("mainDebug", projectLayout, TestUtil.objectFactory(), Stub(Provider), true, false, Stub(FileCollection), componentHeaders, configurations, implementation, Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
+        binary = new DefaultCppBinary("mainDebug", project.layout, project.objects, Stub(Provider), true, false, Stub(FileCollection), componentHeaders, configurations, implementation, Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
     }
 
     def "creates configurations for the binary"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.language.cpp.internal
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.model.ObjectFactory
+import org.gradle.language.ComponentDependencies
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -31,18 +31,10 @@ class DefaultCppComponentTest extends Specification {
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def fileOperations = TestFiles.fileOperations(tmpDir.testDirectory)
     def objectFactory = TestUtil.objectFactory()
-    def implementation = Stub(Configuration)
-    def configurations = Stub(ConfigurationContainer)
     DefaultCppComponent component
 
     def setup() {
-        _ * configurations.create("implementation") >> implementation
-        component = new TestComponent("main", fileOperations, objectFactory, configurations)
-    }
-
-    def "has an implementation configuration"() {
-        expect:
-        component.implementationDependencies == implementation
+        component = new TestComponent("main", fileOperations, objectFactory)
     }
 
     def "has no source files by default"() {
@@ -134,8 +126,8 @@ class DefaultCppComponentTest extends Specification {
         def h1 = tmpDir.createFile("src/a/headers")
         def f2 = tmpDir.createFile("src/b/cpp/b.cpp")
         def h2 = tmpDir.createFile("src/b/headers")
-        def c1 = new TestComponent("a", fileOperations, objectFactory, configurations)
-        def c2 = new TestComponent("b", fileOperations, objectFactory, configurations)
+        def c1 = new TestComponent("a", fileOperations, objectFactory)
+        def c2 = new TestComponent("b", fileOperations, objectFactory)
 
         expect:
         c1.cppSource.files == [f1] as Set
@@ -145,8 +137,18 @@ class DefaultCppComponentTest extends Specification {
     }
 
     static class TestComponent extends DefaultCppComponent {
-        TestComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory, ConfigurationContainer configurations) {
-            super(name, fileOperations, objectFactory, configurations)
+        TestComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory) {
+            super(name, fileOperations, objectFactory)
+        }
+
+        @Override
+        Configuration getImplementationDependencies() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        ComponentDependencies getDependencies() {
+            throw new UnsupportedOperationException()
         }
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
@@ -36,6 +36,11 @@ class DefaultCppLibraryTest extends Specification {
         library = new DefaultCppLibrary("main", project.objects, project, project.configurations)
     }
 
+    def "has implementation configuration"() {
+        expect:
+        library.implementationDependencies == project.configurations.implementation
+    }
+
     def "has api configuration"() {
         expect:
         library.apiDependencies == project.configurations.api

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryCollectionTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultBinaryCollectionTest.groovy
@@ -56,10 +56,11 @@ class DefaultBinaryCollectionTest extends Specification {
 
     def "cannot get elements from when known action"() {
         given:
+        container.add(Stub(SwiftBinary))
         container.whenElementKnown { container.get() }
 
         when:
-        container.add(Stub(SwiftBinary))
+        container.realizeNow()
 
         then:
         def e = thrown(IllegalStateException)
@@ -105,7 +106,7 @@ class DefaultBinaryCollectionTest extends Specification {
         e.message == 'Cannot add an element to this collection as it has already been realized.'
     }
 
-    def "runs actions when collection is realized"() {
+    def "runs actions only when collection is realized"() {
         def known = Mock(Action)
         def configure = Mock(Action)
         def finalized = Mock(Action)
@@ -120,14 +121,19 @@ class DefaultBinaryCollectionTest extends Specification {
         container.add(binary2)
 
         then:
-        1 * known.execute(binary1)
-        1 * known.execute(binary2)
         0 * known._
         0 * configure._
         0 * finalized._
 
         when:
         container.realizeNow()
+
+        then:
+        1 * known.execute(binary1)
+        1 * known.execute(binary2)
+        0 * known._
+        0 * configure._
+        0 * finalized._
 
         then:
         1 * configure.execute(binary1)
@@ -159,13 +165,18 @@ class DefaultBinaryCollectionTest extends Specification {
         container.add(binary2)
 
         then:
-        1 * known.execute(binary2)
         0 * known._
         0 * configure._
         0 * finalized._
 
         when:
         container.realizeNow()
+
+        then:
+        1 * known.execute(binary2)
+        0 * known._
+        0 * configure._
+        0 * finalized._
 
         then:
         1 * configure.execute(binary2)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultComponentDependenciesTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultComponentDependenciesTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.internal
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import spock.lang.Specification
+
+
+class DefaultComponentDependenciesTest extends Specification {
+    def "can add implementation dependency"() {
+        def configurations = Stub(ConfigurationContainer)
+        def dependencyFactory = Mock(DependencyHandler)
+        def implDeps = Mock(Configuration)
+        def deps = Mock(DependencySet)
+        def dep = Stub(Dependency)
+
+        given:
+        configurations.create("impl") >> implDeps
+        implDeps.dependencies >> deps
+
+        def dependencies = new DefaultComponentDependencies(configurations, "impl") {
+            @Override
+            protected DependencyHandler getDependencyHandler() {
+                return dependencyFactory
+            }
+        }
+
+        when:
+        dependencies.implementation("a:b:c")
+
+        then:
+        1 * dependencyFactory.create("a:b:c") >> dep
+        1 * deps.add(dep)
+    }
+
+}

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultLibraryDependenciesTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultLibraryDependenciesTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.internal
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import spock.lang.Specification
+
+
+class DefaultLibraryDependenciesTest extends Specification {
+    def "can add api dependency"() {
+        def configurations = Stub(ConfigurationContainer)
+        def dependencyFactory = Mock(DependencyHandler)
+        def apiDeps = Mock(Configuration)
+        def deps = Mock(DependencySet)
+        def dep = Stub(Dependency)
+
+        given:
+        configurations.create("api") >> apiDeps
+        apiDeps.dependencies >> deps
+
+        def dependencies = new DefaultLibraryDependencies(configurations, "impl", "api") {
+            @Override
+            protected DependencyHandler getDependencyHandler() {
+                return dependencyFactory
+            }
+        }
+
+        when:
+        dependencies.api("a:b:c")
+
+        then:
+        1 * dependencyFactory.create("a:b:c") >> dep
+        1 * deps.add(dep)
+    }
+
+}

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultNativeBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultNativeBinaryTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.internal
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.Provider
+import org.gradle.nativeplatform.platform.NativePlatform
+import org.gradle.nativeplatform.toolchain.NativeToolChain
+import spock.lang.Specification
+
+
+class DefaultNativeBinaryTest extends Specification {
+    ConfigurationContainer configurations = Mock(ConfigurationContainer)
+    DependencyHandler dependencyFactory = Mock(DependencyHandler)
+    Configuration implementation = Stub(Configuration)
+
+    def "has implementation dependencies"() {
+        def implDeps = Mock(Configuration)
+
+        when:
+        def binary = new TestBinary("binary", Stub(ProjectLayout), configurations, implementation)
+
+        then:
+        1 * configurations.create("binaryImplementation") >> implDeps
+        1 * implDeps.extendsFrom(implementation)
+
+        expect:
+        binary.implementationDependencies == implDeps
+    }
+
+    def "can add implementation dependency"() {
+        def implDeps = Mock(Configuration)
+        def deps = Mock(DependencySet)
+        def dep = Stub(Dependency)
+
+        given:
+        configurations.create("binaryImplementation") >> implDeps
+        implDeps.dependencies >> deps
+
+        def binary = new TestBinary("binary", Stub(ProjectLayout), configurations, implementation)
+
+        when:
+        binary.dependencies.implementation("a:b:c")
+
+        then:
+        1 * dependencyFactory.create("a:b:c") >> dep
+        1 * deps.add(dep)
+    }
+
+    class TestBinary extends DefaultNativeBinary {
+        TestBinary(String name, ProjectLayout projectLayout, ConfigurationContainer configurations, Configuration componentImplementation) {
+            super(name, projectLayout, configurations, componentImplementation)
+        }
+
+        @Override
+        protected DependencyHandler getDependencyHandler() {
+            return dependencyFactory
+        }
+
+        @Override
+        Provider<String> getBaseName() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        boolean isDebuggable() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        boolean isOptimized() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        NativePlatform getTargetPlatform() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        NativeToolChain getToolChain() {
+            throw new UnsupportedOperationException()
+        }
+    }
+}

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/NamesTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/NamesTest.groovy
@@ -22,49 +22,83 @@ class NamesTest extends Specification {
     def "names for main"() {
         expect:
         def name = Names.of("main")
+        name.baseName == "main"
+        name.lowerBaseName == "main"
         name.getCompileTaskName("cpp") == "compileCpp"
         name.getTaskName("link") == "link"
-        name.getDirName() == "main/"
+        name.dirName == "main/"
         name.withPrefix("compile") == "compile"
         name.withSuffix("implementation") == "implementation"
     }
 
-    def "names for variants of main"() {
+    def "names for single dimension variant of main"() {
         expect:
         def name = Names.of("mainDebug")
+        name.baseName == "debug"
+        name.lowerBaseName == "debug"
         name.getCompileTaskName("cpp") == "compileDebugCpp"
         name.getTaskName("link") == "linkDebug"
-        name.getDirName() == "main/debug/"
+        name.dirName == "main/debug/"
         name.withPrefix("compile") == "compileDebug"
         name.withSuffix("implementation") == "debugImplementation"
+    }
+
+    def "names for multi-dimension variant of main"() {
+        expect:
+        def name = Names.of("mainDebugStatic")
+        name.baseName == "debugStatic"
+        name.lowerBaseName == "debug-static"
+        name.getCompileTaskName("cpp") == "compileDebugStaticCpp"
+        name.getTaskName("link") == "linkDebugStatic"
+        name.dirName == "main/debug/static/"
+        name.withPrefix("compile") == "compileDebugStatic"
+        name.withSuffix("implementation") == "debugStaticImplementation"
     }
 
     def "names for custom"() {
         expect:
         def name = Names.of("custom")
+        name.baseName == "custom"
+        name.lowerBaseName == "custom"
         name.getCompileTaskName("cpp") == "compileCustomCpp"
         name.getTaskName("link") == "linkCustom"
-        name.getDirName() == "custom/"
+        name.dirName == "custom/"
         name.withPrefix("compile") == "compileCustom"
         name.withSuffix("implementation") == "customImplementation"
     }
 
-    def "names for variants of custom"() {
+    def "names for single dimension variant of custom"() {
         expect:
         def name = Names.of("customRelease")
+        name.baseName == "customRelease"
+        name.lowerBaseName == "custom-release"
         name.getCompileTaskName("cpp") == "compileCustomReleaseCpp"
         name.getTaskName("link") == "linkCustomRelease"
-        name.getDirName() == "custom/release/"
+        name.dirName == "custom/release/"
         name.withPrefix("compile") == "compileCustomRelease"
         name.withSuffix("implementation") == "customReleaseImplementation"
+    }
+
+    def "names for multi-dimension variant of custom"() {
+        expect:
+        def name = Names.of("customReleaseStatic")
+        name.baseName == "customReleaseStatic"
+        name.lowerBaseName == "custom-release-static"
+        name.getCompileTaskName("cpp") == "compileCustomReleaseStaticCpp"
+        name.getTaskName("link") == "linkCustomReleaseStatic"
+        name.dirName == "custom/release/static/"
+        name.withPrefix("compile") == "compileCustomReleaseStatic"
+        name.withSuffix("implementation") == "customReleaseStaticImplementation"
     }
 
     def "names for test variants of custom"() {
         expect:
         def name = Names.of("customExecutable")
+        name.baseName == "custom"
+        name.lowerBaseName == "custom"
         name.getCompileTaskName("cpp") == "compileCustomCpp"
         name.getTaskName("link") == "linkCustom"
-        name.getDirName() == "custom/"
+        name.dirName == "custom/"
         name.withPrefix("compile") == "compileCustom"
         name.withSuffix("implementation") == "customImplementation"
     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -83,6 +83,7 @@ class NativeBasePluginTest extends Specification {
         when:
         binaries.add(b1)
         binaries.add(b2)
+        binaries.realizeNow()
 
         then:
         project.components.size() == 3

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftApplicationTest.groovy
@@ -28,7 +28,12 @@ class DefaultSwiftApplicationTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
-    def app = new DefaultSwiftApplication("main", project.objects, project, project.configurations)
+    def app = new DefaultSwiftApplication("main", project.objects, project)
+
+    def "has implementation dependencies"() {
+        expect:
+        app.implementationDependencies == project.configurations['implementation']
+    }
 
     def "can create executable binary"() {
         def targetPlatform = Stub(SwiftPlatform)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
@@ -21,16 +21,21 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.ProjectLayout
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.provider.Provider
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
+import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultSwiftBinaryTest extends Specification {
-    def implementation = Stub(Configuration)
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    def project = TestUtil.createRootProject(tmpDir.testDirectory)
+    def implementation = Stub(ConfigurationInternal)
     def compile = Stub(Configuration)
     def link = Stub(Configuration)
     def runtime = Stub(Configuration)
@@ -43,7 +48,7 @@ class DefaultSwiftBinaryTest extends Specification {
         _ * configurations.create("nativeLinkDebug") >> link
         _ * configurations.create("nativeRuntimeDebug") >> runtime
 
-        binary = new DefaultSwiftBinary("mainDebug", Mock(ProjectLayout), TestUtil.objectFactory(), Stub(Provider), true, false,false, Stub(FileCollection),  configurations, implementation, Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
+        binary = new DefaultSwiftBinary("mainDebug", project.layout, project.objects, Stub(Provider), true, false,false, Stub(FileCollection),  configurations, implementation, Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
     }
 
     def "compileModules is a transformed view of compile"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.language.swift.internal
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.model.ObjectFactory
+import org.gradle.language.ComponentDependencies
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -31,18 +31,10 @@ class DefaultSwiftComponentTest extends Specification {
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def fileOperations = TestFiles.fileOperations(tmpDir.testDirectory)
     def objectFactory = TestUtil.objectFactory()
-    def implementation = Stub(Configuration)
-    def configurations = Stub(ConfigurationContainer)
     DefaultSwiftComponent component
 
     def setup() {
-        _ * configurations.create("implementation") >> implementation
-        component = new TestComponent("main", fileOperations, objectFactory, configurations)
-    }
-
-    def "has an implementation configuration"() {
-        expect:
-        component.implementationDependencies == implementation
+        component = new TestComponent("main", fileOperations, objectFactory)
     }
 
     def "has no source files by default"() {
@@ -90,8 +82,8 @@ class DefaultSwiftComponentTest extends Specification {
     def "uses component name to determine source directory"() {
         def f1 = tmpDir.createFile("src/a/swift/a.swift")
         def f2 = tmpDir.createFile("src/b/swift/b.swift")
-        def c1 = new TestComponent("a", fileOperations, objectFactory, configurations)
-        def c2 = new TestComponent("b", fileOperations, objectFactory, configurations)
+        def c1 = new TestComponent("a", fileOperations, objectFactory)
+        def c2 = new TestComponent("b", fileOperations, objectFactory)
 
         expect:
         c1.swiftSource.files == [f1] as Set
@@ -99,8 +91,18 @@ class DefaultSwiftComponentTest extends Specification {
     }
 
     class TestComponent extends DefaultSwiftComponent {
-        TestComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory, ConfigurationContainer configurations) {
-            super(name, fileOperations, objectFactory, configurations)
+        TestComponent(String name, FileOperations fileOperations, ObjectFactory objectFactory) {
+            super(name, fileOperations, objectFactory)
+        }
+
+        @Override
+        Configuration getImplementationDependencies() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        ComponentDependencies getDependencies() {
+            throw new UnsupportedOperationException()
         }
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -36,6 +36,11 @@ class DefaultSwiftLibraryTest extends Specification {
         library = new DefaultSwiftLibrary("main", project.objects, project, project.configurations)
     }
 
+    def "has implementation configuration"() {
+        expect:
+        library.implementationDependencies == project.configurations.implementation
+    }
+
     def "has api configuration"() {
         expect:
         library.apiDependencies == project.configurations.api

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language
+
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+
+
+abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def "can define implementation dependencies on binary"() {
+        given:
+        settingsFile << 'include "lib"'
+        makeComponentWithLibrary()
+        buildFile << """
+            ${componentUnderTestDsl} {
+                binaries.configureEach { b ->                
+                    b.dependencies {
+                        implementation project(':lib')
+                    }
+                }
+            }
+"""
+
+        when:
+        run(assembleDevBinaryTask)
+
+        then:
+        result.assertTasksExecuted(libDebugTasks, assembleDevBinaryTasks, assembleDevBinaryTask)
+    }
+
+    /**
+     * Creates a build with the component under test in the root project and a library in the 'lib' project.
+     */
+    protected abstract void makeComponentWithLibrary()
+
+    protected abstract String getComponentUnderTestDsl()
+
+    protected abstract String getAssembleDevBinaryTask()
+
+    protected abstract List<String> getAssembleDevBinaryTasks()
+
+    protected abstract List<String> getLibDebugTasks()
+}

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -26,7 +26,26 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
         """
     }
 
-    def "can define implementation dependencies on binary"() {
+    def "can define implementation dependencies on component"() {
+        given:
+        settingsFile << 'include "lib"'
+        makeComponentWithLibrary()
+        buildFile << """
+            ${componentUnderTestDsl} { c ->
+                c.dependencies {
+                    implementation project(':lib')
+                }
+            }
+"""
+
+        when:
+        run(assembleDevBinaryTask)
+
+        then:
+        result.assertTasksExecuted(libDebugTasks, assembleDevBinaryTasks, assembleDevBinaryTask)
+    }
+
+    def "can define implementation dependencies on each binary"() {
         given:
         settingsFile << 'include "lib"'
         makeComponentWithLibrary()

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -20,6 +20,12 @@ import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationS
 
 
 abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+    }
+
     def "can define implementation dependencies on binary"() {
         given:
         settingsFile << 'include "lib"'

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language
+
+abstract class AbstractNativeProductionComponentDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
+    def "can define different implementation dependencies on each binary"() {
+        given:
+        settingsFile << 'include "lib"'
+        makeComponentWithLibrary()
+        buildFile << """
+            ${componentUnderTestDsl} {
+                binaries.getByName('mainDebug').configure {                
+                    dependencies {
+                        implementation project(':lib')
+                    }
+                }
+            }
+"""
+
+        when:
+        run(':assembleDebug')
+
+        then:
+        result.assertTasksExecuted(libDebugTasks, assembleDebugTasks, ':assembleDebug')
+
+        when:
+        run(':assembleRelease')
+
+        then:
+        result.assertTasksExecuted(assembleReleaseTasks, ':assembleRelease')
+    }
+
+    @Override
+    protected String getAssembleDevBinaryTask() {
+        return ":assembleDebug"
+    }
+
+    @Override
+    protected List<String> getAssembleDevBinaryTasks() {
+        return getAssembleDebugTasks()
+    }
+
+    protected abstract List<String> getAssembleDebugTasks()
+
+    protected abstract List<String> getAssembleReleaseTasks()
+}

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestDependenciesIntegrationTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.cpp.plugins
+
+import org.gradle.language.AbstractNativeDependenciesIntegrationTest
+
+
+class CppUnitTestDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
+    @Override
+    protected void makeComponentWithLibrary() {
+        buildFile << """
+            apply plugin: 'cpp-unit-test'
+            project(':lib') {
+                apply plugin: 'cpp-library'
+            }
+"""
+    }
+
+    @Override
+    protected String getComponentUnderTestDsl() {
+        return "unitTest"
+    }
+
+    @Override
+    protected String getAssembleDevBinaryTask() {
+        return ":installTest"
+    }
+
+    @Override
+    protected List<String> getAssembleDevBinaryTasks() {
+        return [":compileTestCpp", ":linkTest"]
+    }
+
+    @Override
+    protected List<String> getLibDebugTasks() {
+        return [":lib:compileDebugCpp", ":lib:linkDebug"]
+    }
+}

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
@@ -14,38 +14,35 @@
  * limitations under the License.
  */
 
-package org.gradle.nativeplatform.test.cpp.plugins
+package org.gradle.nativeplatform.test.xctest
 
 import org.gradle.language.AbstractNativeDependenciesIntegrationTest
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
-
-class CppUnitTestDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
+@Requires(TestPrecondition.SWIFT_SUPPORT)
+class XCTestDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest {
     @Override
     protected void makeComponentWithLibrary() {
         buildFile << """
-            apply plugin: 'cpp-unit-test'
+            apply plugin: 'xctest'
             project(':lib') {
-                apply plugin: 'cpp-library'
+                apply plugin: 'swift-library'
             }
 """
-        file("src/test/cpp/main.cpp") << """
-            int main() { return 0; }
+        file("src/test/swift/Test.swift") << """
+            class Test {
+            }
 """
-        file("lib/src/main/cpp/lib.cpp") << """
-            #ifdef _WIN32
-            #define EXPORT_FUNC __declspec(dllexport)
-            #else
-            #define EXPORT_FUNC
-            #endif
-            
-            void EXPORT_FUNC lib_func() { }
+        file("lib/src/main/swift/Lib.swift") << """
+            class Lib {
+            }
 """
-
     }
 
     @Override
     protected String getComponentUnderTestDsl() {
-        return "unitTest"
+        return "xctest"
     }
 
     @Override
@@ -55,11 +52,11 @@ class CppUnitTestDependenciesIntegrationTest extends AbstractNativeDependenciesI
 
     @Override
     protected List<String> getAssembleDevBinaryTasks() {
-        return [":compileTestCpp", ":linkTest"]
+        return [":compileTestSwift", ":linkTest"]
     }
 
     @Override
     protected List<String> getLibDebugTasks() {
-        return [":lib:compileDebugCpp", ":lib:linkDebug"]
+        return [":lib:compileDebugSwift", ":lib:linkDebug"]
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuite.java
@@ -17,13 +17,16 @@
 package org.gradle.nativeplatform.test.cpp.internal;
 
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.language.ComponentDependencies;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.internal.DefaultCppComponent;
+import org.gradle.language.internal.DefaultComponentDependencies;
 import org.gradle.nativeplatform.test.cpp.CppTestExecutable;
 import org.gradle.nativeplatform.test.cpp.CppTestSuite;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
@@ -35,13 +38,15 @@ public class DefaultCppTestSuite extends DefaultCppComponent implements CppTestS
     private final ObjectFactory objectFactory;
     private final Property<CppComponent> testedComponent;
     private final Property<CppTestExecutable> testBinary;
+    private final DefaultComponentDependencies dependencies;
 
     @Inject
-    public DefaultCppTestSuite(String name, ObjectFactory objectFactory, final FileOperations fileOperations, ConfigurationContainer configurations) {
-        super(name, fileOperations, objectFactory, configurations);
+    public DefaultCppTestSuite(String name, ObjectFactory objectFactory, FileOperations fileOperations) {
+        super(name, fileOperations, objectFactory);
         this.objectFactory = objectFactory;
         this.testedComponent = objectFactory.property(CppComponent.class);
         this.testBinary = objectFactory.property(CppTestExecutable.class);
+        this.dependencies = objectFactory.newInstance(DefaultComponentDependencies.class, getNames().withSuffix("implementation"));
     }
 
     public CppTestExecutable addExecutable(String nameSuffix, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {
@@ -49,6 +54,20 @@ public class DefaultCppTestSuite extends DefaultCppComponent implements CppTestS
         this.testBinary.set(testBinary);
         getBinaries().add(testBinary);
         return testBinary;
+    }
+
+    @Override
+    public Configuration getImplementationDependencies() {
+        return dependencies.getImplementationDependencies();
+    }
+
+    @Override
+    public ComponentDependencies getDependencies() {
+        return dependencies;
+    }
+
+    public void dependencies(Action<? super ComponentDependencies> action) {
+        action.execute(dependencies);
     }
 
     public Property<CppComponent> getTestedComponent() {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
@@ -21,11 +21,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.Transformer;
-import org.gradle.api.file.Directory;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -37,7 +33,6 @@ import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 import org.gradle.nativeplatform.tasks.InstallExecutable;
-import org.gradle.nativeplatform.test.cpp.CppTestExecutable;
 import org.gradle.nativeplatform.test.cpp.CppTestSuite;
 import org.gradle.nativeplatform.test.cpp.internal.DefaultCppTestExecutable;
 import org.gradle.nativeplatform.test.cpp.internal.DefaultCppTestSuite;
@@ -81,53 +76,50 @@ public class CppUnitTestPlugin implements Plugin<ProjectInternal> {
             @Override
             public void execute(final Project project) {
                 ToolChainSelector.Result<CppPlatform> result = toolChainSelector.select(CppPlatform.class);
-                final DefaultCppTestExecutable binary = (DefaultCppTestExecutable) testComponent.addExecutable("executable", result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
+                testComponent.addExecutable("executable", result.getTargetPlatform(), result.getToolChain(), result.getPlatformToolProvider());
 
                 final TaskContainer tasks = project.getTasks();
                 final ProductionCppComponent mainComponent = project.getComponents().withType(ProductionCppComponent.class).findByName("main");
                 if (mainComponent != null) {
                     testComponent.getTestedComponent().set(mainComponent);
-
-                    // TODO: This should be modeled as a kind of dependency vs wiring tasks together directly.
-                    final AbstractLinkTask linkTest = binary.getLinkTask().get();
-                    Provider<FileCollection> mainObjects = mainComponent.getDevelopmentBinary().map(new Transformer<FileCollection, CppBinary>() {
-                        @Override
-                        public FileCollection transform(CppBinary devBinary) {
-                            return devBinary.getObjects();
-                        }
-                    });
-                    linkTest.source(mainObjects);
-                    // TODO: We shouldn't have to do this
-                    linkTest.dependsOn(mainObjects);
                 }
 
-                // TODO: Replace with native test task
-                final RunTestExecutable testTask = tasks.create("runTest", RunTestExecutable.class, new Action<RunTestExecutable>() {
+                testComponent.getBinaries().whenElementKnown(DefaultCppTestExecutable.class, new Action<DefaultCppTestExecutable>() {
                     @Override
-                    public void execute(RunTestExecutable testTask) {
+                    public void execute(final DefaultCppTestExecutable executable) {
+                        if (mainComponent != null) {
+                            // TODO: This should be modeled as a kind of dependency vs wiring binaries together directly.
+                            mainComponent.getBinaries().whenElementFinalized(new Action<CppBinary>() {
+                                @Override
+                                public void execute(CppBinary cppBinary) {
+                                    if (cppBinary == mainComponent.getDevelopmentBinary().get()) {
+                                        AbstractLinkTask linkTest = executable.getLinkTask().get();
+                                        linkTest.source(cppBinary.getObjects());
+                                    }
+                                }
+                            });
+                        }
+
+                        // TODO: Replace with native test task
+                        final RunTestExecutable testTask = tasks.create(executable.getNames().getTaskName("run"), RunTestExecutable.class);
                         testTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
                         testTask.setDescription("Executes C++ unit tests.");
 
-                        final InstallExecutable installTask = binary.getInstallTask().get();
+                        final InstallExecutable installTask = executable.getInstallTask().get();
                         testTask.onlyIf(new Spec<Task>() {
                             @Override
                             public boolean isSatisfiedBy(Task element) {
-                                return binary.getInstallDirectory().get().getAsFile().exists();
+                                return executable.getInstallDirectory().get().getAsFile().exists();
                             }
                         });
                         testTask.setExecutable(installTask.getRunScript());
-                        testTask.dependsOn(testComponent.getTestBinary().map(new Transformer<Provider<Directory>, CppTestExecutable>() {
-                            @Override
-                            public Provider<Directory> transform(CppTestExecutable cppExecutable) {
-                                return cppExecutable.getInstallDirectory();
-                            }
-                        }));
+                        testTask.dependsOn(testComponent.getTestBinary().get().getInstallDirectory());
                         // TODO: Honor changes to build directory
-                        testTask.setOutputDir(project.getLayout().getBuildDirectory().dir("test-results/unitTest").get().getAsFile());
+                        testTask.setOutputDir(project.getLayout().getBuildDirectory().dir("test-results/" + executable.getNames().getDirName()).get().getAsFile());
+                        executable.getRunTask().set(testTask);
                     }
                 });
 
-                binary.getRunTask().set(testTask);
                 testComponent.getBinaries().realizeNow();
             }
         });

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -260,7 +260,6 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
 
                     linkTest.source(unexportMainSymbol.getObjects());
                 } else {
-
                     linkTest.source(testedBinary.getObjects());
                 }
             }

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
@@ -29,8 +29,15 @@ class DefaultCppTestSuiteTest extends Specification {
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
 
+    def "has implementation dependencies"() {
+        def testSuite = new DefaultCppTestSuite("test", project.objects, project)
+
+        expect:
+        testSuite.implementationDependencies == project.configurations['testImplementation']
+    }
+
     def "can add executable"() {
-        def testSuite = new DefaultCppTestSuite("test", project.objects, project, project.configurations)
+        def testSuite = new DefaultCppTestSuite("test", project.objects, project)
 
         expect:
         def exe = testSuite.addExecutable("exe", Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -29,8 +29,15 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
 
+    def "has implementation dependencies"() {
+        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
+
+        expect:
+        testSuite.implementationDependencies == project.configurations.testImplementation
+    }
+
     def "can add a test executable"() {
-        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects, project.configurations)
+        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
 
         expect:
         def exe = testSuite.addExecutable("Executable", Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
@@ -38,7 +45,7 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
     }
 
     def "can add a test bundle"() {
-        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects, project.configurations)
+        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
 
         expect:
         def exe = testSuite.addBundle("Executable", Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))


### PR DESCRIPTION
This change allows implementation dependencies to be declared on each binary (or variant) of C++ and Swift components. This allows, for example, operating system specific dependencies.

This change also allows implementation and API dependencies to be declared on the components.

In both cases, the DSL looks like the project level `dependencies { }` block.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
