### PR TITLE
Don't reload play application if only assets change

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadIntegrationTest.groovy
@@ -44,7 +44,7 @@ class PlayContinuousBuildReloadIntegrationTest extends AbstractPlayReloadIntegra
         pendingChangesMarker = buildOutput.length()
     }
 
-    def "should reload modified scala controller and routes"() {
+    def "should reload modified scala controller and routes and restart server"() {
         when:
         succeeds("runPlayBinary")
 
@@ -54,12 +54,14 @@ class PlayContinuousBuildReloadIntegrationTest extends AbstractPlayReloadIntegra
         when:
         addNewRoute('hello')
         waitForChangesToBePickedUp()
+        def page = runningApp.playUrl('hello').text
+        serverRestart()
 
         then:
-        runningApp.playUrl('hello').text == 'hello world'
+        page == 'hello world'
     }
 
-    def "should reload with exception when modify scala controller"() {
+    def "should reload with exception when modify scala controller and restart server"() {
         when:
         succeeds("runPlayBinary")
         then:
@@ -72,18 +74,21 @@ class PlayContinuousBuildReloadIntegrationTest extends AbstractPlayReloadIntegra
         then:
         println "CHECKING ERROR PAGE"
         errorPageHasTaskFailure("compilePlayBinaryScala")
+        serverStartCount() == 1
         !executedTasks.contains('runPlayBinary')
 
         when:
         fixBadCode()
         waitForChangesToBePickedUp()
+        runningApp.playUrl().text
+        serverRestart()
         println "CHANGES DETECTED IN BUILD"
 
         then:
         appIsRunningAndDeployed()
     }
 
-    def "should reload modified coffeescript"() {
+    def "should reload modified coffeescript but not restart server"() {
         when:
         succeeds("runPlayBinary")
 
@@ -99,12 +104,16 @@ alert message
 '''
         waitForChangesToBePickedUp()
 
+        def testJs = runningApp.playUrl('assets/javascripts/test.js').text
+        def testMinJs = runningApp.playUrl('assets/javascripts/test.min.js').text
+        serverNotRestart()
+
         then:
-        runningApp.playUrl('assets/javascripts/test.js').text.contains('Hello coffeescript')
-        runningApp.playUrl('assets/javascripts/test.min.js').text.contains('Hello coffeescript')
+        testJs.contains('Hello coffeescript')
+        testMinJs.contains('Hello coffeescript')
     }
 
-    def "should detect new javascript files"() {
+    def "should detect new javascript files but not restart"() {
         when:
         succeeds("runPlayBinary")
 
@@ -117,12 +126,16 @@ var message = "Hello JS";
 '''
         waitForChangesToBePickedUp()
 
+        def helloworldJs = runningApp.playUrl('assets/javascripts/helloworld.js').text
+        def helloworldMinJs = runningApp.playUrl('assets/javascripts/helloworld.min.js').text
+        serverNotRestart()
+
         then:
-        runningApp.playUrl('assets/javascripts/helloworld.js').text.contains('Hello JS')
-        runningApp.playUrl('assets/javascripts/helloworld.min.js').text.contains('Hello JS')
+        helloworldJs.contains('Hello JS')
+        helloworldMinJs.contains('Hello JS')
     }
 
-    def "should reload modified java model"() {
+    def "should reload modified java model and restart server"() {
         when:
         succeeds("runPlayBinary")
 
@@ -136,11 +149,14 @@ var message = "Hello JS";
         }
         waitForChangesToBePickedUp()
 
+        def page = runningApp.playUrl().text
+        serverRestart()
+
         then:
-        runningApp.playUrl().text.contains("<li>Hello foo:1 !</li>")
+        page.contains("<li>Hello foo:1 !</li>")
     }
 
-    def "should reload twirl template"() {
+    def "should reload twirl template and restart server"() {
         when:
         succeeds("runPlayBinary")
 
@@ -152,9 +168,11 @@ var message = "Hello JS";
             text = text.replaceFirst(~/Welcome to Play/, 'Welcome to Play with Gradle')
         }
         waitForChangesToBePickedUp()
+        def page = runningApp.playUrl().text
+        serverRestart()
 
         then:
-        runningApp.playUrl().text.contains("Welcome to Play with Gradle")
+        page.contains("Welcome to Play with Gradle")
     }
 
     def "should reload with exception when task that depends on runPlayBinary fails"() {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadIntegrationTest.groovy
@@ -74,7 +74,7 @@ class PlayContinuousBuildReloadIntegrationTest extends AbstractPlayReloadIntegra
         then:
         println "CHECKING ERROR PAGE"
         errorPageHasTaskFailure("compilePlayBinaryScala")
-        serverStartCount() == 1
+        serverStartCount == 1
         !executedTasks.contains('runPlayBinary')
 
         when:
@@ -106,7 +106,7 @@ alert message
 
         def testJs = runningApp.playUrl('assets/javascripts/test.js').text
         def testMinJs = runningApp.playUrl('assets/javascripts/test.min.js').text
-        serverNotRestart()
+        noServerRestart()
 
         then:
         testJs.contains('Hello coffeescript')
@@ -128,7 +128,7 @@ var message = "Hello JS";
 
         def helloworldJs = runningApp.playUrl('assets/javascripts/helloworld.js').text
         def helloworldMinJs = runningApp.playUrl('assets/javascripts/helloworld.min.js').text
-        serverNotRestart()
+        noServerRestart()
 
         then:
         helloworldJs.contains('Hello JS')

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayMultiProjectReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayMultiProjectReloadIntegrationTest.groovy
@@ -151,7 +151,7 @@ var message = "Hello JS";
 '''
         succeeds()
         def js = runningApp.playUrl('assets/helloworld.js').text
-        serverNotRestart()
+        noServerRestart()
 
         then:
         js.contains('Hello JS')
@@ -170,7 +170,7 @@ var message = "Hello JS";
         fails()
         !executedTasks.contains(':primary:runPlayBinary')
         errorPageHasTaskFailure(":submodule:compilePlayBinaryScala")
-        serverStartCount() == 1
+        serverStartCount == 1
 
         when:
         fixBadScala("submodule/app")
@@ -179,7 +179,7 @@ var message = "Hello JS";
         succeeds()
         appIsRunningAndDeployed()
         runningApp.playUrl().text
-        serverStartCount() > 1
+        serverStartCount > 1
     }
 
     def addBadScala(path) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/DefaultVersionedPlayRunAdapter.java
@@ -37,8 +37,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.Queue;
@@ -59,6 +57,8 @@ public abstract class DefaultVersionedPlayRunAdapter implements VersionedPlayRun
     protected abstract Class<?> getDocHandlerFactoryClass(ClassLoader classLoader) throws ClassNotFoundException;
 
     protected abstract Class<?> getBuildDocHandlerClass(ClassLoader docsClassLoader) throws ClassNotFoundException;
+
+    protected abstract ClassLoader createAssetsClassLoader(File assetsJar, Iterable<File> assetsDirs, ClassLoader classLoader);
 
     @Override
     public Object getBuildLink(final ClassLoader classLoader, final Reloader reloader, final File projectPath, final File applicationJar, final Iterable<File> changingClasspath, final File assetsJar, final Iterable<File> assetsDirs) throws ClassNotFoundException {
@@ -102,14 +102,6 @@ public abstract class DefaultVersionedPlayRunAdapter implements VersionedPlayRun
                 return null;
             }
         });
-    }
-
-    protected ClassLoader createAssetsClassLoader(File assetsJar, Iterable<File> assetsDirs, ClassLoader classLoader) {
-        try {
-            return new URLClassLoader(new URL[]{assetsJar.toURI().toURL()}, classLoader);
-        } catch (MalformedURLException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
     }
 
     private void storeClassLoader(ClassLoader classLoader) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunner.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunner.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public class PlayApplicationRunner {
     private final WorkerProcessFactory workerFactory;
     private final VersionedPlayRunAdapter adapter;
-    private ClasspathSnapshotter snapshotter;
+    private final ClasspathSnapshotter snapshotter;
 
     public PlayApplicationRunner(WorkerProcessFactory workerFactory, VersionedPlayRunAdapter adapter, ClasspathSnapshotter snapshotter) {
         this.workerFactory = workerFactory;
@@ -56,10 +56,10 @@ public class PlayApplicationRunner {
     }
 
     private class PlayClassloaderMonitorDeploymentDecorator implements Deployment {
-        private Deployment delegate;
-        private FileCollection applicationClasspath;
+        private final Deployment delegate;
+        private final FileCollection applicationClasspath;
+        private final boolean isPlay22;
         private HashCode snapshot;
-        private boolean isPlay22;
 
         private PlayClassloaderMonitorDeploymentDecorator(Deployment delegate, PlayRunSpec runSpec, VersionedPlayRunAdapter adapter) {
             this.delegate = delegate;
@@ -86,9 +86,7 @@ public class PlayApplicationRunner {
                 return delegateStatus;
             }
 
-            HashCode oldSnapshot = updateSnapshot();
-
-            if (!snapshot.equals(oldSnapshot)) {
+            if (applicationClasspathChanged()) {
                 return delegateStatus;
             } else {
                 return new Status() {
@@ -105,10 +103,10 @@ public class PlayApplicationRunner {
             }
         }
 
-        private HashCode updateSnapshot() {
+        private boolean applicationClasspathChanged() {
             HashCode oldSnapshot = snapshot;
             snapshot = snapshotter.snapshot(applicationClasspath, InputPathNormalizationStrategy.NONE, InputNormalizationStrategy.NOT_CONFIGURED).getHash();
-            return oldSnapshot;
+            return !snapshot.equals(oldSnapshot);
         }
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunnerFactory.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunnerFactory.java
@@ -16,13 +16,14 @@
 
 package org.gradle.play.internal.run;
 
+import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.play.internal.platform.PlayMajorVersion;
 import org.gradle.play.platform.PlayPlatform;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 
 public class PlayApplicationRunnerFactory {
-    public static PlayApplicationRunner create(PlayPlatform playPlatform, WorkerProcessFactory workerFactory) {
-        return new PlayApplicationRunner(workerFactory, createPlayRunAdapter(playPlatform));
+    public static PlayApplicationRunner create(PlayPlatform playPlatform, WorkerProcessFactory workerFactory, ClasspathSnapshotter snapshotter) {
+        return new PlayApplicationRunner(workerFactory, createPlayRunAdapter(playPlatform), snapshotter);
     }
 
     public static VersionedPlayRunAdapter createPlayRunAdapter(PlayPlatform playPlatform) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayRunAdapterV22X.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayRunAdapterV22X.java
@@ -16,6 +16,13 @@
 
 package org.gradle.play.internal.run;
 
+import org.gradle.internal.UncheckedException;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
 public class PlayRunAdapterV22X extends DefaultVersionedPlayRunAdapter {
     @Override
     protected Class<?> getBuildLinkClass(ClassLoader classLoader) throws ClassNotFoundException {
@@ -30,5 +37,13 @@ public class PlayRunAdapterV22X extends DefaultVersionedPlayRunAdapter {
     @Override
     protected Class<?> getDocHandlerFactoryClass(ClassLoader docsClassLoader) throws ClassNotFoundException {
         return docsClassLoader.loadClass("play.docs.SBTDocHandlerFactory");
+    }
+
+    protected ClassLoader createAssetsClassLoader(File assetsJar, Iterable<File> assetsDirs, ClassLoader classLoader) {
+        try {
+            return new URLClassLoader(new URL[]{assetsJar.toURI().toURL()}, classLoader);
+        } catch (MalformedURLException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
     }
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DefaultPlayToolChain.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DefaultPlayToolChain.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.text.TreeFormatter;
 import org.gradle.language.base.internal.compile.CompileSpec;
@@ -47,14 +48,16 @@ public class DefaultPlayToolChain implements PlayToolChainInternal {
     private final DependencyHandler dependencyHandler;
     private final WorkerProcessFactory workerProcessBuilderFactory;
     private final WorkerDirectoryProvider workerDirectoryProvider;
+    private final ClasspathSnapshotter snapshotter;
 
-    public DefaultPlayToolChain(FileResolver fileResolver, WorkerDaemonFactory workerDaemonFactory, ConfigurationContainer configurationContainer, DependencyHandler dependencyHandler, WorkerProcessFactory workerProcessBuilderFactory, WorkerDirectoryProvider workerDirectoryProvider) {
+    public DefaultPlayToolChain(FileResolver fileResolver, WorkerDaemonFactory workerDaemonFactory, ConfigurationContainer configurationContainer, DependencyHandler dependencyHandler, WorkerProcessFactory workerProcessBuilderFactory, WorkerDirectoryProvider workerDirectoryProvider, ClasspathSnapshotter snapshotter) {
         this.fileResolver = fileResolver;
         this.workerDaemonFactory = workerDaemonFactory;
         this.configurationContainer = configurationContainer;
         this.dependencyHandler = dependencyHandler;
         this.workerProcessBuilderFactory = workerProcessBuilderFactory;
         this.workerDirectoryProvider = workerDirectoryProvider;
+        this.snapshotter = snapshotter;
     }
 
     @Override
@@ -73,7 +76,7 @@ public class DefaultPlayToolChain implements PlayToolChainInternal {
             Set<File> twirlClasspath = resolveToolClasspath(TwirlCompilerFactory.createAdapter(targetPlatform).getDependencyNotation().toArray()).resolve();
             Set<File> routesClasspath = resolveToolClasspath(RoutesCompilerFactory.createAdapter(targetPlatform).getDependencyNotation()).resolve();
             Set<File> javascriptClasspath = resolveToolClasspath(GoogleClosureCompiler.getDependencyNotation()).resolve();
-            return new DefaultPlayToolProvider(fileResolver, workerDirectoryProvider.getIdleWorkingDirectory(), workerDaemonFactory, workerProcessBuilderFactory, targetPlatform, twirlClasspath, routesClasspath, javascriptClasspath);
+            return new DefaultPlayToolProvider(fileResolver, workerDirectoryProvider.getIdleWorkingDirectory(), workerDaemonFactory, workerProcessBuilderFactory, targetPlatform, twirlClasspath, routesClasspath, javascriptClasspath, snapshotter);
         } catch (ResolveException e) {
             return new UnavailablePlayToolProvider(e);
         }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DefaultPlayToolProvider.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DefaultPlayToolProvider.java
@@ -16,6 +16,7 @@
 
 package org.gradle.play.internal.toolchain;
 
+import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -49,10 +50,12 @@ class DefaultPlayToolProvider implements PlayToolProvider {
     private final Set<File> twirlClasspath;
     private final Set<File> routesClasspath;
     private final Set<File> javaScriptClasspath;
+    private final ClasspathSnapshotter snapshotter;
 
     public DefaultPlayToolProvider(FileResolver fileResolver, File daemonWorkingDir, WorkerDaemonFactory workerDaemonFactory,
                                    WorkerProcessFactory workerProcessBuilderFactory, PlayPlatform targetPlatform,
-                                   Set<File> twirlClasspath, Set<File> routesClasspath, Set<File> javaScriptClasspath) {
+                                   Set<File> twirlClasspath, Set<File> routesClasspath, Set<File> javaScriptClasspath,
+                                   ClasspathSnapshotter snapshotter) {
         this.fileResolver = fileResolver;
         this.daemonWorkingDir = daemonWorkingDir;
         this.workerDaemonFactory = workerDaemonFactory;
@@ -61,6 +64,7 @@ class DefaultPlayToolProvider implements PlayToolProvider {
         this.twirlClasspath = twirlClasspath;
         this.routesClasspath = routesClasspath;
         this.javaScriptClasspath = javaScriptClasspath;
+        this.snapshotter = snapshotter;
         // validate that the targetPlatform is valid
         PlayMajorVersion.forPlatform(targetPlatform);
     }
@@ -83,7 +87,7 @@ class DefaultPlayToolProvider implements PlayToolProvider {
     @Override
     public <T> T get(Class<T> toolType) {
         if (PlayApplicationRunner.class.isAssignableFrom(toolType)) {
-            return toolType.cast(PlayApplicationRunnerFactory.create(targetPlatform, workerProcessBuilderFactory));
+            return toolType.cast(PlayApplicationRunnerFactory.create(targetPlatform, workerProcessBuilderFactory, snapshotter));
         }
         throw new IllegalArgumentException(String.format("Don't know how to provide tool of type %s.", toolType.getSimpleName()));
     }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/PlayToolChainServiceRegistry.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/PlayToolChainServiceRegistry.java
@@ -18,6 +18,7 @@ package org.gradle.play.internal.toolchain;
 
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -39,8 +40,8 @@ public class PlayToolChainServiceRegistry extends AbstractPluginServiceRegistry 
     }
 
     private static class ProjectScopeCompileServices {
-        PlayToolChainInternal createPlayToolChain(FileResolver fileResolver, WorkerDaemonFactory workerDaemonFactory, ConfigurationContainer configurationContainer, DependencyHandler dependencyHandler, WorkerProcessFactory workerProcessBuilderFactory, WorkerDirectoryProvider workerDirectoryProvider) {
-            return new DefaultPlayToolChain(fileResolver, workerDaemonFactory, configurationContainer, dependencyHandler, workerProcessBuilderFactory, workerDirectoryProvider);
+        PlayToolChainInternal createPlayToolChain(FileResolver fileResolver, WorkerDaemonFactory workerDaemonFactory, ConfigurationContainer configurationContainer, DependencyHandler dependencyHandler, WorkerProcessFactory workerProcessBuilderFactory, WorkerDirectoryProvider workerDirectoryProvider, ClasspathSnapshotter snapshotter) {
+            return new DefaultPlayToolChain(fileResolver, workerDaemonFactory, configurationContainer, dependencyHandler, workerProcessBuilderFactory, workerDirectoryProvider, snapshotter);
         }
     }
 }

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/DefaultPlayToolChainTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/DefaultPlayToolChainTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.text.TreeFormatter
 import org.gradle.language.scala.ScalaPlatform
@@ -42,7 +43,8 @@ class DefaultPlayToolChainTest extends Specification {
     PlayPlatform playPlatform = Stub(PlayPlatform)
     WorkerProcessFactory workerProcessBuilderFactory = Mock()
     WorkerDirectoryProvider workerDirectoryProvider = Mock()
-    def toolChain = new DefaultPlayToolChain(fileResolver, workerDaemonFactory, configurationContainer, dependencyHandler, workerProcessBuilderFactory, workerDirectoryProvider)
+    ClasspathSnapshotter snapshotter = Mock()
+    def toolChain = new DefaultPlayToolChain(fileResolver, workerDaemonFactory, configurationContainer, dependencyHandler, workerProcessBuilderFactory, workerDirectoryProvider, snapshotter)
 
     def setup() {
         playPlatform.playVersion >> DefaultPlayPlatform.DEFAULT_PLAY_VERSION

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/toolchain/DefaultPlayToolProviderTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/toolchain/DefaultPlayToolProviderTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.play.internal.toolchain
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.language.base.internal.compile.CompileSpec
 import org.gradle.play.internal.DefaultPlayPlatform
@@ -43,11 +44,16 @@ class DefaultPlayToolProviderTest extends Specification {
     PlayPlatform playPlatform = Mock()
     WorkerProcessFactory workerProcessBuilderFactory = Mock()
     File daemonWorkingDir = Mock()
+    ClasspathSnapshotter snapshotter = Mock()
     Set<File> twirlClasspath = Stub(Set)
     Set<File> routesClasspath = Stub(Set)
     Set<File> javascriptClasspath = Stub(Set)
 
     DefaultPlayToolProvider playToolProvider
+
+    private DefaultPlayToolProvider createProvider() {
+        return new DefaultPlayToolProvider(fileResolver, daemonWorkingDir, workerDaemonFactory, workerProcessBuilderFactory, playPlatform, twirlClasspath, routesClasspath, javascriptClasspath, snapshotter)
+    }
 
     @Unroll
     def "provides playRunner for play #playVersion"(){
@@ -55,7 +61,7 @@ class DefaultPlayToolProviderTest extends Specification {
         _ * playPlatform.getPlayVersion() >> playVersion
 
         when:
-        playToolProvider = new DefaultPlayToolProvider(fileResolver, daemonWorkingDir, workerDaemonFactory, workerProcessBuilderFactory, playPlatform, twirlClasspath, routesClasspath, javascriptClasspath)
+        playToolProvider = createProvider()
         def runner = playToolProvider.get(PlayApplicationRunner.class)
 
         then:
@@ -74,7 +80,7 @@ class DefaultPlayToolProviderTest extends Specification {
     def "cannot create tool provider for unsupported play versions"() {
         when:
         _ * playPlatform.getPlayVersion() >> playVersion
-        playToolProvider = new DefaultPlayToolProvider(fileResolver, daemonWorkingDir, workerDaemonFactory, workerProcessBuilderFactory, playPlatform, twirlClasspath, routesClasspath, javascriptClasspath)
+        playToolProvider = createProvider()
 
         then: "fails with meaningful error message"
         def exception = thrown(InvalidUserDataException)
@@ -91,7 +97,7 @@ class DefaultPlayToolProviderTest extends Specification {
     def "newCompiler provides decent error for unsupported CompileSpec"() {
         setup:
         _ * playPlatform.getPlayVersion() >> DefaultPlayPlatform.DEFAULT_PLAY_VERSION
-        playToolProvider = new DefaultPlayToolProvider(fileResolver, daemonWorkingDir, workerDaemonFactory, workerProcessBuilderFactory, playPlatform, twirlClasspath, routesClasspath, javascriptClasspath)
+        playToolProvider = createProvider()
 
         when:
         playToolProvider.newCompiler(UnknownCompileSpec.class)

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayReloadIntegrationTest.groovy
@@ -18,7 +18,23 @@ package org.gradle.play.integtest.fixtures
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.test.fixtures.ConcurrentTestUtil
 
 @TargetCoverage({ JavaVersion.current().isJava8Compatible() ? PlayCoverage.PLAY23_OR_LATER : PlayCoverage.PLAY23_OR_EARLIER })
 abstract class AbstractMultiVersionPlayReloadIntegrationTest extends AbstractMultiVersionPlayContinuousBuildIntegrationTest {
+    protected serverRestart() {
+        ConcurrentTestUtil.poll {
+            assert serverStartCount() > 1
+        }
+    }
+
+    protected serverNotRestart() {
+        if (!versionNumber.toString().startsWith("2.2")) {
+            assert serverStartCount() == 1
+        }
+    }
+
+    protected serverStartCount() {
+        gradle.standardOutput.count('play - Application started')
+    }
 }

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayReloadIntegrationTest.groovy
@@ -24,17 +24,17 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 abstract class AbstractMultiVersionPlayReloadIntegrationTest extends AbstractMultiVersionPlayContinuousBuildIntegrationTest {
     protected serverRestart() {
         ConcurrentTestUtil.poll {
-            assert serverStartCount() > 1
+            assert serverStartCount > 1
         }
     }
 
-    protected serverNotRestart() {
+    protected noServerRestart() {
         if (!versionNumber.toString().startsWith("2.2")) {
-            assert serverStartCount() == 1
+            assert serverStartCount == 1
         }
     }
 
-    protected serverStartCount() {
+    protected getServerStartCount() {
         gradle.standardOutput.count('play - Application started')
     }
 }


### PR DESCRIPTION
### Context

This fixes #3295 . Previously, Play server will reload when any files change (controllers/views/assets, etc.). However, it's not necessary to reload the server since it reads assets from assets directory directly. This PR puts a monitor which watches non-assets files change in `PlayApplicationRunner`, and tells Play server not to reload in this situation. 