### PR TITLE
Added org.gradle.incremental.ignoreAnnotationProcessors system property

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
@@ -72,8 +72,12 @@ public class IncrementalCompilerDecorator {
             return cleaningCompiler;
         }
         if (!annotationProcessorPath.isEmpty()) {
-            LOG.info("{} - is not incremental. Annotation processors are present.", displayName);
-            return cleaningCompiler;
+            if ("true".equals(System.getProperty("org.gradle.incremental.ignoreAnnotationProcessors"))) {
+                LOG.info("{} - is incremental. Annotation processors are present, but org.gradle.incremental.ignoreAnnotationProcessors system property is set to true.", displayName);
+            } else {
+                LOG.info("{} - is not incremental. Annotation processors are present.", displayName);
+                return cleaningCompiler;
+            }
         }
         ClassSetAnalysisData data = compileCaches.getLocalClassSetAnalysisStore().get();
         if (data == null) {


### PR DESCRIPTION
### Context
Currently, the presence of annotation processors completely disables incremental building.  #3434 will improve this, but with some processors (e.g. a simple in-file replacer) this might be a complex analysis approach. This change would allow to easily specify a flag to manually enable incremental in spite the risks involved, if you know what you are doing.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
