### PR TITLE
Do not treat CompileOptions.incremental as input

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -438,7 +438,7 @@ public class CompileOptions extends AbstractOptions {
     /**
      * informs whether to use incremental compilation feature. See {@link #setIncremental(boolean)}
      */
-    @Input
+    @Internal
     public boolean isIncremental() {
         return incremental;
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalCompileMultiProjectTestFixture.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalCompileMultiProjectTestFixture.groovy
@@ -18,10 +18,11 @@ package org.gradle.java.compile
 
 import groovy.transform.SelfType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
 
 @SelfType(AbstractIntegrationSpec)
 trait IncrementalCompileMultiProjectTestFixture {
-    def libraryAppProjectWithIncrementalCompilation() {
+    TestFile libraryAppProjectWithIncrementalCompilation() {
         multiProjectBuild('incremental', ['library', 'app']) {
             buildFile << '''
                 subprojects {
@@ -42,15 +43,15 @@ trait IncrementalCompileMultiProjectTestFixture {
         file('app/src/main/java/AClass.java') << 'public class AClass { }'
     }
 
-    def getAppCompileJava() {
+    static String getAppCompileJava() {
         ':app:compileJava'
     }
 
-    def getLibraryCompileJava() {
+    static String getLibraryCompileJava() {
         ':library:compileJava'
     }
 
-    def writeUnusedLibraryClass() {
+    TestFile writeUnusedLibraryClass() {
         file('library/src/main/java/Unused.java') << 'public class Unused { }'
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalCompileMultiProjectTestFixture.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalCompileMultiProjectTestFixture.groovy
@@ -43,11 +43,11 @@ trait IncrementalCompileMultiProjectTestFixture {
         file('app/src/main/java/AClass.java') << 'public class AClass { }'
     }
 
-    static String getAppCompileJava() {
+    String getAppCompileJava() {
         ':app:compileJava'
     }
 
-    static String getLibraryCompileJava() {
+    String getLibraryCompileJava() {
         ':library:compileJava'
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.java.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
 
 class IncrementalJavaCompileIntegrationTest extends AbstractIntegrationSpec implements IncrementalCompileMultiProjectTestFixture {
 
@@ -123,6 +124,41 @@ class IncrementalJavaCompileIntegrationTest extends AbstractIntegrationSpec impl
         executedAndNotSkipped(libraryCompileJava)
     }
 
+    @Unroll
+    def "does not recompile when only compileOptions.incremental property changes from #from to #to"() {
+        given:
+        libraryAppProjectWithIncrementalCompilation()
+
+        when:
+        buildFile << """
+            subprojects {
+                tasks.compileJava.options.incremental = $from
+            }
+        """
+        run appCompileJava
+
+        then:
+        executedAndNotSkipped libraryCompileJava
+        executedAndNotSkipped appCompileJava
+
+        when:
+        buildFile << """
+            subprojects {
+                tasks.compileJava.options.incremental = $to
+            }
+        """
+        run appCompileJava
+
+        then:
+        skipped libraryCompileJava
+        skipped appCompileJava
+
+        where:
+        from  | to
+        true  | false
+        false | true
+    }
+
     def "recompiles inner class if they are in a separate source file"() {
         given:
         file('src/main/java/Test.java') << 'public class Test{}'
@@ -150,7 +186,7 @@ class IncrementalJavaCompileIntegrationTest extends AbstractIntegrationSpec impl
         file('build/classes/java/main/Test$$InnerClass.class').assertExists()
     }
 
-    private String getBasicInterface() {
+    private static String getBasicInterface() {
         '''
             interface IPerson {
                 String getName();
@@ -158,7 +194,7 @@ class IncrementalJavaCompileIntegrationTest extends AbstractIntegrationSpec impl
         '''.stripIndent()
     }
 
-    private String getExtendedInterface() {
+    private static String getExtendedInterface() {
         '''
             interface IPerson {
                 String getName();
@@ -167,7 +203,7 @@ class IncrementalJavaCompileIntegrationTest extends AbstractIntegrationSpec impl
         '''.stripIndent()
     }
 
-    private String getClassImplementingBasicInterface() {
+    private static String getClassImplementingBasicInterface() {
         '''
             class Person implements IPerson {
                 public String getName() {


### PR DESCRIPTION
Changing this parameter should not influence the output of the task in any way, and thus should not be treated as an input.
