### PR TITLE
Fire gradle.settingsEvaluated right after evaluating the settings script

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -81,10 +81,10 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
         succeeds "all", "-i"
 
         and:
-        mainCache.listCacheFiles().size() == 4 // root, i1, i1BuildSrc, i2
         i1Cache.assertEmpty()
         i1BuildSrcCache.assertEmpty()
         i2Cache.assertEmpty()
+        mainCache.listCacheFiles().size() == 4 // root, i1, i1BuildSrc, i2
 
         buildSrcCache.listCacheFiles().size() == 1
         i3Cache.listCacheFiles().size() == 1

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
@@ -28,11 +28,14 @@ import org.gradle.internal.progress.BuildOperationDescriptor;
 import static org.gradle.initialization.EvaluateSettingsBuildOperationType.Details;
 import static org.gradle.initialization.EvaluateSettingsBuildOperationType.Result;
 
-public class NotifyingSettingsProcessor implements SettingsProcessor {
+public class BuildOperationSettingsProcessor implements SettingsProcessor {
+    private static final Result RESULT = new Result() {
+    };
+
     private final SettingsProcessor settingsProcessor;
     private final BuildOperationExecutor buildOperationExecutor;
 
-    public NotifyingSettingsProcessor(SettingsProcessor settingsProcessor, BuildOperationExecutor buildOperationExecutor) {
+    public BuildOperationSettingsProcessor(SettingsProcessor settingsProcessor, BuildOperationExecutor buildOperationExecutor) {
         this.settingsProcessor = settingsProcessor;
         this.buildOperationExecutor = buildOperationExecutor;
     }
@@ -43,7 +46,7 @@ public class NotifyingSettingsProcessor implements SettingsProcessor {
             @Override
             public SettingsInternal call(BuildOperationContext context) {
                 SettingsInternal settingsInternal = settingsProcessor.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
-                context.setResult(new Result(){});
+                context.setResult(RESULT);
                 return settingsInternal;
             }
 
@@ -51,7 +54,7 @@ public class NotifyingSettingsProcessor implements SettingsProcessor {
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor.displayName("Evaluate settings").
                     progressDisplayName("Evaluating settings").
-                    details(new Details(){
+                    details(new Details() {
                         @Override
                         public String getSettingsDir() {
                             return settingsLocation.getSettingsDir().getAbsolutePath();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -38,12 +38,12 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
 
     @Override
     public SettingsLoader forTopLevelBuild() {
-        return notifyingSettingsLoader(compositeBuildSettingsLoader());
+        return compositeBuildSettingsLoader();
     }
 
     @Override
     public SettingsLoader forNestedBuild() {
-        return notifyingSettingsLoader(defaultSettingsLoader());
+        return defaultSettingsLoader();
     }
 
     private SettingsLoader compositeBuildSettingsLoader() {
@@ -59,11 +59,6 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
             settingsProcessor,
             buildSourceBuilder
         );
-    }
-
-
-    private SettingsLoader notifyingSettingsLoader(SettingsLoader settingsLoader) {
-        return new NotifyingSettingsLoader(settingsLoader);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,22 @@
 
 package org.gradle.initialization;
 
+import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
 
-public class NotifyingSettingsLoader implements SettingsLoader {
-    private final SettingsLoader settingsLoader;
+public class SettingsEvaluatedCallbackFiringSettingsProcessor implements SettingsProcessor {
 
-    public NotifyingSettingsLoader(SettingsLoader settingsLoader) {
-        this.settingsLoader = settingsLoader;
+    private final SettingsProcessor delegate;
+
+    public SettingsEvaluatedCallbackFiringSettingsProcessor(SettingsProcessor delegate) {
+        this.delegate = delegate;
     }
 
     @Override
-    public SettingsInternal findAndLoadSettings(final GradleInternal gradle) {
-        final SettingsInternal settings = settingsLoader.findAndLoadSettings(gradle);
+    public SettingsInternal process(GradleInternal gradle, SettingsLocation settingsLocation, ClassLoaderScope buildRootClassLoaderScope, StartParameter startParameter) {
+        SettingsInternal settings = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
         gradle.getBuildListenerBroadcaster().settingsEvaluated(settings);
         return settings;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressFilter.java
@@ -52,9 +52,6 @@ public class BuildProgressFilter implements RootBuildLifecycleListener, BuildLis
 
     @Override
     public void settingsEvaluated(Settings settings) {
-        if (settings.getGradle() == rootGradle) {
-            logger.settingsEvaluated();
-        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/progress/BuildProgressLogger.java
@@ -46,12 +46,9 @@ public class BuildProgressLogger implements LoggerProvider {
         buildProgress = loggerProvider.start(INITIALIZATION_PHASE_DESCRIPTION, INITIALIZATION_PHASE_SHORT_DESCRIPTION, 0);
     }
 
-    public void settingsEvaluated() {
-        buildProgress.completed();
-        rootBuildInitComplete = true;
-    }
-
     public void projectsLoaded(int totalProjects) {
+        rootBuildInitComplete = true;
+        buildProgress.completed(); // end init
         buildProgress = loggerProvider.start(CONFIGURATION_PHASE_DESCRIPTION, CONFIGURATION_PHASE_SHORT_DESCRIPTION, totalProjects);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -105,6 +105,7 @@ import org.gradle.groovy.scripts.internal.FileCacheBackedScriptClassCompiler;
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildLoader;
+import org.gradle.initialization.BuildOperationSettingsProcessor;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.initialization.DefaultClassLoaderScopeRegistry;
@@ -116,12 +117,12 @@ import org.gradle.initialization.InitScriptHandler;
 import org.gradle.initialization.InstantiatingBuildLoader;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.NotifyingBuildLoader;
-import org.gradle.initialization.NotifyingSettingsProcessor;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.initialization.ProjectPropertySettingBuildLoader;
 import org.gradle.initialization.PropertiesLoadingSettingsProcessor;
 import org.gradle.initialization.RootBuildCacheControllerSettingsProcessor;
 import org.gradle.initialization.ScriptEvaluatingSettingsProcessor;
+import org.gradle.initialization.SettingsEvaluatedCallbackFiringSettingsProcessor;
 import org.gradle.initialization.SettingsFactory;
 import org.gradle.initialization.SettingsLoaderFactory;
 import org.gradle.initialization.SettingsProcessor;
@@ -349,19 +350,21 @@ public class BuildScopeServices extends DefaultServiceRegistry {
 
     protected SettingsProcessor createSettingsProcessor(ScriptPluginFactory scriptPluginFactory, ScriptHandlerFactory scriptHandlerFactory, Instantiator instantiator,
                                                         ServiceRegistryFactory serviceRegistryFactory, IGradlePropertiesLoader propertiesLoader, BuildOperationExecutor buildOperationExecutor) {
-        return new NotifyingSettingsProcessor(
+        return new BuildOperationSettingsProcessor(
             new RootBuildCacheControllerSettingsProcessor(
-                new PropertiesLoadingSettingsProcessor(
-                    new ScriptEvaluatingSettingsProcessor(
-                        scriptPluginFactory,
-                        new SettingsFactory(
-                            instantiator,
-                            serviceRegistryFactory,
-                            scriptHandlerFactory
+                new SettingsEvaluatedCallbackFiringSettingsProcessor(
+                    new PropertiesLoadingSettingsProcessor(
+                        new ScriptEvaluatingSettingsProcessor(
+                            scriptPluginFactory,
+                            new SettingsFactory(
+                                instantiator,
+                                serviceRegistryFactory,
+                                scriptHandlerFactory
+                            ),
+                            propertiesLoader
                         ),
                         propertiesLoader
-                    ),
-                    propertiesLoader
+                    )
                 )
             ),
             buildOperationExecutor);

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/BuildOperationSettingsProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/BuildOperationSettingsProcessorTest.groovy
@@ -25,13 +25,13 @@ import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.progress.BuildOperationCategory
 import spock.lang.Specification
 
-class NotifyingSettingsProcessorTest extends Specification {
+class BuildOperationSettingsProcessorTest extends Specification {
 
     def buildOperationExecutor = new TestBuildOperationExecutor()
     def settingsProcessor = Mock(SettingsProcessor)
     def gradleInternal = Mock(GradleInternal)
     def settingsLocation = Mock(SettingsLocation)
-    def buildOperationScriptPlugin = new NotifyingSettingsProcessor(settingsProcessor, buildOperationExecutor)
+    def buildOperationScriptPlugin = new BuildOperationSettingsProcessor(settingsProcessor, buildOperationExecutor)
     def classLoaderScope = Mock(ClassLoaderScope)
     def startParameter = Mock(StartParameter)
     def settingsInternal = Mock(SettingsInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressFilterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressFilterTest.groovy
@@ -60,7 +60,6 @@ class BuildProgressFilterTest extends Specification {
         f.buildFinished(result)
 
         then: 1 * logger.buildStarted()
-        then: 1 * logger.settingsEvaluated()
         then: 1 * logger.projectsLoaded(2)
         then: 1 * logger.beforeEvaluate(":foo:bar")
         then: 1 * logger.afterEvaluate(":foo:bar")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/BuildProgressLoggerTest.groovy
@@ -35,10 +35,11 @@ class BuildProgressLoggerTest extends Specification {
         0 * _
 
         when:
-        buildProgressLogger.settingsEvaluated()
+        buildProgressLogger.projectsLoaded(1)
 
         then:
         1 * buildProgress.completed()
+        1 * provider.start(BuildProgressLogger.CONFIGURATION_PHASE_DESCRIPTION, _, 1) >> buildProgress
         0 * _
     }
 
@@ -61,10 +62,11 @@ class BuildProgressLoggerTest extends Specification {
         0 * _
 
         when:
-        buildProgressLogger.settingsEvaluated()
+        buildProgressLogger.projectsLoaded(1)
 
         then:
         1 * buildProgress.completed()
+        1 * provider.start(BuildProgressLogger.CONFIGURATION_PHASE_DESCRIPTION, _, 1) >> buildProgress
         0 * _
 
         when:
@@ -77,7 +79,6 @@ class BuildProgressLoggerTest extends Specification {
     def "logs configuration phase"() {
         when:
         buildProgressLogger.buildStarted()
-        buildProgressLogger.settingsEvaluated()
 
         then:
         1 * provider.start(BuildProgressLogger.INITIALIZATION_PHASE_DESCRIPTION, _, 0) >> buildProgress
@@ -86,6 +87,7 @@ class BuildProgressLoggerTest extends Specification {
         buildProgressLogger.projectsLoaded(16)
 
         then:
+        1 * buildProgress.completed()
         1 * provider.start(BuildProgressLogger.CONFIGURATION_PHASE_DESCRIPTION, _, 16) >> buildProgress
         0 * _
 
@@ -137,7 +139,6 @@ class BuildProgressLoggerTest extends Specification {
         //currently this can happen, see the ConfigurationOnDemandIntegrationTest
         when:
         buildProgressLogger.buildStarted()
-        buildProgressLogger.settingsEvaluated()
         buildProgressLogger.projectsLoaded(16)
         buildProgressLogger.graphPopulated(10)
 
@@ -157,7 +158,6 @@ class BuildProgressLoggerTest extends Specification {
     def "build finished cleans up configuration logger"() {
         when:
         buildProgressLogger.buildStarted()
-        buildProgressLogger.settingsEvaluated()
         buildProgressLogger.projectsLoaded(16)
 
         then:


### PR DESCRIPTION
This restores the ability to configure the build cache settings from an init script. More generally, it allows more reliable configuration of the settings object as the callback now fires effectively before anything tries to inspect the settings object. Previously, this callback fired later after some inspections were already done.