### PR TITLE
Fix exclude rule merging performance test

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.performance.regression.corefeature
 
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.WithExternalRepository
-import spock.lang.Ignore
 
 class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 
@@ -28,14 +27,13 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
         runner.minimumVersion = '4.0'
     }
 
-    @Ignore
     def "merge exclude rules"() {
         runner.testProject = TEST_PROJECT_NAME
         startServer()
 
         given:
         runner.tasksToRun = ['resolveDependencies']
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
         runner.targetVersions = ["4.6-20180111105114+0000"]
         runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}"]
 
@@ -55,7 +53,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
 
         given:
         runner.tasksToRun = ['resolveDependencies']
-        runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
+        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
         runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", "--parallel"]
         runner.targetVersions = ["4.6-20180111105114+0000"]
         when:


### PR DESCRIPTION
### Context

This pull request re-enables the exclude rule merging performance test, by making 2 changes:

- reduce the amount of memory the test uses, to make it more stable
- implement a performance improvement in dependency management to make it faster and use less memory

