### PR TITLE
Allow source dependencies to be used for build script classpaths

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
@@ -29,21 +29,15 @@ import java.util.Set;
 public class CompositeBuildClassPathInitializer implements ScriptClassPathInitializer {
     private final IncludedBuildTaskGraph includedBuildTaskGraph;
     private final ServiceRegistry serviceRegistry;
-    private final IncludedBuildRegistry includedBuildRegistry;
     private BuildIdentifier currentBuild;
 
-    public CompositeBuildClassPathInitializer(IncludedBuildRegistry includedBuildRegistry, IncludedBuildTaskGraph includedBuildTaskGraph, ServiceRegistry serviceRegistry) {
-        this.includedBuildRegistry = includedBuildRegistry;
+    public CompositeBuildClassPathInitializer(IncludedBuildTaskGraph includedBuildTaskGraph, ServiceRegistry serviceRegistry) {
         this.includedBuildTaskGraph = includedBuildTaskGraph;
         this.serviceRegistry = serviceRegistry;
     }
 
     @Override
     public void execute(Configuration classpath) {
-        if (!includedBuildRegistry.hasIncludedBuilds()) {
-            return;
-        }
-
         ArtifactCollection artifacts = classpath.getIncoming().getArtifacts();
         for (ResolvedArtifactResult artifactResult : artifacts.getArtifacts()) {
             ComponentArtifactIdentifier componentArtifactIdentifier = artifactResult.getId();
@@ -66,6 +60,7 @@ public class CompositeBuildClassPathInitializer implements ScriptClassPathInitia
         if (artifact instanceof CompositeProjectComponentArtifactMetadata) {
             CompositeProjectComponentArtifactMetadata compositeBuildArtifact = (CompositeProjectComponentArtifactMetadata) artifact;
             BuildIdentifier targetBuild = getBuildIdentifier(compositeBuildArtifact);
+            assert !requestingBuild.equals(targetBuild);
             Set<String> tasks = compositeBuildArtifact.getTasks();
             for (String taskName : tasks) {
                 includedBuildTaskGraph.addTask(requestingBuild, targetBuild, taskName);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -68,8 +68,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
             return new IncludedBuildTaskReferenceResolver(includedBuilds, buildIdentity);
         }
 
-        public ScriptClassPathInitializer createCompositeBuildClasspathResolver(IncludedBuildRegistry includedBuildRegistry, IncludedBuildTaskGraph includedBuildTaskGraph, ServiceRegistry serviceRegistry) {
-            return new CompositeBuildClassPathInitializer(includedBuildRegistry, includedBuildTaskGraph, serviceRegistry);
+        public ScriptClassPathInitializer createCompositeBuildClasspathResolver(IncludedBuildTaskGraph includedBuildTaskGraph, ServiceRegistry serviceRegistry) {
+            return new CompositeBuildClassPathInitializer(includedBuildTaskGraph, serviceRegistry);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -16,6 +16,8 @@
 
 package org.gradle.initialization;
 
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
 import org.gradle.composite.internal.IncludedBuildRegistry;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.internal.composite.CompositeBuildSettingsLoader;
@@ -54,11 +56,19 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
     }
 
     private SettingsLoader defaultSettingsLoader() {
-        return new DefaultSettingsLoader(
+        final DefaultSettingsLoader delegate = new DefaultSettingsLoader(
             settingsFinder,
             settingsProcessor,
             buildSourceBuilder
         );
+        return new SettingsLoader() {
+            @Override
+            public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
+                SettingsInternal settings = delegate.findAndLoadSettings(gradle);
+                gradle.setSettings(settings);
+                return settings;
+            }
+        };
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/InstantiatingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/InstantiatingBuildLoader.java
@@ -35,12 +35,7 @@ public class InstantiatingBuildLoader implements BuildLoader {
      */
     @Override
     public void load(SettingsInternal settings, GradleInternal gradle) {
-        attachSettings(settings, gradle);
         load(settings.getRootProject(), settings.getDefaultProject(), gradle, settings.getRootClassLoaderScope());
-    }
-
-    private void attachSettings(SettingsInternal settings, GradleInternal gradle) {
-        gradle.setSettings(settings);
     }
 
     private void load(ProjectDescriptor rootProjectDescriptor, ProjectDescriptor defaultProject, GradleInternal gradle, ClassLoaderScope buildRootClassLoaderScope) {

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/CompositeBuildSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/CompositeBuildSettingsLoader.java
@@ -21,9 +21,9 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.composite.internal.IncludedBuildRegistry;
+import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.SettingsLoader;
-import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.plugin.management.internal.DefaultPluginRequests;
 
 import java.io.File;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.initialization
 import org.gradle.StartParameter
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.IProjectFactory
@@ -64,25 +63,6 @@ class InstantiatingBuildLoaderTest extends Specification {
         childProject = project(childDescriptor, rootProject)
         build = Mock(GradleInternal)
         build.getStartParameter() >> startParameter
-    }
-
-    def "attaches settings when loaded"() {
-        given:
-        def settings = Stub(SettingsInternal) {
-            getRootProject() >> rootDescriptor
-            getDefaultProject() >> rootDescriptor
-            getRootClassLoaderScope() >> baseClassLoaderScope
-        }
-
-        when:
-        buildLoader.load(settings, build)
-
-        then:
-        1 * build.getRootProject() >> rootProject
-        1 * projectFactory.createProject(rootDescriptor, null, !null, rootProjectClassLoaderScope, baseClassLoaderScope) >> rootProject
-
-        and:
-        1 * build.setSettings(settings)
     }
 
     def createsBuildWithRootProjectAsTheDefaultOne() {

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -169,36 +169,6 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
         gitCheckout.file('.git').assertExists()
     }
 
-    def 'can resolve specific version'() {
-        given:
-        settingsFile << """
-            sourceControl {
-                vcsMappings {
-                    withModule("org.test:dep") {
-                        from(GitVersionControlSpec) {
-                            url = "${repo.url}"
-                        }
-                    }
-                }
-            }
-        """
-        def commit = repo.commit('initial commit')
-        repo.createLightWeightTag('1.3.0')
-
-        def javaFile = file('dep/src/main/java/Dep.java')
-        javaFile.replace('class', 'interface')
-        repo.commit('Changed Dep to an interface')
-
-        buildFile.replace('latest.integration', '1.3.0')
-
-        when:
-        succeeds('assemble')
-
-        then:
-        def gitCheckout = checkoutDir(repo.name, commit.id.name, repo.id)
-        gitCheckout.file('.git').assertExists()
-    }
-
     def 'handle missing version by adding tag to git repository'() {
         given:
         settingsFile << """


### PR DESCRIPTION
### Context

This change adds support for source dependencies in build script classpaths. It also fixes the case where a build defines included builds and VCS mappings.

Source dependencies are not supported for settings or init scripts.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
