### PR TITLE
Add support for dependency reasons

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Incubating;
+
 import javax.annotation.Nullable;
 
 /**
@@ -63,4 +65,23 @@ public interface Dependency {
      * @return The copy. Never returns null.
      */
     Dependency copy();
+
+    /**
+     * Returns a reason why this dependency should be used, in particular with regards to its version. The dependency report
+     * will use it to explain why a specific dependency was selected, or why a specific dependency version was used.
+     *
+     * @return a reason to use this dependency
+     *
+     * @since 4.6
+     */
+    @Incubating
+    String getReason();
+
+    /**
+     * Sets the reason why this dependency should be used.
+     *
+     * @since 4.6
+     */
+    @Incubating
+    void setReason(String reason);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
@@ -75,6 +75,7 @@ public interface Dependency {
      * @since 4.6
      */
     @Incubating
+    @Nullable
     String getReason();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -19,6 +19,8 @@ package org.gradle.api.artifacts;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
+
 /**
  * Describes a metadata about a dependency - direct dependency or dependency constraint - declared in a resolved component's metadata.
  *
@@ -62,6 +64,7 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      * @since 4.6
      */
     @Incubating
+    @Nullable
     String getReason();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 
 /**
  * Describes a metadata about a dependency - direct dependency or dependency constraint - declared in a resolved component's metadata.
@@ -52,4 +53,24 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      * @since 4.5
      */
     SELF version(Action<? super MutableVersionConstraint> configureAction);
+
+    /**
+     * Returns the reason this dependency should be selected.
+     *
+     * @return the reason, or null if no reason is found in metadata.
+     *
+     * @since 4.6
+     */
+    @Incubating
+    String getReason();
+
+    /**
+     * Adjust the reason why this dependency should be selected.
+     *
+     * @param reason modified reason
+     *
+     * @since 4.6
+     */
+    @Incubating
+    SELF reason(String reason);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependency.java
@@ -21,7 +21,10 @@ import org.gradle.api.internal.artifacts.DependencyResolveContext;
 import org.gradle.api.internal.artifacts.ResolvableDependency;
 
 public abstract class AbstractDependency implements ResolvableDependency, DirectDependency {
+    private String reason;
+
     protected void copyTo(AbstractDependency target) {
+        target.reason = reason;
     }
 
     public void resolve(DependencyResolveContext context) {
@@ -33,5 +36,15 @@ public abstract class AbstractDependency implements ResolvableDependency, Direct
         result = 31 * result + getName().hashCode();
         result = 31 * result + (getVersion() != null ? getVersion().hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -163,4 +163,5 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
             validateMutation();
         }
     }
+
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -152,7 +152,9 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
             dependencies {
                 conf 'org:bar:1.0'
                 constraints {
-                    conf 'org:foo:[1.0,1.1]'
+                    conf('org:foo:[1.0,1.1]') {
+                        reason 'tested versions'
+                    }
                 }
             }
         """
@@ -164,9 +166,9 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:bar:1.0") {
-                    edge("org:foo:[1.0,1.2]", "org:foo:1.1")
+                    edge("org:foo:[1.0,1.2]", "org:foo:1.1").byReason('tested versions')
                 }
-                edge("org:foo:[1.0,1.1]", "org:foo:1.1")
+                edge("org:foo:[1.0,1.1]", "org:foo:1.1").byReason('tested versions')
             }
         }
     }
@@ -289,7 +291,9 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 }
                 dependencies {
                     constraints {
-                        conf 'org:foo:1.1'
+                        conf('org:foo:1.1') {
+                            reason 'transitive dependency constraint'
+                        }
                     }
                 }
             }
@@ -301,11 +305,11 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution()
+                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution().byReason('transitive dependency constraint')
                 project(":b", "test:b:") {
                     configuration = "conf"
                     noArtifacts()
-                    module("org:foo:1.1")
+                    module("org:foo:1.1").byReason('transitive dependency constraint')
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -772,4 +772,145 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         "dependencies"           | false
         "dependency constraints" | true
     }
+
+    def "a rule can provide a custom selection reason thanks to dependency reason"() {
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                dependsOn group:'org.test', artifact:'moduleB', version:'1.0', reason: 'will be overwritten by rule'
+            }
+            'org.test:moduleB:1.0'()
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleA') {
+                        withVariant('$variantToTest') {
+                            withDependencies {
+                                it.each {
+                                    it.reason 'can set a custom reason in a rule'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org.test:moduleB:1.0'() {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def expectedVariant = variantToTest
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module("org.test:moduleA:1.0:$expectedVariant") {
+                    module("org.test:moduleB:1.0").byReason('can set a custom reason in a rule')
+                }
+            }
+        }
+
+    }
+
+    def "a rule can provide a custom selection reason thanks to dependency constraint reason"() {
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                dependsOn group:'org.test', artifact:'moduleB', version:'1.0', reason: 'will be overwritten by rule'
+                constraint group:'org.test', artifact:'moduleC', version:'1.0', reason: 'will be overwritten by rule'
+            }
+            'org.test:moduleB:1.0' {
+                dependsOn 'org.test:moduleC:1.0'
+            }
+            'org.test:moduleC:1.0'()
+            'org.test:moduleC:1.1'()
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:moduleA') {
+                        withVariant('$variantToTest') {
+                            withDependencies {
+                                it.each {
+                                    it.reason 'can set a custom reason in a rule'
+                                }
+                            }
+                            withDependencyConstraints {
+                                it.each {
+                                    it.version { prefer '1.1' }
+                                    it.reason '1.0 is buggy'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        boolean constraintsUnsupported = !gradleMetadataEnabled && useIvy()
+
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org.test:moduleB:1.0'() {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org.test:moduleC'() {
+                '1.0' {
+                    expectGetMetadata()
+                    if (constraintsUnsupported) {
+                        expectGetArtifact()
+                    }
+                }
+                if (!constraintsUnsupported) {
+                    '1.1' {
+                        expectResolve()
+                    }
+                }
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def expectedVariant = variantToTest
+        if (constraintsUnsupported) {
+            resolve.expectGraph {
+                root(':', ':test:') {
+                    module("org.test:moduleA:1.0:$expectedVariant") {
+                        module("org.test:moduleB:1.0") {
+                            module("org.test:moduleC:1.0")
+                            byReason('can set a custom reason in a rule')
+                        }
+
+                    }
+                }
+            }
+        } else {
+            resolve.expectGraph {
+                root(':', ':test:') {
+                    module("org.test:moduleA:1.0:$expectedVariant") {
+                        module("org.test:moduleB:1.0") {
+                            edge("org.test:moduleC:1.0", "org.test:moduleC:1.1")
+                            byReason('can set a custom reason in a rule')
+                        }
+                        module("org.test:moduleC:1.1").byConflictResolution()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -136,7 +136,9 @@ project(":a") {
         runtime { extendsFrom api }
     }
     dependencies {
-        api "org.other:externalA:1.2"
+        api("org.other:externalA:1.2") {
+            reason 'also check dependency reasons'
+        }
     }
     task jar(type: Jar) { baseName = 'a' }
     artifacts { api jar }
@@ -146,7 +148,9 @@ project(":b") {
         compile
     }
     dependencies {
-        compile project(path: ':a', configuration: 'runtime')
+        compile(project(path: ':a', configuration: 'runtime')) {
+            reason 'can provide a dependency reason for project dependencies too'
+        }
     }
     task check(dependsOn: configurations.compile) {
         doLast {
@@ -171,8 +175,10 @@ project(":b") {
         resolve.expectGraph {
             root(":b", "test:b:") {
                 project(":a", 'test:a:') {
+                    byReason('can provide a dependency reason for project dependencies too')
                     variant('runtime')
                     module('org.other:externalA:1.2') {
+                        byReason('also check dependency reasons')
                         variant('default')
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+
 /**
  * This also tests maven's optional dependencies for the cases where we only have pom metadata available.
  */
@@ -107,7 +110,7 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             'org:foo:1.0'()
             'org:foo:1.1'()
             'org:first-level:1.0' {
-                constraint 'org:foo:1.1'
+                constraint(group:'org', artifact:'foo', version:'1.1', reason:'published dependency constraint')
             }
         }
 
@@ -145,7 +148,10 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             root(":", ":test:") {
                 module("org:first-level:1.0") {
                     if (available) {
-                        module("org:foo:1.1")
+                        def module = module("org:foo:1.1")
+                        if (GradleMetadataResolveRunner.gradleMetadataEnabled) {
+                            module.byReason('published dependency constraint')
+                        }
                     }
                 }
                 if (available) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
+import com.google.common.base.Joiner;
 import org.gradle.api.artifacts.VersionConstraint;
 
 public abstract class AbstractVersionConstraint implements VersionConstraint {
@@ -44,6 +45,6 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
 
     @Override
     public String toString() {
-        return getPreferredVersion() + (getRejectedVersions().isEmpty() ? "" : " (rejects: " + getRejectedVersions() + ")");
+        return getPreferredVersion() + (getRejectedVersions().isEmpty() ? "" : " (rejects: " + Joiner.on(" - ").join(getRejectedVersions()) + ")");
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -30,6 +30,8 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     private final String name;
     private final MutableVersionConstraint versionConstraint;
 
+    private String reason;
+
     public DefaultDependencyConstraint(String group, String name, String version) {
         this.group = group;
         this.name = name;
@@ -93,7 +95,9 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
 
     @Override
     public DependencyConstraint copy() {
-        return new DefaultDependencyConstraint(group, name, versionConstraint);
+        DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(group, name, versionConstraint);
+        constraint.reason = reason;
+        return constraint;
     }
 
     @Override
@@ -104,5 +108,15 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     @Override
     public VersionConstraint getVersionConstraint() {
         return versionConstraint;
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 48),
+    META_DATA(ROOT, "metadata", 49),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -196,5 +196,10 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         public Dependency getSource() {
             return delegate.getSource();
         }
+
+        @Override
+        public String getReason() {
+            return delegate.getReason();
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.dsl.ComponentSelectorParsers;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 
+import static org.gradle.api.artifacts.result.ComponentSelectionCause.REQUESTED;
 import static org.gradle.api.artifacts.result.ComponentSelectionCause.SELECTED_BY_RULE;
 
 public class DefaultDependencySubstitution implements DependencySubstitutionInternal {
@@ -76,7 +77,7 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
 
     @Override
     public boolean isUpdated() {
-        return selectionDescription != VersionSelectionReasons.REQUESTED;
+        return selectionDescription.getCause() != REQUESTED;
     }
 
     public static void validateTarget(ComponentSelector componentSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
@@ -32,9 +32,14 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
     private ComponentSelectionDescriptorInternal selectionDescription;
     private ComponentSelector target;
 
-    public DefaultDependencySubstitution(ComponentSelector requested) {
+    public DefaultDependencySubstitution(ComponentSelector requested, String reason) {
         this.requested = requested;
         this.target = requested;
+        if (reason != null) {
+            this.selectionDescription = VersionSelectionReasons.REQUESTED.withReason(reason);
+        } else {
+            this.selectionDescription = VersionSelectionReasons.REQUESTED;
+        }
     }
 
     @Override
@@ -71,7 +76,7 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
 
     @Override
     public boolean isUpdated() {
-        return selectionDescription != null;
+        return selectionDescription != VersionSelectionReasons.REQUESTED;
     }
 
     public static void validateTarget(ComponentSelector componentSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
@@ -29,7 +29,7 @@ public class DefaultDependencySubstitutionApplicator implements DependencySubsti
 
     @Override
     public SubstitutionResult apply(DependencyMetadata dependency) {
-        DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector(), null);
+        DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector(), dependency.getReason());
         try {
             rule.execute(details);
         } catch (Throwable e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
@@ -29,7 +29,7 @@ public class DefaultDependencySubstitutionApplicator implements DependencySubsti
 
     @Override
     public SubstitutionResult apply(DependencyMetadata dependency) {
-        DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector());
+        DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector(), null);
         try {
             rule.execute(details);
         } catch (Throwable e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -93,6 +93,10 @@ public class DynamicVersionResolver {
             }
 
             result.resolved(metaDataFactory.transform(latestResolved));
+            String reason = dependency.getReason();
+            if (reason != null) {
+                result.setSelectionDescription(result.getSelectionDescription().withReason(reason));
+            }
             return;
         }
         if (!errors.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -64,6 +64,10 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
                 ModuleComponentIdentifier id = new DefaultModuleComponentIdentifier(module.getGroup(), module.getModule(), version);
                 ModuleVersionIdentifier mvId = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getModule(), version);
                 result.resolved(id, mvId);
+                String reason = dependency.getReason();
+                if (reason != null) {
+                    result.setSelectionDescription(result.getSelectionDescription().withReason(reason));
+                }
             }
             if (result.hasResult()) {
                 result.setResolvedVersionConstraint(resolvedVersionConstraint);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -220,7 +220,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private ModuleDependencyMetadata toDependencyMetadata(ModuleComponentSelector selector) {
-        return new GradleDependencyMetadata(selector, false);
+        return new GradleDependencyMetadata(selector, false, null);
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -132,6 +132,7 @@ public class ModuleMetadataSerializer {
             encoder.writeSmallInt(constraints.size());
             for (ComponentVariant.DependencyConstraint constraint : constraints) {
                 COMPONENT_SELECTOR_SERIALIZER.write(encoder, constraint.getGroup(), constraint.getModule(), constraint.getVersionConstraint());
+                encoder.writeNullableString(constraint.getReason());
             }
         }
 
@@ -139,6 +140,7 @@ public class ModuleMetadataSerializer {
             encoder.writeSmallInt(dependencies.size());
             for (ComponentVariant.Dependency dependency : dependencies) {
                 COMPONENT_SELECTOR_SERIALIZER.write(encoder, dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
+                encoder.writeNullableString(dependency.getReason());
                 writeVariantDependencyExcludes(dependency.getExcludes());
             }
         }
@@ -416,8 +418,9 @@ public class ModuleMetadataSerializer {
             int count = decoder.readSmallInt();
             for (int i = 0; i < count; i++) {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
+                String reason = decoder.readNullableString();
                 ImmutableList<ExcludeMetadata> excludes = readVariantDependencyExcludes();
-                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes);
+                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason);
             }
         }
 
@@ -425,7 +428,8 @@ public class ModuleMetadataSerializer {
             int count = decoder.readSmallInt();
             for (int i = 0; i < count; i++) {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
-                variant.addDependencyConstraint(selector.getGroup(), selector.getModule(), selector.getVersionConstraint());
+                String reason = decoder.readNullableString();
+                variant.addDependencyConstraint(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), reason);
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -49,7 +49,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
-            Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true);
+            Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true, dependencyConstraint.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependencyConstraint);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -46,7 +46,7 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
                 componentId, selector, clientConfiguration, clientAttributes, dependency.getTargetConfiguration(),
                 convertArtifacts(dependency.getArtifacts()),
-                excludes, force, changing, transitive, false);
+                excludes, force, changing, transitive, false, dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -49,7 +49,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
             projectDependency.getTargetConfiguration(),
             convertArtifacts(dependency.getArtifacts()),
             excludes,
-            false, false, dependency.isTransitive(), false);
+            false, false, dependency.isTransitive(), false, dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -95,6 +95,10 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
                 result.failed(new ModuleVersionResolveException(selector, project + " not found."));
             } else {
                 result.resolved(componentMetaData);
+                String reason = dependency.getReason();
+                if (reason != null) {
+                    result.setSelectionDescription(result.getSelectionDescription().withReason(reason));
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -100,6 +100,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getGroup(), details.getName(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()));
-        return new GradleDependencyMetadata(selector, isPending(), null);
+        return new GradleDependencyMetadata(selector, isPending(), details.getReason());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -100,6 +100,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getGroup(), details.getName(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()));
-        return new GradleDependencyMetadata(selector, isPending());
+        return new GradleDependencyMetadata(selector, isPending(), null);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyImpl.java
@@ -28,6 +28,7 @@ public abstract class AbstractDependencyImpl<T extends DirectDependencyMetadata>
     private final String group;
     private final String name;
     private MutableVersionConstraint versionConstraint;
+    private String reason;
 
     public AbstractDependencyImpl(String group, String name, String version) {
         this.group = group;
@@ -53,6 +54,17 @@ public abstract class AbstractDependencyImpl<T extends DirectDependencyMetadata>
     @Override
     public T version(Action<? super MutableVersionConstraint> configureAction) {
         configureAction.execute(versionConstraint);
+        return Cast.uncheckedCast(this);
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public T reason(String reason) {
+        this.reason = reason;
         return Cast.uncheckedCast(this);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
@@ -68,6 +68,17 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
     }
 
     @Override
+    public T reason(String reason) {
+        updateMetadata(getOriginalMetadata().withReason(reason));
+        return Cast.uncheckedCast(this);
+    }
+
+    @Override
+    public String getReason() {
+        return getOriginalMetadata().getReason();
+    }
+
+    @Override
     public String toString() {
         return getGroup() + ":" + getName() + ":" + getVersionConstraint();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -269,13 +269,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
 
         @Override
-        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes) {
-            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes));
+        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason) {
+            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason));
         }
 
         @Override
-        public void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint) {
-            dependencyConstraints.add(new DependencyConstraintImpl(group, module, versionConstraint));
+        public void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason) {
+            dependencyConstraints.add(new DependencyConstraintImpl(group, module, versionConstraint, reason));
         }
 
         @Override
@@ -332,12 +332,14 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         private final String module;
         private final VersionConstraint versionConstraint;
         private final ImmutableList<ExcludeMetadata> excludes;
+        private final String reason;
 
-        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes) {
+        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
             this.excludes = ImmutableList.copyOf(excludes);
+            this.reason = reason;
         }
 
         @Override
@@ -361,6 +363,11 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
 
         @Override
+        public String getReason() {
+            return reason;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -373,12 +380,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
             return Objects.equal(group, that.group)
                 && Objects.equal(module, that.module)
                 && Objects.equal(versionConstraint, that.versionConstraint)
-                && Objects.equal(excludes, that.excludes);
+                && Objects.equal(excludes, that.excludes)
+                && Objects.equal(reason, that.reason);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(group, module, versionConstraint, excludes);
+            return Objects.hashCode(group, module, versionConstraint, excludes, reason);
         }
     }
 
@@ -386,11 +394,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         private final String group;
         private final String module;
         private final VersionConstraint versionConstraint;
+        private final String reason;
 
-        DependencyConstraintImpl(String group, String module, VersionConstraint versionConstraint) {
+        DependencyConstraintImpl(String group, String module, VersionConstraint versionConstraint, String reason) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
+            this.reason = reason;
         }
 
         @Override
@@ -409,6 +419,11 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
 
         @Override
+        public String getReason() {
+            return reason;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -420,12 +435,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
             DependencyConstraintImpl that = (DependencyConstraintImpl) o;
             return Objects.equal(group, that.group)
                 && Objects.equal(module, that.module)
-                && Objects.equal(versionConstraint, that.versionConstraint);
+                && Objects.equal(versionConstraint, that.versionConstraint)
+                && Objects.equal(reason, that.reason);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(group, module, versionConstraint);
+            return Objects.hashCode(group, module, versionConstraint, reason);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -43,6 +43,8 @@ public interface ComponentVariant extends VariantResolveMetadata {
         VersionConstraint getVersionConstraint();
 
         ImmutableList<ExcludeMetadata> getExcludes();
+
+        String getReason();
     }
 
     interface DependencyConstraint {
@@ -51,6 +53,8 @@ public interface ComponentVariant extends VariantResolveMetadata {
         String getModule();
 
         VersionConstraint getVersionConstraint();
+
+        String getReason();
     }
 
     interface File {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationDependencyMetadataWrapper.java
@@ -35,11 +35,17 @@ public class ConfigurationDependencyMetadataWrapper implements ModuleDependencyM
     private final ConfigurationMetadata configuration;
     private final ModuleComponentIdentifier componentId;
     private final ExternalDependencyDescriptor delegate;
+    private final String reason;
 
-    public ConfigurationDependencyMetadataWrapper(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor delegate) {
+    private ConfigurationDependencyMetadataWrapper(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor delegate, String reason) {
         this.configuration = configuration;
         this.componentId = componentId;
         this.delegate = delegate;
+        this.reason = reason;
+    }
+
+    public ConfigurationDependencyMetadataWrapper(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor delegate) {
+        this(configuration, componentId, delegate, null);
     }
 
     @Override
@@ -84,6 +90,14 @@ public class ConfigurationDependencyMetadataWrapper implements ModuleDependencyM
         return withRequested(newSelector);
     }
 
+    @Override
+    public ModuleDependencyMetadata withReason(String reason) {
+        if (reason.equals(this.getReason())) {
+            return this;
+        }
+        return new ConfigurationDependencyMetadataWrapper(configuration, componentId, delegate, reason);
+    }
+
     private ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {
         ExternalDependencyDescriptor newDelegate = delegate.withRequested(newSelector);
         return new ConfigurationDependencyMetadataWrapper(configuration, componentId, newDelegate);
@@ -107,5 +121,10 @@ public class ConfigurationDependencyMetadataWrapper implements ModuleDependencyM
     @Override
     public boolean isPending() {
         return delegate.isOptional();
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationDependencyMetadataWrapper.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.external.model;
 
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -92,7 +93,7 @@ public class ConfigurationDependencyMetadataWrapper implements ModuleDependencyM
 
     @Override
     public ModuleDependencyMetadata withReason(String reason) {
-        if (reason.equals(this.getReason())) {
+        if (Objects.equal(reason, this.getReason())) {
             return this;
         }
         return new ConfigurationDependencyMetadataWrapper(configuration, componentId, delegate, reason);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.external.model;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -69,7 +70,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
 
     @Override
     public ModuleDependencyMetadata withReason(String reason) {
-        if (reason.equals(this.reason)) {
+        if (Objects.equal(reason, this.reason)) {
             return this;
         }
         return new GradleDependencyMetadata(selector, pending, reason);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -38,16 +38,19 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     private final ModuleComponentSelector selector;
     private final List<ExcludeMetadata> excludes;
     private final boolean pending;
+    private final String reason;
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, boolean pending) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, boolean pending, String reason) {
         this.selector = selector;
+        this.reason = reason;
         this.excludes = Collections.emptyList();
         this.pending = pending;
     }
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, String reason) {
         this.selector = selector;
         this.excludes = excludes;
+        this.reason = reason;
         this.pending = false;
     }
 
@@ -61,13 +64,21 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion), pending);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion), pending, reason);
+    }
+
+    @Override
+    public ModuleDependencyMetadata withReason(String reason) {
+        if (reason.equals(this.reason)) {
+            return this;
+        }
+        return new GradleDependencyMetadata(selector, pending, reason);
     }
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
-            return new GradleDependencyMetadata((ModuleComponentSelector) target, pending);
+            return new GradleDependencyMetadata((ModuleComponentSelector) target, pending, reason);
         }
         return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this);
     }
@@ -100,6 +111,11 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     @Override
     public boolean isPending() {
         return pending;
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
@@ -27,4 +27,7 @@ public interface ModuleDependencyMetadata extends DependencyMetadata {
      * Returns a copy of this dependency with the given requested version.
      */
     ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion);
+
+    @Override
+    ModuleDependencyMetadata withReason(String reason);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -48,6 +48,11 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
+    public ModuleDependencyMetadata withReason(String reason) {
+        return new ModuleDependencyMetadataWrapper(delegate.withReason(reason));
+    }
+
+    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         return delegate.withTarget(target);
     }
@@ -80,5 +85,10 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     @Override
     public boolean isPending() {
         return delegate.isPending();
+    }
+
+    @Override
+    public String getReason() {
+        return delegate.getReason();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -24,7 +24,7 @@ import java.util.List;
 public interface MutableComponentVariant {
     void addFile(String name, String uri);
 
-    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes);
+    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason);
 
-    void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint);
+    void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -60,10 +60,10 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            dependencies.add(new GradleDependencyMetadata(selector, excludes, null));
+            dependencies.add(new GradleDependencyMetadata(selector, excludes, dependency.getReason()));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
-            dependencies.add(new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()), true, null));
+            dependencies.add(new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()), true, dependencyConstraint.getReason()));
         }
         this.dependencies = ImmutableList.copyOf(dependencies);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -60,10 +60,10 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            dependencies.add(new GradleDependencyMetadata(selector, excludes));
+            dependencies.add(new GradleDependencyMetadata(selector, excludes, null));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
-            dependencies.add(new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()), true));
+            dependencies.add(new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()), true, null));
         }
         this.dependencies = ImmutableList.copyOf(dependencies);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -67,6 +67,11 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     }
 
     @Override
+    public String getReason() {
+        return delegate.getReason();
+    }
+
+    @Override
     public boolean isTransitive() {
         return delegate.isTransitive();
     }
@@ -79,5 +84,10 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     @Override
     public List<IvyArtifactName> getArtifacts() {
         return delegate.getArtifacts();
+    }
+
+    @Override
+    public DependencyMetadata withReason(String reason) {
+        return delegate.withReason(reason);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
@@ -88,6 +89,11 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
+    public String getReason() {
+        return delegate.getReason();
+    }
+
+    @Override
     public List<IvyArtifactName> getArtifacts() {
         return delegate.getArtifacts();
     }
@@ -95,6 +101,11 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     @Override
     public LocalOriginDependencyMetadata withTarget(ComponentSelector target) {
         return delegate.withTarget(target);
+    }
+
+    @Override
+    public DependencyMetadata withReason(String reason) {
+        return delegate.withReason(reason);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -24,7 +24,7 @@ import org.gradle.internal.component.NoMatchingConfigurationSelectionException;
 
 import java.util.List;
 
-public abstract class AttributeConfigurationSelector implements DependencyMetadata {
+public abstract class AttributeConfigurationSelector {
 
     public static ConfigurationMetadata selectConfigurationUsingAttributeMatching(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         List<? extends ConfigurationMetadata> consumableConfigurations = targetComponent.getVariantsForGraphTraversal();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -72,4 +72,15 @@ public interface DependencyMetadata {
      * by another dependency? ("Optional" dependencies are "constraints")
      */
     boolean isPending();
+
+    /**
+     * An optional human readable reason why this dependency is used.
+     * @return if not null, a description why this dependency is used.
+     */
+    String getReason();
+
+    /**
+     * Returns a copy of this dependency with the given selection reason.
+     */
+    DependencyMetadata withReason(String reason);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -162,7 +163,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
 
     @Override
     public DependencyMetadata withReason(String reason) {
-        if (reason.equals(this.reason)) {
+        if (Objects.equal(reason, this.reason)) {
             return this;
         }
         return copyWithReason(reason);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -40,6 +40,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     private final boolean changing;
     private final boolean transitive;
     private final boolean pending;
+    private final String reason;
 
     private final AttributeContainer moduleAttributes;
 
@@ -49,7 +50,8 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             AttributeContainer moduleAttributes,
                                             String dependencyConfiguration,
                                             List<IvyArtifactName> artifactNames, List<ExcludeMetadata> excludes,
-                                            boolean force, boolean changing, boolean transitive, boolean pending) {
+                                            boolean force, boolean changing, boolean transitive, boolean pending,
+                                            String reason) {
         this.componentId = componentId;
         this.selector = selector;
         this.moduleConfiguration = moduleConfiguration;
@@ -61,6 +63,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         this.changing = changing;
         this.transitive = transitive;
         this.pending = pending;
+        this.reason = reason;
     }
 
     @Override
@@ -140,6 +143,11 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
     public List<IvyArtifactName> getArtifacts() {
         return artifactNames;
     }
@@ -152,7 +160,19 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         return copyWithTarget(target);
     }
 
+    @Override
+    public DependencyMetadata withReason(String reason) {
+        if (reason.equals(this.reason)) {
+            return this;
+        }
+        return copyWithReason(reason);
+    }
+
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
+    }
+
+    private LocalOriginDependencyMetadata copyWithReason(String reason) {
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.48'
-        cacheLayout.version == VersionNumber.parse("2.48.0")
-        cacheLayout.formattedVersion == '2.48'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.48')
+        cacheLayout.key == 'metadata-2.49'
+        cacheLayout.version == VersionNumber.parse("2.49.0")
+        cacheLayout.formattedVersion == '2.49'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.49')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -34,7 +34,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         !details.updated
-        !details.selectionDescription
+        details.selectionDescription == VersionSelectionReasons.REQUESTED
 
         when:
         details.useVersion("1.0") //the same version
@@ -202,7 +202,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
     }
 
     private static def newDependencyResolveDetails(String group, String name, String version) {
-        return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version)), newVersionSelector(group, name, version))
+        return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version),), newVersionSelector(group, name, version))
     }
 
     private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -201,8 +201,36 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
     }
 
-    private static def newDependencyResolveDetails(String group, String name, String version) {
-        return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version),), newVersionSelector(group, name, version))
+    def "can provide a custom selection reason on dependency details"() {
+        when:
+        def details = newDependencyResolveDetails("org", "foo", "1.0", 'with a custom description')
+
+        then:
+        details.target.toString() == 'org:foo:1.0'
+        !details.updated
+        details.selectionDescription.cause == ComponentSelectionCause.REQUESTED
+        details.selectionDescription.description == "with a custom description"
+
+    }
+
+    def "overwrites dependency reason"() {
+        given:
+        def details = newDependencyResolveDetails("org", "foo", "1.0", 'with a custom description')
+
+        when:
+        details.useVersion("2.0")
+        details.because("forcefully upgrade dependency")
+
+        then:
+        details.target.toString() == 'org:foo:2.0'
+        details.updated
+        details.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.selectionDescription.description == "forcefully upgrade dependency"
+
+    }
+
+    private static def newDependencyResolveDetails(String group, String name, String version, String reason = null) {
+        return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version), reason), newVersionSelector(group, name, version))
     }
 
     private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class DefaultDependencySubstitutionSpec extends Specification {
     def componentSelector = Mock(ComponentSelector)
-    def details = new DefaultDependencySubstitution(componentSelector)
+    def details = new DefaultDependencySubstitution(componentSelector,)
 
     def "can override target and selection reason for project"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class DefaultDependencySubstitutionSpec extends Specification {
     def componentSelector = Mock(ComponentSelector)
-    def details = new DefaultDependencySubstitution(componentSelector,)
+    def details = new DefaultDependencySubstitution(componentSelector, null)
 
     def "can override target and selection reason for project"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -117,9 +117,9 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile"),) >> variant
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant
         1 * variant.addFile("a.zip", "a.zop")
-        1 * variant.addDependency("g1", "m1", prefers("v1"), [])
+        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null)
         0 * _
     }
 
@@ -146,8 +146,8 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile"),) >> variant1
-        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip"),) >> variant2
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
+        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         0 * _
     }
 
@@ -182,10 +182,10 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile"),) >> variant1
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
         1 * variant1.addFile("api.zip", "api.zop")
         1 * variant1.addFile("api-2.zip", "api-2.zop")
-        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip"),) >> variant2
+        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addFile("api.zip", "api.zop")
         1 * variant2.addFile("runtime.zip", "runtime.zop")
         0 * _
@@ -224,7 +224,8 @@ class ModuleMetadataParserTest extends Specification {
                 "dependencies": [ 
                     { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
                     { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
-                    { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"}
+                    { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
+                    { "module": "m6", "group": "g6", "version": { "prefers": "v6" }, "reason": "v5 is buggy"}
                 ],
                 "name": "runtime"
             }
@@ -233,15 +234,16 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile"),) >> variant1
-        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [])
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [])
-        1 * variant1.addDependency("g2", "m2", prefers("v2"), [])
-        1 * variant1.addDependency("g3", "m3", prefers("v3"), excludes("gx:mx", "*:*"))
-        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip"),) >> variant2
-        1 * variant2.addDependency("g3", "m3", prefers("v3"), [])
-        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]), [])
-        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [])
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
+        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null)
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null)
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null)
+        1 * variant1.addDependency("g3", "m3", prefers("v3"), excludes("gx:mx", "*:*"), null)
+        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
+        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null)
+        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]), [], null)
+        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null)
+        1 * variant2.addDependency("g6", "m6", prefers("v6"), [], "v5 is buggy")
         0 * _
     }
 
@@ -273,7 +275,8 @@ class ModuleMetadataParserTest extends Specification {
                 "dependencyConstraints": [ 
                     { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
                     { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
-                    { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"}
+                    { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
+                    { "module": "m6", "group": "g6", "version": { "prefers": "v6" }, "reason": "v5 is buggy"}
                 ],
                 "name": "runtime"
             }
@@ -282,14 +285,15 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile"),) >> variant1
-        1 * variant1.addDependencyConstraint("g1", "m1", prefers("v1"))
-        1 * variant1.addDependencyConstraint("g2", "m2", prefers("v2"))
-        1 * variant1.addDependencyConstraint("g3", "m3", prefers("v3"))
-        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip"),) >> variant2
-        1 * variant2.addDependencyConstraint("g3", "m3", prefers("v3"))
-        1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]))
-        1 * variant2.addDependencyConstraint("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]))
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
+        1 * variant1.addDependencyConstraint("g1", "m1", prefers("v1"), null)
+        1 * variant1.addDependencyConstraint("g2", "m2", prefers("v2"), null)
+        1 * variant1.addDependencyConstraint("g3", "m3", prefers("v3"), null)
+        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
+        1 * variant2.addDependencyConstraint("g3", "m3", prefers("v3"), null)
+        1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]), null)
+        1 * variant2.addDependencyConstraint("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), null)
+        1 * variant2.addDependencyConstraint("g6", "m6", prefers("v6"), "v5 is buggy")
         0 * _
     }
 
@@ -312,7 +316,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile", debuggable: true, testable: false),) >> variant
+        1 * metadata.addVariant("api", attributes(usage: "compile", debuggable: true, testable: false)) >> variant
         0 * _
     }
 
@@ -340,8 +344,8 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(),) >> variant1
-        1 * metadata.addVariant("runtime", attributes(),) >> variant2
+        1 * metadata.addVariant("api", attributes()) >> variant1
+        1 * metadata.addVariant("runtime", attributes()) >> variant2
         0 * _
     }
 
@@ -380,10 +384,10 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(usage: "compile"),) >> variant1
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [])
-        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip"),) >> variant2
-        1 * variant2.addDependency("g2", "m2", prefers("v2"), [])
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null)
+        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
+        1 * variant2.addDependency("g2", "m2", prefers("v2"), [], null)
         0 * _
     }
 
@@ -438,7 +442,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(),)
+        1 * metadata.addVariant("api", attributes())
         0 * metadata._
     }
 
@@ -469,7 +473,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(),) >> variant
+        1 * metadata.addVariant("api", attributes()) >> variant
         0 * metadata._
     }
 
@@ -504,8 +508,8 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes(),) >> variant
-        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"))
+        1 * metadata.addVariant("api", attributes()) >> variant
+        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null)
         0 * metadata._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal
 import org.gradle.internal.component.local.model.LocalComponentMetadata
 import org.gradle.internal.component.local.model.TestComponentIdentifiers
 import org.gradle.internal.component.model.ComponentOverrideMetadata
@@ -43,7 +44,6 @@ class ProjectDependencyResolverTest extends Specification {
         def dependencyMetaData = Stub(DependencyMetadata) {
             getSelector() >> selector
         }
-        def targetModuleId = Stub(ModuleIdentifier)
         def id = newProjectId(":project")
 
         when:
@@ -53,6 +53,8 @@ class ProjectDependencyResolverTest extends Specification {
         1 * componentIdentifierFactory.createProjectComponentIdentifier(selector) >> id
         1 * registry.getComponent(id) >> componentMetaData
         1 * result.resolved(componentMetaData)
+        1 * result.getSelectionDescription() >> Mock(ComponentSelectionDescriptorInternal)
+        1 * result.setSelectionDescription(_)
         0 * result._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1081,7 +1081,7 @@ class DependencyGraphBuilderTest extends Specification {
         }
         def dependencyMetaData = new LocalComponentDependencyMetadata(from.componentId, componentSelector,
             "default", null, "default", [] as List<IvyArtifactName>,
-            excludeRules, force, false, transitive, false)
+            excludeRules, force, false, transitive, false, null)
         dependencyMetaData = new DslOriginDependencyMetadataWrapper(dependencyMetaData, Stub(ModuleDependency))
         from.getConfiguration("default").addDependency(dependencyMetaData)
         return dependencyMetaData

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -152,7 +152,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "consumer", "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.group, consumerIdentifier.name, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true, false)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true, false, null)
 
         def configuration = consumer.selectConfigurations(attributes, immutable, schema)[0]
         configuration.dependencies

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -173,7 +173,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
             ModuleComponentSelector requested = newSelector("org.gradle.test", "module$size", "1.0")
-            dependenciesMetadata += [ new GradleDependencyMetadata(requested, []) ]
+            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], null) ]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
@@ -74,7 +74,7 @@ class DefaultIvyModuleDescriptorWriterTest extends Specification {
     def addDependencyDescriptor(BuildableLocalConfigurationMetadata metadata, String organisation = "org.test", String moduleName, String revision = "1.0") {
         def dep = new LocalComponentDependencyMetadata(metadata.getComponentId(),
             DefaultModuleComponentSelector.newSelector(organisation, moduleName, new DefaultMutableVersionConstraint(revision)),
-            "runtime", null, "default", [] as List, [], false, false, true, false)
+            "runtime", null, "default", [] as List, [], false, false, true, false, null)
         metadata.addDependency(dep)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -92,9 +92,9 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         defaultVariant = metadata.addVariant("default", attributes)
         deps.each { name ->
             if (addAllDependenciesAsConstraints()) {
-                defaultVariant.addDependencyConstraint("org.test", name, new DefaultMutableVersionConstraint("1.0"))
+                defaultVariant.addDependencyConstraint("org.test", name, new DefaultMutableVersionConstraint("1.0"), null)
             } else {
-                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [])
+                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null)
             }
         }
         metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -270,7 +270,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "consumer", "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.group, consumerIdentifier.name, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true, false)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, null, [] as List, [], false, false, true, false, null)
 
         consumer.selectConfigurations(attributes, immutable, schema)[0]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -231,10 +231,10 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
 
         given:
         def v1 = metadata.addVariant("api", attributes(usage: "compile"),)
-        v1.addDependency("g1", "m1", v("v1"), [])
-        v1.addDependency("g2", "m2", v("v2"), [])
+        v1.addDependency("g1", "m1", v("v1"), [], null)
+        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested")
         def v2 = metadata.addVariant("runtime", attributes(usage: "runtime"),)
-        v2.addDependency("g1", "m1", v("v1"), [])
+        v2.addDependency("g1", "m1", v("v1"), [], null)
 
         expect:
         metadata.variants.size() == 2
@@ -245,6 +245,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         metadata.variants[0].dependencies[1].group == "g2"
         metadata.variants[0].dependencies[1].module == "m2"
         metadata.variants[0].dependencies[1].versionConstraint.preferredVersion == "v2"
+        metadata.variants[0].dependencies[1].reason == "v2 is tested"
         metadata.variants[1].dependencies.size() == 1
         metadata.variants[1].dependencies[0].group == "g1"
         metadata.variants[1].dependencies[0].module == "m1"
@@ -281,11 +282,11 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         def v1 = metadata.addVariant("api", attributes1,)
         v1.addFile("f1.jar", "f1.jar")
         v1.addFile("f2.jar", "f2-1.2.jar")
-        v1.addDependency("g1", "m1", v("v1"), [])
+        v1.addDependency("g1", "m1", v("v1"), [], null)
         def v2 = metadata.addVariant("runtime", attributes2,)
         v2.addFile("f2", "f2-version.zip")
-        v2.addDependency("g2", "m2", v("v2"), [])
-        v2.addDependency("g3", "m3", v("v3"), [])
+        v2.addDependency("g2", "m2", v("v2"), [], null)
+        v2.addDependency("g3", "m3", v("v3"), [], null)
 
         expect:
         def immutable = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -63,14 +63,14 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     def "returns this when same target requested"() {
         def selector = Stub(ProjectComponentSelector)
-        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, "to", [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, "to", [] as List, [], false, false, true, false, null)
 
         expect:
         dep.withTarget(selector).is(dep)
     }
 
     def "selects the target configuration from target component"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         def toConfig = Stub(LocalConfigurationMetadata) {
             isCanBeConsumed() >> true
@@ -86,7 +86,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     @Unroll("selects configuration '#expected' from target component (#scenario)")
     def "selects the target configuration from target component which matches the attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -121,7 +121,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     def "revalidates default configuration if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false, null)
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
             isCanBeResolved() >> true
@@ -150,7 +150,7 @@ Configuration 'default': Required key 'other' and found incompatible value 'noth
     }
 
     def "revalidates explicit configuration selection if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, 'bar', [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, 'bar', [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -188,7 +188,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -258,7 +258,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy using short-hand notation (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy using short-hand notation"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -328,7 +328,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     def "fails to select target configuration when not present in the target component"() {
         def fromId = Stub(ComponentIdentifier) { getDisplayName() >> "thing a" }
-        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         toComponent.componentId >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
 
@@ -345,7 +345,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     def "excludes nothing when no exclude rules provided"() {
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [], false, false, true, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -357,7 +357,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
         def exclude1 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "*"))
         def exclude2 = new DefaultExclude(DefaultModuleIdentifier.newId("group2", "*"))
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [exclude1, exclude2], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, "to", [] as List, [exclude1, exclude2], false, false, true, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -388,7 +388,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
 
     @Unroll("can select a compatible attribute value (#scenario)")
     def "can select a compatible attribute value"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
@@ -20,7 +20,8 @@
                 { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
                 { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
-                { "module": "m6", "version": { "rejects": ["+"] }, "group": "g6"}
+                { "module": "m6", "version": { "rejects": ["+"] }, "group": "g6"},
+                { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"}
             ],
             "name": "runtime"
         }

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -25,7 +25,8 @@
                 { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
                 { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
-                { "module": "m6", "version": { "rejects": ["v8"] }, "group": "g6"}
+                { "module": "m6", "version": { "rejects": ["v8"] }, "group": "g6"},
+                { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"}
             ],
             "name": "runtime"
         }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.api.tasks.diagnostics
 
+import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Ignore
+import spock.lang.Unroll
 
 class DependencyInsightReportTaskIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
@@ -245,15 +247,15 @@ org:leaf:2.0 -> 1.0
         given:
         ivyRepo.module("org", "leaf", "1.0").publish()
         ivyRepo.module("org", "middle", "1.0")
-                .dependsOn("org", "leaf", "1.0")
-                .dependsOn("org", "leaf", "[1.0,2.0]")
-                .dependsOn("org", "leaf", "latest.integration")
-                .publish()
+            .dependsOn("org", "leaf", "1.0")
+            .dependsOn("org", "leaf", "[1.0,2.0]")
+            .dependsOn("org", "leaf", "latest.integration")
+            .publish()
         ivyRepo.module("org", "top", "1.0")
-                .dependsOn("org", "middle", "1.0")
-                .dependsOn("org", "middle", "[1.0,2.0]")
-                .dependsOn("org", "middle", "latest.integration")
-                .publish()
+            .dependsOn("org", "middle", "1.0")
+            .dependsOn("org", "middle", "[1.0,2.0]")
+            .dependsOn("org", "middle", "latest.integration")
+            .publish()
 
         file("build.gradle") << """
             repositories {
@@ -528,10 +530,10 @@ org:foo:1.0 -> 2.0
         given:
         ivyRepo.module("org", "leaf", "1.6").publish()
         ivyRepo.module("org", "top", "1.0")
-                .dependsOn("org", "leaf", "[1.5,1.9]")
-                .dependsOn("org", "leaf", "latest.integration")
-                .dependsOn("org", "leaf", "1.+")
-                .publish()
+            .dependsOn("org", "leaf", "[1.5,1.9]")
+            .dependsOn("org", "leaf", "latest.integration")
+            .dependsOn("org", "leaf", "1.+")
+            .publish()
 
         file("build.gradle") << """
             repositories {
@@ -905,10 +907,10 @@ org:middle:1.0 -> 2.0+ FAILED
         given:
         mavenRepo.module("org", "leaf", "1.5").publish()
         mavenRepo.module("org", "top", "1.0")
-                .dependsOn("org", "leaf", "1.0")
-                .dependsOn("org", "leaf", "[1.5,1.9]")
-                .dependsOn("org", "leaf", "0.8+")
-                .publish()
+            .dependsOn("org", "leaf", "1.0")
+            .dependsOn("org", "leaf", "[1.5,1.9]")
+            .dependsOn("org", "leaf", "0.8+")
+            .publish()
 
         file("build.gradle") << """
             repositories {
@@ -950,10 +952,10 @@ org:leaf:[1.5,1.9] -> 1.5
     def "shows multiple failed outgoing dependencies"() {
         given:
         ivyRepo.module("org", "top", "1.0")
-                .dependsOn("org", "leaf", "1.0")
-                .dependsOn("org", "leaf", "[1.5,2.0]")
-                .dependsOn("org", "leaf", "1.6+")
-                .publish()
+            .dependsOn("org", "leaf", "1.0")
+            .dependsOn("org", "leaf", "[1.5,2.0]")
+            .dependsOn("org", "leaf", "1.6+")
+            .publish()
 
         file("build.gradle") << """
             repositories {
@@ -1351,4 +1353,95 @@ foo:bar:2.0
 foo:foo:1.0
 \\--- compile"""
     }
+
+
+    @Unroll
+    @NotYetImplemented
+    def "renders custom dependency constraint reasons"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "foo", "1.1").publish()
+        mavenRepo.module("org", "foo", "1.2").publish()
+        mavenRepo.module("org", "foo", "1.3").publish()
+        mavenRepo.module("org", "foo", "1.4").publish()
+        mavenRepo.module("org", "foo", "1.5").publish()
+        mavenRepo.module("org", "foo", "2.0").publish()
+
+        file("build.gradle") << """
+            apply plugin: 'java-library'
+            
+            repositories {
+               maven { url "${mavenRepo.uri}" }
+            }
+            
+            dependencies {
+                implementation 'org:foo' // no version
+                constraints {
+                    implementation('org:foo') {
+                         version { $version }
+                         reason '$reason'
+                    }
+                }
+            }
+        """
+
+        when:
+        run "dependencyInsight", "--dependency", "foo"
+
+        then:
+        output.contains """org:foo:$selected ($reason)
+
+org:foo: -> $selected
+\\--- compileClasspath
+"""
+        where:
+        version                             | reason                                          | selected
+        "prefer '[1.0, 2.0)'"               | "foo v2+ has an incompatible API for project X" | '1.5'
+        "strictly '[1.1, 1.4]'"             | "versions of foo verified to run on platform Y" | '1.4'
+        "prefer '[1.0, 1.4]'; reject '1.4'" | "1.4 has a critical bug"                        | '1.3'
+    }
+
+    @Unroll
+    @NotYetImplemented
+    def "renders custom dependency reasons"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "foo", "1.1").publish()
+        mavenRepo.module("org", "foo", "1.2").publish()
+        mavenRepo.module("org", "foo", "1.3").publish()
+        mavenRepo.module("org", "foo", "1.4").publish()
+        mavenRepo.module("org", "foo", "1.5").publish()
+        mavenRepo.module("org", "foo", "2.0").publish()
+
+        file("build.gradle") << """
+            apply plugin: 'java-library'
+            
+            repositories {
+               maven { url "${mavenRepo.uri}" }
+            }
+            
+            dependencies {
+                implementation('org:foo') {
+                   version { $version }
+                   reason '$reason'
+                }
+            }
+        """
+
+        when:
+        run "dependencyInsight", "--dependency", "foo"
+
+        then:
+        output.contains """org:foo:$selected ($reason)
+
+org:foo:$displayVersion -> $selected
+\\--- compileClasspath
+"""
+        where:
+        version                             | displayVersion | reason                                          | selected
+        "prefer '[1.0, 2.0)'"               | '[1.0, 2.0)'   | "foo v2+ has an incompatible API for project X" | '1.5'
+        "strictly '[1.1, 1.4]'"             | '[1.1, 1.4]'   | "versions of foo verified to run on platform Y" | '1.4'
+        "prefer '[1.0, 1.4]'; reject '1.4'" | '[1.0, 1.4]'   | "1.4 has a critical bug"                        | '1.3'
+    }
+
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.diagnostics
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -1356,7 +1355,6 @@ foo:foo:1.0
 
 
     @Unroll
-    @NotYetImplemented
     def "renders custom dependency constraint reasons"() {
         given:
         mavenRepo.module("org", "foo", "1.0").publish()
@@ -1402,7 +1400,6 @@ org:foo: -> $selected
     }
 
     @Unroll
-    @NotYetImplemented
     def "renders custom dependency reasons"() {
         given:
         mavenRepo.module("org", "foo", "1.0").publish()

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
 import java.util.Collections;
 import java.util.Set;
@@ -55,6 +56,10 @@ public class DependencyReportHeader implements RenderableDependency {
     }
 
     private String getReasonDescription(ComponentSelectionReason reason) {
-        return !reason.isExpected() ? reason.getDescription() : null;
+        String description = reason.getDescription();
+        if (reason.isExpected() && !((ComponentSelectionReasonInternal) reason).hasCustomDescriptions()) {
+            description = null;
+        }
+        return description;
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
@@ -17,11 +17,11 @@
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
 import java.util.Collections;
 import java.util.Set;
+
+import static org.gradle.api.tasks.diagnostics.internal.graph.nodes.SelectionReasonHelper.getReasonDescription;
 
 public class DependencyReportHeader implements RenderableDependency {
     private final DependencyEdge dependency;
@@ -55,11 +55,4 @@ public class DependencyReportHeader implements RenderableDependency {
         return Collections.emptySet();
     }
 
-    private String getReasonDescription(ComponentSelectionReason reason) {
-        String description = reason.getDescription();
-        if (reason.isExpected() && !((ComponentSelectionReasonInternal) reason).hasCustomDescriptions()) {
-            description = null;
-        }
-        return description;
-    }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
+
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
+
+public abstract class SelectionReasonHelper {
+    public static String getReasonDescription(ComponentSelectionReason reason) {
+        String description = reason.getDescription();
+        if (reason.isExpected() && !((ComponentSelectionReasonInternal) reason).hasCustomDescriptions()) {
+            description = null;
+        }
+        return description;
+    }
+}

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
@@ -20,10 +20,9 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 
 public abstract class SelectionReasonHelper {
     public static String getReasonDescription(ComponentSelectionReason reason) {
-        String description = reason.getDescription();
         if (reason.isExpected() && !((ComponentSelectionReasonInternal) reason).hasCustomDescriptions()) {
-            description = null;
+            return null;
         }
-        return description;
+        return reason.getDescription();
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks.diagnostics.internal.insight;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
@@ -36,6 +35,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+
+import static org.gradle.api.tasks.diagnostics.internal.graph.nodes.SelectionReasonHelper.getReasonDescription;
 
 public class DependencyInsightReporter {
     public Collection<RenderableDependency> prepare(Collection<DependencyResult> input, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
@@ -78,9 +79,4 @@ public class DependencyInsightReporter {
 
         return out;
     }
-
-    private String getReasonDescription(ComponentSelectionReason reason) {
-        return !reason.isExpected() ? reason.getDescription() : null;
-    }
-
 }

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -1,6 +1,6 @@
 # Gradle module metadata specification
 
-_Note: this format is not yet stable and may change at any time. Gradle does not guarantee to offer any long term support for this version of the format._
+_Note: this format is not yet stable and may change at any time. Gradle does not guarantee to offer any long term support for this version of the format. Any version before 1.0 is intentionally assumed not backwards compatible, and the parsers are not required to support pre 1.0 releases._
 
 This document describes version 0.3 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
 
@@ -89,6 +89,7 @@ This value must contain an array with zero or more elements. Each element must b
    - `prefers`: optional. The preferred version for this dependency
    - `rejects`: optional. An array of rejected versions for this dependency.
 - `excludes`: optional. Defines the exclusions that apply to this dependency. 
+- `reason`: optional. A explanation why the dependency is used. Can typically be used to explain why a specific version is requested.
 
 #### `excludes` value
 
@@ -110,6 +111,7 @@ This value must contain an array with zero or more elements. Each element must b
 - `version`: optional. The version constraint of the dependency constraint. Has the same meaning as in the Gradle DSL. A version constraint consists of:
    - `prefers`: optional. The preferred version for this dependency constraint
    - `rejects`: optional. An array of rejected versions for this dependency constraint.
+- `reason`: optional. A explanation why the constraint is used. Can typically be used to explain why a specific version is rejected, or from where a platform comes from.
 
 ### `files` value
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -145,7 +145,9 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public VersionNumber getArtifactCacheLayoutVersion() {
-        if (isSameOrNewer("4.5-rc-1")) {
+        if (isSameOrNewer("4.6-rc-1")) {
+            return VersionNumber.parse("2.49");
+        } else if (isSameOrNewer("4.5-rc-1")) {
             return VersionNumber.parse("2.48");
         } else if (isSameOrNewer("4.4-rc-1")) {
             return VersionNumber.parse("2.36");

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -151,7 +151,7 @@ class GradleModuleMetadata {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {
                     def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
-                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions)
+                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions, it.reason)
                 }
             }
             dependencies
@@ -168,7 +168,7 @@ class GradleModuleMetadata {
         List<DependencyConstraint> getDependencyConstraints() {
             if (dependencyConstraints == null) {
                 dependencyConstraints = (values.dependencyConstraints ?: []).collect {
-                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [])
+                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [], it.reason)
                 }
             }
             dependencyConstraints
@@ -199,7 +199,7 @@ class GradleModuleMetadata {
             view
         }
 
-        DependencyConstraintView constraint(String notation, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = {}) {
+        DependencyConstraintView constraint(String notation, @DelegatesTo(value=DependencyConstraintView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = {}) {
             def (String group, String module, String version) = notation.split(':') as List
             constraint(group, module, version, action)
         }
@@ -250,6 +250,12 @@ class GradleModuleMetadata {
                 Set<String> actualRejects = find()?.rejectsVersion
                 Set<String> expectedRejects = rejections as Set
                 assert actualRejects == expectedRejects
+                this
+            }
+
+            DependencyView hasReason(String reason) {
+                assert find()?.reason == reason
+                this
             }
         }
 
@@ -279,6 +285,12 @@ class GradleModuleMetadata {
                 Set<String> actualRejects = find()?.rejectsVersion
                 Set<String> expectedRejects = rejections as Set
                 assert actualRejects == expectedRejects
+                this
+            }
+
+            DependencyConstraintView hasReason(String reason) {
+                assert find()?.reason == reason
+                this
             }
         }
     }
@@ -288,12 +300,14 @@ class GradleModuleMetadata {
         final String module
         final String version
         final List<String> rejectsVersion
+        final String reason
 
-        Coords(String group, String module, String version, List<String> rejectsVersion = []) {
+        Coords(String group, String module, String version, List<String> rejectsVersion = [], String reason = null) {
             this.group = group
             this.module = module
             this.version = version
             this.rejectsVersion = rejectsVersion
+            this.reason = reason
         }
 
         String getCoords() {
@@ -320,8 +334,8 @@ class GradleModuleMetadata {
 
     static class Dependency extends Coords {
         final List<String> excludes
-        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes) {
-            super(group, module, version, rejectedVersions)
+        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes, String reason) {
+            super(group, module, version, rejectedVersions, reason)
             this.excludes = excludes*.toString()
         }
 
@@ -335,8 +349,8 @@ class GradleModuleMetadata {
     }
 
     static class DependencyConstraint extends Coords {
-        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions) {
-            super(group, module, version, rejectedVersions)
+        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions, String reason) {
+            super(group, module, version, rejectedVersions, reason)
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
@@ -24,11 +24,13 @@ class DependencyConstraintSpec {
     String module
     String prefers
     List<String> rejects
+    String reason
 
-    DependencyConstraintSpec(String g, String m, String version, List<String> r) {
+    DependencyConstraintSpec(String g, String m, String version, List<String> r, String desc) {
         group = g
         module = m
         prefers = version
         rejects = r?:Collections.<String>emptyList()
+        reason = desc
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -27,8 +27,9 @@ class DependencySpec {
     String prefers
     List<String> rejects
     List<ExcludeSpec> exclusions = []
+    String reason
 
-    DependencySpec(String g, String m, String version, List<String> r, Collection<Map> e) {
+    DependencySpec(String g, String m, String version, List<String> r, Collection<Map> e, String reason) {
         group = g
         module = m
         prefers = version
@@ -40,5 +41,6 @@ class DependencySpec {
                 new ExcludeSpec(group, module)
             }
         }
+        this.reason = reason
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -75,6 +75,9 @@ class GradleFileModuleAdapter {
                                 prefers d.prefers
                                 rejects d.rejects
                             }
+                            if (d.reason) {
+                                reason d.reason
+                            }
                             if (d.exclusions) {
                                 excludes(d.exclusions.collect { e ->
                                     { ->
@@ -96,6 +99,9 @@ class GradleFileModuleAdapter {
                                 if (dc.rejects) {
                                     rejects dc.rejects
                                 }
+                            }
+                            if (dc.reason) {
+                                reason dc.reason
                             }
                         }
                     })

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -46,7 +46,7 @@ class VariantMetadataSpec {
         attributes[name] = value
     }
 
-    void dependsOn(String group, String module, String version) {
-        dependencies += new DependencySpec(group, module, version, null, null)
+    void dependsOn(String group, String module, String version, String reason = null) {
+        dependencies += new DependencySpec(group, module, version, null, null, reason)
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -397,10 +397,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, d.exclusions)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, d.exclusions, d.reason)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
-                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.rejects)
+                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.rejects, d.reason)
                     },
                     v.artifacts ?: defaultArtifacts
                 )

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -124,7 +124,11 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
     @Override
     MavenModule dependsOn(Map<String, ?> attributes, Module target) {
-        this.dependencies << [groupId: target.group, artifactId: target.module, version: target.version, type: attributes.type, scope: attributes.scope, classifier: attributes.classifier, optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects]
+        this.dependencies << [groupId: target.group, artifactId: target.module, version: target.version,
+                              type: attributes.type, scope: attributes.scope, classifier: attributes.classifier,
+                              optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects,
+                              reason: attributes.reason
+        ]
         return this
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -432,10 +432,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, d.exclusions)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, d.exclusions, d.reason)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
-                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.rejects)
+                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.rejects, d.reason)
                     },
                     v.artifacts?:defaultArtifacts
                 )

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -357,4 +357,60 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
         variant.dependencies[1].version == '2.0'
         variant.dependencies[1].rejectsVersion == []
     }
+
+    def "publishes dependency reasons"() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
+                    dependencyConstraints: configurations.implementation.allDependencies.withType(DependencyConstraint),
+                    attributes: configurations.implementation.attributes))
+
+            dependencies {
+                implementation("org:foo:1.0") {
+                   reason 'version 1.0 is tested'                
+                }
+                constraints {                
+                    implementation("org:bar:2.0") {
+                        reason 'because 2.0 is cool'
+                    }
+                }
+            }
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variant('api') {
+            dependency('org:foo:1.0') {
+                hasReason 'version 1.0 is tested'
+            }
+            constraint('org:bar:2.0') {
+                hasReason 'because 2.0 is cool'
+            }
+            noMoreDependencies()
+        }
+    }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -157,7 +157,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
             selector, usageConfigurationName, null, mappedUsageConfiguration,
             ImmutableList.<IvyArtifactName>of(),
             EXCLUDE_RULES,
-            false, false, true, false);
+            false, false, true, false, null);
     }
 
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -18,6 +18,7 @@ package org.gradle.api.publish.internal;
 
 import com.google.common.base.Strings;
 import com.google.gson.stream.JsonWriter;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Named;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
@@ -395,6 +396,11 @@ public class ModuleMetadataFileGenerator {
         }
         if (dependency instanceof ModuleDependency) {
             writeExcludes((ModuleDependency) dependency, jsonWriter);
+        }
+        String reason = dependency.getReason();
+        if (StringUtils.isNotEmpty(reason)) {
+            jsonWriter.name("reason");
+            jsonWriter.value(reason);
         }
         jsonWriter.endObject();
     }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -237,6 +237,13 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d5.versionConstraint >> prefersAndRejects('', ['1.0'])
         d5.transitive >> true
 
+        def d6 = Stub(ExternalDependency)
+        d6.group >> "g6"
+        d6.name >> "m6"
+        d6.versionConstraint >> prefers('1.0')
+        d6.transitive >> true
+        d6.reason >> 'custom reason'
+
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
@@ -245,7 +252,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
-        v2.dependencies >> [d2, d3, d4, d5]
+        v2.dependencies >> [d2, d3, d4, d5, d6]
 
         component.usages >> [v1, v2]
 
@@ -339,6 +346,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
               "1.0"
             ]
           }
+        },
+        {
+          "group": "g6",
+          "module": "m6",
+          "version": {
+            "prefers": "1.0"
+          },
+          "reason": "custom reason"
         }
       ]
     }


### PR DESCRIPTION
### Context

This pull requests adds the ability to attach a descriptive message to dependencies and dependency constraints. This message is used when a dependency is selected, to provide a human readable explanation for the selection.

The pull request is reviewable commit by commit. It adds a "reason" to dependencies, dependency metadata, and makes sure everything is published and consumed properly. The new "component metadata rules" can also be used to tweak the dependency reasons.

If a reason is associated with a dependency, the dependency (insight) report will show it.

See #3820 

