### PR TITLE
Show less tiny methods in flame graphs

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/HonestProfilerCollector.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/HonestProfilerCollector.groovy
@@ -146,7 +146,7 @@ class HonestProfilerCollector implements DataCollector {
 
     private static void invokeFlameGraphGenerator(File sanitizedOutput, File svgDestFile) {
         File flameGraphHomeDir = locateFlameGraphInstallation()
-        def process = ["$flameGraphHomeDir/flamegraph.pl", sanitizedOutput].execute()
+        def process = ["$flameGraphHomeDir/flamegraph.pl", "--minwidth", "0.5", sanitizedOutput].execute()
         def fos = svgDestFile.newOutputStream()
         process.waitForProcessOutput(fos, System.err)
         fos.close()


### PR DESCRIPTION
The default resolution of 0.1 pixels leads to
large flamegraphs that take forever to load and
tempt users to investigate tiny issues that don't
solve the actual problem. Use 0.5 for a much smoother
experience instead.