### PR TITLE
Restore blank line above task headers in rich console

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/BasicGroupedTaskLoggingFunctionalSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.console.taskgrouping
 
 import org.fusesource.jansi.Ansi
 import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.sink.GroupingProgressLogEventGenerator
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -193,7 +194,7 @@ class BasicGroupedTaskLoggingFunctionalSpec extends AbstractConsoleGroupedTaskFu
 
         when:
         handle.waitForAllPendingCalls()
-        assertOutputContains(gradle, "Before")
+        assertOutputContains(gradle, "Before${SystemProperties.instance.lineSeparator}")
         handle.releaseAll()
         result = gradle.waitForFinish()
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/RichVerboseConsoleTypeFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/RichVerboseConsoleTypeFunctionalTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
+import org.gradle.internal.SystemProperties
 import spock.lang.Unroll
 
 import static org.gradle.api.logging.configuration.ConsoleOutput.Rich
@@ -100,5 +101,24 @@ task upToDate{
 
         then:
         result.groupedOutput.task(':upToDate').outcome == 'UP-TO-DATE'
+    }
+
+    def 'verbose task header has no blank line above it'() {
+        given:
+        buildFile << '''
+task upToDate{
+    outputs.upToDateWhen {true}
+    doLast {}
+}
+'''
+
+        when:
+        succeeds('upToDate')
+        executer.withConsole(Verbose)
+        succeeds('upToDate')
+
+        then:
+        result.output.contains("> Task :upToDate")
+        !result.output.contains("${SystemProperties.instance.lineSeparator}> Task :upToDate")
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
@@ -35,10 +35,11 @@ public class PrettyPrefixedLogHeaderFormatter implements LogHeaderFormatter {
         final String message = header != null ? header : description;
         if (message != null) {
             // Visually indicate group by adding surrounding lines, if requested
+            final List<StyledTextOutputEvent.Span> result = Lists.newArrayList(header(message, failed), status(status, failed), eol());
             if (spaceBefore) {
-                return Lists.newArrayList(eol(), header(message, failed), status(status, failed), eol());
+                result.add(0, eol());
             }
-            return Lists.newArrayList(header(message, failed), status(status, failed), eol());
+            return result;
         } else {
             return Collections.emptyList();
         }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatter.java
@@ -24,11 +24,20 @@ import java.util.Collections;
 import java.util.List;
 
 public class PrettyPrefixedLogHeaderFormatter implements LogHeaderFormatter {
+    private final boolean spaceBefore;
+
+    public PrettyPrefixedLogHeaderFormatter(boolean spaceBefore) {
+        this.spaceBefore = spaceBefore;
+    }
+
     @Override
     public List<StyledTextOutputEvent.Span> format(@Nullable String header, String description, @Nullable String shortDescription, @Nullable String status, boolean failed) {
         final String message = header != null ? header : description;
         if (message != null) {
-            // Visually indicate group by adding surrounding lines
+            // Visually indicate group by adding surrounding lines, if requested
+            if (spaceBefore) {
+                return Lists.newArrayList(eol(), header(message, failed), status(status, failed), eol());
+            }
             return Lists.newArrayList(header(message, failed), status(status, failed), eol());
         } else {
             return Collections.emptyList();

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -225,7 +225,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
                 new BuildStatusRenderer(
                     new WorkInProgressRenderer(
                         new BuildLogLevelFilterRenderer(
-                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), clock, new PrettyPrefixedLogHeaderFormatter(), verbose)),
+                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), clock, new PrettyPrefixedLogHeaderFormatter(!verbose), verbose)),
                         console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
                     console.getStatusBar(), console, consoleMetaData, clock),
                 console),

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/format/PrettyPrefixedLogHeaderFormatterTest.groovy
@@ -23,7 +23,7 @@ class PrettyPrefixedLogHeaderFormatterTest extends Specification {
 
     def "prints header of failing tasks red"() {
         setup:
-        def formatter = new PrettyPrefixedLogHeaderFormatter()
+        def formatter = new PrettyPrefixedLogHeaderFormatter(false)
 
         when:
         def formattedText = formatter.format(":test", "", null, "XYZ", true)
@@ -34,12 +34,24 @@ class PrettyPrefixedLogHeaderFormatterTest extends Specification {
 
     def "prints header of not-failing tasks white"() {
         setup:
-        def formatter = new PrettyPrefixedLogHeaderFormatter()
+        def formatter = new PrettyPrefixedLogHeaderFormatter(false)
 
         when:
         def formattedText = formatter.format(":test", "", null, "XYZ", false)
 
         then:
         formattedText[0].style == StyledTextOutput.Style.Header
+    }
+
+    def "prints empty line before header if requested"() {
+        setup:
+        def formatter = new PrettyPrefixedLogHeaderFormatter(true)
+
+        when:
+        def formattedText = formatter.format(":test", "", null, "XYZ", false)
+
+        then:
+        formattedText[0].text == LogHeaderFormatter.EOL
+        formattedText[1].text == "> :test"
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -266,7 +266,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        console.buildOutputArea.toString().readLines() == ['{header}> description{info} status{normal}', 'info', '{error}error', '{normal}']
+        console.buildOutputArea.toString().readLines() == ['', '{header}> description{info} status{normal}', 'info', '{error}error', '{normal}']
     }
 
     def rendersLogEventsWhenOnlyStdOutIsConsole() {
@@ -281,7 +281,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        console.buildOutputArea.toString().readLines() == ['{header}> description{info} status{normal}', 'info']
+        console.buildOutputArea.toString().readLines() == ['', '{header}> description{info} status{normal}', 'info']
     }
 
     def rendersLogEventsWhenOnlyStdErrIsConsole() {


### PR DESCRIPTION
This change allows the LogHeaderFormatter to be configured to have
a blank line above the header, and this is made false in
`--console=verbose` mode.

Issue: #4071

Signed-off-by: Eric Wendelin <eric@gradle.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
