### PR TITLE
Introduce experimental stage for running Java 10 tests on demand

### DIFF
--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -90,7 +90,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?) : BaseGr
     }
 
     dependencies {
-        if (prevStage != null) {
+        if (!stage.runsIndependent && prevStage != null) {
             dependency("${model.projectPrefix}Stage_${prevStage.name.replace(" ", "").replace("-", "")}_Trigger") {
                 snapshot {
                     onDependencyFailure = FailureAction.ADD_PROBLEM

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -56,7 +56,7 @@ data class CIBuildModel (
                             PerformanceTestType.historical)),
             Stage("Experimental", "On demand: Run experimental tests",
                     trigger = Trigger.never,
-                    performanceTests = listOf(
+                    functionalTests = listOf(
                             TestCoverage(TestType.platform, OS.linux, JvmVersion.java10))))
     ) {
 

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -56,6 +56,7 @@ data class CIBuildModel (
                             PerformanceTestType.historical)),
             Stage("Experimental", "On demand: Run experimental tests",
                     trigger = Trigger.never,
+                    runsIndependent = true
                     functionalTests = listOf(
                             TestCoverage(TestType.platform, OS.linux, JvmVersion.java10))))
     ) {
@@ -170,7 +171,7 @@ object NoBuildCache : BuildCache {
     }
 }
 
-data class Stage(val name: String, val description: String, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false)
+data class Stage(val name: String, val description: String, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false, val runsIndependent: Boolean = false)
 
 data class TestCoverage(val testType: TestType, val os: OS, val version: JvmVersion, val vendor: JvmVendor = JvmVendor.oracle) {
     fun asId(model : CIBuildModel): String {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -53,7 +53,11 @@ data class CIBuildModel (
             Stage("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions",
                     trigger = Trigger.weekly,
                     performanceTests = listOf(
-                            PerformanceTestType.historical)))
+                            PerformanceTestType.historical)),
+            Stage("Experimental", "On demand: Run experimental tests",
+                    trigger = Trigger.never,
+                    performanceTests = listOf(
+                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java10))))
     ) {
 
     val subProjects = listOf(
@@ -188,7 +192,7 @@ enum class OS(val agentRequirement: String, val ignoredSubprojects: List<String>
 }
 
 enum class JvmVersion {
-    java7, java8, java9
+    java7, java8, java9, java10
 }
 
 enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false) {


### PR DESCRIPTION
### Context

For more information see https://github.com/gradle/gradle-private/issues/1066.

I see up a new stage that can be triggered on demand. That may be a compromise of having Java 10 tests as part of the pipeline but without necessarily blocking the rest.