### PR TITLE
Fix #4012 AWS Java SDK libraries are too old

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -124,7 +124,7 @@ libraries.bouncycastle_pgp = "org.bouncycastle:bcpg-jdk15on:${versions.bouncycas
 
 libraries.joda = 'joda-time:joda-time:2.8.2'
 
-versions.aws = "1.11.6"
+versions.aws = "1.11.262"
 versions.jackson = "2.8.11"
 libraries.awsS3 = [
         "com.amazonaws:aws-java-sdk-s3:${versions.aws}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -124,7 +124,7 @@ libraries.bouncycastle_pgp = "org.bouncycastle:bcpg-jdk15on:${versions.bouncycas
 
 libraries.joda = 'joda-time:joda-time:2.8.2'
 
-versions.aws = "1.11.262"
+versions.aws = "1.11.264"
 versions.jackson = "2.8.11"
 libraries.awsS3 = [
         "com.amazonaws:aws-java-sdk-s3:${versions.aws}",

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -16,25 +16,19 @@
 
 package org.gradle.internal.resource.transport.aws.s3;
 
-import java.io.InputStream;
-import java.net.URI;
-import java.util.List;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.regions.Region;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.S3ClientOptions;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.*;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
@@ -47,14 +41,18 @@ import org.gradle.internal.resource.transport.http.HttpProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+
 public class S3Client {
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Client.class);
 
     private S3ResourceResolver resourceResolver = new S3ResourceResolver();
-    private AmazonS3Client amazonS3Client;
+    private AmazonS3 amazonS3Client;
     private final S3ConnectionProperties s3ConnectionProperties;
 
-    public S3Client(AmazonS3Client amazonS3Client, S3ConnectionProperties s3ConnectionProperties) {
+    public S3Client(AmazonS3 amazonS3Client, S3ConnectionProperties s3ConnectionProperties) {
         this.s3ConnectionProperties = s3ConnectionProperties;
         this.amazonS3Client = amazonS3Client;
     }
@@ -66,8 +64,10 @@ public class S3Client {
     @Incubating
     public S3Client(S3ConnectionProperties s3ConnectionProperties) {
         this.s3ConnectionProperties = s3ConnectionProperties;
-        amazonS3Client = new AmazonS3Client(createConnectionProperties());
-        setAmazonS3ConnectionEndpoint();
+        AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard()
+            .withClientConfiguration(createConnectionProperties());
+        setAmazonS3ConnectionEndpoint(s3ClientBuilder);
+        amazonS3Client = s3ClientBuilder.build();
     }
 
     public S3Client(AwsCredentials awsCredentials, S3ConnectionProperties s3ConnectionProperties) {
@@ -80,18 +80,22 @@ public class S3Client {
                 credentials =  new BasicSessionCredentials(awsCredentials.getAccessKey(), awsCredentials.getSecretKey(), awsCredentials.getSessionToken());
             }
         }
-        amazonS3Client = new AmazonS3Client(credentials, createConnectionProperties());
-        setAmazonS3ConnectionEndpoint();
+
+        AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withClientConfiguration(createConnectionProperties());
+
+        setAmazonS3ConnectionEndpoint(s3ClientBuilder);
+        amazonS3Client = s3ClientBuilder.build();
     }
 
-    private void setAmazonS3ConnectionEndpoint() {
-        S3ClientOptions.Builder clientOptionsBuilder = S3ClientOptions.builder();
+    private void setAmazonS3ConnectionEndpoint(AmazonS3ClientBuilder s3ClientBuilder) {
         Optional<URI> endpoint = s3ConnectionProperties.getEndpoint();
         if (endpoint.isPresent()) {
-            amazonS3Client.setEndpoint(endpoint.get().toString());
-            clientOptionsBuilder.setPathStyleAccess(true);
+            EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(endpoint.get().toString(), endpoint.get().getHost());
+            s3ClientBuilder.withEndpointConfiguration(endpointConfiguration);
+            s3ClientBuilder.withPathStyleAccessEnabled(true);
         }
-        amazonS3Client.setS3ClientOptions(clientOptionsBuilder.build());
     }
 
     private void checkRequiredJigsawModuleIsOnPath() {

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -85,7 +85,7 @@ public class S3Client {
         Optional<URI> endpoint = s3ConnectionProperties.getEndpoint();
         if (endpoint.isPresent()) {
             amazonS3Client.setEndpoint(endpoint.get().toString());
-            clientOptionsBuilder.setPathStyleAccess(true);
+            clientOptionsBuilder.setPathStyleAccess(true).disableChunkedEncoding();
         }
         amazonS3Client.setS3ClientOptions(clientOptionsBuilder.build());
     }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -80,7 +80,6 @@ public class S3Client {
                 credentials =  new BasicSessionCredentials(awsCredentials.getAccessKey(), awsCredentials.getSecretKey(), awsCredentials.getSessionToken());
             }
         }
-
         AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard()
             .withCredentials(new AWSStaticCredentialsProvider(credentials))
             .withClientConfiguration(createConnectionProperties());

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.aws.s3
 
-import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.ObjectListing
 import com.amazonaws.services.s3.model.PutObjectRequest
@@ -41,7 +41,7 @@ class S3ClientTest extends Specification {
     @Requires(FIX_TO_WORK_ON_JAVA9)
     def "Should upload to s3"() {
         given:
-        AmazonS3 amazonS3Client = Mock()
+        AmazonS3Client amazonS3Client = Mock()
         S3Client client = new S3Client(amazonS3Client, s3ConnectionProperties)
         URI uri = new URI("s3://localhost/maven/snapshot/myFile.txt")
 
@@ -57,7 +57,7 @@ class S3ClientTest extends Specification {
     }
 
     def "should make batch call when more than one object listing exists"() {
-        def amazonS3Client = Mock(AmazonS3)
+        def amazonS3Client = Mock(AmazonS3Client)
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         def uri = new URI("s3://mybucket.com.au/maven/release/")
         ObjectListing firstListing = Mock()
@@ -143,7 +143,7 @@ class S3ClientTest extends Specification {
     }
 
     def "should include uri when meta-data not found"() {
-        AmazonS3 amazonS3Client = Mock()
+        AmazonS3Client amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         AmazonS3Exception amazonS3Exception = new AmazonS3Exception("test exception")
@@ -157,7 +157,7 @@ class S3ClientTest extends Specification {
     }
 
     def "should include uri when file not found"() {
-        AmazonS3 amazonS3Client = Mock()
+        AmazonS3Client amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         AmazonS3Exception amazonS3Exception = new AmazonS3Exception("test exception")
@@ -172,7 +172,7 @@ class S3ClientTest extends Specification {
 
     @Requires(FIX_TO_WORK_ON_JAVA9)
     def "should include uri when upload fails"() {
-        AmazonS3 amazonS3Client = Mock()
+        AmazonS3Client amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         AmazonS3Exception amazonS3Exception = new AmazonS3Exception("test exception")

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport.aws.s3
 
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.ObjectListing
 import com.amazonaws.services.s3.model.PutObjectRequest
@@ -41,7 +41,7 @@ class S3ClientTest extends Specification {
     @Requires(FIX_TO_WORK_ON_JAVA9)
     def "Should upload to s3"() {
         given:
-        AmazonS3Client amazonS3Client = Mock()
+        AmazonS3 amazonS3Client = Mock()
         S3Client client = new S3Client(amazonS3Client, s3ConnectionProperties)
         URI uri = new URI("s3://localhost/maven/snapshot/myFile.txt")
 
@@ -57,7 +57,7 @@ class S3ClientTest extends Specification {
     }
 
     def "should make batch call when more than one object listing exists"() {
-        def amazonS3Client = Mock(AmazonS3Client)
+        def amazonS3Client = Mock(AmazonS3)
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         def uri = new URI("s3://mybucket.com.au/maven/release/")
         ObjectListing firstListing = Mock()
@@ -143,7 +143,7 @@ class S3ClientTest extends Specification {
     }
 
     def "should include uri when meta-data not found"() {
-        AmazonS3Client amazonS3Client = Mock()
+        AmazonS3 amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         AmazonS3Exception amazonS3Exception = new AmazonS3Exception("test exception")
@@ -157,7 +157,7 @@ class S3ClientTest extends Specification {
     }
 
     def "should include uri when file not found"() {
-        AmazonS3Client amazonS3Client = Mock()
+        AmazonS3 amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         AmazonS3Exception amazonS3Exception = new AmazonS3Exception("test exception")
@@ -172,7 +172,7 @@ class S3ClientTest extends Specification {
 
     @Requires(FIX_TO_WORK_ON_JAVA9)
     def "should include uri when upload fails"() {
-        AmazonS3Client amazonS3Client = Mock()
+        AmazonS3 amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")
         S3Client s3Client = new S3Client(amazonS3Client, s3ConnectionProperties)
         AmazonS3Exception amazonS3Exception = new AmazonS3Exception("test exception")


### PR DESCRIPTION
Signed-off-by: Dennis Hoer <dennis.hoer@pearson.com>

### Context
Update AWS SDK in order to publish to new regions and avoid "Please upgrade to a newer version of the SDK" warning.

Fix #4012 AWS Java SDK libraries are too old

@bmuschko Tests failed because of deprecation warnings.  I think this is fine, but I will let you guys make the decision whether to accept this as-is or require refactor to remove deprecation warnings.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
