### PR TITLE
Upgrade Google GCS library to latest version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -139,7 +139,7 @@ libraries.awsS3 = [
 libraries.zinc = 'com.typesafe.zinc:zinc:0.3.15'
 
 libraries.gcs = [
-        dependencies.create('com.google.apis:google-api-services-storage:v1-rev78-1.22.0') {
+        dependencies.create('com.google.apis:google-api-services-storage:v1-rev116-1.23.0') {
             exclude group: 'commons-logging', module: 'commons-logging'
         },
         "com.fasterxml.jackson.core:jackson-core:${versions.jackson}",


### PR DESCRIPTION
### Context
https://github.com/gradle/gradle/issues/4113#issuecomment-359756113

Minor upgrade to the Google GCS library to increase reliability


We've noticed a failure rate in about 1 in 100 to 1 in 1,000
builds (note: a given build might make 100s of GCS requests),
where Gradle loses connection to the data stream that GCS is
returning.

The error appears as follows:
```
* What went wrong:
Could not resolve all files for configuration ':CENSORED:compileClasspath'.
> Could not download google-api-services-datastore-protobuf.jar (com.google.apis:google-api-services-datastore-protobuf:v1beta2-rev1-3.0.0)
   > Could not get resource 'gcs://CENSORED/releases/com/google/apis/google-api-services-datastore-protobuf/v1beta2-rev1-3.0.0/google-api-services-datastore-protobuf-v1beta2-rev1-3.0.0.jar'.
      > Connection closed prematurely: bytesRead = 31425, Content-Length = 445521
```

As we're running on Google Compute Engine Hardware we reached
out to Google and they recommended upgrading the library to
rev116.

Internally we compiled a version of the Gradle 4.3 release with the
library upgrade and we've seen the error rate disappear entirely
(no failures for this reason in the last 90,000 builds).


NOTE: no tests were added as functionality did not change, but I
did run 
`g8 clean resourcesGcs:check resourcesGcs:test resourcesGcs:integTest` 
locally

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes 
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
