### PR TITLE
Fix misordered setup() in play tests

### DIFF
--- a/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginAdvancedIntegrationTest.groovy
+++ b/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginAdvancedIntegrationTest.groovy
@@ -18,25 +18,32 @@ package org.gradle.play.plugins.ide
 
 import org.gradle.play.integtest.fixtures.PlayApp
 import org.gradle.play.integtest.fixtures.app.AdvancedPlayApp
+import org.gradle.play.internal.platform.PlayMajorVersion
 
 class PlayIdeaPluginAdvancedIntegrationTest extends PlayIdeaPluginIntegrationTest {
+    static final Map PLAY_VERSION_TO_CLASSPATH_SIZE = [(PlayMajorVersion.PLAY_2_2_X): 111,
+                                                       (PlayMajorVersion.PLAY_2_3_X): 114,
+                                                       (PlayMajorVersion.PLAY_2_4_X): 108,
+                                                       (PlayMajorVersion.PLAY_2_5_X): 118,
+                                                       (PlayMajorVersion.PLAY_2_6_X): 108]
+
     @Override
     PlayApp getPlayApp() {
         new AdvancedPlayApp()
     }
 
     String[] getSourcePaths() {
-        [ "public", "conf", "app",
-          "templates", "app/assets",
-          "build/src/play/binary/javaTwirlTemplatesScalaSources", "build/src/play/binary/minifyPlayBinaryPlayBinaryCoffeeScriptJavaScript", "build/src/play/binary/minifyPlayBinaryPlayJavaScript", "build/src/play/binary/coffeeScriptJavaScript",
-          "build/src/play/binary/routesScalaSources", "build/src/play/binary/twirlTemplatesScalaSources" ]
+        ["public", "conf", "app",
+         "templates", "app/assets",
+         "build/src/play/binary/javaTwirlTemplatesScalaSources", "build/src/play/binary/minifyPlayBinaryPlayBinaryCoffeeScriptJavaScript", "build/src/play/binary/minifyPlayBinaryPlayJavaScript", "build/src/play/binary/coffeeScriptJavaScript",
+         "build/src/play/binary/routesScalaSources", "build/src/play/binary/twirlTemplatesScalaSources"]
     }
 
     String[] getBuildTasks() {
-        [ ":compilePlayBinaryPlayCoffeeScript", ":compilePlayBinaryPlayJavaTwirlTemplates", ":compilePlayBinaryPlayRoutes", ":compilePlayBinaryPlayTwirlTemplates", ":ideaProject", ":minifyPlayBinaryPlayBinaryCoffeeScriptJavaScript", ":minifyPlayBinaryPlayJavaScript", ":ideaModule", ":ideaWorkspace", ":idea" ]
+        [":compilePlayBinaryPlayCoffeeScript", ":compilePlayBinaryPlayJavaTwirlTemplates", ":compilePlayBinaryPlayRoutes", ":compilePlayBinaryPlayTwirlTemplates", ":ideaProject", ":minifyPlayBinaryPlayBinaryCoffeeScriptJavaScript", ":minifyPlayBinaryPlayJavaScript", ":ideaModule", ":ideaWorkspace", ":idea"]
     }
 
     int getExpectedScalaClasspathSize() {
-        114
+        return PLAY_VERSION_TO_CLASSPATH_SIZE[PlayMajorVersion.forPlayVersion(version.toString())]
     }
 }

--- a/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginBasicIntegrationTest.groovy
+++ b/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginBasicIntegrationTest.groovy
@@ -18,10 +18,16 @@ package org.gradle.play.plugins.ide
 
 import org.gradle.play.integtest.fixtures.PlayApp
 import org.gradle.play.integtest.fixtures.app.BasicPlayApp
+import org.gradle.play.internal.platform.PlayMajorVersion
 
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIml
 
 class PlayIdeaPluginBasicIntegrationTest extends PlayIdeaPluginIntegrationTest {
+    static final Map PLAY_VERSION_TO_CLASSPATH_SIZE = [(PlayMajorVersion.PLAY_2_2_X): 99,
+                                                       (PlayMajorVersion.PLAY_2_3_X): 102,
+                                                       (PlayMajorVersion.PLAY_2_4_X): 96,
+                                                       (PlayMajorVersion.PLAY_2_5_X): 105,
+                                                       (PlayMajorVersion.PLAY_2_6_X): 108]
 
     @Override
     PlayApp getPlayApp() {
@@ -29,15 +35,15 @@ class PlayIdeaPluginBasicIntegrationTest extends PlayIdeaPluginIntegrationTest {
     }
 
     String[] getSourcePaths() {
-        [ "public", "conf", "app", "test", "build/src/play/binary/routesScalaSources", "build/src/play/binary/twirlTemplatesScalaSources" ]
+        ["public", "conf", "app", "test", "build/src/play/binary/routesScalaSources", "build/src/play/binary/twirlTemplatesScalaSources"]
     }
 
     String[] getBuildTasks() {
-        [ ":compilePlayBinaryPlayRoutes", ":compilePlayBinaryPlayTwirlTemplates", ":ideaProject", ":ideaModule", ":ideaWorkspace", ":idea" ]
+        [":compilePlayBinaryPlayRoutes", ":compilePlayBinaryPlayTwirlTemplates", ":ideaProject", ":ideaModule", ":ideaWorkspace", ":idea"]
     }
 
     int getExpectedScalaClasspathSize() {
-        102
+        return PLAY_VERSION_TO_CLASSPATH_SIZE[PlayMajorVersion.forPlayVersion(version.toString())]
     }
 
     def "when model configuration changes, IDEA metadata can be rebuilt"() {

--- a/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginMultiprojectIntegrationTest.groovy
+++ b/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginMultiprojectIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.play.plugins.ide
 
 import org.gradle.play.integtest.fixtures.PlayApp
 import org.gradle.play.integtest.fixtures.app.PlayMultiProject
+import org.gradle.play.internal.platform.PlayMajorVersion
 
 class PlayIdeaPluginMultiprojectIntegrationTest extends PlayIdeaPluginIntegrationTest {
 
@@ -32,28 +33,28 @@ class PlayIdeaPluginMultiprojectIntegrationTest extends PlayIdeaPluginIntegratio
 
     @Override
     List<File> getIdeFiles() {
-        return super.getIdeFiles() + [ "${playApp.name}.iml", 'submodule/submodule.iml', 'javalibrary/javalibrary.iml' ]
+        return super.getIdeFiles() + ["${playApp.name}.iml", 'submodule/submodule.iml', 'javalibrary/javalibrary.iml']
     }
 
     String[] getSourcePaths() {
-        [ "public", "conf", "app", "build/src/play/binary/routesScalaSources" ]
+        ["public", "conf", "app", "build/src/play/binary/routesScalaSources"]
     }
 
     String[] getBuildTasks() {
-        [ ":ideaModule",
-        ":ideaProject",
-        ":ideaWorkspace",
-        ":idea",
-        ":javalibrary:ideaModule",
-        ":javalibrary:idea",
-        ":primary:compilePlayBinaryPlayRoutes",
-        ":primary:ideaModule",
-        ":primary:idea",
-        ":submodule:ideaModule",
-        ":submodule:idea" ]
+        [":ideaModule",
+         ":ideaProject",
+         ":ideaWorkspace",
+         ":idea",
+         ":javalibrary:ideaModule",
+         ":javalibrary:idea",
+         ":primary:compilePlayBinaryPlayRoutes",
+         ":primary:ideaModule",
+         ":primary:idea",
+         ":submodule:ideaModule",
+         ":submodule:idea"]
     }
 
     int getExpectedScalaClasspathSize() {
-        102
+        return PlayIdeaPluginBasicIntegrationTest.PLAY_VERSION_TO_CLASSPATH_SIZE[PlayMajorVersion.forPlayVersion(version.toString())]
     }
 }

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayBinaryApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayBinaryApplicationIntegrationTest.groovy
@@ -39,6 +39,7 @@ abstract class PlayBinaryApplicationIntegrationTest extends PlayMultiVersionRunA
 
     def "can run play app"() {
         setup:
+        patchForPlay()
         run "assemble"
         buildFile << """
             model {
@@ -66,16 +67,16 @@ abstract class PlayBinaryApplicationIntegrationTest extends PlayMultiVersionRunA
 
     void verifyJars() {
         jar("build/playBinary/lib/${playApp.name}.jar").containsDescendants(
-                "Routes.class",
-                "views/html/index.class",
-                "views/html/main.class",
-                "controllers/Application.class",
-                "application.conf",
-                "logback.xml")
+            determineRoutesClassName(),
+            "views/html/index.class",
+            "views/html/main.class",
+            "controllers/Application.class",
+            "application.conf",
+            "logback.xml")
         jar("build/playBinary/lib/${playApp.name}-assets.jar").containsDescendants(
-                "public/images/favicon.svg",
-                "public/stylesheets/main.css",
-                "public/javascripts/hello.js")
+            "public/images/favicon.svg",
+            "public/stylesheets/main.css",
+            "public/javascripts/hello.js")
     }
 
     String[] getBuildTasks() {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayDistributionApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayDistributionApplicationIntegrationTest.groovy
@@ -52,6 +52,7 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
         ExecHandleBuilder builder
         ExecHandle handle
         String distDirPath = new File(testDirectory, "build/stage").path
+        patchForPlay()
 
         setup:
         run "stage"
@@ -99,7 +100,7 @@ abstract class PlayDistributionApplicationIntegrationTest extends PlayMultiVersi
 
     void verifyJars() {
         jar("build/distributionJars/playBinary/${playApp.name}.jar").containsDescendants(
-                "Routes.class",
+                determineRoutesClassName(),
                 "views/html/index.class",
                 "views/html/main.class",
                 "controllers/Application.class",

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayMultiProjectApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayMultiProjectApplicationIntegrationTest.groovy
@@ -111,7 +111,7 @@ class PlayMultiProjectApplicationIntegrationTest extends AbstractIntegrationSpec
         runningApp.verifyStarted()
 
         and:
-        runningApp.verifyContent();
+        runningApp.verifyContent()
 
         when: "stopping gradle"
         build.cancelWithEOT().waitForFinish()

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/PlayRunIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/PlayRunIntegrationTest.groovy
@@ -37,6 +37,7 @@ class PlayRunIntegrationTest extends PlayMultiVersionRunApplicationIntegrationTe
         withLoadProjectClassController()
 
         setup:
+        patchForPlay()
         // build once to speed up the playRun build and avoid spurious timeouts
         succeeds "assemble"
 

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionApplicationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.integtest.fixtures
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.archive.TarTestFixture
 import org.gradle.test.fixtures.archive.ZipTestFixture
@@ -25,6 +26,7 @@ abstract class PlayMultiVersionApplicationIntegrationTest extends PlayMultiVersi
     abstract PlayApp getPlayApp()
 
     def setup() {
+        playApp.writeSources(testDirectory)
         buildFile << """
             model {
                 components {
@@ -34,8 +36,6 @@ abstract class PlayMultiVersionApplicationIntegrationTest extends PlayMultiVersi
                 }
             }
         """
-
-        playApp.writeSources(testDirectory)
         settingsFile << """
             rootProject.name = '${playApp.name}'
         """
@@ -51,5 +51,13 @@ abstract class PlayMultiVersionApplicationIntegrationTest extends PlayMultiVersi
 
     TarTestFixture tar(String fileName) {
         new TarTestFixture(file(fileName))
+    }
+
+    @Override
+    protected ExecutionResult succeeds(String... tasks) {
+        // trait Controller in package mvc is deprecated (since 2.6.0)
+        // application - Logger configuration in conf files is deprecated and has no effect (since 2.4.0)
+        executer.noDeprecationChecks()
+        return super.succeeds(tasks)
     }
 }

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionRunApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionRunApplicationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.integtest.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.util.VersionNumber
 
 abstract class PlayMultiVersionRunApplicationIntegrationTest extends PlayMultiVersionApplicationIntegrationTest {
     RunningPlayApp runningApp
@@ -27,7 +28,40 @@ abstract class PlayMultiVersionRunApplicationIntegrationTest extends PlayMultiVe
     }
 
     def startBuild(tasks) {
-        build = executer.withTasks(tasks).withForceInteractive(true).withStdinPipe().start()
+        build = executer.withTasks(tasks).withForceInteractive(true).withStdinPipe().noDeprecationChecks().start()
         runningApp.initialize(build)
+    }
+
+    def patchForPlay() {
+        if (versionNumber >= VersionNumber.parse('2.6.0')) {
+            addDependency("com.typesafe.play:play-guice_2.12:${version.toString()}")
+            // method at in object Assets is deprecated (since 2.6.0): Inject Assets and use Assets#at
+            // https://www.playframework.com/documentation/2.4.x/ScalaRouting#Dependency-Injection
+            replace('conf/routes', 'controllers.Assets', '@controllers.Assets')
+            // Don't know why deadlock happens on Play 2.6 System.exit
+            replace('app/controllers/Application.scala', 'System.exit(0)', 'Runtime.getRuntime().halt(0)')
+        }
+
+        if (versionNumber >= VersionNumber.parse('2.5.0')) {
+            // Failed to load class "org.slf4j.impl.StaticLoggerBinder"
+            addDependency("ch.qos.logback:logback-classic:1.2.3")
+        }
+    }
+
+    private replace(String filePath, String oldText, String newText) {
+        String text = file(filePath).text
+        file(filePath).write(text.replace(oldText, newText))
+    }
+
+    private addDependency(String dependency) {
+        buildFile << """ 
+dependencies {
+    play "${dependency}"
+}
+"""
+    }
+
+    String determineRoutesClassName() {
+        return versionNumber >= VersionNumber.parse('2.4.0') ? "router/Routes.class" : "Routes.class"
     }
 }

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/RunningPlayApp.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/RunningPlayApp.groovy
@@ -67,7 +67,7 @@ class RunningPlayApp {
 
 
     static int regexParseHttpPortStandalone(output, int occurrence) {
-        return parseHttpPort(output, /play - Listening for HTTP on .*:([0-9]+)/, occurrence)
+        return parseHttpPort(output, /(?:play|Server) - Listening for HTTP on .*:([0-9]+)/, occurrence)
     }
 
 

--- a/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/playmultiproject/build.gradle
+++ b/subprojects/platform-play/src/testFixtures/resources/org/gradle/play/integtest/fixtures/app/playmultiproject/build.gradle
@@ -1,1 +1,3 @@
-// repositories added in PlayApp class
+plugins {
+    id 'play'
+}


### PR DESCRIPTION
### Context

There's a small mistake in our play multi version test infrastructure which however has a huge impact on the cross-version tests: play version should be written **AFTER** the application code is written to test directory, not **BEFORE**: https://github.com/gradle/gradle/blob/98067d9e0ac9dd910d2adf559c402a9e10977d0a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionApplicationIntegrationTest.groovy#L28

This leads to a severe consequence that we keep testing the default Play version (`2.3.10`) all the time. This PR fixed this problem and fixed all failed tests after this change.
