### PR TITLE
Disable dependency check build step

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -30,8 +30,7 @@ data class CIBuildModel (
                     specificBuilds = listOf(
                             SpecificBuild.BuildDistributions,
                             SpecificBuild.Gradleception,
-                            SpecificBuild.SmokeTests,
-                            SpecificBuild.DependenciesCheck),
+                            SpecificBuild.SmokeTests),
                     functionalTests = listOf(
                             TestCoverage(TestType.platform, OS.linux, JvmVersion.java7),
                             TestCoverage(TestType.platform, OS.windows, JvmVersion.java8)),


### PR DESCRIPTION
### Context

The plugin used in the build step fails intermittently. Remove the step from the pipeline until it is not resolved but keep the history.