### PR TITLE
Add a plugin that generates a Swift package manager manifest for C++ and Swift builds

### DIFF
--- a/gradle/publicApi.gradle
+++ b/gradle/publicApi.gradle
@@ -42,6 +42,7 @@ ext.publicApiIncludes = [
     'org/gradle/testfixtures/**',
     'org/gradle/testing/jacoco/**',
     'org/gradle/tooling/**',
+    'org/gradle/swiftpm/**',
     'org/gradle/model/**',
     'org/gradle/testkit/**',
     'org/gradle/testing/**',

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -17,6 +17,10 @@
 package org.gradle.swiftpm
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
+import org.gradle.nativeplatform.fixtures.app.CppLib
+import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
+import org.gradle.nativeplatform.fixtures.app.SwiftLib
 import org.gradle.vcs.fixtures.GitFileRepository
 
 class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
@@ -62,6 +66,8 @@ let package = Package(
                 id 'swift-library'
             }
 """
+        def lib = new SwiftLib()
+        lib.writeToProject(testDirectory)
 
         when:
         run("generateSwiftPmManifest")
@@ -79,7 +85,15 @@ let package = Package(
         .library(name: "Test", targets: ["Test"]),
     ],
     targets: [
-        .target(name: "Test"),
+        .target(
+            name: "Test",
+            path: ".",
+            sources: [
+                "src/main/swift/greeter.swift",
+                "src/main/swift/multiply.swift",
+                "src/main/swift/sum.swift",
+            ]
+        ),
     ]
 )
 """
@@ -93,6 +107,8 @@ let package = Package(
                 id 'cpp-library'
             }
 """
+        def lib = new CppLib()
+        lib.writeToProject(testDirectory)
 
         when:
         run("generateSwiftPmManifest")
@@ -110,7 +126,14 @@ let package = Package(
         .library(name: "test", targets: ["test"]),
     ],
     targets: [
-        .target(name: "test"),
+        .target(
+            name: "test",
+            path: ".",
+            sources: [
+                "src/main/cpp/greeter.cpp",
+                "src/main/cpp/sum.cpp",
+            ]
+        ),
     ]
 )
 """
@@ -128,6 +151,10 @@ let package = Package(
                 apply plugin: 'swift-library'
             }
 """
+        def app = new SwiftAppWithLibraries()
+        app.main.writeToProject(testDirectory)
+        app.library.writeToProject(file("lib1"))
+        app.logLibrary.writeToProject(file("lib2"))
 
         when:
         run("generateSwiftPmManifest")
@@ -147,9 +174,27 @@ let package = Package(
         .library(name: "Lib2", targets: ["Lib2"]),
     ],
     targets: [
-        .target(name: "Test"),
-        .target(name: "Lib1"),
-        .target(name: "Lib2"),
+        .target(
+            name: "Test",
+            path: ".",
+            sources: [
+                "src/main/swift/main.swift",
+            ]
+        ),
+        .target(
+            name: "Lib1",
+            path: "lib1",
+            sources: [
+                "src/main/swift/greeter.swift",
+            ]
+        ),
+        .target(
+            name: "Lib2",
+            path: "lib2",
+            sources: [
+                "src/main/swift/log.swift",
+            ]
+        ),
     ]
 )
 """
@@ -167,6 +212,10 @@ let package = Package(
                 apply plugin: 'cpp-library'
             }
 """
+        def app = new CppAppWithLibraries()
+        app.main.writeToProject(testDirectory)
+        app.greeterLib.writeToProject(file("lib1"))
+        app.loggerLib.writeToProject(file("lib2"))
 
         when:
         run("generateSwiftPmManifest")
@@ -186,9 +235,27 @@ let package = Package(
         .library(name: "lib2", targets: ["lib2"]),
     ],
     targets: [
-        .target(name: "test"),
-        .target(name: "lib1"),
-        .target(name: "lib2"),
+        .target(
+            name: "test",
+            path: ".",
+            sources: [
+                "src/main/cpp/main.cpp",
+            ]
+        ),
+        .target(
+            name: "lib1",
+            path: "lib1",
+            sources: [
+                "src/main/cpp/greeter.cpp",
+            ]
+        ),
+        .target(
+            name: "lib2",
+            path: "lib2",
+            sources: [
+                "src/main/cpp/logger.cpp",
+            ]
+        ),
     ]
 )
 """
@@ -225,6 +292,8 @@ let package = Package(
                 implementation "test:lib2:1.0"
             }
 """
+        def app = new SwiftAppWithLibraries()
+        app.library.writeToProject(testDirectory)
 
         when:
         run("generateSwiftPmManifest")
@@ -242,7 +311,13 @@ let package = Package(
         .library(name: "Test", targets: ["Test"]),
     ],
     targets: [
-        .target(name: "Test"),
+        .target(
+            name: "Test",
+            path: ".",
+            sources: [
+                "src/main/swift/greeter.swift",
+            ]
+        ),
     ]
 )
 """

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.vcs.fixtures.GitFileRepository
+
+class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
+    def "produces manifest for build with no native components"() {
+        given:
+        settingsFile << "include 'lib1', 'lib2'"
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+            }
+"""
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").file
+    }
+
+    def "produces manifest for single project Swift build"() {
+        given:
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+                id 'swift-library'
+            }
+"""
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").file
+    }
+
+    def "produces manifest for single project C++ build"() {
+        given:
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+                id 'cpp-library'
+            }
+"""
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").file
+    }
+
+    def "produces manifest for multi project Swift build"() {
+        given:
+        settingsFile << "include 'lib1', 'lib2'"
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+                id 'swift-application' 
+            }
+            subprojects {
+                apply plugin: 'swift-library'
+            }
+"""
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").file
+    }
+
+    def "produces manifest for multi project C++ build"() {
+        given:
+        settingsFile << "include 'lib1', 'lib2'"
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+                id 'cpp-application' 
+            }
+            subprojects {
+                apply plugin: 'cpp-library'
+            }
+"""
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").file
+    }
+
+    def "produces manifest for Swift component with source dependencies"() {
+        given:
+        def lib1Repo = GitFileRepository.init(testDirectory.file("repos/lib1"))
+        def lib2Repo = GitFileRepository.init(testDirectory.file("repos/lib2"))
+
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("test:lib1") {
+                        from(GitVersionControlSpec) {
+                            url = uri('${lib1Repo.url}')
+                        }
+                    }
+                    withModule("test:lib2") {
+                        from(GitVersionControlSpec) {
+                            url = uri('${lib2Repo.url}')
+                        }
+                    }
+                }
+            }
+"""
+        buildFile << """
+            plugins {
+                id 'swift-library'
+                id 'swiftpm-export'
+            }
+            dependencies {
+                api "test:lib1:1.0"
+                implementation "test:lib2:1.0"
+            }
+"""
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").file
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -21,8 +21,11 @@ import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppLib
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.gradle.vcs.fixtures.GitFileRepository
 
+@Requires(TestPrecondition.NOT_WINDOWS)
 class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         settingsFile << """rootProject.name = 'test'
@@ -150,6 +153,14 @@ let package = Package(
             subprojects {
                 apply plugin: 'swift-library'
             }
+            dependencies {
+                implementation project(':lib1')
+            }
+            project(':lib1') {
+                dependencies {
+                    implementation project(':lib2')
+                }
+            }
 """
         def app = new SwiftAppWithLibraries()
         app.main.writeToProject(testDirectory)
@@ -176,6 +187,9 @@ let package = Package(
     targets: [
         .target(
             name: "Test",
+            dependencies: [
+                .target(name: "Lib1"),
+            ],
             path: ".",
             sources: [
                 "src/main/swift/main.swift",
@@ -183,6 +197,9 @@ let package = Package(
         ),
         .target(
             name: "Lib1",
+            dependencies: [
+                .target(name: "Lib2"),
+            ],
             path: "lib1",
             sources: [
                 "src/main/swift/greeter.swift",
@@ -211,6 +228,14 @@ let package = Package(
             subprojects {
                 apply plugin: 'cpp-library'
             }
+            dependencies {
+                implementation project(':lib1')
+            }
+            project(':lib1') {
+                dependencies {
+                    implementation project(':lib2')
+                }
+            }
 """
         def app = new CppAppWithLibraries()
         app.main.writeToProject(testDirectory)
@@ -237,6 +262,9 @@ let package = Package(
     targets: [
         .target(
             name: "test",
+            dependencies: [
+                .target(name: "lib1"),
+            ],
             path: ".",
             sources: [
                 "src/main/cpp/main.cpp",
@@ -244,6 +272,9 @@ let package = Package(
         ),
         .target(
             name: "lib1",
+            dependencies: [
+                .target(name: "lib2"),
+            ],
             path: "lib1",
             sources: [
                 "src/main/cpp/greeter.cpp",

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -20,6 +20,11 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.vcs.fixtures.GitFileRepository
 
 class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        settingsFile << """rootProject.name = 'test'
+"""
+    }
+
     def "produces manifest for build with no native components"() {
         given:
         settingsFile << "include 'lib1', 'lib2'"
@@ -33,10 +38,23 @@ class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
         run("generateSwiftPmManifest")
 
         then:
-        file("Package.swift").file
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+    ],
+    targets: [
+    ]
+)
+"""
     }
 
-    def "produces manifest for single project Swift build"() {
+    def "produces manifest for single project Swift library"() {
         given:
         buildFile << """
             plugins { 
@@ -49,10 +67,25 @@ class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
         run("generateSwiftPmManifest")
 
         then:
-        file("Package.swift").file
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+        .library(name: "Test", targets: ["Test"]),
+    ],
+    targets: [
+        .target(name: "Test"),
+    ]
+)
+"""
     }
 
-    def "produces manifest for single project C++ build"() {
+    def "produces manifest for single project C++ library"() {
         given:
         buildFile << """
             plugins { 
@@ -65,10 +98,25 @@ class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
         run("generateSwiftPmManifest")
 
         then:
-        file("Package.swift").file
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+        .library(name: "test", targets: ["test"]),
+    ],
+    targets: [
+        .target(name: "test"),
+    ]
+)
+"""
     }
 
-    def "produces manifest for multi project Swift build"() {
+    def "produces manifest for multi-project Swift build"() {
         given:
         settingsFile << "include 'lib1', 'lib2'"
         buildFile << """
@@ -85,7 +133,26 @@ class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
         run("generateSwiftPmManifest")
 
         then:
-        file("Package.swift").file
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+        .executable(name: "Test", targets: ["Test"]),
+        .library(name: "Lib1", targets: ["Lib1"]),
+        .library(name: "Lib2", targets: ["Lib2"]),
+    ],
+    targets: [
+        .target(name: "Test"),
+        .target(name: "Lib1"),
+        .target(name: "Lib2"),
+    ]
+)
+"""
     }
 
     def "produces manifest for multi project C++ build"() {
@@ -105,7 +172,26 @@ class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
         run("generateSwiftPmManifest")
 
         then:
-        file("Package.swift").file
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+        .executable(name: "test", targets: ["test"]),
+        .library(name: "lib1", targets: ["lib1"]),
+        .library(name: "lib2", targets: ["lib2"]),
+    ],
+    targets: [
+        .target(name: "test"),
+        .target(name: "lib1"),
+        .target(name: "lib2"),
+    ]
+)
+"""
     }
 
     def "produces manifest for Swift component with source dependencies"() {
@@ -144,6 +230,21 @@ class SwiftPackageManagerExportIntegrationTest extends AbstractIntegrationSpec {
         run("generateSwiftPmManifest")
 
         then:
-        file("Package.swift").file
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+        .library(name: "Test", targets: ["Test"]),
+    ],
+    targets: [
+        .target(name: "Test"),
+    ]
+)
+"""
     }
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -85,7 +85,7 @@ import PackageDescription
 let package = Package(
     name: "test",
     products: [
-        .library(name: "Test", targets: ["Test"]),
+        .library(name: "test", targets: ["Test"]),
     ],
     targets: [
         .target(
@@ -180,9 +180,9 @@ import PackageDescription
 let package = Package(
     name: "test",
     products: [
-        .executable(name: "Test", targets: ["Test"]),
-        .library(name: "Lib1", targets: ["Lib1"]),
-        .library(name: "Lib2", targets: ["Lib2"]),
+        .executable(name: "test", targets: ["Test"]),
+        .library(name: "lib1", targets: ["Lib1"]),
+        .library(name: "lib2", targets: ["Lib2"]),
     ],
     targets: [
         .target(
@@ -320,7 +320,7 @@ let package = Package(
             }
             dependencies {
                 api "test:lib1:1.0"
-                implementation "test:lib2:1.0"
+                implementation "test:lib2:2.0"
             }
 """
         def app = new SwiftAppWithLibraries()
@@ -339,7 +339,11 @@ import PackageDescription
 let package = Package(
     name: "test",
     products: [
-        .library(name: "Test", targets: ["Test"]),
+        .library(name: "test", targets: ["Test"]),
+    ],
+    dependencies: [
+        .package(url: "repos/lib2", from: "2.0"),
+        .package(url: "repos/lib1", from: "1.0"),
     ],
     targets: [
         .target(

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -135,7 +135,8 @@ let package = Package(
             sources: [
                 "src/main/cpp/greeter.cpp",
                 "src/main/cpp/sum.cpp",
-            ]
+            ],
+            publicHeadersPath: "src/main/public"
         ),
     ]
 )
@@ -278,14 +279,16 @@ let package = Package(
             path: "lib1",
             sources: [
                 "src/main/cpp/greeter.cpp",
-            ]
+            ],
+            publicHeadersPath: "src/main/public"
         ),
         .target(
             name: "lib2",
             path: "lib2",
             sources: [
                 "src/main/cpp/logger.cpp",
-            ]
+            ],
+            publicHeadersPath: "src/main/public"
         ),
     ]
 )

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -348,6 +348,10 @@ let package = Package(
     targets: [
         .target(
             name: "Test",
+            dependencies: [
+                .product(name: "lib2"),
+                .product(name: "lib1"),
+            ],
             path: ".",
             sources: [
                 "src/main/swift/greeter.swift",

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/Package.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/Package.java
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.swiftpm.internal;
+package org.gradle.swiftpm;
 
-import org.gradle.api.file.FileCollection;
+import org.gradle.internal.HasInternalProtocol;
 
-import java.io.File;
-import java.util.Collection;
+import java.util.Set;
 
-public class DefaultExecutableProduct extends AbstractProduct {
-    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
-        super(name, targetName, path, sourceFiles, dependencies);
-    }
-
-    @Override
-    public boolean isExecutable() {
-        return true;
-    }
+/**
+ * Represents a Swift Package Manager package.
+ */
+@HasInternalProtocol
+public interface Package {
+    /**
+     * Returns the products of this package.
+     */
+    Set<? extends Product> getProducts();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm;
+
+import org.gradle.api.Named;
+
+/**
+ * A product in a Swift Package Manager package.
+ */
+public interface Product extends Named {
+    /**
+     * Returns the name of this product.
+     */
+    String getName();
+}

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
@@ -16,13 +16,16 @@
 
 package org.gradle.swiftpm;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A product in a Swift Package Manager package.
+ *
+ * @since 4.6
  */
-@HasInternalProtocol
+@HasInternalProtocol @Incubating
 public interface Product extends Named {
     /**
      * Returns the name of this product.

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
@@ -17,10 +17,12 @@
 package org.gradle.swiftpm;
 
 import org.gradle.api.Named;
+import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A product in a Swift Package Manager package.
  */
+@HasInternalProtocol
 public interface Product extends Named {
     /**
      * Returns the name of this product.

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
@@ -22,17 +22,19 @@ import org.gradle.swiftpm.Product;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.Set;
+import java.util.Collection;
 
 public abstract class AbstractProduct implements Product, Serializable {
     private final String name;
     private final File path;
-    private final Set<File> sourceFiles;
+    private final Collection<File> sourceFiles;
+    private final Collection<String> dependencies;
 
-    AbstractProduct(String name, File path, FileCollection sourceFiles) {
+    AbstractProduct(String name, File path, FileCollection sourceFiles, Collection<String> dependencies) {
         this.name = name;
         this.path = path;
         this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
+        this.dependencies = dependencies;
     }
 
     @Override
@@ -44,8 +46,12 @@ public abstract class AbstractProduct implements Product, Serializable {
         return path;
     }
 
-    public Set<File> getSourceFiles() {
+    public Collection<File> getSourceFiles() {
         return sourceFiles;
+    }
+
+    public Collection<String> getDependencies() {
+        return dependencies;
     }
 
     public abstract boolean isExecutable();

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
@@ -16,17 +16,37 @@
 
 package org.gradle.swiftpm.internal;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
+import org.gradle.swiftpm.Product;
 
 import java.io.File;
+import java.io.Serializable;
+import java.util.Set;
 
-public class DefaultLibraryProduct extends AbstractProduct {
-    public DefaultLibraryProduct(String name, File path, FileCollection sourceFiles) {
-        super(name, path, sourceFiles);
+public abstract class AbstractProduct implements Product, Serializable {
+    private final String name;
+    private final File path;
+    private final Set<File> sourceFiles;
+
+    AbstractProduct(String name, File path, FileCollection sourceFiles) {
+        this.name = name;
+        this.path = path;
+        this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
     }
 
     @Override
-    public boolean isExecutable() {
-        return false;
+    public String getName() {
+        return name;
     }
+
+    public File getPath() {
+        return path;
+    }
+
+    public Set<File> getSourceFiles() {
+        return sourceFiles;
+    }
+
+    public abstract boolean isExecutable();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
@@ -20,25 +20,27 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.swiftpm.Product;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public abstract class AbstractProduct implements Product, Serializable {
     private final String name;
     private final String targetName;
     private final File path;
     private final Collection<File> sourceFiles;
-    private final Collection<String> requiredTargets;
-    private final Collection<String> requiredProducts;
+    private final List<String> requiredTargets = new ArrayList<String>();
+    private final List<String> requiredProducts = new ArrayList<String>();
+    private File publicHeaderDir;
 
-    AbstractProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> requiredTargets, Collection<String> requiredProducts) {
+    AbstractProduct(String name, String targetName, File path, FileCollection sourceFiles) {
         this.name = name;
         this.targetName = targetName;
         this.path = path;
         this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
-        this.requiredTargets = requiredTargets;
-        this.requiredProducts = requiredProducts;
     }
 
     @Override
@@ -56,6 +58,15 @@ public abstract class AbstractProduct implements Product, Serializable {
 
     public Collection<File> getSourceFiles() {
         return sourceFiles;
+    }
+
+    @Nullable
+    public File getPublicHeaderDir() {
+        return publicHeaderDir;
+    }
+
+    public void setPublicHeaderDir(File publicHeaderDir) {
+        this.publicHeaderDir = publicHeaderDir;
     }
 
     public Collection<String> getRequiredTargets() {

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
@@ -29,14 +29,16 @@ public abstract class AbstractProduct implements Product, Serializable {
     private final String targetName;
     private final File path;
     private final Collection<File> sourceFiles;
-    private final Collection<String> dependencies;
+    private final Collection<String> requiredTargets;
+    private final Collection<String> requiredProducts;
 
-    AbstractProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
+    AbstractProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> requiredTargets, Collection<String> requiredProducts) {
         this.name = name;
         this.targetName = targetName;
         this.path = path;
         this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
-        this.dependencies = dependencies;
+        this.requiredTargets = requiredTargets;
+        this.requiredProducts = requiredProducts;
     }
 
     @Override
@@ -56,8 +58,12 @@ public abstract class AbstractProduct implements Product, Serializable {
         return sourceFiles;
     }
 
-    public Collection<String> getDependencies() {
-        return dependencies;
+    public Collection<String> getRequiredTargets() {
+        return requiredTargets;
+    }
+
+    public Collection<String> getRequiredProducts() {
+        return requiredProducts;
     }
 
     public abstract boolean isExecutable();

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/AbstractProduct.java
@@ -26,12 +26,14 @@ import java.util.Collection;
 
 public abstract class AbstractProduct implements Product, Serializable {
     private final String name;
+    private final String targetName;
     private final File path;
     private final Collection<File> sourceFiles;
     private final Collection<String> dependencies;
 
-    AbstractProduct(String name, File path, FileCollection sourceFiles, Collection<String> dependencies) {
+    AbstractProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
         this.name = name;
+        this.targetName = targetName;
         this.path = path;
         this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
         this.dependencies = dependencies;
@@ -40,6 +42,10 @@ public abstract class AbstractProduct implements Product, Serializable {
     @Override
     public String getName() {
         return name;
+    }
+
+    public String getTargetName() {
+        return targetName;
     }
 
     public File getPath() {

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm.internal;
+
+import org.gradle.swiftpm.Product;
+
+import java.io.Serializable;
+
+public class DefaultExecutableProduct implements Product, Serializable {
+    private final String name;
+
+    public DefaultExecutableProduct(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
@@ -16,19 +16,17 @@
 
 package org.gradle.swiftpm.internal;
 
-import org.gradle.swiftpm.Product;
+import org.gradle.api.file.FileCollection;
 
-import java.io.Serializable;
+import java.io.File;
 
-public class DefaultExecutableProduct implements Product, Serializable {
-    private final String name;
-
-    public DefaultExecutableProduct(String name) {
-        this.name = name;
+public class DefaultExecutableProduct extends AbstractProduct {
+    public DefaultExecutableProduct(String name, File path, FileCollection sourceFiles) {
+        super(name, path, sourceFiles);
     }
 
     @Override
-    public String getName() {
-        return name;
+    public boolean isExecutable() {
+        return true;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
@@ -19,10 +19,11 @@ package org.gradle.swiftpm.internal;
 import org.gradle.api.file.FileCollection;
 
 import java.io.File;
+import java.util.Collection;
 
 public class DefaultExecutableProduct extends AbstractProduct {
-    public DefaultExecutableProduct(String name, File path, FileCollection sourceFiles) {
-        super(name, path, sourceFiles);
+    public DefaultExecutableProduct(String name, File path, FileCollection sourceFiles, Collection<String> dependencies) {
+        super(name, path, sourceFiles, dependencies);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
@@ -19,11 +19,10 @@ package org.gradle.swiftpm.internal;
 import org.gradle.api.file.FileCollection;
 
 import java.io.File;
-import java.util.Collection;
 
 public class DefaultExecutableProduct extends AbstractProduct {
-    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> requiredTargets, Collection<String> requiredProducts) {
-        super(name, targetName, path, sourceFiles, requiredTargets, requiredProducts);
+    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles) {
+        super(name, targetName, path, sourceFiles);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultExecutableProduct.java
@@ -22,8 +22,8 @@ import java.io.File;
 import java.util.Collection;
 
 public class DefaultExecutableProduct extends AbstractProduct {
-    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
-        super(name, targetName, path, sourceFiles, dependencies);
+    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> requiredTargets, Collection<String> requiredProducts) {
+        super(name, targetName, path, sourceFiles, requiredTargets, requiredProducts);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
@@ -19,10 +19,11 @@ package org.gradle.swiftpm.internal;
 import org.gradle.api.file.FileCollection;
 
 import java.io.File;
+import java.util.Collection;
 
 public class DefaultLibraryProduct extends AbstractProduct {
-    public DefaultLibraryProduct(String name, File path, FileCollection sourceFiles) {
-        super(name, path, sourceFiles);
+    public DefaultLibraryProduct(String name, File path, FileCollection sourceFiles, Collection<String> dependencies) {
+        super(name, path, sourceFiles, dependencies);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm.internal;
+
+import org.gradle.swiftpm.Product;
+
+import java.io.Serializable;
+
+public class DefaultLibraryProduct implements Product, Serializable {
+    private final String name;
+
+    public DefaultLibraryProduct(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
@@ -22,8 +22,8 @@ import java.io.File;
 import java.util.Collection;
 
 public class DefaultLibraryProduct extends AbstractProduct {
-    public DefaultLibraryProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
-        super(name, targetName, path, sourceFiles, dependencies);
+    public DefaultLibraryProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> requiredTargets, Collection<String> requiredProducts) {
+        super(name, targetName, path, sourceFiles, requiredTargets, requiredProducts);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
@@ -19,11 +19,10 @@ package org.gradle.swiftpm.internal;
 import org.gradle.api.file.FileCollection;
 
 import java.io.File;
-import java.util.Collection;
 
 public class DefaultLibraryProduct extends AbstractProduct {
-    public DefaultLibraryProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> requiredTargets, Collection<String> requiredProducts) {
-        super(name, targetName, path, sourceFiles, requiredTargets, requiredProducts);
+    public DefaultLibraryProduct(String name, String targetName, File path, FileCollection sourceFiles) {
+        super(name, targetName, path, sourceFiles);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultLibraryProduct.java
@@ -22,8 +22,8 @@ import java.io.File;
 import java.util.Collection;
 
 public class DefaultLibraryProduct extends AbstractProduct {
-    public DefaultLibraryProduct(String name, File path, FileCollection sourceFiles, Collection<String> dependencies) {
-        super(name, path, sourceFiles, dependencies);
+    public DefaultLibraryProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
+        super(name, targetName, path, sourceFiles, dependencies);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultPackage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/DefaultPackage.java
@@ -16,18 +16,27 @@
 
 package org.gradle.swiftpm.internal;
 
-import org.gradle.api.file.FileCollection;
+import org.gradle.swiftpm.Package;
 
-import java.io.File;
-import java.util.Collection;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
 
-public class DefaultExecutableProduct extends AbstractProduct {
-    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
-        super(name, targetName, path, sourceFiles, dependencies);
+public class DefaultPackage implements Package, Serializable {
+    private final Set<AbstractProduct> products;
+    private final List<Dependency> dependencies;
+
+    public DefaultPackage(Set<AbstractProduct> products, List<Dependency> dependencies) {
+        this.products = products;
+        this.dependencies = dependencies;
+    }
+
+    public List<Dependency> getDependencies() {
+        return dependencies;
     }
 
     @Override
-    public boolean isExecutable() {
-        return true;
+    public Set<AbstractProduct> getProducts() {
+        return products;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/Dependency.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/Dependency.java
@@ -16,18 +16,23 @@
 
 package org.gradle.swiftpm.internal;
 
-import org.gradle.api.file.FileCollection;
+import java.io.Serializable;
+import java.net.URI;
 
-import java.io.File;
-import java.util.Collection;
+public class Dependency implements Serializable {
+    private final URI url;
+    private final String version;
 
-public class DefaultExecutableProduct extends AbstractProduct {
-    public DefaultExecutableProduct(String name, String targetName, File path, FileCollection sourceFiles, Collection<String> dependencies) {
-        super(name, targetName, path, sourceFiles, dependencies);
+    public Dependency(URI url, String version) {
+        this.url = url;
+        this.version = version;
     }
 
-    @Override
-    public boolean isExecutable() {
-        return true;
+    public URI getUrl() {
+        return url;
+    }
+
+    public String getVersion() {
+        return version;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/package-info.java
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.swiftpm;
-
-import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
-
-import java.util.Set;
-
 /**
- * Represents a Swift Package Manager package.
- *
- * @since 4.6
+ * Model classes that describe a Swift Package Manager package.
  */
-@HasInternalProtocol @Incubating
-public interface Package {
-    /**
-     * Returns the products of this package.
-     */
-    Set<? extends Product> getProducts();
-}
+package org.gradle.swiftpm;

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -47,16 +47,16 @@ public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
                     for (ProductionComponent component : p.getComponents().withType(ProductionComponent.class)) {
                         if (component instanceof CppApplication) {
                             CppApplication application = (CppApplication) component;
-                            result.add(new DefaultExecutableProduct(application.getBaseName().get()));
+                            result.add(new DefaultExecutableProduct(application.getBaseName().get(), p.getProjectDir(), application.getCppSource()));
                         } else if (component instanceof CppLibrary) {
                             CppLibrary library = (CppLibrary) component;
-                            result.add(new DefaultLibraryProduct(library.getBaseName().get()));
+                            result.add(new DefaultLibraryProduct(library.getBaseName().get(), p.getProjectDir(), library.getCppSource()));
                         } else if (component instanceof SwiftApplication) {
                             SwiftApplication application = (SwiftApplication) component;
-                            result.add(new DefaultExecutableProduct(application.getModule().get()));
+                            result.add(new DefaultExecutableProduct(application.getModule().get(), p.getProjectDir(), application.getSwiftSource()));
                         } else if (component instanceof SwiftLibrary) {
                             SwiftLibrary library = (SwiftLibrary) component;
-                            result.add(new DefaultLibraryProduct(library.getModule().get()));
+                            result.add(new DefaultLibraryProduct(library.getModule().get(), p.getProjectDir(), library.getSwiftSource()));
                         }
                     }
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.swiftpm.tasks.GenerateSwiftPackageManagerManifest;
+
+public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        GenerateSwiftPackageManagerManifest manifestTask = project.getTasks().create("generateSwiftPmManifest", GenerateSwiftPackageManagerManifest.class);
+        manifestTask.getManifestFile().set(project.getLayout().getProjectDirectory().file("Package.swift"));
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -17,6 +17,7 @@
 package org.gradle.swiftpm.plugins;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -51,6 +52,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+/**
+ * A plugin that produces a Swift Package Manager manifests from the Gradle model.
+ *
+ * <p>This plugin should only be applied to the root project of a build.</p>
+ *
+ * @since 4.6
+ */
+@Incubating
 public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
     private final VcsMappingsStore vcsMappingsStore;
     private final VcsMappingFactory vcsMappingFactory;

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/package-info.java
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.swiftpm;
-
-import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
-
-import java.util.Set;
-
 /**
- * Represents a Swift Package Manager package.
- *
- * @since 4.6
+ * Plugins that produce Swift Package Manager manifests from the Gradle model.
  */
-@HasInternalProtocol @Incubating
-public interface Package {
-    /**
-     * Returns the products of this package.
-     */
-    Set<? extends Product> getProducts();
-}
+package org.gradle.swiftpm.plugins;

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class GenerateSwiftPackageManagerManifest extends DefaultTask {
+    private final RegularFileProperty manifestFile = newOutputFile();
+
+    @OutputFile
+    public RegularFileProperty getManifestFile() {
+        return manifestFile;
+    }
+
+    @TaskAction
+    public void generate() {
+        File file = manifestFile.get().getAsFile();
+        file.getParentFile().mkdirs();
+        try {
+            PrintWriter writer = new PrintWriter(new FileWriter(file));
+            try {
+                writer.println("// swift-tools-version:4.0");
+                writer.println("//");
+                writer.println("// GENERATED FILE - do not edit");
+                writer.println("//");
+                writer.println("import PackageDescription");
+                writer.println();
+                writer.println("let package = Package(");
+                writer.println("  name: \"" + getProject().getName() + "\"");
+                writer.println(")");
+            } finally {
+                writer.close();
+            }
+        } catch (IOException e) {
+            throw new GradleException(String.format("Could not write manifest file %s.", file), e);
+        }
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -32,6 +32,8 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class GenerateSwiftPackageManagerManifest extends DefaultTask {
     private final RegularFileProperty manifestFile = newOutputFile();
@@ -85,15 +87,28 @@ public class GenerateSwiftPackageManagerManifest extends DefaultTask {
                     writer.print("            name: \"");
                     writer.print(product.getName());
                     writer.println("\",");
+                    if (!product.getDependencies().isEmpty()) {
+                        writer.println("            dependencies: [");
+                        for (String dep : product.getDependencies()) {
+                            writer.print("                .target(name: \"");
+                            writer.print(dep);
+                            writer.println("\"),");
+                        }
+                        writer.println("            ],");
+                    }
                     writer.print("            path: \"");
                     Path productPath = product.getPath().toPath();
                     String relPath = baseDir.relativize(productPath).toString();
                     writer.print(relPath.isEmpty() ? ".": relPath);
                     writer.println("\",");
                     writer.println("            sources: [");
+                    Set<String> sorted = new TreeSet<String>();
                     for (File sourceFile : product.getSourceFiles()) {
+                        sorted.add(productPath.relativize(sourceFile.toPath()).toString());
+                    }
+                    for (String sourcePath : sorted) {
                         writer.print("                \"");
-                        writer.print(productPath.relativize(sourceFile.toPath()));
+                        writer.print(sourcePath);
                         writer.println("\",");
                     }
                     writer.println("            ]");

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -139,7 +139,15 @@ public class GenerateSwiftPackageManagerManifest extends DefaultTask {
                         writer.print(sourcePath);
                         writer.println("\",");
                     }
-                    writer.println("            ]");
+                    writer.print("            ]");
+                    if (product.getPublicHeaderDir() != null) {
+                        writer.println(",");
+                        writer.print("            publicHeadersPath: \"");
+                        writer.print(productPath.relativize(product.getPublicHeaderDir().toPath()));
+                        writer.println("\"");
+                    } else {
+                        writer.println();
+                    }
                     writer.println("        ),");
                 }
                 writer.println("    ]");

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -18,6 +18,7 @@ package org.gradle.swiftpm.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -37,6 +38,12 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.TreeSet;
 
+/**
+ * A task that produces a Swift Package Manager manifest.
+ *
+ * @since 4.6
+ */
+@Incubating
 public class GenerateSwiftPackageManagerManifest extends DefaultTask {
     private final RegularFileProperty manifestFile = newOutputFile();
     private final Property<Package> packageProperty = getProject().getObjects().property(Package.class);

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -110,10 +110,15 @@ public class GenerateSwiftPackageManagerManifest extends DefaultTask {
                     writer.print("            name: \"");
                     writer.print(product.getTargetName());
                     writer.println("\",");
-                    if (!product.getDependencies().isEmpty()) {
+                    if (!product.getRequiredTargets().isEmpty() || !product.getRequiredProducts().isEmpty()) {
                         writer.println("            dependencies: [");
-                        for (String dep : product.getDependencies()) {
+                        for (String dep : product.getRequiredTargets()) {
                             writer.print("                .target(name: \"");
+                            writer.print(dep);
+                            writer.println("\"),");
+                        }
+                        for (String dep : product.getRequiredProducts()) {
+                            writer.print("                .product(name: \"");
                             writer.print(dep);
                             writer.println("\"),");
                         }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/package-info.java
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.swiftpm;
-
-import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
-
-import java.util.Set;
-
 /**
- * Represents a Swift Package Manager package.
- *
- * @since 4.6
+ * Tasks that produce Swift Package Manager manifests from the Gradle model.
  */
-@HasInternalProtocol @Incubating
-public interface Package {
-    /**
-     * Returns the products of this package.
-     */
-    Set<? extends Product> getProducts();
-}
+package org.gradle.swiftpm.tasks;

--- a/subprojects/language-native/src/main/resources/META-INF/gradle-plugins/org.gradle.swiftpm-export.properties
+++ b/subprojects/language-native/src/main/resources/META-INF/gradle-plugins/org.gradle.swiftpm-export.properties
@@ -1,0 +1,1 @@
+implementation-class=org.gradle.swiftpm.plugins.SwiftPackageManagerExportPlugin

--- a/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm.plugins
+
+import org.gradle.swiftpm.tasks.GenerateSwiftPackageManagerManifest
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import spock.lang.Specification
+
+class SwiftPackageManagerExportPluginTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    def projectDir = tmpDir.createDir("project")
+    def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testLib").build()
+
+    def "adds generate task"() {
+        when:
+        project.pluginManager.apply(SwiftPackageManagerExportPlugin)
+
+        then:
+        def generateManifest = project.tasks['generateSwiftPmManifest']
+        generateManifest instanceof GenerateSwiftPackageManagerManifest
+        generateManifest.manifestFile.get().asFile == project.file("Package.swift")
+    }
+}

--- a/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
@@ -52,7 +52,7 @@ class SwiftPackageManagerExportPluginTest extends Specification {
 
         expect:
         def generateManifest = project.tasks['generateSwiftPmManifest']
-        def products = generateManifest.products.get()
+        def products = generateManifest.package.get().products
         products.name == ["app1", "app2"]
         products.every { it instanceof DefaultExecutableProduct }
     }
@@ -69,8 +69,9 @@ class SwiftPackageManagerExportPluginTest extends Specification {
 
         expect:
         def generateManifest = project.tasks['generateSwiftPmManifest']
-        def products = generateManifest.products.get()
+        def products = generateManifest.package.get().products
         products.name == ["lib1", "lib2"]
+        products.targetName == ["lib1", "lib2"]
         products.every { it instanceof DefaultLibraryProduct }
     }
 
@@ -86,8 +87,9 @@ class SwiftPackageManagerExportPluginTest extends Specification {
 
         expect:
         def generateManifest = project.tasks['generateSwiftPmManifest']
-        def products = generateManifest.products.get()
-        products.name == ["App1", "App2"]
+        def products = generateManifest.package.get().products
+        products.name == ["app1", "app2"]
+        products.targetName == ["App1", "App2"]
         products.every { it instanceof DefaultExecutableProduct }
     }
 
@@ -103,8 +105,9 @@ class SwiftPackageManagerExportPluginTest extends Specification {
 
         expect:
         def generateManifest = project.tasks['generateSwiftPmManifest']
-        def products = generateManifest.products.get()
-        products.name == ["Lib1", "Lib2"]
+        def products = generateManifest.package.get().products
+        products.name == ["lib1", "lib2"]
+        products.targetName == ["Lib1", "Lib2"]
         products.every { it instanceof DefaultLibraryProduct }
     }
 
@@ -118,8 +121,8 @@ class SwiftPackageManagerExportPluginTest extends Specification {
 
         expect:
         def generateManifest = project.tasks['generateSwiftPmManifest']
-        def products = generateManifest.products.get()
-        products.name == ["TestLib"]
+        def products = generateManifest.package.get().products
+        products.name == ["testLib"]
     }
 
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
@@ -54,6 +54,8 @@ class SwiftPackageManagerExportPluginTest extends Specification {
         def generateManifest = project.tasks['generateSwiftPmManifest']
         def products = generateManifest.package.get().products
         products.name == ["app1", "app2"]
+        products.targetName == ["app1", "app2"]
+        products.publicHeaderDir == [null, null]
         products.every { it instanceof DefaultExecutableProduct }
     }
 
@@ -72,6 +74,7 @@ class SwiftPackageManagerExportPluginTest extends Specification {
         def products = generateManifest.package.get().products
         products.name == ["lib1", "lib2"]
         products.targetName == ["lib1", "lib2"]
+        products.publicHeaderDir == [app1Project.file("src/main/public"), app2Project.file("src/main/public")]
         products.every { it instanceof DefaultLibraryProduct }
     }
 
@@ -90,6 +93,7 @@ class SwiftPackageManagerExportPluginTest extends Specification {
         def products = generateManifest.package.get().products
         products.name == ["app1", "app2"]
         products.targetName == ["App1", "App2"]
+        products.publicHeaderDir == [null, null]
         products.every { it instanceof DefaultExecutableProduct }
     }
 
@@ -108,6 +112,7 @@ class SwiftPackageManagerExportPluginTest extends Specification {
         def products = generateManifest.package.get().products
         products.name == ["lib1", "lib2"]
         products.targetName == ["Lib1", "Lib2"]
+        products.publicHeaderDir == [null, null]
         products.every { it instanceof DefaultLibraryProduct }
     }
 

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -118,7 +118,7 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
 
         then:
         failure.assertHasDescription("Execution failed for task '$developmentBinaryCompileTask'.")
-        failure.assertHasCause("swiftc compiler version '${toolChain.version}' doesn't support Swift language version '${SwiftVersion.SWIFT4.version}'")
+        failure.assertHasCause("Swift compiler version '${toolChain.version}' doesn't support Swift language version '${SwiftVersion.SWIFT4.version}'")
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_3)

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
@@ -67,7 +67,7 @@ class SwiftCompiler extends AbstractCompiler<SwiftCompileSpec> {
     @Override
     public WorkResult execute(SwiftCompileSpec spec) {
         if (swiftCompilerVersion.getMajor() < spec.getSourceCompatibility().getVersion()) {
-            throw new IllegalArgumentException(String.format("swiftc compiler version '%s' doesn't support Swift language version '%d'", swiftCompilerVersion.toString(), spec.getSourceCompatibility().getVersion()));
+            throw new IllegalArgumentException(String.format("Swift compiler version '%s' doesn't support Swift language version '%d'", swiftCompilerVersion.toString(), spec.getSourceCompatibility().getVersion()));
         }
 
         return super.execute(spec);


### PR DESCRIPTION
### Context

This change introduces a 'swiftpm-export' plugin that generates a Swift PM description of the build so that the products of the build can be consumed by Swift PM. This is roughly the same as generating a Maven POM for a project, in the sense that it describes one or more components that can be used by some other tool, and in the sense that this is only a part of the process for publishing a version of some components.

This new plugin is intended to eventually be replaced by something that can deal with the whole publishing process for Swift PM and other tools. You could certainly see a conan.io integration working in a similar way.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
