### PR TITLE
Upgrade kotlin-dsl {0.15.1 => 0.15.2}

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     libraries = [:]
 }
 
-versions.gradle_kotlin_dsl = '0.15.1'
+versions.gradle_kotlin_dsl = '0.15.2'
 versions.commons_io = '2.2'
 versions.groovy = '2.4.12'
 versions.bouncycastle = '1.58'


### PR DESCRIPTION
This release has a better `ClassLoaderId` naming scheme to help diagnose `ClassLoader` leaks.

- [x] [CI build status](https://builds.gradle.org/viewLog.html?buildId=10387448&tab=queuedBuildOverviewTab)
