### PR TITLE
Put code quality integration tests into separate packages

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginClasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginClasspathIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.checkstyle
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginDependenciesIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.checkstyle
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
-package org.gradle.api.plugins.quality
-
+package org.gradle.api.plugins.quality.checkstyle
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 
-class FindBugsPluginIntegrationTest extends WellBehavedPluginTest {
-    @Override
-    String getPluginName() {
-        return "findbugs"
-    }
-
+class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
     @Override
     String getMainTask() {
         return "check"
@@ -32,7 +24,7 @@ class FindBugsPluginIntegrationTest extends WellBehavedPluginTest {
 
     def setup() {
         buildFile << """
-            apply plugin: 'java'
+            apply plugin: 'groovy'
         """
     }
 }

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.checkstyle
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcCompilationClasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcCompilationClasspathIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.codenarc
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.codenarc
 
+import org.gradle.api.plugins.quality.CodeNarcPlugin
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import spock.lang.Unroll
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginVersionIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.codenarc
 
+import org.gradle.api.plugins.quality.CodeNarcPlugin
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcRelocationIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.codenarc
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/AbstractFindBugsPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/AbstractFindBugsPluginIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.findbugs
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsClasspathValidationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsClasspathValidationIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.findbugs
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.Requires

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
-import org.gradle.integtests.fixtures.WellBehavedPluginTest
+package org.gradle.api.plugins.quality.findbugs
 
-class PmdPluginIntegrationTest extends WellBehavedPluginTest {
-    def setup() {
-        buildFile << """
-            apply plugin: "java"
-        """
-    }
-
-    @Override
-    String getMainTask() {
-        return "check"
-    }
+class FindBugsIntegrationTest extends AbstractFindBugsPluginIntegrationTest {
 }

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsPluginIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+
+
+package org.gradle.api.plugins.quality.findbugs
+
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 
-class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
+class FindBugsPluginIntegrationTest extends WellBehavedPluginTest {
+    @Override
+    String getPluginName() {
+        return "findbugs"
+    }
+
     @Override
     String getMainTask() {
         return "check"
@@ -24,7 +32,7 @@ class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
 
     def setup() {
         buildFile << """
-            apply plugin: 'groovy'
+            apply plugin: 'java'
         """
     }
 }

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/FindBugsRelocationIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.findbugs
 
 import groovy.xml.XmlUtil
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/jdepend/JDependPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/jdepend/JDependPluginIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.jdepend
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/jdepend/JDependRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/jdepend/JDependRelocationIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.jdepend
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
 
+import org.gradle.api.plugins.quality.PmdPlugin
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.util.TestPrecondition

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.util.TestPrecondition
 import org.gradle.util.VersionNumber

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.TestPrecondition

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
+import org.gradle.integtests.fixtures.WellBehavedPluginTest
 
-class FindBugsIntegrationTest extends AbstractFindBugsPluginIntegrationTest {
+class PmdPluginIntegrationTest extends WellBehavedPluginTest {
+    def setup() {
+        buildFile << """
+            apply plugin: "java"
+        """
+    }
+
+    @Override
+    String getMainTask() {
+        return "check"
+    }
 }

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginSubtypeParamIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginSubtypeParamIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.util.VersionNumber
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.util.TestPrecondition
 import org.gradle.util.ToBeImplemented

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdRelocationIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,49 +14,33 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins.quality
+package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 
-import java.util.regex.Pattern
-
-class CheckstyleRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
+class PmdRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
-        return ":checkstyle"
+        return ":pmd"
     }
 
     @Override
     protected void setupProjectIn(TestFile projectDir) {
-        projectDir.file("config/checkstyle/checkstyle.xml") << """<?xml version="1.0"?>
-<!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-<module name="Checker">
-    <module name="RegexpSingleline">
-       <property name="format" value="\\s+\$"/>
-       <property name="minimum" value="0"/>
-       <property name="maximum" value="0"/>
-       <property name="message" value="Line has trailing spaces."/>
-    </module>
-</module>
-        """
-
         projectDir.file("src/main/java/org/gradle/Class1.java") <<
-            "package org.gradle; class Class1 { public boolean is() { return true; } }  "
+            "package org.gradle; class Class1 { public boolean is() { return true; } }"
         projectDir.file("src/main/java/org/gradle/Class1Test.java") <<
             "package org.gradle; class Class1Test { public boolean is() { return true; } }"
 
         projectDir.file("build.gradle") << """
-            apply plugin: "checkstyle"
+            apply plugin: "java"
+            apply plugin: "pmd"
 
             ${mavenCentralRepository()}
 
-            task checkstyle(type: Checkstyle) {
+            task pmd(type: Pmd) {
                 source "src/main/java"
-                classpath = files()
                 ignoreFailures = true
             }
         """
@@ -64,7 +48,7 @@ class CheckstyleRelocationIntegrationTest extends AbstractProjectRelocationInteg
 
     @Override
     protected extractResultsFrom(TestFile projectDir) {
-        return projectDir.file("build/reports/checkstyle/checkstyle.xml").text
-            .replaceAll(Pattern.quote(projectDir.absolutePath + File.separator) + ".*?" + Pattern.quote(File.separator), "")
+        projectDir.file("build/reports/pmd/pmd.xml").text
+            .replaceAll(/timestamp=".*?"/, 'timestamp="[NUMBER]"')
     }
 }


### PR DESCRIPTION
### Context

Previously, all pmd/jdepend/checkstyle/findbugs/jacoco integration tests are placed in a single package, which makes it a bit hard to locate. This PR separate them to different packages.