### PR TITLE
Java 9 smoke testing make use of testJavaHome

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,15 +105,6 @@ buildTypes {
         tasks "verifyIsProductionBuildEnvironment", "clean", "docs:check", "buildDists", "distributions:integTest", "uploadArchives"
     }
 
-    //Initial smoke test for java 9
-    java9Build {
-        tasks "java9Test", "java9IntegTest"
-    }
-
-    java9SmokeTest {
-        tasks "java9IntegTest"
-    }
-
     soakTest {
         tasks "soak:soakTest"
         projectProperties testAllVersions: true

--- a/gradle/java9.gradle
+++ b/gradle/java9.gradle
@@ -1,177 +1,159 @@
-/**
- * Tests tasks to allow the gradual introduction of JDK 9 support
- */
-String jdkVarName = 'JAVA_9'
+import org.gradle.build.DefaultJavaInstallation
 
-task java9IntegTest(type: org.gradle.testing.IntegrationTest) {
-    description "Run integTests with Java9 and forking executer"
-    excludes = [
-        // TODO requires investigation
-        "DaemonGroovyCompilerIntegrationTest",
-        "DaemonJavaCompilerIntegrationTest",
-        "InProcessJavaCompilerIntegrationTest",
-        "CommandLineJavaCompilerIntegrationTest",
-        "CommandLineJavaCompilerForExecutableIntegrationTest",
-        "JavadocIntegrationTest",
+import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 
-        // Caused by: java.lang.IncompatibleClassChangeError: Method Person.getName()Ljava/lang/String; must be InterfaceMethodref constant
-        // Fail since build 125
-        "InterfaceBackedManagedTypeIntegrationTest",
+if (testJavaHome) {
 
-        // "targetplatforms sample creates a binary specific source set" tries to compile for Java 5 - need to update test, samples and userguide
-        "SampleJavaLanguageIntegrationTest",
+    def testJavaInstallation = new DefaultJavaInstallation()
+    gradle.services.get(JavaInstallationProbe)
+        .checkJdk(new File(testJavaHome))
+        .configure(testJavaInstallation)
 
-        // Cannot obtain Jvm arguments via java.lang.management.ManagementFactory.runtimeMXBean.inputArguments module java.management does not export sun.management to unnamed module @6427ecb
-        "BuildEnvironmentModelCrossVersionSpec",  // "informs about java args as in the build script"
-        "JavaConfigurabilityCrossVersionSpec", // "customized java args are reflected in the inputArguments and the build model", "tooling api provided jvm args take precedence over gradle.properties"
-        "GradlePropertiesToolingApiCrossVersionSpec", // "tooling api honours jvm args specified in gradle.properties"
+    if (testJavaInstallation.javaVersion.java9) {
 
-        // Add a dedicated Findbugs test for Java 9
-        "FindBugsIntegrationTest",
-        "FindBugsRelocationIntegrationTest",
+        tasks.withType(org.gradle.testing.IntegrationTest) {
+            [
+                // TODO requires investigation
+                "DaemonGroovyCompilerIntegrationTest",
+                "DaemonJavaCompilerIntegrationTest",
+                "InProcessJavaCompilerIntegrationTest",
+                "CommandLineJavaCompilerIntegrationTest",
+                "CommandLineJavaCompilerForExecutableIntegrationTest",
+                "JavadocIntegrationTest",
 
-        // Osgi is broken with a NPE in Processor - need to investigate
-        "OsgiPluginIntegrationSpec",
+                // Caused by: java.lang.IncompatibleClassChangeError: Method Person.getName()Ljava/lang/String; must be InterfaceMethodref constant
+                // Fail since build 125
+                "InterfaceBackedManagedTypeIntegrationTest",
 
-        // Attempts to run Gradle 2.8 on Java 9
-        "HeterogeneousCompositeBuildCrossVersionSpec",
+                // "targetplatforms sample creates a binary specific source set" tries to compile for Java 5 - need to update test, samples and userguide
+                "SampleJavaLanguageIntegrationTest",
 
-        // Broken scala and twirl compilation
-        "MixedPlayAndJvmLibraryProjectIntegrationTest",
-        "PlayAppWithFailingTestsIntegrationTest",
-        "PlayMultiProjectApplicationIntegrationTest",
-        "PlayPlatformIntegrationTest",
-        "PlayBinaryAdvancedAppIntegrationTest",
-        "PlayDistributionAdvancedAppIntegrationTest",
-        "PlayBinaryBasicAppIntegrationTest",
-        "PlayDistributionBasicAppIntegrationTest",
-        "PlayTestBasicAppIntegrationTest",
-        "PlayContinuousBuildIntegrationTest",
-        "PlayContinuousBuildReloadIntegrationTest",
-        "PlayContinuousBuildReloadWaitingIntegrationTest",
-        "PlayMultiProjectContinuousBuildIntegrationTest",
-        "PlayMultiProjectReloadIntegrationTest",
-        "PlayReloadIntegrationTest",
-        "PlayReloadWaitingIntegrationTest",
-        "PlayTwirlCompilerContinuousIntegrationTest",
-        "PlayBinaryAppWithDependenciesIntegrationTest",
-        "PlayDistributionAppWithDependenciesIntegrationTest",
-        "PlayTestAppWithDependenciesIntegrationTest",
-        "AdvancedPlaySampleIntegrationTest",
-        "BasicPlaySampleIntegrationTest",
-        "MultiprojectPlaySampleIntegrationTest",
-        "UserGuidePlaySamplesIntegrationTest",
-        "PlayApplicationPluginIntegrationTest",
-        "Play23RoutesCompileIntegrationTest",
-        "Play24RoutesCompileIntegrationTest",
-        "PlayAssetsJarIntegrationTest",
-        "PlayRunIntegrationTest",
-        "TwirlCompileIntegrationTest",
-        "TwirlVersionIntegrationTest",
-        "PlayIdeaPluginAdvancedIntegrationTest",
-        "PlayIdeaPluginBasicIntegrationTest",
-        "PlayIdeaPluginMultiprojectIntegrationTest",
-        "ProjectLayoutIntegrationTest",
-        "SamplesMixedJavaAndScalaIntegrationTest",
-        "SamplesScalaCustomizedLayoutIntegrationTest",
-        "SamplesScalaQuickstartIntegrationTest",
-        "JointScalaLangIntegrationTest",
-        "SampleScalaLanguageIntegrationTest",
-        "ScalaCompileParallelIntegrationTest",
-        "ScalaCompilerContinuousIntegrationTest",
-        "ScalaLanguageIncrementalBuildIntegrationTest",
-        "ScalaLanguageIntegrationTest",
-        "ScalaCrossCompilationIntegrationTest",
-        "IncrementalScalaCompileIntegrationTest",
-        "ZincScalaCompilerIntegrationTest",
-        "ScalaTestIntegrationTest",
-        "ScalaLibraryInitIntegrationTest",
-        "ZincScalaCompilerMultiVersionIntegrationTest",
-        "PlayCompositeBuildIntegrationTest",
-        "PlayJavaAnnotationProcessingIntegrationTest",
-        "ScalaAnnotationProcessingIntegrationTest",
-        "CachedScalaCompileIntegrationTest",
-        "ScalaCompileRelocationIntegrationTest",
-        "UpToDateScalaCompileIntegrationTest",
-        "ScalaDocIntegrationTest",
-        "ScalaCompilerDaemonReuseIntegrationTest",
-        "ScalaComponentCompilerDaemonReuseIntegrationTest",
+                // Cannot obtain Jvm arguments via java.lang.management.ManagementFactory.runtimeMXBean.inputArguments module java.management does not export sun.management to unnamed module @6427ecb
+                "BuildEnvironmentModelCrossVersionSpec",  // "informs about java args as in the build script"
+                "JavaConfigurabilityCrossVersionSpec", // "customized java args are reflected in the inputArguments and the build model", "tooling api provided jvm args take precedence over gradle.properties"
+                "GradlePropertiesToolingApiCrossVersionSpec", // "tooling api honours jvm args specified in gradle.properties"
 
-        // Sample attempts to set max perm space
-        "SamplesScalaZincIntegrationTest",
+                // Add a dedicated Findbugs test for Java 9
+                "FindBugsIntegrationTest",
+                "FindBugsRelocationIntegrationTest",
 
-        // Cannot build Gradle with Java 9, compiler bug
-        "SrcDistributionIntegrationSpec",
+                // Osgi is broken with a NPE in Processor - need to investigate
+                "OsgiPluginIntegrationSpec",
 
-        // Test compiles for Java 5
-        "ToolingApiUnsupportedClientJvmCrossVersionSpec",
-        "MavenConversionIntegrationTest",
+                // Attempts to run Gradle 2.8 on Java 9
+                "HeterogeneousCompositeBuildCrossVersionSpec",
 
-        // Jetty version does not work on Java 9
-        "JettyIntegrationSpec",
-        "SamplesWebQuickstartIntegrationTest",
+                // Broken scala and twirl compilation
+                "MixedPlayAndJvmLibraryProjectIntegrationTest",
+                "PlayAppWithFailingTestsIntegrationTest",
+                "PlayMultiProjectApplicationIntegrationTest",
+                "PlayPlatformIntegrationTest",
+                "PlayBinaryAdvancedAppIntegrationTest",
+                "PlayDistributionAdvancedAppIntegrationTest",
+                "PlayBinaryBasicAppIntegrationTest",
+                "PlayDistributionBasicAppIntegrationTest",
+                "PlayTestBasicAppIntegrationTest",
+                "PlayContinuousBuildIntegrationTest",
+                "PlayContinuousBuildReloadIntegrationTest",
+                "PlayContinuousBuildReloadWaitingIntegrationTest",
+                "PlayMultiProjectContinuousBuildIntegrationTest",
+                "PlayMultiProjectReloadIntegrationTest",
+                "PlayReloadIntegrationTest",
+                "PlayReloadWaitingIntegrationTest",
+                "PlayTwirlCompilerContinuousIntegrationTest",
+                "PlayBinaryAppWithDependenciesIntegrationTest",
+                "PlayDistributionAppWithDependenciesIntegrationTest",
+                "PlayTestAppWithDependenciesIntegrationTest",
+                "AdvancedPlaySampleIntegrationTest",
+                "BasicPlaySampleIntegrationTest",
+                "MultiprojectPlaySampleIntegrationTest",
+                "UserGuidePlaySamplesIntegrationTest",
+                "PlayApplicationPluginIntegrationTest",
+                "Play23RoutesCompileIntegrationTest",
+                "Play24RoutesCompileIntegrationTest",
+                "PlayAssetsJarIntegrationTest",
+                "PlayRunIntegrationTest",
+                "TwirlCompileIntegrationTest",
+                "TwirlVersionIntegrationTest",
+                "PlayIdeaPluginAdvancedIntegrationTest",
+                "PlayIdeaPluginBasicIntegrationTest",
+                "PlayIdeaPluginMultiprojectIntegrationTest",
+                "ProjectLayoutIntegrationTest",
+                "SamplesMixedJavaAndScalaIntegrationTest",
+                "SamplesScalaCustomizedLayoutIntegrationTest",
+                "SamplesScalaQuickstartIntegrationTest",
+                "JointScalaLangIntegrationTest",
+                "SampleScalaLanguageIntegrationTest",
+                "ScalaCompileParallelIntegrationTest",
+                "ScalaCompilerContinuousIntegrationTest",
+                "ScalaLanguageIncrementalBuildIntegrationTest",
+                "ScalaLanguageIntegrationTest",
+                "ScalaCrossCompilationIntegrationTest",
+                "IncrementalScalaCompileIntegrationTest",
+                "ZincScalaCompilerIntegrationTest",
+                "ScalaTestIntegrationTest",
+                "ScalaLibraryInitIntegrationTest",
+                "ZincScalaCompilerMultiVersionIntegrationTest",
+                "PlayCompositeBuildIntegrationTest",
+                "PlayJavaAnnotationProcessingIntegrationTest",
+                "ScalaAnnotationProcessingIntegrationTest",
+                "CachedScalaCompileIntegrationTest",
+                "ScalaCompileRelocationIntegrationTest",
+                "UpToDateScalaCompileIntegrationTest",
+                "ScalaDocIntegrationTest",
+                "ScalaCompilerDaemonReuseIntegrationTest",
+                "ScalaComponentCompilerDaemonReuseIntegrationTest",
 
-        // Missing class javax/xml/bind/DatatypeConverter on PUT to S3
-        // These tests need jvmArgs '-addmods', 'java.xml.bind'
-        // At some point Gradle should import this module automatically
-        "IvyPublishS3IntegrationTest",
-        "IvyS3UploadArchivesIntegrationTest",
-        "MavenPublishS3IntegrationTest",
-        "MavenPublishS3ErrorsIntegrationTest",
+                // Sample attempts to set max perm space
+                "SamplesScalaZincIntegrationTest",
 
-        // Various problems, eg scala compile
-        "UserGuideSamplesIntegrationTest",
+                // Cannot build Gradle with Java 9, compiler bug
+                "SrcDistributionIntegrationSpec",
 
-        /*
-         Changes in Javadoc generation
-         */
-        "SamplesJavaMultiProjectIntegrationTest",
+                // Test compiles for Java 5
+                "ToolingApiUnsupportedClientJvmCrossVersionSpec",
+                "MavenConversionIntegrationTest",
 
-        /*
-         Caused by: java.lang.IllegalAccessException: class org.mozilla.javascript.MemberBox cannot access class sun.net.www.protocol.http.HttpURLConnection (in module java.base) because module java.base does not export sun.net.www.protocol.http to unnamed module @2afcc5b3
-            at jdk.internal.reflect.Reflection.throwIllegalAccessException(java.base@9-ea/Reflection.java:405)
-            at jdk.internal.reflect.Reflection.throwIllegalAccessException(java.base@9-ea/Reflection.java:396)
-            at jdk.internal.reflect.Reflection.ensureMemberAccess(java.base@9-ea/Reflection.java:98)
-            at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:161)
-            for "can evaluate content"
-         */
-        "EnvJsPluginIntegrationTest",
+                // Jetty version does not work on Java 9
+                "JettyIntegrationSpec",
+                "SamplesWebQuickstartIntegrationTest",
 
-        /*
-         Uses bytebuddy in a test which uses asm which cannot read Java 9 classfiles
-         */
-        "DirectoryScanningIntegTest",
+                // Missing class javax/xml/bind/DatatypeConverter on PUT to S3
+                // These tests need jvmArgs '-addmods', 'java.xml.bind'
+                // At some point Gradle should import this module automatically
+                "IvyPublishS3IntegrationTest",
+                "IvyS3UploadArchivesIntegrationTest",
+                "MavenPublishS3IntegrationTest",
+                "MavenPublishS3ErrorsIntegrationTest",
 
-        /*
-          MaxPermSize as GRADLE_OPTS
-         */
-        "ClientShutdownCrossVersionSpec",
-    ].collect { "**/*${it}*" }
-}
+                // Various problems, eg scala compile
+                "UserGuideSamplesIntegrationTest",
 
-task java9Test(type: Test) {
-}
+                /*
+                 Changes in Javadoc generation
+                 */
+                "SamplesJavaMultiProjectIntegrationTest",
 
-tasks.withType(Test).matching { it.name.startsWith("java9") }.all {
-    def java9Home = System.getenv('JAVA_9')
-    executable = "${java9Home}/bin/java"
-    environment['JAVA_HOME'] = java9Home
-    reports.junitXml.destination = file("${project.testResultsDir}/$name")
-    reports.html.destination = file("${project.reporting.baseDir}/$name")
-    if (name.contains('IntegTest')) {
-        systemProperties['org.gradle.integtest.executer'] = 'forking'
-    }
-}
+                /*
+                 Caused by: java.lang.IllegalAccessException: class org.mozilla.javascript.MemberBox cannot access class sun.net.www.protocol.http.HttpURLConnection (in module java.base) because module java.base does not export sun.net.www.protocol.http to unnamed module @2afcc5b3
+                    at jdk.internal.reflect.Reflection.throwIllegalAccessException(java.base@9-ea/Reflection.java:405)
+                    at jdk.internal.reflect.Reflection.throwIllegalAccessException(java.base@9-ea/Reflection.java:396)
+                    at jdk.internal.reflect.Reflection.ensureMemberAccess(java.base@9-ea/Reflection.java:98)
+                    at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:161)
+                    for "can evaluate content"
+                 */
+                "EnvJsPluginIntegrationTest",
 
-if (!gradle.hasProperty("haveInstalledJava9Guard")) {
-    gradle.taskGraph.whenReady { graph ->
-        if (gradle.taskGraph.allTasks.any { it.name.startsWith("java9") }) {
-            // Ideally, this would be a validate rule but it's not convenient to express this in the DSL yet
-            if (!System.getenv(jdkVarName)) {
-                throw new GradleException("A '$jdkVarName' environment variable, " +
-                    "pointing to a java 9 JDK image, is required to run java9 tests!")
-            }
+                /*
+                 Uses bytebuddy in a test which uses asm which cannot read Java 9 classfiles
+                 */
+                "DirectoryScanningIntegTest",
+
+                /*
+                  MaxPermSize as GRADLE_OPTS
+                 */
+                "ClientShutdownCrossVersionSpec",
+            ].collect { "**/*${it}*" }.each { exclude it }
         }
     }
-    gradle.ext.haveInstalledJava9Guard = true
 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -467,15 +467,13 @@ tasks.addRule("view«Doc Task Name» - Opens entry point") { String taskName ->
 
 sourceSets.main.output.dir generatedResourcesDir, builtBy: defaultImports
 
-['test', 'java9Test'].each {
-    tasks[it].configure {
-        dependsOn releaseNotes
-        inputs.files releaseNotesMarkdown.markdownFile withPropertyName "releaseNotesSource" withPathSensitivity PathSensitivity.NONE
-        inputs.dir releaseNotes.destinationDir withPropertyName "releaseNotesRendered" withPathSensitivity PathSensitivity.NONE
-        inputs.property "systemProperties", [:]
-        systemProperty "org.gradle.docs.releasenotes.source", releaseNotesMarkdown.markdownFile
-        systemProperty "org.gradle.docs.releasenotes.rendered", new File(releaseNotes.destinationDir, releaseNotes.fileName)
-    }
+test {
+    dependsOn releaseNotes
+    inputs.files releaseNotesMarkdown.markdownFile withPropertyName "releaseNotesSource" withPathSensitivity PathSensitivity.NONE
+    inputs.dir releaseNotes.destinationDir withPropertyName "releaseNotesRendered" withPathSensitivity PathSensitivity.NONE
+    inputs.property "systemProperties", [:]
+    systemProperty "org.gradle.docs.releasenotes.source", releaseNotesMarkdown.markdownFile
+    systemProperty "org.gradle.docs.releasenotes.rendered", new File(releaseNotes.destinationDir, releaseNotes.fileName)
 }
 
 task docs {

--- a/subprojects/testing-jvm/testing-jvm.gradle
+++ b/subprojects/testing-jvm/testing-jvm.gradle
@@ -30,7 +30,7 @@ dependencies {
 
 }
 
-configure([test, java9Test]) {
+test {
     exclude 'org/gradle/api/internal/tasks/testing/junit/ATestClass*.*'
     exclude 'org/gradle/api/internal/tasks/testing/junit/ABroken*TestClass*.*'
 }


### PR DESCRIPTION
instead of creating ad-hoc `java9*Test` tasks.