### PR TITLE
Polish Gradle warning summary

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
@@ -60,7 +60,7 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         warningCountInConsole == stdOut.toString().count(message)
-        warningCountInSummary == stdOut.toString().count("There are ${incrementWarningCountIfJava7(warningCountInSummary)} deprecation warnings")
+        warningCountInSummary == stdOut.toString().count("There were ${incrementWarningCountIfJava7(warningCountInSummary)} Gradle warnings")
 
         where:
         issue                                          | deprecatedArgs        | warningsType     | warningCountInConsole | warningCountInSummary | message

--- a/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
+++ b/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
@@ -420,7 +420,7 @@ Set to `verbose` to enable color and other rich output like the `rich`, but outp
 By default, Gradle won't display all warnings (e.g. deprecation warnings). Instead, Gradle will collect them and render a summary at the end of the build like:
 
 ----
-There are <number> deprecation warnings, which may break the build in Gradle 5.0. Please run with --warning-mode=all to see them.
+There were <number> Gradle warnings. Please run with --warning-mode=all to see them.
 ----
 
 You can control the verbosity of warnings on the console with the following options:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -104,7 +104,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         output.contains('The deprecated task has been deprecated') == warningsCountInConsole > 0
 
         and:
-        output.contains("There are ${incrementWarningCountIfJava7(warningsCountInSummary)} deprecation warnings") == (warningsCountInSummary > 0)
+        output.contains("There were ${incrementWarningCountIfJava7(warningsCountInSummary)} Gradle warnings") == (warningsCountInSummary > 0)
 
         and:
         assertFullStacktraceResult(fullStacktraceEnabled, warningsCountInConsole)

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningMode.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningMode.java
@@ -19,7 +19,7 @@ package org.gradle.api.logging.configuration;
 import org.gradle.api.Incubating;
 
 /**
- * Specifies the warning mode a user wants to see.
+ * Specifies how to present Gradle warnings to the user.
  *
  * @since 4.5
  */
@@ -31,12 +31,12 @@ public enum WarningMode {
     All,
 
     /**
-     * Display a summary at the end of the build instead of rendering all warnings into the console output.
+     * Display a summary at the end of the build.
      */
     Summary,
 
     /**
-     * No deprecation warnings at all.
+     * Show no warnings at all.
      */
     None
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -18,7 +18,6 @@ package org.gradle.internal.featurelifecycle;
 
 import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.internal.SystemProperties;
-import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,9 +75,8 @@ public class LoggingDeprecatedFeatureHandler implements DeprecatedFeatureHandler
 
     public void reportSuppressedDeprecations() {
         if (warningMode == WarningMode.Summary && !messages.isEmpty()) {
-            LOGGER.warn("\nThere are {} deprecation warnings, which may break the build in Gradle {}. Please run with --warning-mode=all to see them.",
-                messages.size(),
-                GradleVersion.current().getNextMajor().getVersion());
+            LOGGER.warn("\nThere were {} Gradle warnings. Please run with --warning-mode=all to see them.",
+                messages.size());
         }
     }
 


### PR DESCRIPTION
These warnings are not just about deprecations, but will
include other kinds of warnings in the future. Calling them
Gradle warnings also makes it clear that we are not talking
about Java compiler warnings for instance.

Mentioning that this may break is redundant with what the
individual warnings are already saying and might actually
be wrong. E.g. if there is a single deprecation for Gradle
6.0, then saying "this may break in 5.0" is incorrect. It
also sounds scarier than it needs to be.