### PR TITLE
Do not restart unnamed property counter

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/FilePropertyContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FilePropertyContainer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.internal.tasks.TaskFilePropertySpec;
+import org.gradle.api.tasks.TaskFilePropertyBuilder;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Container for {@link org.gradle.api.internal.tasks.TaskPropertySpec}s that might not have a name. The container
+ * ensures that whenever properties are iterated they are always assigned a name.
+ */
+public class FilePropertyContainer<T extends TaskFilePropertyBuilder & TaskFilePropertySpec> implements Iterable<T> {
+    private final List<T> properties = Lists.newArrayList();
+    private boolean changed;
+    private int unnamedPropertyCounter;
+
+    private FilePropertyContainer() {
+    }
+
+    public static <T extends TaskFilePropertyBuilder & TaskFilePropertySpec> FilePropertyContainer<T> create() {
+        return new FilePropertyContainer<T>();
+    }
+
+    public void add(T property) {
+        properties.add(property);
+        changed = true;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        if (changed) {
+            for (T propertySpec : properties) {
+                String propertyName = propertySpec.getPropertyName();
+                if (propertyName == null) {
+                    propertyName = "$" + (++unnamedPropertyCounter);
+                    propertySpec.withPropertyName(propertyName);
+                }
+            }
+            changed = false;
+        }
+        return properties.iterator();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.FilePropertyContainer;
 import org.gradle.api.internal.TaskInputsInternal;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.CompositeFileCollection;
@@ -37,8 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.tasks.TaskPropertyUtils.ensurePropertiesHaveNames;
-
 @NonNullApi
 public class DefaultTaskInputs implements TaskInputsInternal {
     private final FileCollection allInputFiles;
@@ -47,7 +46,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
     private final TaskMutator taskMutator;
     private final PropertyWalker propertyWalker;
     private final List<DeclaredTaskInputProperty> registeredProperties = Lists.newArrayList();
-    private final List<DeclaredTaskInputFileProperty> registeredFileProperties = Lists.newArrayList();
+    private final FilePropertyContainer<DeclaredTaskInputFileProperty> registeredFileProperties = FilePropertyContainer.create();
     private final TaskInputs deprecatedThis;
     private final PropertySpecFactory specFactory;
 
@@ -71,7 +70,6 @@ public class DefaultTaskInputs implements TaskInputsInternal {
 
     @Override
     public void visitRegisteredProperties(PropertyVisitor visitor) {
-        ensurePropertiesHaveNames(registeredFileProperties);
         for (DeclaredTaskInputFileProperty fileProperty : registeredFileProperties) {
             visitor.visitInputFileProperty(fileProperty);
         }
@@ -133,7 +131,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
 
     @Override
     public boolean getHasSourceFiles() {
-        GetInputFilesVisitor visitor = new GetInputFilesVisitor(task.toString());
+        GetInputFilesVisitor visitor = new GetInputFilesVisitor();
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.hasSourceFiles();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -17,12 +17,12 @@
 package org.gradle.api.internal.tasks;
 
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 import org.gradle.api.Describable;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.FilePropertyContainer;
 import org.gradle.api.internal.OverlappingOutputs;
 import org.gradle.api.internal.TaskExecutionHistory;
 import org.gradle.api.internal.TaskInternal;
@@ -62,7 +62,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     private List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<SelfDescribingSpec<TaskInternal>>();
     private List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<SelfDescribingSpec<TaskInternal>>();
     private TaskExecutionHistory history;
-    private final List<DeclaredTaskOutputFileProperty> registeredFileProperties = Lists.newArrayList();
+    private final FilePropertyContainer<DeclaredTaskOutputFileProperty> registeredFileProperties = FilePropertyContainer.create();
     private final TaskInternal task;
     private final TaskMutator taskMutator;
 
@@ -76,7 +76,6 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public void visitRegisteredProperties(PropertyVisitor visitor) {
-        TaskPropertyUtils.ensurePropertiesHaveNames(registeredFileProperties);
         for (DeclaredTaskOutputFileProperty fileProperty : registeredFileProperties) {
             visitor.visitOutputFileProperty(fileProperty);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
-import org.gradle.api.tasks.TaskFilePropertyBuilder;
 import org.gradle.internal.Cast;
 
 import java.util.Iterator;
@@ -61,17 +60,6 @@ public class TaskPropertyUtils {
             builder.add(propertySpec);
         }
         return builder.build();
-    }
-
-    public static <T extends TaskPropertySpec & TaskFilePropertyBuilder> void ensurePropertiesHaveNames(Iterable<T> properties) {
-        int unnamedPropertyCounter = 0;
-        for (T propertySpec : properties) {
-            String propertyName = propertySpec.getPropertyName();
-            if (propertyName == null) {
-                propertyName = "$" + (++unnamedPropertyCounter);
-                propertySpec.withPropertyName(propertyName);
-            }
-        }
     }
 
     public static <T extends TaskFilePropertySpec> SortedSet<ResolvedTaskOutputFilePropertySpec> resolveFileProperties(ImmutableSortedSet<T> properties) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskProperties.java
@@ -67,7 +67,7 @@ public class DefaultTaskProperties implements TaskProperties {
 
     public static TaskProperties resolve(PropertyWalker propertyWalker, PathToFileResolver resolver, TaskInternal task) {
         String beanName = task.toString();
-        GetInputFilesVisitor inputFilesVisitor = new GetInputFilesVisitor(beanName);
+        GetInputFilesVisitor inputFilesVisitor = new GetInputFilesVisitor();
         GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor();
         GetInputPropertiesVisitor inputPropertiesVisitor = new GetInputPropertiesVisitor(beanName);
         GetLocalStateVisitor localStateVisitor = new GetLocalStateVisitor(beanName, resolver);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.properties;
 
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.tasks.CacheableTaskOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.CompositeTaskOutputPropertySpec;
@@ -25,12 +26,11 @@ import org.gradle.api.internal.tasks.TaskOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.TaskPropertyUtils;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 @NonNullApi
 public class GetOutputFilesVisitor extends PropertyVisitor.Adapter {
-    private List<TaskOutputFilePropertySpec> specs = new ArrayList<TaskOutputFilePropertySpec>();
+    private final List<TaskOutputFilePropertySpec> specs = Lists.newArrayList();
     private ImmutableSortedSet<TaskOutputFilePropertySpec> fileProperties;
     private boolean hasDeclaredOutputs;
 


### PR DESCRIPTION
When unnamed properties are assigned a name like  etc., we now keep track
of the last number assigned, and if more unnamed properties are registered,
we don't restart counting from , resulting in property name collisions.

Fixes #4085.