### PR TITLE
testingJvm: Enhance JUnit test status reporting

### DIFF
--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionListener.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionListener.java
@@ -19,5 +19,5 @@ package org.gradle.api.internal.tasks.testing.junit;
 public interface TestClassExecutionListener {
     void testClassStarted(String testClassName);
 
-    void testClassFinished(Throwable failure);
+    void testClassFinished(Throwable failure, boolean testClassSkipped);
 }

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -28,7 +28,9 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import static org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE
 import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED
+import static org.gradle.api.tasks.testing.TestResult.ResultType.SUCCESS
 
 class JUnitTestClassProcessorTest extends Specification {
 
@@ -60,8 +62,8 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.name == ATestClass.name && it.className == ATestClass.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == "ok" && it.className == ATestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null }) //wondering why result type is null? Failures are notified via failure() method
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -71,7 +73,7 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({it.id == 1}, {it.parentId == null})
         then: 1 * processor.started({ it.id == 2 && it.name == "ignored" && it.className == ATestClassWithIgnoredMethod.name }, { it.parentId == 1 })
         then: 1 * processor.completed(2, { it.resultType == SKIPPED })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -81,7 +83,7 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({it.id == 1}, {it.parentId == null})
         then: 1 * processor.started({ it.id == 2 && it.name == "assumed" && it.className == ATestClassWithFailedTestAssumption.name }, { it.parentId == 1 })
         then: 1 * processor.completed(2, { it.resultType == SKIPPED })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -93,7 +95,7 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.completed(2, { it.resultType == SKIPPED })
         then: 1 * processor.started({ it.id == 3 && it.name == "ignored" && it.className == AnIgnoredTestClass.name }, { it.parentId == 1 })
         then: 1 * processor.completed(3, { it.resultType == SKIPPED })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -102,8 +104,8 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({it.id == 1}, {it.parentId == null})
         then: 1 * processor.started({ it.id == 2 && it.name == "testOk" && it.className == AJunit3TestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -112,13 +114,13 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.name == ATestClass.name && it.className == ATestClass.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == "ok" && it.className == ATestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
 
         then: 1 * processor.started({ it.id == 3 && it.name == AJunit3TestClass.name && it.className == AJunit3TestClass.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 4 && it.name == "testOk" && it.className == AJunit3TestClass.name }, { it.parentId == 3 })
-        then: 1 * processor.completed(4, { it.resultType == null })
-        then: 1 * processor.completed(3, { it.resultType == null })
+        then: 1 * processor.completed(4, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -129,9 +131,9 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({ it.id == 2 && it.name == "broken" && it.className == ATestClassWithRunner.name }, { it.parentId == 1 })
         then: 1 * processor.started({ it.id == 3 && it.name == "ok" && it.className == ATestClassWithRunner.name }, { it.parentId == 1 })
         then: 1 * processor.failure(2, CustomRunner.failure)
-        then: 1 * processor.completed(3, { it.resultType == null })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(2, { it.resultType == FAILURE })
+        then: 1 * processor.completed(1, { it.resultType == FAILURE })
         0 * processor._
     }
 
@@ -140,10 +142,10 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == "testOk" && it.className == AJunit3TestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 3 && it.name == "testOk" && it.className == BJunit3TestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(3, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -154,8 +156,8 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({ it.id == 2 && it.name == 'test' && it.className == ATestClassWithBrokenBeforeAndAfterMethod.name }, { it.parentId == 1 })
         then: 1 * processor.failure(2, ATestClassWithBrokenBeforeAndAfterMethod.beforeFailure)
         then: 1 * processor.failure(2, ATestClassWithBrokenBeforeAndAfterMethod.afterFailure)
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == FAILURE })
+        then: 1 * processor.completed(1, { it.resultType == FAILURE })
         0 * processor._
     }
 
@@ -166,8 +168,8 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == testMethodName && it.className == testClass.name }, { it.parentId == 1 })
         then: 1 * processor.failure(2, failure)
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == FAILURE })
+        then: 1 * processor.completed(1, { it.resultType == FAILURE })
         0 * processor._
 
         where:
@@ -180,7 +182,7 @@ class JUnitTestClassProcessorTest extends Specification {
         ATestClassWithBrokenConstructor       |'test'                |ATestClassWithBrokenConstructor.failure
         ATestClassWithBrokenBeforeMethod      |'test'                |ATestClassWithBrokenBeforeMethod.failure
         ATestClassWithBrokenSuiteMethod       |'initializationError' |ATestClassWithBrokenSuiteMethod.failure
-        ATestSetUpWithBrokenSetUp               |AJunit3TestClass.name  |ATestSetUpWithBrokenSetUp.failure
+        ATestSetUpWithBrokenSetUp             |AJunit3TestClass.name |ATestSetUpWithBrokenSetUp.failure
     }
 
     def executesATestClassWithRunnerThatBreaksAfterRunningSomeTests() {
@@ -189,13 +191,13 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
 
         then: 1 * processor.started({ it.id == 2 && it.name == 'ok1' && it.className == ATestClassWithRunnerThatBreaksAfterRunningSomeTests.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
 
         then: 1 * processor.started({ it.id == 3 && it.name == 'broken' && it.className == ATestClassWithRunnerThatBreaksAfterRunningSomeTests.name }, { it.parentId == 1 })
         then: 1 * processor.failure(3, CustomRunnerWithRunMethodThatBreaksAfterRunningSomeTests.failure)
-        then: 1 * processor.completed(3, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == FAILURE })
 
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == FAILURE })
         0 * processor._
     }
 
@@ -206,8 +208,8 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == 'pass' && it.className == testClassName }, { it.parentId == 1 })
         then: 1 * processor.failure(2, _ as NoClassDefFoundError)
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == FAILURE })
+        then: 1 * processor.completed(1, { it.resultType == FAILURE })
         0 * processor._
     }
 
@@ -216,8 +218,8 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == 'testOk' && it.className == AJunit3TestThatRenamesItself.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -228,8 +230,8 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == "pass" && it.className == ATestClassWithSeveralMethods.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -270,9 +272,9 @@ class JUnitTestClassProcessorTest extends Specification {
         then: 1 * processor.started({ it.id == 2 && it.name == "broken" && it.className == ATestClassWithRunner.name }, { it.parentId == 1 })
         then: 1 * processor.started({ it.id == 3 && it.name == "ok" && it.className == ATestClassWithRunner.name }, { it.parentId == 1 })
         then: 1 * processor.failure(2, CustomRunner.failure)
-        then: 1 * processor.completed(3, { it.resultType == null })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(2, { it.resultType == FAILURE })
+        then: 1 * processor.completed(1, { it.resultType == FAILURE })
         0 * processor._
     }
 
@@ -282,7 +284,7 @@ class JUnitTestClassProcessorTest extends Specification {
         when: process(ATestClassWithRunner)
 
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         0 * processor._
     }
 
@@ -292,7 +294,7 @@ class JUnitTestClassProcessorTest extends Specification {
         when: process(ATestClassWithSeveralMethods)
 
         then: 1 * processor.started({ it.id == 1 }, { it.parentId == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         0 * processor._
     }
 
@@ -304,12 +306,12 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.className == ATestClassWithSuiteMethod.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.name == "testOk" && it.className == AJunit3TestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 3 && it.name == "testOk" && it.className == BJunit3TestClass.name }, { it.parentId == 1 })
-        then: 1 * processor.completed(3, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 4 && it.className == ATestSuite.name }, { it.parentId == null })
-        then: 1 * processor.completed(4, { it.resultType == null })
+        then: 1 * processor.completed(4, { it.resultType == SKIPPED })
         0 * processor._
     }
 
@@ -320,34 +322,34 @@ class JUnitTestClassProcessorTest extends Specification {
         when: process(ATestClassWithSuiteMethod, ATestSuite)
 
         then: 1 * processor.started({ it.id == 1 && it.className == ATestClassWithSuiteMethod.name }, { it.parentId == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         then: 1 * processor.started({ it.id == 2 && it.className == ATestSuite.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 3 && it.name == "ok" && it.className == ATestClass.name }, { it.parentId == 2 })
-        then: 1 * processor.completed(3, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 4 && it.name == "coolName" && it.className == BTestClass.name }, { it.parentId == 2 })
-        then: 1 * processor.completed(4, { it.resultType == null })
+        then: 1 * processor.completed(4, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 5 && it.name == "ok" && it.className == BTestClass.name }, { it.parentId == 2 })
-        then: 1 * processor.completed(5, { it.resultType == null })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(5, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         0 * processor._
     }
 
     def "executes all tests within a custom runner suite class name matches"() {
         classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ACustomSuite"] as Set, [] as Set))
 
-        //Run tests in ATestSuite only
+        //Run tests in ACustomSuite only
         when: process(ATestClassWithSuiteMethod, ACustomSuite)
 
         then: 1 * processor.started({ it.id == 1 && it.className == ATestClassWithSuiteMethod.name }, { it.parentId == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         then: 1 * processor.started({ it.id == 2 && it.className == ACustomSuite.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 3 && it.name == "ok" && it.className == ATestClass.name }, { it.parentId == 2 })
-        then: 1 * processor.completed(3, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 4 && it.name == "coolName" && it.className == BTestClass.name }, { it.parentId == 2 })
-        then: 1 * processor.completed(4, { it.resultType == null })
+        then: 1 * processor.completed(4, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 5 && it.name == "ok" && it.className == BTestClass.name }, { it.parentId == 2 })
-        then: 1 * processor.completed(5, { it.resultType == null })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(5, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -358,9 +360,9 @@ class JUnitTestClassProcessorTest extends Specification {
         when: process(ATestClassWithSuiteMethod, ATestSuite)
 
         then: 1 * processor.started({ it.id == 1 && it.className == ATestClassWithSuiteMethod.name }, { it.parentId == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         then: 1 * processor.started({ it.id == 2 && it.className == ATestSuite.name }, { it.parentId == null })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SKIPPED })
         0 * processor._
     }
 
@@ -372,7 +374,7 @@ class JUnitTestClassProcessorTest extends Specification {
         when: process(AnEmptyTestSuite)
 
         then: 1 * processor.started({ it.id == 1 && it.className == AnEmptyTestSuite.name }, { it.parentId == null})
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         0 * processor._
     }
 
@@ -384,14 +386,14 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.className == AParameterizedTest.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.className == AParameterizedTest.name && it.name == "helpfulTest[0]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 3 && it.className == AParameterizedTest.name && it.name == "unhelpfulTest[0]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(3, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 4 && it.className == AParameterizedTest.name && it.name == "helpfulTest[1]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(4, { it.resultType == null })
+        then: 1 * processor.completed(4, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 5 && it.className == AParameterizedTest.name && it.name == "unhelpfulTest[1]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(5, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(5, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -404,10 +406,10 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.className == AParameterizedTest.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.className == AParameterizedTest.name && it.name == "helpfulTest[0]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 3 && it.className == AParameterizedTest.name && it.name == "helpfulTest[1]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(3, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -420,10 +422,10 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.className == AParameterizedTest.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.className == AParameterizedTest.name && it.name == "helpfulTest[1]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
         then: 1 * processor.started({ it.id == 3 && it.className == AParameterizedTest.name && it.name == "unhelpfulTest[1]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(3, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(3, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -436,8 +438,8 @@ class JUnitTestClassProcessorTest extends Specification {
 
         then: 1 * processor.started({ it.id == 1 && it.className == AParameterizedTest.name }, { it.parentId == null })
         then: 1 * processor.started({ it.id == 2 && it.className == AParameterizedTest.name && it.name == "helpfulTest[1]" }, { it.parentId == 1 })
-        then: 1 * processor.completed(2, { it.resultType == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(2, { it.resultType == SUCCESS })
+        then: 1 * processor.completed(1, { it.resultType == SUCCESS })
         0 * processor._
     }
 
@@ -449,7 +451,7 @@ class JUnitTestClassProcessorTest extends Specification {
         when: process(AnEmptyParameterizedTest)
 
         then: 1 * processor.started({ it.id == 1 && it.className == AnEmptyParameterizedTest.name }, { it.parentId == null })
-        then: 1 * processor.completed(1, { it.resultType == null })
+        then: 1 * processor.completed(1, { it.resultType == SKIPPED })
         0 * processor._
     }
 }


### PR DESCRIPTION
### Context
Improve status reporting for test classes and individual tests by
populating TestCompleteEvent with the TestResult.ResultType. Change unit
tests accordingly.

Test classes with report FAILURE if the runner failed or at least one
test failed, SKIPPED, if the runner never ran, and SUCCESS otherwise.

This work can be used in the future to optimize the forkEvery behavior
of the RestartEveryNTestClassProcessor to not restart the JVM if the
test runner never ran (issue #3851)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
