### PR TITLE
gradle signing plugin documentation update

### DIFF
--- a/subprojects/docs/src/docs/userguide/signingPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/signingPlugin.adoc
@@ -35,8 +35,8 @@ To use the Signing plugin, include the following in your build script:
 
 In order to create OpenPGP signatures, you will need a key pair (instructions on creating a key pair using the https://www.gnupg.org/[GnuPG tools] can be found in the https://www.gnupg.org/documentation/howtos.html[GnuPG HOWTOs]). You need to provide the signing plugin with your key information, which means three things:
 
-* The public key ID (an 8 character hexadecimal string).
-* The absolute path to the secret key ring file containing your private key.
+* The public key ID (the last 8 symbols of the keyId. Use gpg -K to find it out).
+* The absolute path to the secret key ring file containing your private key. (Since gpg 2.1 you need to export the keys with command gpg --keyring secring.gpg --export-secret-keys  > ~/.gnupg/secring.gpg).
 * The passphrase used to protect your private key.
 
 These items must be supplied as the values of properties `signing.keyId`, `signing.secretKeyRingFile`, and `signing.password` respectively. Given the personal and private nature of these values, a good practice is to store them in the user `gradle.properties` file (described in <<sec:gradle_system_properties>>).


### PR DESCRIPTION
### Context
It is hard to figure out how to use the signing plugin correctly now.

1. It turns out that we need to provide last 8 hex digits of gpg -K output.
2. the secring.pgp file is deprecated since pgp 2.1. It is better to have it documented.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
