### PR TITLE
Use JaCoCo 0.8.0 by default

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.7.9</literal></td>
+                <td><literal>0.8.0</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,6 +10,10 @@ Add-->
 ### Example new and noteworthy
 -->
 
+### Default JaCoCo version upgraded to 0.8.0
+
+[The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.0](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
@@ -23,7 +23,7 @@ apply plugin: "jacoco"
 
 // START SNIPPET jacoco-configuration
 jacoco {
-    toolVersion = "0.7.9"
+    toolVersion = "0.8.0"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // END SNIPPET jacoco-configuration

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -52,7 +52,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * The jacoco version used if none is explicitly specified.
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.7.9";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.0";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -43,6 +43,7 @@ class JacocoAgentJarTest extends Specification {
         '0.7.6.201602180812'  | true
         '0.7.8'               | true
         '0.7.9'               | true
+        '0.8.0'               | true
     }
 
     @Unroll
@@ -63,5 +64,6 @@ class JacocoAgentJarTest extends Specification {
         '0.7.6.201602180812'  | true
         '0.7.8'               | true
         '0.7.9'               | true
+        '0.8.0'               | true
     }
 }


### PR DESCRIPTION
This version provides long awaited feature - http://www.jacoco.org/jacoco/trunk/doc/changes.html :
During creation of reports various compiler generated artifacts are filtered out, which otherwise require unnecessary and sometimes impossible tricks to not have partial or missed coverage.
  