### PR TITLE
Upgrade kotlin-dsl {0.15.0 => 0.15.1}

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     libraries = [:]
 }
 
-versions.gradle_kotlin_dsl = '0.15.0'
+versions.gradle_kotlin_dsl = '0.15.1'
 versions.commons_io = '2.2'
 versions.groovy = '2.4.12'
 versions.bouncycastle = '1.58'


### PR DESCRIPTION
This release changes the `ClassLoaderScope` ids created by the `kotlin-dsl` in order to minimize the chance of collisions.

- [ ] [CI build status](https://builds.gradle.org/viewLog.html?buildId=10373084&tab=buildResultsDiv&buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger)