### PR TITLE
Introduces a glossary describing terms used in dependency management

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -182,6 +182,7 @@
                                     <li><a href="/userguide/troubleshooting_dependency_resolution.html">Troubleshooting Dependency Resolution</a></li>
                                     <li><a class="nav-dropdown" data-toggle="collapse" href="#dependency-management-glossary" aria-expanded="false" aria-controls="dependency-management-glossary">Glossary</a>
                                         <ul id="dependency-management-glossary">
+                                            <li><a href="/userguide/dependency_management_terminology.html">Dependency Management Terminology</a></li>
                                             <li><a href="/userguide/dependency_types.html">Dependency Types</a></li>
                                             <li><a href="/userguide/repository_types.html">Repository Types</a></li>
                                         </ul>

--- a/subprojects/docs/src/docs/userguide/dependencyManagementTerminology.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyManagementTerminology.adoc
@@ -42,6 +42,3 @@ A repository hosts a set of dependencies. The repository can be based on a binar
 Resolution rule::
 
 A resolution rule influences the behavior of how a <<sec:sub:terminology_dependency,dependency>> is resolved. Resolution rules are defined as part of the build logic. For more information, see <<customizing_dependency_resolution_behavior>>.
-
-
-

--- a/subprojects/docs/src/docs/userguide/dependencyManagementTerminology.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyManagementTerminology.adoc
@@ -1,0 +1,47 @@
+[[dependency_management_terminology]]
+== Dependency Management Terminology
+
+Dependency management comes with a wealth of terminology. Here you can find the most commonly-used terms including references to the user guide to learn about their practical application.
+
+[[sub:terminology_module]]
+Module::
+
+A piece of software that evolves over time e.g. link:https://github.com/google/guava[Google Guava]. Every module has a name. Each release of a module is optimally represented by a <<sub:terminology_version,version>>. For convenient consumption, modules can be hosted in a <<sub:terminology_repository,repository>>.
+
+[[sub:terminology_version]]
+Version::
+
+A <<sub:terminology_module,module>> indicates its revision with the help of a version. Each module version contains a distinct set of changes. In practice there's no limitation to the scheme of the version. Timestamps, numbers, special suffixes like GA are all allowed identifiers. The most widely-used versioning strategy is link:https://semver.org/[semantic versioning]. Semantic versioning is represented by the scheme _major_._minor_._patch_ e.g. `1.4.15`. Each part conveys a special meaning about the backwards-compatibility of the release.
+
+[[sub:terminology_dependency]]
+Dependency::
+
+A dependency is defined as a versioned or unversioned module. Dependencies may provide <<sub:terminology_dependency_metadata,metadata>> to indicate that they depend on other dependencies required for it work properly, so-called <<sub:terminology_transitive_dependency,transitive dependencies>>. For more information, see <<declaring_dependencies>>. Gradle's dependency resolution process can apply constraints declared in the build script to select a specific version.
+
+[[sub:terminology_transitive_dependency]]
+Transitive dependency::
+
+A transitive dependency is a dependency required by another dependency to work properly. Dependencies hosted on a <<sec:terminology_repository,repository>> can provide <<sub:terminology_dependency_metadata,metadata>> declaring transitive dependencies. By default, Gradle resolves transitive dependencies if defined by metadata. The behavior is highly customizable. For more information, see <<managing_transitive_dependencies>>.
+
+[[sub:terminology_dependency_metadata]]
+Dependency metadata::
+
+Dependencies can provide metadata. Metadata is the data that describes the dependency in more detail e.g. the coordinates for locating it in a repository, information about the project or required <<sub:terminology_transitive_dependency,transitive dependencies>>. In Maven the metadata file is called `pom.xml`, in Ivy it is called `ivy.xml`.
+
+[[sub:terminology_configuration]]
+Configuration::
+
+A configuration represents the scope in a Gradle project a set of <<sub:terminology_dependency,dependencies>> should apply to e.g. the Guava dependency should be used to compile source code. The word "configuration" is an overloaded term and has a different meaning outside of the context of dependency management. For more information, see <<sub:scope_of_dependency_configurations>>.
+
+[[sub:terminology_repository]]
+Repository::
+
+A repository hosts a set of dependencies. The repository can be based on a binary repository product e.g. Artifactory or Nexus or a directory structure in the filesystem. Build scripts can define a set of repositories for resolving <<sub:terminology_dependency,dependencies>>. For more information, see <<declaring_repositories>>.
+
+[[sub:resolution_rule]]
+Resolution rule::
+
+A resolution rule influences the behavior of how a <<sec:sub:terminology_dependency,dependency>> is resolved. Resolution rules are defined as part of the build logic. For more information, see <<customizing_dependency_resolution_behavior>>.
+
+
+

--- a/subprojects/docs/src/docs/userguide/userguide.xml
+++ b/subprojects/docs/src/docs/userguide/userguide.xml
@@ -129,6 +129,7 @@
     </part>
     <part>
         <title>Glossary</title>
+        <xi:include href='../../../build/asciidoc/userguide/dependencyManagementTerminology.xml'/>
         <xi:include href='../../../build/asciidoc/userguide/dependencyTypes.xml'/>
         <xi:include href='../../../build/asciidoc/userguide/repositoryTypes.xml'/>
     </part>


### PR DESCRIPTION
### Context

See https://github.com/gradle/dotorg-docs/issues/172 for more information.

__Additional information:__

- Does not explain the term "variant" as there's no documentation about the functionality in the user guide.
- Does not explain the term "constraint" as it's currently in flux AFAIU. Happy to accept proposals.
- Cleanup of existing documentation according to terminology will happen in another PR.

Once PR https://github.com/gradle/gradle/pull/4060 is merged I am going to add a link to the terminology from the introduction.