### PR TITLE
Show dependency constraints in dependency insight report

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
@@ -58,7 +58,12 @@ public enum ComponentSelectionCause {
     /**
      * This component was selected because another version was rejected by a rule
      */
-    REJECTION("rejection");
+    REJECTION("rejection"),
+
+    /**
+     * This component was selected because of a dependency constraint
+     */
+    CONSTRAINT("constraint");
 
     private final String defaultReason;
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -83,4 +83,13 @@ public interface ComponentSelectionReason {
      */
     List<ComponentSelectionDescriptor> getDescriptions();
 
+    /**
+     * Informs whether the selected component version has been influenced by a dependency constraint.
+     *
+     * @return true if a dependency constraint influenced the selection of this component
+     *
+     * @since 4.6
+     */
+    @Incubating
+    boolean isConstrained();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
@@ -84,37 +84,24 @@ task retrieve(type: Sync) {
 
         def parent = mavenRepo.module("org", "parent", "1.0")
         parent.hasPackaging('pom')
+        parent.dependencyConstraint(mavenRepo.module('org', 'child_dep', '1.7'))
+        parent.dependencyConstraint(mavenRepo.module('org', 'child_dep', '44'), type: 'bar')
+        parent.dependencyConstraint(mavenRepo.module('org', 'child_dep', '44'), classifier: 'classy')
+
+        parent.dependencyConstraint(mavenRepo.module('org', 'typed_dep', '44'))
+        parent.dependencyConstraint(mavenRepo.module('org', 'typed_dep', '1.8'), type: 'bar')
+        parent.dependencyConstraint(mavenRepo.module('org', 'typed_dep', '44'), type: 'zip')
+
+        parent.dependencyConstraint(mavenRepo.module('org', 'classified_dep', '44'))
+        parent.dependencyConstraint(mavenRepo.module('org', 'classified_dep', '1.9'), classifier: 'classy')
+        parent.dependencyConstraint(mavenRepo.module('org', 'classified_dep', '44'), classifier: 'other')
+
+        parent.dependencyConstraint(mavenRepo.module('org', 'fq_dep', '44'))
+        parent.dependencyConstraint(mavenRepo.module('org', 'fq_dep', '44'), classifier: 'classy')
+        parent.dependencyConstraint(mavenRepo.module('org', 'fq_dep', '44'), type: 'bar')
+        parent.dependencyConstraint(mavenRepo.module('org', 'fq_dep', '2.1'), classifier: 'classy', type: 'bar')
+
         parent.publish()
-
-        def dep = { Map vals ->
-            def depString = "<dependency><groupId>org</groupId>"
-            vals.each { key, val -> depString += "<$key>$val</$key>" }
-            depString += "</dependency>"
-        }
-
-        parent.pomFile.text = parent.pomFile.text.replace("</project>", """
-<dependencyManagement>
-    <dependencies>
-        ${dep(artifactId: 'child_dep', version: '1.7')}
-        ${dep(artifactId: 'child_dep', version: '44', type: 'bar')}
-        ${dep(artifactId: 'child_dep', version: '44', classifier: 'classy')}
-
-        ${dep(artifactId: 'typed_dep', version: '44')}
-        ${dep(artifactId: 'typed_dep', version: '1.8', type: 'bar')}
-        ${dep(artifactId: 'typed_dep', version: '44', type: 'zip')}
-
-        ${dep(artifactId: 'classified_dep', version: '44')}
-        ${dep(artifactId: 'classified_dep', version: '1.9', classifier: 'classy')}
-        ${dep(artifactId: 'classified_dep', version: '44', classifier: 'other')}
-
-        ${dep(artifactId: 'fq_dep', version: '44')}
-        ${dep(artifactId: 'fq_dep', version: '44', classifier: 'classy')}
-        ${dep(artifactId: 'fq_dep', version: '44', type: 'bar')}
-        ${dep(artifactId: 'fq_dep', version: '2.1', classifier: 'classy', type: 'bar')}
-    </dependencies>
-</dependencyManagement>
-</project>
-""")
 
         def child = mavenRepo.module("org", "child", "1.0")
         child.parent("org", "parent", "1.0")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -34,6 +34,7 @@ public class VersionSelectionReasons {
     public static final ComponentSelectionDescriptorInternal CONFLICT_RESOLUTION = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONFLICT_RESOLUTION);
     public static final ComponentSelectionDescriptorInternal SELECTED_BY_RULE = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.SELECTED_BY_RULE);
     public static final ComponentSelectionDescriptorInternal COMPOSITE_BUILD = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.COMPOSITE_BUILD);
+    public static final ComponentSelectionDescriptorInternal CONSTRAINT = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT);
 
     public static ComponentSelectionReasonInternal requested() {
         return new DefaultComponentSelectionReason(REQUESTED);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -136,6 +136,11 @@ public class VersionSelectionReasons {
         }
 
         @Override
+        public boolean isConstrained() {
+            return hasCause(ComponentSelectionCause.CONSTRAINT);
+        }
+
+        @Override
         public boolean hasCustomDescriptions() {
             for (ComponentSelectionDescriptorInternal description : descriptions) {
                 if (description.hasCustomDescription()) {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1393,10 +1393,10 @@ org:foo: -> $selected
 \\--- compileClasspath
 """
         where:
-        version                             | reason                                          | selected
-        "prefer '[1.0, 2.0)'"               | "foo v2+ has an incompatible API for project X" | '1.5'
-        "strictly '[1.1, 1.4]'"             | "versions of foo verified to run on platform Y" | '1.4'
-        "prefer '[1.0, 1.4]'; reject '1.4'" | "1.4 has a critical bug"                        | '1.3'
+        version                             | selected
+        "prefer '[1.0, 2.0)'"               | '1.5'
+        "strictly '[1.1, 1.4]'"             | '1.4'
+        "prefer '[1.0, 1.4]'; reject '1.4'" | '1.3'
     }
 
     @Unroll

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
@@ -20,7 +20,20 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 
 public abstract class SelectionReasonHelper {
     public static String getReasonDescription(ComponentSelectionReason reason) {
-        if (reason.isExpected() && !((ComponentSelectionReasonInternal) reason).hasCustomDescriptions()) {
+        ComponentSelectionReasonInternal r = (ComponentSelectionReasonInternal) reason;
+        String description = getReasonDescription(r);
+        if (reason.isConstrained()) {
+            if (description == null || !r.hasCustomDescriptions()) {
+                return "via constraint";
+            } else {
+                return "via constraint, " + description;
+            }
+        }
+        return description;
+    }
+
+    private static String getReasonDescription(ComponentSelectionReasonInternal reason) {
+        if (reason.isExpected() && !reason.hasCustomDescriptions()) {
             return null;
         }
         return reason.getDescription();

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SelectionReasonHelper.java
@@ -15,7 +15,10 @@
  */
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
+import com.google.common.collect.Iterables;
+import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
 public abstract class SelectionReasonHelper {
@@ -23,7 +26,7 @@ public abstract class SelectionReasonHelper {
         ComponentSelectionReasonInternal r = (ComponentSelectionReasonInternal) reason;
         String description = getReasonDescription(r);
         if (reason.isConstrained()) {
-            if (description == null || !r.hasCustomDescriptions()) {
+            if (!r.hasCustomDescriptions()) {
                 return "via constraint";
             } else {
                 return "via constraint, " + description;
@@ -33,9 +36,19 @@ public abstract class SelectionReasonHelper {
     }
 
     private static String getReasonDescription(ComponentSelectionReasonInternal reason) {
-        if (reason.isExpected() && !reason.hasCustomDescriptions()) {
-            return null;
+        if (!reason.hasCustomDescriptions()) {
+            return reason.isExpected() ? null : Iterables.getLast(reason.getDescriptions()).getDescription();
         }
-        return reason.getDescription();
+        return getLastCustomReason(reason);
+    }
+
+    private static String getLastCustomReason(ComponentSelectionReasonInternal reason) {
+        String lastCustomReason = null;
+        for (ComponentSelectionDescriptor descriptor : reason.getDescriptions()) {
+            if (((ComponentSelectionDescriptorInternal)descriptor).hasCustomDescription()) {
+                lastCustomReason = descriptor.getDescription();
+            }
+        }
+        return lastCustomReason;
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -481,7 +481,43 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                         version(parentPom.version)
                     }
                 }
-                if (dependencies || !variants.dependencies.flatten().empty) {
+                boolean isBom = pomPackaging == 'pom' && !dependencies.isEmpty() && dependencies.findAll { it.optional }.size() == dependencies.size()
+
+                if (isBom) {
+                    dependencyManagement {
+                        dependencies {
+                            dependencies.each { dep ->
+                                dependency {
+                                    groupId(dep.groupId)
+                                    artifactId(dep.artifactId)
+                                    if (dep.version) {
+                                        version(dep.version)
+                                    }
+                                    // not sure if we need the following for a BOM
+                                    if (dep.type) {
+                                        type(dep.type)
+                                    }
+                                    if (dep.scope) {
+                                        scope(dep.scope)
+                                    }
+                                    if (dep.classifier) {
+                                        classifier(dep.classifier)
+                                    }
+                                    if (dep.exclusions) {
+                                        exclusions {
+                                            for (exc in dep.exclusions) {
+                                                exclusion {
+                                                    groupId(exc.group ?: '*')
+                                                    artifactId(exc.module ?: '*')
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if (dependencies || !variants.dependencies.flatten().empty) {
                     dependencies {
                         dependencies.each { dep ->
                             dependency {


### PR DESCRIPTION
### Context

This pull request implements #3554 by adding a new "cause" for component selection reason, which is "constraint". This allows us to make the difference between a component which was selected because it was required from a component which version has been influenced by a dependency constraint.

Here's an example of output, where the dependency version comes from a BOM:

```
> Task :dependencyInsight 
com.google.guava:guava:23.6-jre (via constraint)
\--- nebula.example:bom:1.0.0
     \--- testRuntimeClasspath

com.google.guava:guava: -> 23.6-jre
\--- testRuntimeClasspath

```

It's worth noting that if the constraint also has a custom reason, it will also be displayed:

```
> Task :dependencyInsight 
com.google.guava:guava:23.6-jre (via constraint, My Awesome Platform 1.0)
\--- nebula.example:bom:1.0.0
     \--- testRuntimeClasspath

com.google.guava:guava: -> 23.6-jre
\--- testRuntimeClasspath
```

As discussed with @breskeby, if this is merged, we need a new release of the build scans plugin, otherwise it may fail with:

```
----------
Gradle version: 4.6-20180124152122+0000
Plugin version: 1.11

com.gradle.scan.plugin.BuildScanException: Unknown selection reason constraint
        at com.gradle.scan.plugin.internal.a.e.y.a(SourceFile:146)
        at com.gradle.scan.plugin.internal.a.e.y.a(SourceFile:127)
        at com.gradle.scan.plugin.internal.a.e.y.a(SourceFile:95)
        at com.gradle.scan.plugin.internal.a.e.y.a(SourceFile:95)
        at com.gradle.scan.plugin.internal.a.e.y.<init>(SourceFile:57)
        at com.gradle.scan.plugin.internal.a.e.y.<init>(SourceFile:41)
        at com.gradle.scan.plugin.internal.a.e.x.a(SourceFile:32)
        at com.gradle.scan.plugin.internal.a.e.p.a(SourceFile:69)
        at com.gradle.scan.plugin.internal.d.d.run(SourceFile:63)

----------
```