### PR TITLE
Add documentation about metadata sources

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -43,30 +43,28 @@ Sometimes a user wants to declare the value of an exposed task property on the c
 
 The following examples exposes a command line parameter `--url` for the custom task type `UrlVerify`. Let's assume you wanted to pass a URL to a task of this type named `verifyUrl`. The invocation looks as such: `gradle verifyUrl --url=https://gradle.org/`. You can find more information about this feature in the [user guide](userguide/custom_tasks.html#sec:declaring_and_using_command_line_options).
 
-```
-import org.gradle.api.tasks.options.Option;
-
-public class UrlVerify extends DefaultTask {
-    private String url;
-
-    @Option(option = "url", description = "Configures the URL to be verified.")
-    public void setUrl(String url) {
-        this.url = url;
+    import org.gradle.api.tasks.options.Option;
+    
+    public class UrlVerify extends DefaultTask {
+        private String url;
+    
+        @Option(option = "url", description = "Configures the URL to be verified.")
+        public void setUrl(String url) {
+            this.url = url;
+        }
+    
+        @Input
+        public String getUrl() {
+            return url;
+        }
+    
+        @TaskAction
+        public void verify() {
+            getLogger().quiet("Verifying URL '{}'", url);
+    
+            // verify URL by making a HTTP call
+        }
     }
-
-    @Input
-    public String getUrl() {
-        return url;
-    }
-
-    @TaskAction
-    public void verify() {
-        getLogger().quiet("Verifying URL '{}'", url);
-
-        // verify URL by making a HTTP call
-    }
-}
-```
 
 ## Promoted features
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -18,6 +18,21 @@ The new metadata format is still under active development, but it can already be
 ### Example new and noteworthy
 -->
 
+### Specifying metadata sources for repositories
+
+Gradle now allows you to explicitly state for [which metadata files](userguide/repository_types.html#sub:supported_metadata_sources) it should search in a repository. You can use this, for example, to gain efficiency when querying a Maven repository by telling Gradle not to look for plain `jar` files anymore when the `pom` file for a module is missing.
+
+    repositories {
+         mavenCentral {
+             metadataSources {
+                 mavenPom() // Look for Maven '.pom' files
+                 // artifact() - Do not look for artifacts without metadata file
+             }
+         }
+    }
+
+You can also use this to selectively opt into using the new Gradle metadata format for one repository using `metadataSources { gradleMetadata() }`.
+
 ### Default JaCoCo version upgraded to 0.8.0
 
 [The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.0](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -20,7 +20,7 @@ The new metadata format is still under active development, but it can already be
 
 ### Specifying metadata sources for repositories
 
-Gradle now allows you to explicitly state for [which metadata files](userguide/repository_types.html#sub:supported_metadata_sources) it should search in a repository. You can use this, for example, to gain efficiency when querying a Maven repository by telling Gradle not to look for plain `jar` files anymore when the `pom` file for a module is missing.
+Gradle now allows you to explicitly state for [which metadata files](userguide/repository_types.html#sub:supported_metadata_sources) it should search in a repository. Use the following to configure Gradle to fail-fast resolving a dependency if a POM file is not found first.
 
     repositories {
          mavenCentral {
@@ -31,7 +31,9 @@ Gradle now allows you to explicitly state for [which metadata files](userguide/r
          }
     }
 
-You can also use this to selectively opt into using the new Gradle metadata format for one repository using `metadataSources { gradleMetadata() }`.
+This avoids a 2nd request for the JAR file when the POM is missing, making dependency resolution from Maven repositories faster in this case.
+
+You can also use this to programmatically opt-in to using the new Gradle metadata format for one repository using `metadataSources { gradleMetadata() }`.
 
 ### Default JaCoCo version upgraded to 0.8.0
 

--- a/subprojects/docs/src/docs/userguide/declaringRepositories.adoc
+++ b/subprojects/docs/src/docs/userguide/declaringRepositories.adoc
@@ -15,7 +15,7 @@
 [[declaring_repositories]]
 == Declaring Repositories
 
-Gradle can resolve external dependencies from one or many repositories based on Maven, Ivy or flat directory directory formats. Check out the <<repository_types,full reference on all types of repositories>> for more information.
+Gradle can resolve external dependencies from one or many repositories based on Maven, Ivy or flat directory formats. Check out the <<repository_types,full reference on all types of repositories>> for more information.
 
 [[sec:declaring_public_repository]]
 === Declaring a publicly-available repository
@@ -55,6 +55,8 @@ Add the following code to declare an in-house repository for your build reachabl
 ++++
 
 Repositories with custom URLs can be specified as Maven or Ivy repositories by calling the corresponding methods available on the api:org.gradle.api.artifacts.dsl.RepositoryHandler[] API. Gradle supports other protocols than `http` or `https` as part of the custom URL e.g. `file`, `sftp` or `s3`. For a full coverage see the <<sub:supported_transport_protocols,reference manual on supported transport protocols>>.
+
+You can also <<sec:defining_custom_pattern_layout_for_an_ivy_repository,define your own repository layout>> by using `ivy { }` repositories as they are very flexible in terms of how modules are organised in a repository.
 
 [[sec:declaring_multiple_repositories]]
 === Declaring multiple repositories

--- a/subprojects/docs/src/docs/userguide/dependencyTypes.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyTypes.adoc
@@ -18,7 +18,7 @@ Gradle provides different notations for module dependencies. There is a string n
 
 [NOTE]
 ====
-If you declare a module dependency, Gradle looks for a module descriptor file (`pom.xml` or `ivy.xml`) in the repositories. If such a module descriptor file exists, it is parsed and the artifacts of this module (e.g. `hibernate-3.0.5.jar`) as well as its dependencies (e.g. cglib) are downloaded. If no such module descriptor file exists, Gradle looks for a file called `hibernate-3.0.5.jar` to retrieve. In Maven, a module can have one and only one artifact. In Gradle and Ivy, a module can have multiple artifacts. Each artifact can have a different set of dependencies.
+If you declare a module dependency, Gradle looks for a module metadata file (`.module`, `.pom` or `ivy.xml`) in the repositories. If such a module metadata file exists, it is parsed and the artifacts of this module (e.g. `hibernate-3.0.5.jar`) as well as its dependencies (e.g. cglib) are downloaded. If no such module metadata file exists, Gradle may look, depending on the <<sub:supported_metadata_sources,metadata sources definitions>>, for an artifact file called `hibernate-3.0.5.jar` directly. In Maven, a module can have one and only one artifact. In Gradle and Ivy, a module can have multiple artifacts. Each artifact can have a different set of dependencies.
 ====
 
 [[sub:file_dependencies]]

--- a/subprojects/docs/src/docs/userguide/introductionDependencyManagement.adoc
+++ b/subprojects/docs/src/docs/userguide/introductionDependencyManagement.adoc
@@ -60,7 +60,7 @@ Projects with tens or hundreds of declared dependencies can easily suffer from d
 
 Gradle takes your dependency declarations and repository definitions and attempts to download all of your dependencies by a process called _dependency resolution_. Below is a brief outline of how this process works.
 
-* Given a required dependency, Gradle first attempts to resolve the _module_ the dependency points at. Each repository is inspected in order, searching first for a _module descriptor_ file (POM or Ivy file) that indicates the presence of that module. If no module descriptor is found, Gradle will search for the presence of the primary _module artifact_ file indicating that the module exists in the repository.
+* Given a required dependency, Gradle attempts to resolve the dependency by searching for the module the dependency points at. Each repository is inspected in order. Depending on the type of repository, Gradle looks for metadata files describing the module (`.module`, `.pom` or `ivy.xml` file) or directly for artifact files.
 
 ** If the dependency is declared as a dynamic version (like `1.+`), Gradle will resolve this to the highest available concrete version (like `1.2`) in the repository. For Maven repositories, this is done using the `maven-metadata.xml` file, while for Ivy repositories this is done by directory listing.
 
@@ -70,11 +70,11 @@ Gradle takes your dependency declarations and repository definitions and attempt
 
 ** For a dynamic version, a 'higher' concrete version is preferred over a 'lower' version.
 
-** Modules declared by a module descriptor file (Ivy or POM file) are preferred over modules that have an artifact file only.
+** Modules declared by a module metadata file (`.module`, `.pom` or `ivy.xml` file) are preferred over modules that have an artifact file only.
 
 ** Modules from earlier repositories are preferred over modules in later repositories.
 
-** When the dependency is declared by a concrete version and a module descriptor file is found in a repository, there is no need to continue searching later repositories and the remainder of the process is short-circuited.
+** When the dependency is declared by a concrete version and a module metadata file is found in a repository, there is no need to continue searching later repositories and the remainder of the process is short-circuited.
 
 * All of the artifacts for the module are then requested from the _same repository_ that was chosen in the process above.
 

--- a/subprojects/docs/src/docs/userguide/repositoryTypes.adoc
+++ b/subprojects/docs/src/docs/userguide/repositoryTypes.adoc
@@ -181,6 +181,60 @@ You can specify credentials for Ivy repositories secured by basic authentication
 </sample>
 ++++
 
+[[sub:supported_metadata_sources]]
+=== Supported metadata sources
+
+When searching for a module in a repository, Gradle, by default, checks for supported metadata file formats in that repository. In a Maven repository, Gradle looks for a `.pom` file, in an ivy repository it looks for an `ivy.xml` file and in a flat directory repository it looks directly for `.jar` files as it does not expect any metadata. Starting with 5.0, Gradle also looks for `.module` (Gradle module metadata) files.
+
+However, if you define a customized repository you might want to configure this behavior. For example, you can define a Maven repository without `.pom` files but only jars. To do so, you can configure _metadata sources_ for any repository. You can specify multiple sources to tell Gradle to keep looking if a file was not found. For example, you can configure a Maven repository such that Gradle looks for artifacts only if the metadata is missing.
+
+++++
+<sample id="metadataSources" dir="userguide/artifacts/defineRepository" title="Maven repository that supports artifacts without metadata">
+    <sourcefile file="build.gradle" snippet="maven-repo-with-metadata-sources"/>
+</sample>
+++++
+
+In case multiple sources are defined, the order of checking for sources is predefined. The following metadata sources are supported:
+
+.Repository transport protocols
+[cols="2,2,1,1,1", options="header"]
+|===
+| Metadata source
+| Description
+| Order
+| Maven
+| Ivy / flat dir
+
+| `gradleMetadata()`
+| Look for Gradle `.module` files
+| 1st
+| yes
+| yes
+
+| `mavenPom()`
+| Look for Maven `.pom` files
+| 2nd
+| yes
+| yes
+
+| `ivyDescriptor()`
+| Look for `ivy.xml` files
+| 2nd
+| no
+| yes
+
+| `artifact()`
+| Look directly for artifact
+| 3rd
+| yes
+| yes
+|===
+
+[NOTE]
+====
+The defaults for Ivy and Maven repositories change with Gradle 5.0. Before 5.0, `artifact()` was included in the defaults. Leading to some inefficiency when modules are missing completey. To restore this behavior, for example, for Maven central you can use `mavenCentral { mavenPom(); artifact() }`. In a similar way, you can opt into the new behavior in older Gradle verisions using `mavenCentral { mavenPom() }`
+====
+
 [[sub:supported_transport_protocols]]
 === Supported repository transport protocols
 

--- a/subprojects/docs/src/docs/userguide/repositoryTypes.adoc
+++ b/subprojects/docs/src/docs/userguide/repositoryTypes.adoc
@@ -186,7 +186,7 @@ You can specify credentials for Ivy repositories secured by basic authentication
 
 When searching for a module in a repository, Gradle, by default, checks for supported metadata file formats in that repository. In a Maven repository, Gradle looks for a `.pom` file, in an ivy repository it looks for an `ivy.xml` file and in a flat directory repository it looks directly for `.jar` files as it does not expect any metadata. Starting with 5.0, Gradle also looks for `.module` (Gradle module metadata) files.
 
-However, if you define a customized repository you might want to configure this behavior. For example, you can define a Maven repository without `.pom` files but only jars. To do so, you can configure _metadata sources_ for any repository. You can specify multiple sources to tell Gradle to keep looking if a file was not found. For example, you can configure a Maven repository such that Gradle looks for artifacts only if the metadata is missing.
+However, if you define a customized repository you might want to configure this behavior. For example, you can define a Maven repository without `.pom` files but only jars. To do so, you can configure _metadata sources_ for any repository.
 
 ++++
 <sample id="metadataSources" dir="userguide/artifacts/defineRepository" title="Maven repository that supports artifacts without metadata">
@@ -194,7 +194,9 @@ However, if you define a customized repository you might want to configure this 
 </sample>
 ++++
 
-In case multiple sources are defined, the order of checking for sources is predefined. The following metadata sources are supported:
+You can specify multiple sources to tell Gradle to keep looking if a file was not found. In that case, the order of checking for sources is predefined.
+
+The following metadata sources are supported:
 
 .Repository transport protocols
 [cols="2,2,1,1,1", options="header"]
@@ -232,7 +234,7 @@ In case multiple sources are defined, the order of checking for sources is prede
 
 [NOTE]
 ====
-The defaults for Ivy and Maven repositories change with Gradle 5.0. Before 5.0, `artifact()` was included in the defaults. Leading to some inefficiency when modules are missing completey. To restore this behavior, for example, for Maven central you can use `mavenCentral { mavenPom(); artifact() }`. In a similar way, you can opt into the new behavior in older Gradle verisions using `mavenCentral { mavenPom() }`
+The defaults for Ivy and Maven repositories change with Gradle 5.0. Before 5.0, `artifact()` was included in the defaults. Leading to some inefficiency when modules are missing completely. To restore this behavior, for example, for Maven central you can use `mavenCentral { mavenPom(); artifact() }`. In a similar way, you can opt into the new behavior in older Gradle verisions using `mavenCentral { mavenPom() }`
 ====
 
 [[sub:supported_transport_protocols]]

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/build.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/build.gradle
@@ -217,6 +217,18 @@ repositories {
 }
 //END SNIPPET ivy-repo-with-custom-pattern
 
+//START SNIPPET maven-repo-with-metadata-sources
+repositories {
+    maven {
+        url "http://repo.mycompany.com/repo"
+        metadataSources {
+            mavenPom()
+            artifact()
+        }
+    }
+}
+//END SNIPPET maven-repo-with-metadata-sources
+
 //START SNIPPET authenticated-ivy-repo
 repositories {
     ivy {


### PR DESCRIPTION
This is roughly based on https://github.com/gradle/dependency-management-samples/tree/master/samples/opt-out-maven-legacy, which can be removed once this PR is merged.