### PR TITLE
Make Swift implementation dependencies behave like api dependencies

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLibraryDependenciesIntegrationTest.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language
+
+abstract class AbstractNativeLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
+    def "can define api dependencies on component"() {
+        given:
+        settingsFile << 'include "lib"'
+        makeComponentWithLibrary()
+        buildFile << """
+            ${componentUnderTestDsl} { c ->
+                c.dependencies {
+                    api project(':lib')
+                }
+            }
+        """
+
+        when:
+        run(assembleDevBinaryTask)
+
+        then:
+        result.assertTasksExecuted(libDebugTasks, assembleDevBinaryTasks, assembleDevBinaryTask)
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationDependenciesIntegrationTest.groovy
@@ -26,8 +26,32 @@ class CppApplicationDependenciesIntegrationTest extends AbstractNativeProduction
             project(':lib') {
                 apply plugin: 'cpp-library'
             }
-"""
-        file("lib/src/main/cpp/lib.cpp") << """
+        """
+
+        file("lib/src/main/cpp/lib.cpp") << librarySource
+        file("src/main/cpp/app.cpp") << applicationSource
+    }
+
+    @Override
+    protected void makeComponentWithIncludedBuildLibrary() {
+        buildFile << """
+            apply plugin: 'cpp-application'
+        """
+
+        file('lib/build.gradle') << """
+            apply plugin: 'cpp-library'
+            
+            group = 'org.gradle.test'
+            version = '1.0'
+        """
+        file('lib/settings.gradle').createFile()
+
+        file("lib/src/main/cpp/lib.cpp") << librarySource
+        file("src/main/cpp/app.cpp") << applicationSource
+    }
+
+    private static String getLibrarySource() {
+        return """
             #ifdef _WIN32
             #define EXPORT_FUNC __declspec(dllexport)
             #else
@@ -35,12 +59,15 @@ class CppApplicationDependenciesIntegrationTest extends AbstractNativeProduction
             #endif
             
             void EXPORT_FUNC lib_func() { }
-"""
-        file("src/main/cpp/app.cpp") << """
+        """
+    }
+
+    private static String getApplicationSource() {
+        return """
             int main() {
                 return 0;
             }
-"""
+        """
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryDependenciesIntegrationTest.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.language.cpp
 
-import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
+import org.gradle.language.AbstractNativeLibraryDependenciesIntegrationTest
 
-class CppLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest implements CppTaskNames {
+class CppLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDependenciesIntegrationTest implements CppTaskNames {
     @Override
     protected void makeComponentWithLibrary() {
         buildFile << """
@@ -26,8 +26,31 @@ class CppLibraryDependenciesIntegrationTest extends AbstractNativeProductionComp
             project(':lib') {
                 apply plugin: 'cpp-library'
             }
-"""
-        file("lib/src/main/cpp/lib.cpp") << """
+        """
+        file("lib/src/main/cpp/lib.cpp") << librarySource
+        file("src/main/cpp/lib.cpp") << mainLibrarySource
+    }
+
+    @Override
+    protected void makeComponentWithIncludedBuildLibrary() {
+        buildFile << """
+            apply plugin: 'cpp-library'
+        """
+
+        file('lib/build.gradle') << """
+            apply plugin: 'cpp-library'
+            
+            group = 'org.gradle.test'
+            version = '1.0'
+        """
+        file('lib/settings.gradle').createFile()
+
+        file("lib/src/main/cpp/lib.cpp") << librarySource
+        file("src/main/cpp/lib.cpp") << mainLibrarySource
+    }
+
+    private static getLibrarySource() {
+        return """
             #ifdef _WIN32
             #define EXPORT_FUNC __declspec(dllexport)
             #else
@@ -35,12 +58,15 @@ class CppLibraryDependenciesIntegrationTest extends AbstractNativeProductionComp
             #endif
             
             void EXPORT_FUNC lib_func() { }
-"""
-        file("src/main/cpp/lib.cpp") << """
+        """
+    }
+
+    private static getMainLibrarySource() {
+        return """
             int main_func() {
                 return 0;
             }
-"""
+        """
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationDependenciesIntegrationTest.groovy
@@ -29,14 +29,39 @@ class SwiftApplicationDependenciesIntegrationTest extends AbstractNativeProducti
             project(':lib') {
                 apply plugin: 'swift-library'
             }
-"""
+        """
 
-        file("src/main/swift/main.swift") << """
-"""
-        file("lib/src/main/swift/Lib.swift") << """
+        file("src/main/swift/main.swift") << applicationSource
+        file("lib/src/main/swift/Lib.swift") << librarySource
+    }
+
+    @Override
+    protected void makeComponentWithIncludedBuildLibrary() {
+        buildFile << """
+            apply plugin: 'swift-application'
+        """
+
+        file('lib/build.gradle') << """
+            apply plugin: 'swift-library'
+            
+            group = 'org.gradle.test'
+            version = '1.0'
+        """
+        file('lib/settings.gradle').createFile()
+
+        file("src/main/swift/main.swift") << applicationSource
+        file("lib/src/main/swift/Lib.swift") << librarySource
+    }
+
+    private static String getLibrarySource() {
+        return """
             class Lib {
             }
-"""
+        """
+    }
+
+    private static String getApplicationSource() {
+        return ""
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.language.swift
 
-import org.gradle.language.AbstractNativeProductionComponentDependenciesIntegrationTest
+import org.gradle.language.AbstractNativeLibraryDependenciesIntegrationTest
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 @Requires(TestPrecondition.SWIFT_SUPPORT)
-class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeProductionComponentDependenciesIntegrationTest {
+class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDependenciesIntegrationTest {
     @Override
     protected void makeComponentWithLibrary() {
         buildFile << """
@@ -29,16 +29,35 @@ class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeProductionCo
             project(':lib') {
                 apply plugin: 'swift-library'
             }
-"""
+        """
 
-        file("src/main/swift/Lib.swift") << """
+        file("src/main/swift/Lib.swift") << librarySource
+        file("lib/src/main/swift/Lib.swift") << librarySource
+    }
+
+    @Override
+    protected void makeComponentWithIncludedBuildLibrary() {
+        buildFile << """
+            apply plugin: 'swift-library'
+        """
+
+        file('lib/build.gradle') << """
+            apply plugin: 'swift-library'
+            
+            group = 'org.gradle.test'
+            version = '1.0'
+        """
+        file('lib/settings.gradle').createFile()
+
+        file("src/main/swift/Lib.swift") << librarySource
+        file("lib/src/main/swift/Lib.swift") << librarySource
+    }
+
+    private static String getLibrarySource() {
+        return """
             class Lib {
             }
-"""
-        file("lib/src/main/swift/Lib.swift") << """
-            class Lib {
-            }
-"""
+        """
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryDependenciesIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.util.TestPrecondition
 
 @Requires(TestPrecondition.SWIFT_SUPPORT)
 class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDependenciesIntegrationTest {
-    def "implementation dependencies are visible to downstream consumers"() {
+    def "can compile against a library with implementation dependencies"() {
         settingsFile << """
             include ":lib1", ":lib2"
         """
@@ -66,7 +66,7 @@ class SwiftLibraryDependenciesIntegrationTest extends AbstractNativeLibraryDepen
         result.assertTasksExecuted([":lib1:compileDebugSwift", ":lib1:linkDebug", ":lib2:compileDebugSwift", ":lib2:linkDebug"], assembleDevBinaryTasks, assembleDevBinaryTask)
     }
 
-    def "binary-specific implementation dependencies are visible to downstream consumers"() {
+    def "can compile against a library with binary-specific implementation dependencies"() {
         settingsFile << """
             include ":lib1", ":lib2"
         """

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeDependenciesIntegrationTest.groovy
@@ -36,7 +36,7 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
                     implementation project(':lib')
                 }
             }
-"""
+        """
 
         when:
         run(assembleDevBinaryTask)
@@ -57,7 +57,7 @@ abstract class AbstractNativeDependenciesIntegrationTest extends AbstractInstall
                     }
                 }
             }
-"""
+        """
 
         when:
         run(assembleDevBinaryTask)

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeProductionComponentDependenciesIntegrationTest.groovy
@@ -29,7 +29,33 @@ abstract class AbstractNativeProductionComponentDependenciesIntegrationTest exte
                     }
                 }
             }
-"""
+        """
+
+        when:
+        run(':assembleDebug')
+
+        then:
+        result.assertTasksExecuted(libDebugTasks, assembleDebugTasks, ':assembleDebug')
+
+        when:
+        run(':assembleRelease')
+
+        then:
+        result.assertTasksExecuted(assembleReleaseTasks, ':assembleRelease')
+    }
+
+    def "can define an included build implementation dependency on a binary"() {
+        settingsFile << 'includeBuild "lib"'
+        makeComponentWithIncludedBuildLibrary()
+        buildFile << """
+            ${componentUnderTestDsl} {
+                binaries.getByName('mainDebug').configure {                
+                    dependencies {
+                        implementation 'org.gradle.test:lib:1.0'
+                    }
+                }
+            }
+        """
 
         when:
         run(':assembleDebug')
@@ -57,4 +83,6 @@ abstract class AbstractNativeProductionComponentDependenciesIntegrationTest exte
     protected abstract List<String> getAssembleDebugTasks()
 
     protected abstract List<String> getAssembleReleaseTasks()
+
+    protected abstract void makeComponentWithIncludedBuildLibrary()
 }


### PR DESCRIPTION
This adds some more coverage for binary-specific dependencies and makes implementation dependencies behave like api dependencies for Swift.  This is a workaround for limitations in swift that require transitive implementation dependencies to be on the import path for a consuming application/library.