### PR TITLE
Build Initialization related build operation are typed, expose build path and can be consumed from build scan plugin

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -41,6 +41,7 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
 
         def loadBuildBuildOperation = buildOperations.first(LoadBuildBuildOperationType)
         def evaluateSettingsBuildOperation = buildOperations.first(EvaluateSettingsBuildOperationType)
+        def configureBuildBuildOperations = buildOperations.first(ConfigureBuildBuildOperationType)
         def loadProjectsBuildOperation = buildOperations.first(LoadProjectsBuildOperationType)
 
         then:
@@ -50,6 +51,9 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         evaluateSettingsBuildOperation.details.buildPath == ":"
         evaluateSettingsBuildOperation.result.isEmpty()
         assert loadBuildBuildOperation.id == evaluateSettingsBuildOperation.parentId
+
+        configureBuildBuildOperations.details.buildPath == ":"
+        configureBuildBuildOperations.result.isEmpty()
 
         loadProjectsBuildOperation.details.buildPath == ":"
         loadProjectsBuildOperation.result.rootProject.projectDir == settingsFile.parent
@@ -76,6 +80,7 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
 
         def loadBuildBuildOperations = buildOperations.all(LoadBuildBuildOperationType)
         def evaluateSettingsBuildOperations = buildOperations.all(EvaluateSettingsBuildOperationType)
+        def configureBuildBuildOperations = buildOperations.all(ConfigureBuildBuildOperationType)
         def loadProjectsBuildOperations = buildOperations.all(LoadProjectsBuildOperationType)
 
         then:
@@ -84,6 +89,9 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
 
         evaluateSettingsBuildOperations*.details.buildPath == [':nested', ':']
         evaluateSettingsBuildOperations*.result.isEmpty() == [true, true]
+
+        configureBuildBuildOperations*.details.buildPath == [':nested', ':']
+        configureBuildBuildOperations*.result.isEmpty() == [true, true]
 
         loadProjectsBuildOperations*.details.buildPath == [':nested', ':']
         loadProjectsBuildOperations*.result.rootProject.projectDir == [nestedSettings.parent, settingsFile.parent]

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -19,16 +19,15 @@ package org.gradle.initialization
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.internal.operations.trace.BuildOperationRecord
 
-class LoadBuildBuildOperationIntegrationTest extends AbstractIntegrationSpec {
+class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
 
     final buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
     @SuppressWarnings("GroovyUnusedDeclaration")
     final operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
-    def "build operation fired"() {
+    def "build operations are fired and build path is exposed"() {
         buildFile << """
             task foo {
                 doLast {
@@ -40,12 +39,14 @@ class LoadBuildBuildOperationIntegrationTest extends AbstractIntegrationSpec {
         succeeds('foo')
 
         then:
-        operation().details.buildPath == ":"
-        operation().result.isEmpty()
-    }
+        buildOperations.first(LoadBuildBuildOperationType).details.buildPath == ":"
+        buildOperations.first(LoadBuildBuildOperationType).result.isEmpty()
 
-    private BuildOperationRecord operation() {
-        buildOperations.first(LoadBuildBuildOperationType)
+        buildOperations.first(EvaluateSettingsBuildOperationType).details.buildPath == ":"
+        buildOperations.first(EvaluateSettingsBuildOperationType).result.isEmpty()
+
+        buildOperations.first(LoadProjectsBuildOperationType).details.buildPath == ":"
+        buildOperations.first(LoadProjectsBuildOperationType).result.rootProject.projectDir == settingsFile.parent
     }
 
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -32,7 +32,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         verifySettings(operation(), settingsFile)
-        assert operation().details.buildPath == ":"
+        operation().details.buildPath == ":"
     }
 
     def "settings with master folder are exposed"() {
@@ -51,7 +51,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         verifySettings(operation(), customSettingsFile)
-        assert operation().details.buildPath == ":"
+        operation().details.buildPath == ":"
     }
 
     def "settings set via cmdline flag are exposed"() {
@@ -69,7 +69,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         verifySettings(operation(), customSettingsFile)
-        assert operation().details.buildPath == ":"
+        operation().details.buildPath == ":"
     }
 
     def "composite participants expose their settings details"() {
@@ -98,7 +98,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
         operations().size() == 2
         verifySettings(operations()[0], nestedSettingsFile)
         verifySettings(operations()[1], settingsFile)
-        assert operations()[1].details.buildPath == ":"
+        operations()[1].details.buildPath == ":"
     }
 
     private List<BuildOperationRecord> operations() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -32,6 +32,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         verifySettings(operation(), settingsFile)
+        assert operation().details.buildPath == ":"
     }
 
     def "settings with master folder are exposed"() {
@@ -50,6 +51,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         verifySettings(operation(), customSettingsFile)
+        assert operation().details.buildPath == ":"
     }
 
     def "settings set via cmdline flag are exposed"() {
@@ -67,6 +69,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         verifySettings(operation(), customSettingsFile)
+        assert operation().details.buildPath == ":"
     }
 
     def "composite participants expose their settings details"() {
@@ -95,6 +98,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
         operations().size() == 2
         verifySettings(operations()[0], nestedSettingsFile)
         verifySettings(operations()[1], settingsFile)
+        assert operations()[1].details.buildPath == ":"
     }
 
     private List<BuildOperationRecord> operations() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildBuildOperationIntegrationTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.operations.trace.BuildOperationRecord
+
+class LoadBuildBuildOperationIntegrationTest extends AbstractIntegrationSpec {
+
+    final buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    final operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
+
+    def "build operation fired"() {
+        buildFile << """
+            task foo {
+                doLast {
+                    println 'foo'
+                }
+            }
+        """
+        when:
+        succeeds('foo')
+
+        then:
+        operation().details.buildPath == ":"
+        operation().result.isEmpty()
+    }
+
+    private BuildOperationRecord operation() {
+        buildOperations.first(LoadBuildBuildOperationType)
+    }
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -16,76 +16,20 @@
 
 package org.gradle.internal.operations.notify
 
-import groovy.json.JsonBuilder
+import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
 import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType
 import org.gradle.configuration.ApplyScriptPluginBuildOperationType
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
+import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.EvaluateSettingsBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.initialization.LoadProjectsBuildOperationType
+import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.execution.ExecuteTaskBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 
 class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec {
-
-    String registerListener() {
-        listenerClass() + """
-        registrar.registerBuildScopeListener(listener)
-        """
-    }
-
-    String registerListenerWithDrainRecordings() {
-        listenerClass() + """
-        registrar.registerBuildScopeListenerAndReceiveStoredOperations(listener)
-        """
-    }
-
-    String listenerClass(){
-        """
-            def listener = new $BuildOperationNotificationListener.name() {
-
-                static def toJson(Object o) {                
-                    def builder = new groovy.json.JsonBuilder()
-                    toJson(o, builder)
-                    builder
-                }
-    
-                static void toJson(Object o, groovy.json.JsonBuilder builder) {
-                    builder { 
-                        o.properties.each { p ->
-                            if (!(p.key in ['class', 'metaClass'])) {
-                                "\${p.key}"("\${p.value}") 
-                            }
-                        }
-                    }
-                }
-    
-                static void toJson(Map m, groovy.json.JsonBuilder builder) {
-                    builder {
-                        m.each { p ->
-                            "\${p.key}"("\${p.value}") 
-                        }
-                    }
-                }
-
-                void started($BuildOperationStartedNotification.name notification) {
-                    def details = notification.notificationOperationDetails
-                    if (details instanceof $ExecuteTaskBuildOperationType.Details.name) {
-                        details = [taskPath: details.taskPath, buildPath: details.buildPath, taskClass: details.taskClass.name]
-                    } else  if (details instanceof $ApplyPluginBuildOperationType.Details.name) {
-                        details = [pluginId: details.pluginId, pluginClass: details.pluginClass.name, targetType: details.targetType, targetPath: details.targetPath, buildPath: details.buildPath]
-                    }
-                    println "STARTED: \${notification.details.class.interfaces.first().name} - \${toJson(details)} - \$notification.notificationOperationId - \$notification.notificationOperationParentId"   
-                }
-
-                void finished($BuildOperationFinishedNotification.name notification) {
-                    println "FINISHED: \${notification.result?.class?.interfaces?.first()?.name} - \${toJson(notification.notificationOperationResult)} - \$notification.notificationOperationId - \$notification.notificationOperationParentId"
-                }
-            }
-            def registrar = services.get($BuildOperationNotificationListenerRegistrar.name)            
-        """
-    }
 
     def "obtains notifications about init scripts"() {
         when:
@@ -117,15 +61,15 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         succeeds "t", "-S"
 
         then:
-        started(LoadBuildBuildOperationType.Details, [buildPath:":"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: testDirectory.absolutePath, settingsFile: settingsFile.absolutePath, buildPath:":"])
+        started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
+        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: testDirectory.absolutePath, settingsFile: settingsFile.absolutePath, buildPath: ":"])
         finished(EvaluateSettingsBuildOperationType.Result, [:])
-        started(LoadProjectsBuildOperationType.Details, [buildPath:":"])
+        started(LoadProjectsBuildOperationType.Details, [buildPath: ":"])
         finished(LoadProjectsBuildOperationType.Result)
         started(ConfigureProjectBuildOperationType.Details, [buildPath: ':', projectPath: ':'])
         started(ApplyPluginBuildOperationType.Details, [pluginId: "org.gradle.help-tasks", pluginClass: "org.gradle.api.plugins.HelpTasksPlugin", targetType: "project", targetPath: ":", buildPath: ":"])
         finished(ApplyPluginBuildOperationType.Result, [:])
-        started(ApplyScriptPluginBuildOperationType.Details, [targetType: "project", targetPath: ":", file: buildFile.absolutePath, buildPath: ":", uri:null])
+        started(ApplyScriptPluginBuildOperationType.Details, [targetType: "project", targetPath: ":", file: buildFile.absolutePath, buildPath: ":", uri: null])
         finished(ApplyScriptPluginBuildOperationType.Result, [:])
         finished(ConfigureProjectBuildOperationType.Result, [:])
 
@@ -146,12 +90,12 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         then:
         // Operations that started before the listener registration are not included (even if they finish _after_ listener registration)
-        notIncluded(EvaluateSettingsBuildOperationType)
-        notIncluded(LoadProjectsBuildOperationType)
-        notIncluded(ApplyPluginBuildOperationType)
-        notIncluded(ConfigureProjectBuildOperationType)
+        notIncluded(EvaluateSettingsBuildOperationType.Details)
+        notIncluded(LoadProjectsBuildOperationType.Details)
+        notIncluded(ApplyPluginBuildOperationType.Details)
+        notIncluded(ConfigureProjectBuildOperationType.Details)
 
-        started(CalculateTaskGraphBuildOperationType.Details, [buildPath:':'])
+        started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
         finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
         started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
         finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
@@ -174,22 +118,53 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         succeeds "t"
 
         then:
-        started(LoadBuildBuildOperationType.Details, [buildPath:":"])
+        started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
 
-        started(LoadBuildBuildOperationType.Details, [buildPath:":"])
-        started(LoadBuildBuildOperationType.Details, [buildPath:":buildSrc"])
-        started(LoadBuildBuildOperationType.Details, [buildPath:":a"])
-        started(LoadBuildBuildOperationType.Details, [buildPath:":a:buildSrc"])
+        started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
+        started(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"])
+        started(LoadBuildBuildOperationType.Details, [buildPath: ":a"])
+        started(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"])
 
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('buildSrc').absolutePath, settingsFile: file('buildSrc/settings.gradle').absolutePath, buildPath:":buildSrc"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a').absolutePath, settingsFile: file('a/settings.gradle').absolutePath, buildPath:":a"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a/buildSrc').absolutePath, settingsFile: file('a/buildSrc/settings.gradle').absolutePath, buildPath:":a:buildSrc"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('.').absolutePath, settingsFile: file('settings.gradle').absolutePath, buildPath:":"])
+        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('buildSrc').absolutePath, settingsFile: file('buildSrc/settings.gradle').absolutePath, buildPath: ":buildSrc"])
+        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a').absolutePath, settingsFile: file('a/settings.gradle').absolutePath, buildPath: ":a"])
+        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a/buildSrc').absolutePath, settingsFile: file('a/buildSrc/settings.gradle').absolutePath, buildPath: ":a:buildSrc"])
+        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('.').absolutePath, settingsFile: file('settings.gradle').absolutePath, buildPath: ":"])
+
+        started(LoadProjectsBuildOperationType.Details, [buildPath: ":buildSrc"])
+        started(LoadProjectsBuildOperationType.Details, [buildPath: ":a:buildSrc"])
+        started(LoadProjectsBuildOperationType.Details, [buildPath: ":a"])
+        started(LoadProjectsBuildOperationType.Details, [buildPath: ":"])
 
         started(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"])
         started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"])
         started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"])
         started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
+
+        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"])
+        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"])
+        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"])
+        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
+
+        // evaluate hierarchies
+        op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).parentId == null // Run build build operation is not typed -> no id.
+        op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == null // Run build build operation is not typed -> no id.
+        op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
+        op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
+
+        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
+        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).id
+        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).id
+        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
+
+        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).parentId == null // Run build build operation is not typed -> no id
+        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == null // Run build build operation is not typed -> no id
+        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
+        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
+
+        op(LoadProjectsBuildOperationType.Details, [buildPath: ":"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
+        op(LoadProjectsBuildOperationType.Details, [buildPath: ":a"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).id
+        op(LoadProjectsBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).id
+        op(LoadProjectsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
     }
 
     def "does not emit for GradleBuild tasks"() {
@@ -215,7 +190,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         // Rough test for not getting notifications for the nested build
         executedTasks.find { it.endsWith(":o") }
-        output.count(ConfigureProjectBuildOperationType.Details.name) == 1
+        recordedOps.findAll { it.detailsType == ConfigureProjectBuildOperationType.Details.name }.size() == 1
     }
 
     def "listeners are deregistered after build"() {
@@ -233,7 +208,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         succeeds("x")
 
         then:
-        output.count(CalculateTaskGraphBuildOperationType.Result.name) == 0
+        recordedOps.findAll { it.detailsType == CalculateTaskGraphBuildOperationType.Result.name }.size() == 0
     }
 
     // This test simulates what the build scan plugin does.
@@ -250,8 +225,20 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         then:
         output.contains(":buildSrc:compileJava") // executedTasks check fails with in process executer
-        output.count(ConfigureProjectBuildOperationType.Details.name) == 2
-        output.count(ExecuteTaskBuildOperationType.Details.name) == 14 // including all buildSrc task execution events
+        recordedOps.findAll { it.detailsType == ConfigureProjectBuildOperationType.Details.name }.size() == 2
+        recordedOps.findAll { it.detailsType == ExecuteTaskBuildOperationType.Details.name }.size() == 14 // including all buildSrc task execution events
+    }
+
+
+    def isChildren(def parent, def child) {
+        assert parent.id == child.parentId
+        true
+    }
+
+    def op(Class<ConfigureProjectBuildOperationType.Details> detailsClass, Map<String, String> details = [:]) {
+        recordedOps.find { op ->
+            return op.detailsType == detailsClass.name && op.details.subMap(details.keySet()) == details
+        }
     }
 
     void started(Class<?> type, Map<String, ?> payload = null) {
@@ -263,45 +250,99 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
     }
 
     void has(boolean started, Class<?> type, Map<String, ?> payload) {
-        def string = notificationLogLine(started, type, payload)
-        assert output.contains(string) : "did not emit event string: $string"
+        def typedOps = recordedOps.findAll { op ->
+            return started ? op.detailsType == type.name : op.resultType == type.name
+        }
+        assert typedOps.size() > 0
+
+        if (payload != null) {
+            def matchingOps = typedOps.findAll { matchingOp ->
+                started ? matchingOp.details == payload : matchingOp.result == payload
+            }
+            assert matchingOps.size()
+        }
+    }
+
+    def getRecordedOps() {
+        def jsonSlurper = new groovy.json.JsonSlurper()
+        jsonSlurper.parse(file('buildOpNotifications.json'))
     }
 
     void notIncluded(Class<?> type) {
-        assert !output.contains(type.name)
+        assert !recordedOps.any { it.detailsType == type.name }
     }
 
-    String notificationLogLine(boolean started, Class<?> type, Map<String, ?> payload) {
-        def line = "${started ? "STARTED" : "FINISHED"}: $type.name"
-        if (payload != null) {
-            line += " - " + toJson(payload)
-        }
-        return line
+    String registerListener() {
+        listenerClass() + """
+        registrar.registerBuildScopeListener(listener)
+        """
     }
 
-    def toJson(Object o) {
-        JsonBuilder builder = new JsonBuilder()
-        toJson(o, builder)
-        builder
+    String registerListenerWithDrainRecordings() {
+        listenerClass() + """
+        registrar.registerBuildScopeListenerAndReceiveStoredOperations(listener)
+        """
     }
 
-    void toJson(Object o, JsonBuilder builder) {
-        def confClosure = {
-            o.properties.each { p ->
-                if (!(p.key in ['class', 'metaClass'])) {
-                    "${p.key}"("${p.value}")
+    String listenerClass() {
+        """
+            def listener = new ${BuildOperationNotificationListener.name}() {
+
+                LinkedHashMap<Object,BuildOpsEntry> ops = new LinkedHashMap()
+            
+                @Override
+                void started(${BuildOperationStartedNotification.name} startedNotification) {
+            
+                    def details = startedNotification.notificationOperationDetails
+                    if (details instanceof org.gradle.internal.execution.ExecuteTaskBuildOperationType.Details) {
+                        details = [taskPath: details.taskPath, buildPath: details.buildPath, taskClass: details.taskClass.name]
+                    } else  if (details instanceof org.gradle.api.internal.plugins.ApplyPluginBuildOperationType.Details) {
+                        details = [pluginId: details.pluginId, pluginClass: details.pluginClass.name, targetType: details.targetType, targetPath: details.targetPath, buildPath: details.buildPath]
+                    }
+
+                    ops.put(startedNotification.notificationOperationId, new BuildOpsEntry(id: startedNotification.notificationOperationId?.id,
+                            parentId: startedNotification.notificationOperationParentId?.id,
+                            detailsType: startedNotification.notificationOperationDetails.getClass().getInterfaces()[0].getName(),
+                            details: details, 
+                            started: startedNotification.notificationOperationStartedTimestamp))
+                }
+            
+                @Override
+                void finished(${BuildOperationFinishedNotification.name} finishedNotification) {
+                    def result = finishedNotification.getNotificationOperationResult()
+                    if (result instanceof ${ResolveConfigurationDependenciesBuildOperationType.Result.name}) {
+                        result = []
+                    }
+                    def op = ops.get(finishedNotification.notificationOperationId)
+                    op.resultType = finishedNotification.getNotificationOperationResult().getClass().getInterfaces()[0].getName()
+                    op.result = result
+                    op.finished = finishedNotification.getNotificationOperationFinishedTimestamp()
+                }
+            
+                void store(File target){
+                    target.withPrintWriter { pw ->
+                        String json = groovy.json.JsonOutput.toJson(ops.values());
+                        pw.append(json)
+                    }
+                }
+            
+                static class BuildOpsEntry {
+                    Object id
+                    Object parentId
+                    Object details
+                    Object result
+                    String detailsType
+                    String resultType
+                    long started
+                    long finished
                 }
             }
-        }
-        confClosure.call(builder)
-        builder
+
+            def registrar = services.get($BuildOperationNotificationListenerRegistrar.name)            
+            gradle.buildFinished {
+                listener.store(file('${file('buildOpNotifications.json')}'))
+            }
+        """
     }
 
-    void toJson(Map m, JsonBuilder builder) {
-        builder {
-            m.each { p ->
-                delegate.delegate."${p.key}"("${p.value}")
-            }
-        }
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationSettingsProcessor.java
@@ -55,6 +55,12 @@ public class BuildOperationSettingsProcessor implements SettingsProcessor {
                 return BuildOperationDescriptor.displayName("Evaluate settings").
                     progressDisplayName("Evaluating settings").
                     details(new Details() {
+
+                        @Override
+                        public String getBuildPath() {
+                            return gradle.getIdentityPath().toString();
+                        }
+
                         @Override
                         public String getSettingsDir() {
                             return settingsLocation.getSettingsDir().getAbsolutePath();
@@ -64,6 +70,8 @@ public class BuildOperationSettingsProcessor implements SettingsProcessor {
                         public String getSettingsFile() {
                             return settingsLocation.getSettingsScriptSource().getFileName();
                         }
+
+
                     });
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/initialization/ConfigureBuildBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ConfigureBuildBuildOperationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.initialization.buildsrc;
+package org.gradle.initialization;
 
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-/**
- * Building the buildSrc project.
- *
- * @since 4.3
- */
-public final class BuildBuildSrcBuildOperationType implements BuildOperationType<BuildBuildSrcBuildOperationType.Details, BuildBuildSrcBuildOperationType.Result> {
-
+public class ConfigureBuildBuildOperationType implements BuildOperationType<ConfigureBuildBuildOperationType.Details, ConfigureBuildBuildOperationType.Result> {
     @UsedByScanPlugin
     public interface Details {
         /**
@@ -34,10 +28,9 @@ public final class BuildBuildSrcBuildOperationType implements BuildOperationType
         String getBuildPath();
     }
 
-    @UsedByScanPlugin
     public interface Result {
     }
 
-    private BuildBuildSrcBuildOperationType(){
+    private ConfigureBuildBuildOperationType(){
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -45,6 +45,9 @@ import java.util.Set;
 
 public class DefaultGradleLauncher implements GradleLauncher {
 
+    private static final ConfigureBuildBuildOperationType.Result CONFIGURE_BUILD_RESULT = new ConfigureBuildBuildOperationType.Result() {
+    };
+
     private enum Stage {
         Load, LoadBuild, Configure, TaskGraph, Build, Finished
     }
@@ -267,12 +270,18 @@ public class DefaultGradleLauncher implements GradleLauncher {
             }
 
             modelConfigurationListener.onConfigure(gradle);
+            context.setResult(CONFIGURE_BUILD_RESULT);
         }
 
         @Override
         public BuildOperationDescriptor.Builder description() {
             return BuildOperationDescriptor.displayName(contextualize("Configure build")).
-                parent(getGradle().getBuildOperation());
+                details(new ConfigureBuildBuildOperationType.Details(){
+                    @Override
+                    public String getBuildPath() {
+                        return getGradle().getIdentityPath().toString();
+                    }
+                }).parent(getGradle().getBuildOperation());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -234,22 +234,17 @@ public class DefaultGradleLauncher implements GradleLauncher {
     private class LoadBuild implements RunnableBuildOperation {
         @Override
         public void run(BuildOperationContext context) {
-            try {
-                // Evaluate init scripts
-                initScriptHandler.executeScripts(gradle);
-
-                // Build `buildSrc`, load settings.gradle, and construct composite (if appropriate)
-                settings = settingsLoader.findAndLoadSettings(gradle);
-
-            } finally {
-                context.setResult(RESULT);
-            }
+            // Evaluate init scripts
+            initScriptHandler.executeScripts(gradle);
+            // Build `buildSrc`, load settings.gradle, and construct composite (if appropriate)
+            settings = settingsLoader.findAndLoadSettings(gradle);
+            context.setResult(RESULT);
         }
 
         @Override
         public BuildOperationDescriptor.Builder description() {
             return BuildOperationDescriptor.displayName(contextualize("Load build"))
-                .details(new LoadBuildBuildOperationType.Details(){
+                .details(new LoadBuildBuildOperationType.Details() {
                     @Override
                     public String getBuildPath() {
                         return gradle.getIdentityPath().toString();
@@ -276,12 +271,12 @@ public class DefaultGradleLauncher implements GradleLauncher {
         @Override
         public BuildOperationDescriptor.Builder description() {
             return BuildOperationDescriptor.displayName(contextualize("Configure build")).
-                details(new ConfigureBuildBuildOperationType.Details(){
+                details(new ConfigureBuildBuildOperationType.Details() {
                     @Override
                     public String getBuildPath() {
                         return getGradle().getIdentityPath().toString();
                     }
-                }).parent(getGradle().getBuildOperation());
+                });
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -106,7 +106,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
         // the settings script to reference classes in the buildSrc.
         StartParameter buildSrcStartParameter = startParameter.newBuild();
         buildSrcStartParameter.setCurrentDir(new File(settingsLocation.getSettingsDir(), DefaultSettings.DEFAULT_BUILD_SRC_DIR));
-        ClassLoaderScope buildSourceClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(buildSrcStartParameter);
+        ClassLoaderScope buildSourceClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(gradle, buildSrcStartParameter);
 
         return settingsProcessor.process(gradle, settingsLocation, buildSourceClassLoaderScope, startParameter);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/EvaluateSettingsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/EvaluateSettingsBuildOperationType.java
@@ -40,4 +40,6 @@ public class EvaluateSettingsBuildOperationType implements BuildOperationType<Ev
 
     public interface Result {
     }
+
+    private EvaluateSettingsBuildOperationType(){}
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/EvaluateSettingsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/EvaluateSettingsBuildOperationType.java
@@ -23,11 +23,7 @@ public class EvaluateSettingsBuildOperationType implements BuildOperationType<Ev
     @UsedByScanPlugin
     public interface Details {
         /**
-         * The path of the build configuration that contains these projects.
-         * This will be ':' for top-level builds. Nested builds will have a sub-path.
-         *
          * @since 4.6
-         * @see org.gradle.api.internal.GradleInternal#getIdentityPath()
          */
         String getBuildPath();
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/LoadBuildBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LoadBuildBuildOperationType.java
@@ -23,11 +23,7 @@ public final class LoadBuildBuildOperationType implements BuildOperationType<Loa
     @UsedByScanPlugin
     public interface Details {
         /**
-         * The path of the build configuration that contains these projects.
-         * This will be ':' for top-level builds. Nested builds will have a sub-path.
-         *
          * @since 4.6
-         * @see org.gradle.api.internal.GradleInternal#getIdentityPath()
          */
         String getBuildPath();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/LoadBuildBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LoadBuildBuildOperationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.gradle.initialization;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-public class EvaluateSettingsBuildOperationType implements BuildOperationType<EvaluateSettingsBuildOperationType.Details, EvaluateSettingsBuildOperationType.Result> {
+public final class LoadBuildBuildOperationType implements BuildOperationType<LoadBuildBuildOperationType.Details, LoadBuildBuildOperationType.Result> {
     @UsedByScanPlugin
     public interface Details {
         /**
@@ -30,16 +30,6 @@ public class EvaluateSettingsBuildOperationType implements BuildOperationType<Ev
          * @see org.gradle.api.internal.GradleInternal#getIdentityPath()
          */
         String getBuildPath();
-
-        /**
-         * The absolute path to the settings directory.
-         */
-        String getSettingsDir();
-
-        /**
-         * The absolute path to the settings file.
-         */
-        String getSettingsFile();
     }
 
     public interface Result {

--- a/subprojects/core/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
@@ -31,6 +31,13 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
 
     @UsedByScanPlugin
     public interface Details {
+        /**
+         * The path of the build configuration that contains these projects.
+         * This will be ':' for top-level builds. Nested builds will have a sub-path.
+         *
+         * @see org.gradle.api.internal.GradleInternal#getIdentityPath()
+         */
+        String getBuildPath();
     }
 
     public interface Result {

--- a/subprojects/core/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
@@ -32,10 +32,7 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
     @UsedByScanPlugin
     public interface Details {
         /**
-         * The path of the build configuration that contains these projects.
-         * This will be ':' for top-level builds. Nested builds will have a sub-path.
-         *
-         * @see org.gradle.api.internal.GradleInternal#getIdentityPath()
+         * @since 4.6
          */
         String getBuildPath();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/NotifyingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NotifyingBuildLoader.java
@@ -46,7 +46,12 @@ public class NotifyingBuildLoader implements BuildLoader {
                 public BuildOperationDescriptor.Builder description() {
                     return BuildOperationDescriptor.displayName("Load projects").
                         progressDisplayName("Loading projects").
-                        details(new BuildStructureOperationDetails());
+                        details(new LoadProjectsBuildOperationType.Details() {
+                            @Override
+                            public String getBuildPath() {
+                                return gradle.getIdentityPath().toString();
+                            }
+                        });
                 }
 
                 @Override
@@ -83,9 +88,6 @@ public class NotifyingBuildLoader implements BuildLoader {
             builder.add(convert(child));
         }
         return builder.build();
-    }
-
-    private static class BuildStructureOperationDetails implements LoadProjectsBuildOperationType.Details {
     }
 
     private static class BuildStructureOperationResult implements LoadProjectsBuildOperationType.Result {


### PR DESCRIPTION
Tweaked initialization related build operations handling

- change `load projects` build operation to expose build path in details
- make `load build` build operation typed; expose build path in details
- change `evaluate settings` build operation to track build path in details.
     - kept buildpath in result for now for compatibility reasons
- fix bug in BuildOperationNotificationIntegrationTest only checking for one
    details property
- due to https://github.com/gradle/gradle/issues/3873 we only check buildpath for root builds.
    - BuildOperationNotificationsFixture ensures the scan plugin use case is covered and buildpath can be consumed from build scan plugin