### PR TITLE
Refactor SingleMessageLogger

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.deprecation;
 
+import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.util.DeprecationLogger;
-import org.gradle.util.SingleMessageLogger;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -38,7 +38,7 @@ public class LoggingDeprecatable implements Deprecatable {
 
     @Override
     public void checkDeprecation() {
-        String suffix = SingleMessageLogger.getDeprecationMessage();
+        String suffix = LoggingDeprecatedFeatureHandler.getDeprecationMessage();
         for (String deprecation : deprecations) {
             DeprecationLogger.nagUserWith(String.format("%s %s.", deprecation, suffix));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.TaskValidationException;
+import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.util.DeprecationLogger;
 
 import java.util.List;
@@ -33,7 +34,7 @@ public interface TaskValidationContext {
                 StringBuilder builder = new StringBuilder();
                 builder.append(getMainMessage(task, messages));
                 builder.append(" Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods ");
-                builder.append(DeprecationLogger.getDeprecationMessage());
+                builder.append(LoggingDeprecatedFeatureHandler.getDeprecationMessage());
                 builder.append(".");
                 for (String message : messages) {
                     builder.append("\n - ");

--- a/subprojects/core/src/main/java/org/gradle/internal/featurelifecycle/ScriptUsageLocationReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/featurelifecycle/ScriptUsageLocationReporter.java
@@ -43,7 +43,7 @@ public class ScriptUsageLocationReporter implements ScriptExecutionListener, Usa
         }
     }
 
-    public void reportLocation(DeprecatedFeatureUsage usage, StringBuilder target) {
+    public void reportLocation(FeatureUsage usage, StringBuilder target) {
         lock.lock();
         try {
             doReportLocation(usage, target);
@@ -52,7 +52,7 @@ public class ScriptUsageLocationReporter implements ScriptExecutionListener, Usa
         }
     }
 
-    private void doReportLocation(DeprecatedFeatureUsage usage, StringBuilder target) {
+    private void doReportLocation(FeatureUsage usage, StringBuilder target) {
         List<StackTraceElement> stack = usage.getStack();
         if (stack.isEmpty()) {
             return;

--- a/subprojects/core/src/test/groovy/org/gradle/internal/featurelifecycle/ScriptUsageLocationReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/featurelifecycle/ScriptUsageLocationReporterTest.groovy
@@ -27,7 +27,7 @@ class ScriptUsageLocationReporterTest extends Specification {
         def stack = [
                 new StackTraceElement("SomeClass", "method", "SomeClass.java", 12),
                 new StackTraceElement("SomeClass", "method", "SomeClass.java", 77)]
-        def usage = Stub(DeprecatedFeatureUsage) {
+        def usage = Stub(FeatureUsage) {
             getStack() >> stack
         }
         def result = new StringBuilder()
@@ -47,7 +47,7 @@ class ScriptUsageLocationReporterTest extends Specification {
         def stack = [
                 new StackTraceElement("SomeClass", "method", "some-file.gradle", 12),
                 new StackTraceElement("SomeClass", "method", "some-file.gradle", 77)]
-        def usage = Stub(DeprecatedFeatureUsage) {
+        def usage = Stub(FeatureUsage) {
             getStack() >> stack
         }
         def result = new StringBuilder()
@@ -72,7 +72,7 @@ class ScriptUsageLocationReporterTest extends Specification {
                 new StackTraceElement("SomeLibrary", "method", "SomeLibrary.java", 67),
                 new StackTraceElement("SomeClass", "method", "some-file.gradle", 12)
                 ]
-        def usage = Stub(DeprecatedFeatureUsage) {
+        def usage = Stub(FeatureUsage) {
             getStack() >> stack
         }
         def result = new StringBuilder()
@@ -97,7 +97,7 @@ class ScriptUsageLocationReporterTest extends Specification {
                 new StackTraceElement("OtherLibrary", "method", "OtherLibrary.java", 67),
                 new StackTraceElement("SomeClass", "method", "some-file.gradle", 12)
                 ]
-        def usage = Stub(DeprecatedFeatureUsage) {
+        def usage = Stub(FeatureUsage) {
             getStack() >> stack
         }
         def result = new StringBuilder()

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.project.taskfactory.TaskFactory
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.featurelifecycle.DeprecatedFeatureUsage
+import org.gradle.internal.featurelifecycle.FeatureUsage
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
@@ -49,7 +49,7 @@ class NameValidatorTest extends Specification {
     def loggingDeprecatedFeatureHandler = Mock(LoggingDeprecatedFeatureHandler)
 
     def setup() {
-        SingleMessageLogger.handler = loggingDeprecatedFeatureHandler
+        SingleMessageLogger.deprecatedFeatureHandler = loggingDeprecatedFeatureHandler
     }
 
     def cleanup() {
@@ -62,7 +62,7 @@ class NameValidatorTest extends Specification {
         new TaskFactory(Mock(ClassGenerator), null, Mock(Instantiator)).create(name, DefaultTask)
 
         then:
-        1 * loggingDeprecatedFeatureHandler.deprecatedFeatureUsed(_  as DeprecatedFeatureUsage) >> { DeprecatedFeatureUsage usage ->
+        1 * loggingDeprecatedFeatureHandler.featureUsed(_  as FeatureUsage) >> { FeatureUsage usage ->
             assertForbidden(name, usage.message)
         }
 
@@ -76,7 +76,7 @@ class NameValidatorTest extends Specification {
         domainObjectContainer.create(name)
 
         then:
-        1 * loggingDeprecatedFeatureHandler.deprecatedFeatureUsed(_  as DeprecatedFeatureUsage) >> { DeprecatedFeatureUsage usage ->
+        1 * loggingDeprecatedFeatureHandler.featureUsed(_  as FeatureUsage) >> { FeatureUsage usage ->
             assertForbidden(name, usage.message)
         }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureHandler.java
@@ -21,6 +21,6 @@ package org.gradle.internal.featurelifecycle;
  *
  * <p>Implementations need not be thread-safe.
  */
-public interface DeprecatedFeatureHandler {
-    void deprecatedFeatureUsed(DeprecatedFeatureUsage usage);
+public interface FeatureHandler {
+    void featureUsed(FeatureUsage usage);
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
@@ -23,18 +23,18 @@ import java.util.List;
 /**
  * An immutable description of the usage of a deprecated feature.
  */
-public class DeprecatedFeatureUsage {
+public class FeatureUsage {
     private final String message;
     private final List<StackTraceElement> stack;
     private final Class<?> calledFrom;
 
-    public DeprecatedFeatureUsage(String message, Class<?> calledFrom) {
+    public FeatureUsage(String message, Class<?> calledFrom) {
         this.message = message;
         this.calledFrom = calledFrom;
         this.stack = Collections.emptyList();
     }
 
-    DeprecatedFeatureUsage(DeprecatedFeatureUsage usage, List<StackTraceElement> stack) {
+    FeatureUsage(FeatureUsage usage, List<StackTraceElement> stack) {
         if (stack == null) {
             throw new NullPointerException("stack");
         }
@@ -55,7 +55,7 @@ public class DeprecatedFeatureUsage {
      * Creates a copy of this usage with the stack trace populated. Implementation is a bit limited in that it assumes that
      * this method is called from the same thread that triggered the usage.
      */
-    public DeprecatedFeatureUsage withStackTrace() {
+    public FeatureUsage withStackTrace() {
         if (!stack.isEmpty()) {
             return this;
         }
@@ -83,7 +83,7 @@ public class DeprecatedFeatureUsage {
         for (; caller < originalStack.length; caller++) {
             result.add(originalStack[caller]);
         }
-        return new DeprecatedFeatureUsage(this, result);
+        return new FeatureUsage(this, result);
     }
 
     private static int skipSystemStackElements(StackTraceElement[] stackTrace, int caller) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingIncubatingFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingIncubatingFeatureHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.featurelifecycle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class LoggingIncubatingFeatureHandler implements FeatureHandler {
+    private static final String INCUBATION_MESSAGE = "%s is an incubating feature.";
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingIncubatingFeatureHandler.class);
+
+    private final Set<String> features = new HashSet<String>();
+
+    @Override
+    public void featureUsed(FeatureUsage usage) {
+        if (features.add(usage.getMessage())) {
+            LOGGER.warn(String.format(INCUBATION_MESSAGE, usage.getMessage()));
+        }
+    }
+
+    public void reset() {
+        features.clear();
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/UsageLocationReporter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/UsageLocationReporter.java
@@ -17,5 +17,5 @@
 package org.gradle.internal.featurelifecycle;
 
 public interface UsageLocationReporter {
-    void reportLocation(DeprecatedFeatureUsage usage, StringBuilder target);
+    void reportLocation(FeatureUsage usage, StringBuilder target);
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/FeatureUsageTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/FeatureUsageTest.groovy
@@ -24,8 +24,8 @@ import static org.gradle.internal.featurelifecycle.SimulatedDeprecationMessageLo
 import static org.gradle.internal.featurelifecycle.SimulatedDeprecationMessageLogger.INDIRECT_CALL
 import static org.gradle.internal.featurelifecycle.SimulatedDeprecationMessageLogger.INDIRECT_CALL_2
 
-@Subject(DeprecatedFeatureUsage)
-class DeprecatedFeatureUsageTest extends Specification {
+@Subject(FeatureUsage)
+class FeatureUsageTest extends Specification {
 
     @Unroll
     def "stack is evaluated correctly for #callLocationClass.simpleName and #expectedMessage."() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -43,9 +43,9 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def 'logs each deprecation warning only once'() {
         when:
-        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature1'))
-        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature2'))
-        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature2'))
+        handler.featureUsed(deprecatedFeatureUsage('feature1'))
+        handler.featureUsed(deprecatedFeatureUsage('feature2'))
+        handler.featureUsed(deprecatedFeatureUsage('feature2'))
 
         then:
         def events = outputEventListener.events
@@ -58,7 +58,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def 'deprecations are logged at WARN level'() {
         when:
-        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature'))
+        handler.featureUsed(deprecatedFeatureUsage('feature'))
 
         then:
         outputEventListener.events.size() == 1
@@ -72,7 +72,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     def "no warnings should be displayed in #mode"() {
         when:
         handler.init(locationReporter, type)
-        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature1'))
+        handler.featureUsed(deprecatedFeatureUsage('feature1'))
 
         then:
         outputEventListener.events.empty
@@ -87,7 +87,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'true')
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
+        handler.featureUsed(new FeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
         def events = outputEventListener.events
 
         then:
@@ -125,7 +125,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'false')
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
+        handler.featureUsed(new FeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
         def events = outputEventListener.events
 
         then:
@@ -163,7 +163,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'false')
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
+        handler.featureUsed(new FeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
         def events = outputEventListener.events
 
         then:
@@ -201,7 +201,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'false')
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
+        handler.featureUsed(new FeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
         def events = outputEventListener.events
 
         then:
@@ -231,7 +231,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'false')
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
+        handler.featureUsed(new FeatureUsage(deprecatedFeatureUsage('fake'), fakeStackTrace))
         def events = outputEventListener.events
 
         then:
@@ -255,7 +255,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'true')
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage(new DeprecatedFeatureUsage('fake', DeprecatedFeatureUsageTest), fakeStackTrace))
+        handler.featureUsed(new FeatureUsage(new FeatureUsage('fake', FeatureUsageTest), fakeStackTrace))
         def events = outputEventListener.events
 
         then:
@@ -280,7 +280,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, '' + deprecationTraceProperty)
 
         when:
-        handler.deprecatedFeatureUsed(new DeprecatedFeatureUsage('fake', DeprecatedFeatureUsageTest))
+        handler.featureUsed(new FeatureUsage('fake', FeatureUsageTest))
         def events = outputEventListener.events
 
         then:
@@ -296,10 +296,10 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def 'location reporter can prepend text'() {
         when:
-        handler.deprecatedFeatureUsed(deprecatedFeatureUsage('feature'))
+        handler.featureUsed(deprecatedFeatureUsage('feature'))
 
         then:
-        1 * locationReporter.reportLocation(_, _) >> { DeprecatedFeatureUsage param1, StringBuilder message ->
+        1 * locationReporter.reportLocation(_, _) >> { FeatureUsage param1, StringBuilder message ->
             message.append('location')
         }
 
@@ -353,7 +353,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         deprecationTracePropertyName = LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME
     }
 
-    private static DeprecatedFeatureUsage deprecatedFeatureUsage(String message) {
-        new DeprecatedFeatureUsage(message, LoggingDeprecatedFeatureHandlerTest)
+    private static FeatureUsage deprecatedFeatureUsage(String message) {
+        new FeatureUsage(message, LoggingDeprecatedFeatureHandlerTest)
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedDeprecationMessageLogger.java
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedDeprecationMessageLogger.java
@@ -21,15 +21,15 @@ public class SimulatedDeprecationMessageLogger {
     public static final String INDIRECT_CALL = "indirect call";
     public static final String INDIRECT_CALL_2 = "second-level indirect call";
 
-    public static DeprecatedFeatureUsage indirectlySecondLevel(String message) {
+    public static FeatureUsage indirectlySecondLevel(String message) {
         return indirectly(message);
     }
 
-    public static DeprecatedFeatureUsage indirectly(String message) {
+    public static FeatureUsage indirectly(String message) {
         return nagUserWith(message);
     }
 
-    public static DeprecatedFeatureUsage nagUserWith(String message) {
-        return new DeprecatedFeatureUsage(message, SimulatedDeprecationMessageLogger.class).withStackTrace();
+    public static FeatureUsage nagUserWith(String message) {
+        return new FeatureUsage(message, SimulatedDeprecationMessageLogger.class).withStackTrace();
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedGroovyCallLocation.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedGroovyCallLocation.groovy
@@ -20,15 +20,15 @@ package org.gradle.internal.featurelifecycle
  * This class is used to test proper call stack evaluation of Groovy classes.
  */
 class SimulatedGroovyCallLocation {
-    static DeprecatedFeatureUsage create() {
+    static FeatureUsage create() {
         return SimulatedDeprecationMessageLogger.nagUserWith(SimulatedDeprecationMessageLogger.DIRECT_CALL)
     }
 
-    static DeprecatedFeatureUsage indirectly() {
+    static FeatureUsage indirectly() {
         return SimulatedDeprecationMessageLogger.indirectly(SimulatedDeprecationMessageLogger.INDIRECT_CALL)
     }
 
-    static DeprecatedFeatureUsage indirectly2() {
+    static FeatureUsage indirectly2() {
         return SimulatedDeprecationMessageLogger.indirectlySecondLevel(SimulatedDeprecationMessageLogger.INDIRECT_CALL_2)
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedJavaCallLocation.java
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedJavaCallLocation.java
@@ -21,15 +21,15 @@ package org.gradle.internal.featurelifecycle;
  */
 public class SimulatedJavaCallLocation {
 
-    static DeprecatedFeatureUsage create() {
+    static FeatureUsage create() {
         return SimulatedDeprecationMessageLogger.nagUserWith(SimulatedDeprecationMessageLogger.DIRECT_CALL);
     }
 
-    static DeprecatedFeatureUsage indirectly() {
+    static FeatureUsage indirectly() {
         return SimulatedDeprecationMessageLogger.indirectly(SimulatedDeprecationMessageLogger.INDIRECT_CALL);
     }
 
-    static DeprecatedFeatureUsage indirectly2() {
+    static FeatureUsage indirectly2() {
         return SimulatedDeprecationMessageLogger.indirectlySecondLevel(SimulatedDeprecationMessageLogger.INDIRECT_CALL_2);
     }
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/platform/PlayMajorVersion.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/platform/PlayMajorVersion.java
@@ -18,6 +18,7 @@ package org.gradle.play.internal.platform;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.language.scala.ScalaPlatform;
 import org.gradle.play.platform.PlayPlatform;
 import org.gradle.util.CollectionUtils;
@@ -62,7 +63,7 @@ public enum PlayMajorVersion {
         VersionNumber versionNumber = VersionNumber.parse(playVersion);
         if (versionNumber.getMajor() == 2) {
             if (versionNumber.getMinor() == 2) {
-                DeprecationLogger.nagUserWith("Play 2.2 support " + DeprecationLogger.getDeprecationMessage() + ". Please upgrade your Play.");
+                DeprecationLogger.nagUserWith("Play 2.2 support " + LoggingDeprecatedFeatureHandler.getDeprecationMessage() + ". Please upgrade your Play.");
             }
             int index = versionNumber.getMinor() - 2;
             if (index < 0 || index >= values().length) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetContainerTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetContainerTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.api.internal.tasks
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.SourceSet
-import org.gradle.internal.featurelifecycle.DeprecatedFeatureUsage
+import org.gradle.internal.featurelifecycle.FeatureUsage
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.util.NameValidator
@@ -45,13 +45,13 @@ class DefaultSourceSetContainerTest extends Specification {
     def "source sets are not allowed to be named '#name'"() {
         given:
         def loggingDeprecatedFeatureHandler = Mock(LoggingDeprecatedFeatureHandler)
-        SingleMessageLogger.handler = loggingDeprecatedFeatureHandler
+        SingleMessageLogger.deprecatedFeatureHandler = loggingDeprecatedFeatureHandler
 
         when:
         container.create(name)
 
         then:
-        1 * loggingDeprecatedFeatureHandler.deprecatedFeatureUsed(_  as DeprecatedFeatureUsage) >> { DeprecatedFeatureUsage usage ->
+        1 * loggingDeprecatedFeatureHandler.featureUsed(_  as FeatureUsage) >> { FeatureUsage usage ->
             assertForbidden(name, usage.message)
         }
 


### PR DESCRIPTION
Signed-off-by: Bo Zhang <bo@gradle.com>

### Context

All this PR does is refactoring work:

- Rename `DeprecationFeatureHandler`/`DeprecationFeatureUsage` to `FeatureHandler`/`FeatureUsage`
- Move incubating logging out of `SingleMessageLogger`
- Use synchronized method instead of reentrant lock in `SingleMessageLogger`


