### PR TITLE
Fix class loader leak

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/MutableClassDetails.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/MutableClassDetails.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.reflect;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.lang.reflect.Method;
 import java.util.*;
 
@@ -45,9 +47,14 @@ class MutableClassDetails implements ClassDetails {
         return superTypes;
     }
 
+    /*
+     * Does a defensive copy to avoid leaking class references through the MutablePropertyDetails
+     * contained in the maps values. The keyset would keep a strong reference back to the map
+     * and all its entries.
+     */
     @Override
     public Set<String> getPropertyNames() {
-        return properties.keySet();
+        return ImmutableSet.copyOf(properties.keySet());
     }
 
     @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/initialization/loadercache/ClassLoaderLeakAvoidanceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/initialization/loadercache/ClassLoaderLeakAvoidanceIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization.loadercache
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class ClassLoaderLeakAvoidanceIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        executer.requireDaemon().requireIsolatedDaemons()
+    }
+
+    def "convention mapping does not leak old classloaders"() {
+        given:
+        def myTask = file("buildSrc/src/main/groovy/MyTask.groovy") << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            
+            class MyTask extends DefaultTask {
+                static final byte[] MEMORY_HOG = new byte[70 * 1024 * 1024]
+                
+                @Input 
+                String someProperty
+                
+                @TaskAction
+                public void runAction0() {} 
+            }
+        """
+        buildFile << """
+            task myTask(type: MyTask) {
+                conventionMapping.someProperty = {"Foo"}
+            }
+        """
+
+        expect:
+        for(int i = 0; i < 5; i++) {
+            myTask.text = myTask.text.replace("runAction$i", "runAction${i + 1}")
+            executer.withBuildJvmOpts("-Xmx256m", "-XX:+HeapDumpOnOutOfMemoryError")
+            assert succeeds("myTask")
+        }
+    }
+}


### PR DESCRIPTION
The reflection cache keeps a set of property names for each class.
This set was provided by calling keySet() on a map which contains
class values. The keyset would thus keep a strong reference back
to its map and all of its values, leading to a classloader leak.

We now do a defensive copy of they keyset to avoid surprises for
callers of this method.