### PR TITLE
Prepare Java 10-specific builds similar to Java 9 setup

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -23,6 +23,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
         param("env.JAVA_HOME", "%${testCoverage.os}.java8.oracle.64bit%")
         if (testCoverage.os == OS.linux) {
             param("env.JAVA_9", "%linux.java9.oracle.64bit%")
+            param("env.JAVA_10", "%linux.java10.oracle.64bit%")
             param("env.ANDROID_HOME", "/opt/android/sdk")
         }
     }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -37,6 +37,7 @@ data class CIBuildModel (
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.linux, JvmVersion.java7),
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java7),
                             TestCoverage(TestType.java9Smoke, OS.linux, JvmVersion.java8),
+                            TestCoverage(TestType.java10Smoke, OS.linux, JvmVersion.java8),
                             TestCoverage(TestType.parallel, OS.linux, JvmVersion.java7, JvmVendor.ibm))),
             Stage("Release Accept", "Once a day: Rerun tests in more environments",
                     trigger = Trigger.daily,
@@ -194,7 +195,7 @@ enum class JvmVersion {
 enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false) {
     quick(true, true, false), platform(true, true, false),
     quickFeedbackCrossVersion(false, false, true), allVersionsCrossVersion(false, false, true),
-    parallel(false, true, false), noDaemon(false, true, false), java9Smoke(false, true, false),
+    parallel(false, true, false), noDaemon(false, true, false), java9Smoke(false, true, false), java10Smoke(false, true, false),
     soak(false, false, false)
 }
 

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -48,6 +48,7 @@ data class CIBuildModel (
                             TestCoverage(TestType.noDaemon, OS.linux, JvmVersion.java8),
                             TestCoverage(TestType.noDaemon, OS.windows, JvmVersion.java8),
                             TestCoverage(TestType.platform, OS.macos, JvmVersion.java8)),
+                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java10)
                     performanceTests = listOf(
                             PerformanceTestType.experiment)),
             Stage("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions",


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/1066 for more information. I believe @donat already installed JDK 10 on all agents. Can't find the coresponding issue anymore.

I wasn't quite sure `JvmVersion.java8`. That seems to be wrong already for `TestCoverage(TestType.java9Smoke, OS.linux, JvmVersion.java8)`.