### PR TITLE
Remove the `show-variant-details` flag

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -390,8 +390,10 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         then:
         output.contains(""":dependencyInsight
 org:b:1 (A replaced with B)
+   variant "default"
 
 org:a:1 -> org:b:1
+   variant "default"
 \\--- conf""")
 
         when:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -138,6 +138,7 @@ No dependencies matching given input were found in configuration ':conf'
         then:
         output.contains """
 org:leaf2:1.0
+   variant "runtime"
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf
@@ -186,10 +187,12 @@ org:leaf2:1.0
         then:
         output.contains """
 org:leaf2:2.5 (conflict resolution)
+   variant "runtime"
 \\--- org:toplevel3:1.0
      \\--- conf
 
 org:leaf2:1.0 -> 2.5
+   variant "runtime"
 +--- org:middle1:1.0
 |    \\--- org:toplevel:1.0
 |         \\--- conf
@@ -198,6 +201,7 @@ org:leaf2:1.0 -> 2.5
           \\--- conf
 
 org:leaf2:1.5 -> 2.5
+   variant "runtime"
 \\--- org:toplevel2:1.0
      \\--- conf
 """
@@ -234,10 +238,12 @@ org:leaf2:1.5 -> 2.5
         then:
         output.contains """
 org:leaf:1.0 (forced)
+   variant "runtime"
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
+   variant "runtime"
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -281,16 +287,19 @@ org:leaf:2.0 -> 1.0
         then:
         output.contains """
 org:leaf:1.0
+   variant "runtime"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:[1.0,2.0] -> 1.0
+   variant "runtime"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:latest.integration -> 1.0
+   variant "runtime"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
@@ -329,10 +338,12 @@ org:leaf:latest.integration -> 1.0
         then:
         output.contains """
 org:leaf:1.0 (selected by rule)
+   variant "runtime"
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
+   variant "runtime"
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -383,16 +394,21 @@ org:leaf:2.0 -> 1.0
         then:
         output.contains """
 org.test:bar:2.0 (why not?)
+   variant "default"
 
 org:bar:1.0 -> org.test:bar:2.0
+   variant "default"
 \\--- conf
 
 org:baz:1.0 (selected by rule)
+   variant "default"
 \\--- conf
 
 org:foo:2.0 (because I am in control)
+   variant "default"
 
 org:foo:1.0 -> 2.0
+   variant "default"
 \\--- conf
 """
     }
@@ -430,8 +446,10 @@ org:foo:1.0 -> 2.0
 
         then:
         output.contains """org:bar:1.0 (foo superceded by bar)
+   variant "default"
 
 org:foo:1.0 -> org:bar:1.0
+   variant "default"
 \\--- conf
 """
     }
@@ -470,12 +488,15 @@ org:foo:1.0 -> org:bar:1.0
         then:
         output.contains """
 org:new-leaf:77 (selected by rule)
+   variant "runtime"
 
 org:leaf:1.0 -> org:new-leaf:77
+   variant "runtime"
 \\--- org:foo:2.0
      \\--- conf
 
 org:leaf:2.0 -> org:new-leaf:77
+   variant "runtime"
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -515,13 +536,17 @@ org:leaf:2.0 -> org:new-leaf:77
         then:
         output.contains """
 org:bar:2.0 (I am not sure I want to explain)
+   variant "default"
 
 org:bar:1.0 -> 2.0
+   variant "default"
 \\--- conf
 
 org:foo:2.0 (I want to)
+   variant "default"
 
 org:foo:1.0 -> 2.0
+   variant "default"
 \\--- conf
 """
     }
@@ -557,16 +582,20 @@ org:foo:1.0 -> 2.0
         then:
         output.contains """
 org:leaf:1.6
+   variant "runtime"
 
 org:leaf:1.+ -> 1.6
+   variant "runtime"
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:[1.5,1.9] -> 1.6
+   variant "runtime"
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:latest.integration -> 1.6
+   variant "runtime"
 \\--- org:top:1.0
      \\--- conf
 """
@@ -603,10 +632,12 @@ org:leaf:latest.integration -> 1.6
         then:
         output.contains """
 org:leaf:2.0 (forced)
+   variant "runtime"
 \\--- org:bar:1.0
      \\--- conf
 
 org:leaf:1.0 -> 2.0
+   variant "runtime"
 \\--- org:foo:1.0
      \\--- conf
 """
@@ -644,12 +675,15 @@ org:leaf:1.0 -> 2.0
         then:
         output.contains """
 org:leaf:1.5 (forced)
+   variant "runtime"
 
 org:leaf:1.0 -> 1.5
+   variant "runtime"
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.5
+   variant "runtime"
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -688,11 +722,13 @@ org:leaf:2.0 -> 1.5
         then:
         output.contains """
 org:leaf:1.0 (forced)
+   variant "default"
 +--- conf
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
+   variant "default"
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -1019,6 +1055,7 @@ org:leaf:[1.5,2.0] FAILED
         then:
         output.contains """
 org:leaf2:1.0
+   variant "runtime"
 \\--- org:leaf1:1.0
      +--- conf
      \\--- org:leaf2:1.0 (*)
@@ -1056,6 +1093,7 @@ org:leaf2:1.0
         then:
         output.contains """
 project :
+   variant "compile"
 \\--- project :impl
      \\--- project : (*)
 """
@@ -1098,6 +1136,7 @@ project :
         then:
         output.contains """
 org:leaf2:1.0
+   variant "runtime"
 \\--- org:leaf1:1.0
      \\--- project :impl
           \\--- compile
@@ -1141,6 +1180,9 @@ org:leaf2:1.0
         then:
         output.contains """
 project :impl
+   variant "runtimeElements" [
+      org.gradle.usage = java-runtime-jars (not requested)
+   ]
 \\--- compile
 """
     }
@@ -1185,6 +1227,10 @@ project :impl
         then:
         output.contains """
 org:leaf4:1.0
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- project :impl
      \\--- compileClasspath
 """
@@ -1212,6 +1258,10 @@ org:leaf4:1.0
         then:
         output.contains """
 org:leaf1:1.0
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- compileClasspath
 """
 
@@ -1221,6 +1271,10 @@ org:leaf1:1.0
         then:
         output.contains """
 org:leaf2:1.0
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- compileClasspath
 """
     }
@@ -1265,6 +1319,9 @@ org:leaf2:1.0
         then:
         output.contains """
 project :api
+   variant "apiElements" [
+      org.gradle.usage = java-api
+   ]
 \\--- project :impl
      \\--- compileClasspath
 """
@@ -1309,6 +1366,10 @@ project :api
         then:
         output.contains """
 org:leaf3:1.0
+   variant "runtime" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- org:leaf2:1.0
      +--- project :api
      |    \\--- project :impl
@@ -1348,9 +1409,11 @@ org:leaf3:1.0
         then:
         output.contains """:dependencyInsight
 foo:bar:2.0
+   variant "default"
 \\--- compile
 
 foo:foo:1.0
+   variant "default"
 \\--- compile"""
     }
 
@@ -1388,8 +1451,16 @@ foo:foo:1.0
 
         then:
         output.contains """org:foo:$selected (via constraint)
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 
 org:foo: -> $selected
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- compileClasspath
 """
         where:
@@ -1433,8 +1504,16 @@ org:foo: -> $selected
 
         then:
         output.contains """org:foo:$selected (via constraint, $reason)
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 
 org:foo: -> $selected
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- compileClasspath
 """
         where:
@@ -1475,8 +1554,16 @@ org:foo: -> $selected
 
         then:
         output.contains """org:foo:$selected ($reason)
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 
 org:foo:$displayVersion -> $selected
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- compileClasspath
 """
         where:
@@ -1514,10 +1601,16 @@ org:foo:$displayVersion -> $selected
 
         then:
         output.contains """org:leaf:1.0 (via constraint)
+   variant "compile" [
+      org.gradle.usage = java-api
+   ]
 \\--- org:bom:1.0
      \\--- compileClasspath
 
 org:leaf: -> 1.0
+   variant "compile" [
+      org.gradle.usage = java-api
+   ]
 \\--- compileClasspath
 """
     }
@@ -1551,6 +1644,10 @@ org:leaf: -> 1.0
 
         then:
         output.contains """org.test:leaf:1.0 (first reason)
+   variant "default" [
+      Requested attributes not found in the selected variant:
+         org.gradle.usage = java-api
+   ]
 \\--- org.test:a:1.0
      \\--- compileClasspath"""
     }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -47,7 +47,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         }
 
         when:
-        run "a:dependencyInsight", "--dependency", ":$expectedProject", "--configuration", configuration, '--show-variant-details'
+        run "a:dependencyInsight", "--dependency", ":$expectedProject", "--configuration", configuration
 
         then:
         outputContains """project :$expectedProject
@@ -91,7 +91,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         """
 
         when:
-        run "dependencyInsight", "--dependency", "leaf", "--show-variant-details"
+        run "dependencyInsight", "--dependency", "leaf"
 
         then:
         output.contains """org.test:leaf:1.0
@@ -124,7 +124,6 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
             task insight(type: DependencyInsightReportTask) {
                 setDependencySpec { it.requested.module == 'middle' }
                 configuration = configurations.conf
-                showVariantDetails = true
             }
         """
 
@@ -157,7 +156,6 @@ org:middle:1.0 FAILED
             task insight(type: DependencyInsightReportTask) {
                 setDependencySpec { it.requested.module == 'leaf' }
                 configuration = configurations.conf
-                showVariantDetails = true
             }
         """
 
@@ -193,7 +191,6 @@ org:leaf:1.0
             task insight(type: DependencyInsightReportTask) {
                 setDependencySpec { it.requested.module == 'leaf' }
                 configuration = configurations.conf
-                showVariantDetails = true
             }
         """
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -84,7 +84,6 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
 public class DependencyInsightReportTask extends DefaultTask {
 
     private Configuration configuration;
-    private boolean showVariantDetails;
     private Spec<DependencyResult> dependencySpec;
 
     /**
@@ -117,35 +116,6 @@ public class DependencyInsightReportTask extends DefaultTask {
     public void setDependencySpec(Object dependencyInsightNotation) {
         NotationParser<Object, Spec<DependencyResult>> parser = DependencyResultSpecNotationConverter.parser();
         this.dependencySpec = parser.parseNotation(dependencyInsightNotation);
-    }
-
-    /**
-     * Configures the report to show variant matching details. When this flag is set to true, the report will also
-     * display the variant details, in particular variant attributes and how they were matched.
-     *
-     * <p>
-     * This method is exposed to the command line interface. Example usage:
-     * <pre>gradle dependencyInsight --configuration compileClasspath --dependency slf4j --variant-details</pre>
-     *
-     * @param showDetails if set to true, display selected variant details
-     *
-     * @since 4.6
-     */
-    @Option(option = "show-variant-details", description = "Shows the details of variant matching")
-    public void setShowVariantDetails(boolean showDetails) {
-        this.showVariantDetails = showDetails;
-    }
-
-    /**
-     * Determine if variant details need to be displayed.
-     *
-     * @return true if variant details need to be displayed
-     *
-     * @since 4.6
-     */
-    @Internal
-    public boolean isShowVariantDetails() {
-        return showVariantDetails;
     }
 
     /**
@@ -240,7 +210,7 @@ public class DependencyInsightReportTask extends DefaultTask {
 
         int i = 1;
         for (final RenderableDependency dependency : sortedDeps) {
-            renderer.visit(new RenderDependencyAction(dependency, configuration, showVariantDetails), true);
+            renderer.visit(new RenderDependencyAction(dependency, configuration), true);
             dependencyGraphRenderer.render(dependency);
             boolean last = i++ == sortedDeps.size();
             if (!last) {
@@ -295,12 +265,10 @@ public class DependencyInsightReportTask extends DefaultTask {
     private static class RenderDependencyAction implements Action<StyledTextOutput> {
         private final RenderableDependency dependency;
         private final Configuration configuration;
-        private final boolean showVariantDetails;
 
-        public RenderDependencyAction(RenderableDependency dependency, Configuration configuration, boolean showVariantDetails) {
+        public RenderDependencyAction(RenderableDependency dependency, Configuration configuration) {
             this.dependency = dependency;
             this.configuration = configuration;
-            this.showVariantDetails = showVariantDetails;
         }
 
         public void execute(StyledTextOutput out) {
@@ -323,7 +291,7 @@ public class DependencyInsightReportTask extends DefaultTask {
 
         private void printVariantDetails(StyledTextOutput out) {
             ResolvedVariantResult resolvedVariant = dependency.getResolvedVariant();
-            if (resolvedVariant != null && showVariantDetails) {
+            if (resolvedVariant != null) {
                 out.println();
                 out.withStyle(Description).text("   variant \"" + resolvedVariant.getDisplayName() + "\"");
                 AttributeContainer attributes = resolvedVariant.getAttributes();

--- a/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
@@ -1,7 +1,9 @@
 commons-codec:commons-codec:1.7 (conflict resolution)
+   variant "default"
 \--- scm
 
 commons-codec:commons-codec:1.6 -> 1.7
+   variant "default"
 \--- org.apache.httpcomponents:httpclient:4.3.6
      \--- org.eclipse.jgit:org.eclipse.jgit:4.9.2.201712150930-r
           \--- scm


### PR DESCRIPTION
### Context

This pull request removes the flag to enable variant details display, and
instead displays the variant details in every case. The rationale is
that usage of `dependencyInsight` is rare, and that without knowing
the existence of the flag, it's unlikely to be used. The additional
details also don't add too much overhead to the output, making it
reasonable to show the variant details by default.
