### PR TITLE
Forbid resolving file collections with non-executed task dependency

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
@@ -115,4 +115,20 @@ The following types/formats are supported:
   - A RegularFile instance.
   - A URI or URL instance.""")
     }
+
+    def "file collections cannot be resolved if task dependency not executed yet"() {
+        buildFile << """
+
+task dep {}
+
+def f = files(dep)
+f.files.each { println it }
+"""
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause "Cannot resolve outputs for task ':dep' because it has not been executed yet."
+    }
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -22,6 +22,18 @@ The new metadata format is still under active development, but it can already be
 
 [The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.0](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.
 
+### Safer handling of task dependencies in file collections
+
+File collections can contain the output of tasks, but if the file collection gets resolved before the tasks are executed, the files returned would not include the output of the tasks.
+This can happen when a file collection is unintentionally resolved during configuration time (before any tasks are executed); or a file collection is resolved during the execution of a task, but the file collection is not declared as an input of the task.
+Previously Gradle would silently ignore these kind of problems.
+Since Gradle 4.6 an exception is thrown instead that clearly states the problem:
+
+    * What went wrong:
+    A problem occurred evaluating root project 'test'.
+    > Cannot resolve outputs for task ':unexecutedTask' because it has not been executed yet.
+
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.


### PR DESCRIPTION
When a file collection contains a task, and the file collection is resolved
before the task has been executed, an exception is thrown. Previously we'd
simply resolve the file collection and miss the outputs of the task.
