### PR TITLE
Implement a workaround to make build operation traces fully functional for composite builds.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
@@ -21,14 +21,12 @@ import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
-import spock.lang.Issue
 
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 
 class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
 
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
-    def operationNotifications = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
     def "captures gradle script events"() {
         given:
@@ -86,13 +84,12 @@ class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegration
         operations.search(ops[2], ApplyScriptPluginBuildOperationType).size() == 0
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/3873")
-    def "build operation trace of settings script events is broken for composite builds"() {
+    def "identifies build of application target"() {
         given:
         def subBuildSettingsFile = file("subBuild/settings.gradle")
         subBuildSettingsFile << "rootProject.name = 'subBuild'"
         settingsFile << """
-        includeBuild 'subBuild'
+            includeBuild 'subBuild'
         """
 
         when:
@@ -103,15 +100,14 @@ class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegration
             it.details.targetType == "settings"
         }
         ops.size() == 2
-
-        // works as expected for root build
-        ops[1].details.file == settingsFile.absolutePath
-        ops[1].details.containsKey('buildPath')
-
-        // accessing buildPath in ApplyScriptPluginBuildOperationType.Details when tracing is broken
-        // and therefore not stored
-        ops[0].details.file == subBuildSettingsFile.absolutePath
-        !ops[0].details.containsKey('buildPath')
+        with(ops[0]) {
+            details.file == settingsFile.absolutePath
+            details.buildPath == ":"
+        }
+        with(ops[1]) {
+            details.file == subBuildSettingsFile.absolutePath
+            details.buildPath == ":subBuild"
+        }
     }
 
     def "captures project script events"() {
@@ -184,7 +180,7 @@ class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegration
         then:
         def op = operations.only(ApplyScriptPluginBuildOperationType) {
             it.details.targetType == "project" &&
-            it.details.uri != null
+                it.details.uri != null
         }
 
         op.details.file == null

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -96,9 +96,10 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
 
         then:
         operations().size() == 2
-        verifySettings(operations()[0], nestedSettingsFile)
-        verifySettings(operations()[1], settingsFile)
-        operations()[1].details.buildPath == ":"
+        verifySettings(operations()[0], settingsFile)
+        operations()[0].details.buildPath == ":"
+        verifySettings(operations()[1], nestedSettingsFile)
+        operations()[1].details.buildPath == ":nested"
     }
 
     private List<BuildOperationRecord> operations() {

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
@@ -18,12 +18,31 @@ package org.gradle.internal.operations.trace;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public final class BuildOperationRecord {
+
+    public static final Ordering<BuildOperationRecord> ORDERING = Ordering.natural()
+        .onResultOf(new Function<BuildOperationRecord, Comparable>() {
+            @Override
+            public Comparable apply(BuildOperationRecord input) {
+                return input.startTime;
+            }
+        })
+        .compound(Ordering.natural().onResultOf(new Function<BuildOperationRecord, Comparable>() {
+            @Override
+            public Comparable apply(BuildOperationRecord input) {
+                if (input.id instanceof Comparable) {
+                    return (Comparable) input.id;
+                } else {
+                    return input.id.hashCode();
+                }
+            }
+        }));
 
     public final Object id;
     public final Object parentId;
@@ -123,7 +142,7 @@ public final class BuildOperationRecord {
     public static class Progress {
         public final long time;
         public final Map<String, ?> details;
-        private final String detailsClassName;
+        public final String detailsClassName;
 
         public Progress(
             long time,

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -21,10 +21,12 @@ import com.google.common.io.Files;
 import com.google.common.io.LineProcessor;
 import groovy.json.JsonOutput;
 import groovy.json.JsonSlurper;
+import org.gradle.BuildAdapter;
 import org.gradle.StartParameter;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.progress.BuildOperationListener;
+import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.progress.BuildOperationListenerManager;
 import org.gradle.util.GFileUtils;
 
@@ -80,10 +82,10 @@ public class BuildOperationTrace implements Stoppable {
     private final OutputStream logOutputStream;
     private final BuildOperationListenerManager listenerManager;
 
-    private BuildOperationListener listener;
+    private SerializingBuildOperationListener listener;
 
-    public BuildOperationTrace(StartParameter startParameter, BuildOperationListenerManager listenerManager) {
-        this.listenerManager = listenerManager;
+    public BuildOperationTrace(StartParameter startParameter, BuildOperationListenerManager buildOperationListenerManager, ListenerManager listenerManager) {
+        this.listenerManager = buildOperationListenerManager;
 
         Map<String, String> sysProps = startParameter.getSystemPropertiesArgs();
         String basePath = sysProps.get(SYSPROP);
@@ -112,9 +114,26 @@ public class BuildOperationTrace implements Stoppable {
         }
 
         listener = new SerializingBuildOperationListener(logOutputStream);
-        listenerManager.addListener(listener);
-    }
+        buildOperationListenerManager.addListener(listener);
 
+        // This is a workaround for https://github.com/gradle/gradle/issues/3873
+        // Several early typed operations have `buildPath` property,
+        // the value of which can only be determined after the settings file for the build has loaded.
+        //
+        // The workaround is to buffer all operation notifications in memory until the root build's settings have loaded.
+        // This works because all possible settings files have been evaluated by the time the root one has been.
+        // This is not guaranteed to hold into the future.
+        // A proper solution would be to change the operation details/results to be
+        // truly immutable and convey values known at the time.
+        listenerManager.addListener(new BuildAdapter() {
+            @Override
+            public void projectsLoaded(Gradle gradle) {
+                if (gradle.getParent() == null) {
+                    listener.write();
+                }
+            }
+        });
+    }
 
     @Override
     public void stop() {
@@ -272,7 +291,7 @@ public class BuildOperationTrace implements Stoppable {
                             finish.resultClassName,
                             finish.failureMsg,
                             progresses,
-                            children
+                            BuildOperationRecord.ORDERING.immutableSortedCopy(children)
                         );
 
                         if (start.parentId == null) {

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -22,6 +22,7 @@ import com.google.common.io.LineProcessor;
 import groovy.json.JsonOutput;
 import groovy.json.JsonSlurper;
 import org.gradle.BuildAdapter;
+import org.gradle.BuildResult;
 import org.gradle.StartParameter;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.UncheckedException;
@@ -131,6 +132,12 @@ public class BuildOperationTrace implements Stoppable {
                 if (gradle.getParent() == null) {
                     listener.write();
                 }
+            }
+
+            // Build may have failed before getting to projectsLoaded
+            @Override
+            public void buildFinished(BuildResult result) {
+                listener.write();
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTree.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTree.java
@@ -33,7 +33,7 @@ public class BuildOperationTree {
         for (BuildOperationRecord record : roots) {
             visit(records, record);
         }
-        this.roots = roots;
+        this.roots = BuildOperationRecord.ORDERING.immutableSortedCopy(roots);
         this.records = records.build();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.trace;
+
+import java.util.Map;
+
+interface SerializedOperation {
+
+    Map<String, ?> toMap();
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperationFinish.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperationFinish.java
@@ -25,7 +25,7 @@ import org.gradle.internal.progress.OperationFinishEvent;
 import java.util.Collections;
 import java.util.Map;
 
-class SerializedOperationFinish {
+class SerializedOperationFinish implements SerializedOperation {
 
     final Object id;
 
@@ -61,7 +61,7 @@ class SerializedOperationFinish {
         this.failureMsg = (String) map.get("failure");
     }
 
-    Map<String, ?> toMap() {
+    public Map<String, ?> toMap() {
         ImmutableMap.Builder<String, Object> map = ImmutableMap.builder();
 
         // Order is optimised for humans looking at the log.

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperationProgress.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperationProgress.java
@@ -23,7 +23,7 @@ import org.gradle.internal.progress.OperationProgressEvent;
 
 import java.util.Map;
 
-class SerializedOperationProgress {
+class SerializedOperationProgress implements SerializedOperation {
 
     final Object id;
     final long time;
@@ -48,7 +48,7 @@ class SerializedOperationProgress {
         this.detailsClassName = (String) map.get("detailsClassName");
     }
 
-    Map<String, ?> toMap() {
+    public Map<String, ?> toMap() {
         ImmutableMap.Builder<String, Object> map = ImmutableMap.builder();
 
         // Order is optimised for humans looking at the log.

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperationStart.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializedOperationStart.java
@@ -26,7 +26,7 @@ import org.gradle.internal.progress.OperationStartEvent;
 import java.util.HashMap;
 import java.util.Map;
 
-class SerializedOperationStart {
+class SerializedOperationStart implements SerializedOperation {
 
     final Object id;
     final Object parentId;
@@ -80,7 +80,7 @@ class SerializedOperationStart {
         this.detailsClassName = (String) map.get("detailsClassName");
     }
 
-    Map<String, ?> toMap() {
+    public Map<String, ?> toMap() {
         ImmutableMap.Builder<String, Object> map = ImmutableMap.builder();
 
         // Order is optimised for humans looking at the log.

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializingBuildOperationListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/SerializingBuildOperationListener.java
@@ -26,7 +26,10 @@ import org.gradle.internal.progress.OperationStartEvent;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Map;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Note: this is relying on Gradle's listener infrastructure serializing dispatch
@@ -37,38 +40,87 @@ class SerializingBuildOperationListener implements BuildOperationListener {
     private static final byte[] NEWLINE = "\n".getBytes();
     private static final byte[] INDENT = "    ".getBytes();
 
-    private OutputStream out;
+    private final OutputStream out;
 
     SerializingBuildOperationListener(OutputStream out) {
         this.out = out;
     }
 
+    private boolean buffering = true;
+    private final Lock bufferLock = new ReentrantLock();
+    private final Queue<Entry> buffer = new ArrayDeque<Entry>();
+
     @Override
     public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-        write(new SerializedOperationStart(buildOperation, startEvent).toMap(), false);
+        new Entry(new SerializedOperationStart(buildOperation, startEvent), false).add();
     }
 
     @Override
     public void progress(BuildOperationDescriptor buildOperation, OperationProgressEvent progressEvent) {
-        write(new SerializedOperationProgress(buildOperation, progressEvent).toMap(), false);
+        new Entry(new SerializedOperationProgress(buildOperation, progressEvent), false).add();
     }
 
     @Override
     public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
-        write(new SerializedOperationFinish(buildOperation, finishEvent).toMap(), true);
+        new Entry(new SerializedOperationFinish(buildOperation, finishEvent), false).add();
     }
 
-    private void write(Map<String, ?> entry, boolean indent) {
-        String json = JsonOutput.toJson(entry);
-        try {
-            if (indent) {
-                out.write(INDENT);
+    public void write() {
+        if (buffering) {
+            bufferLock.lock();
+            try {
+                if (buffering) {
+                    for (Entry entry : buffer) {
+                        entry.write();
+                    }
+                    buffer.clear();
+                    buffering = false;
+                }
+            } finally {
+                bufferLock.unlock();
             }
-            out.write(json.getBytes("UTF-8"));
-            out.write(NEWLINE);
-        } catch (IOException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    private final class Entry {
+        final SerializedOperation operation;
+        final boolean indent;
+
+        Entry(SerializedOperation operation, boolean indent) {
+            this.operation = operation;
+            this.indent = indent;
+        }
+
+        public void add() {
+            if (buffering) {
+                bufferLock.lock();
+                try {
+                    if (buffering) {
+                        buffer.add(this);
+                    } else {
+                        write();
+                    }
+                } finally {
+                    bufferLock.unlock();
+                }
+            } else {
+                write();
+            }
+        }
+
+        private void write() {
+            String json = JsonOutput.toJson(operation.toMap());
+            try {
+                if (indent) {
+                    out.write(INDENT);
+                }
+                out.write(json.getBytes("UTF-8"));
+                out.write(NEWLINE);
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+        }
+
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -140,8 +140,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultBuildOperationListenerManager(listenerManager);
     }
 
-    BuildOperationTrace createBuildOperationTrace(StartParameter startParameter, BuildOperationListenerManager listenerManager) {
-        return new BuildOperationTrace(startParameter, listenerManager);
+    BuildOperationTrace createBuildOperationTrace(StartParameter startParameter, BuildOperationListenerManager buildOperationlistenerManager, ListenerManager listenerManager) {
+        return new BuildOperationTrace(startParameter, buildOperationlistenerManager, listenerManager);
     }
 
     BuildOperationExecutor createBuildOperationExecutor(

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -192,23 +192,23 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         then:
         def resolveOperations = operations.all(ResolveConfigurationDependenciesBuildOperationType)
         resolveOperations.size() == 2
-        resolveOperations[0].details.configurationName == "compileClasspath"
-        resolveOperations[0].details.projectPath == ":"
-        resolveOperations[0].details.buildPath == ":my-composite-app"
-        resolveOperations[0].details.scriptConfiguration == false
-        resolveOperations[0].details.configurationDescription == "Compile classpath for source set 'main'."
-        resolveOperations[0].details.configurationVisible == false
+        resolveOperations[0].details.configurationName == "classpath"
+        resolveOperations[0].details.projectPath == null
+        resolveOperations[0].details.buildPath == ":"
+        resolveOperations[0].details.scriptConfiguration == true
+        resolveOperations[0].details.configurationDescription == null
+        resolveOperations[0].details.configurationVisible == true
         resolveOperations[0].details.configurationTransitive == true
-        resolveOperations[0].result.resolvedDependenciesCount == 1
+        resolveOperations[0].result.resolvedDependenciesCount == 2
 
-        resolveOperations[1].details.configurationName == "classpath"
-        resolveOperations[1].details.projectPath == null
-        resolveOperations[1].details.buildPath == ":"
-        resolveOperations[1].details.scriptConfiguration == true
-        resolveOperations[1].details.configurationDescription == null
-        resolveOperations[1].details.configurationVisible == true
+        resolveOperations[1].details.configurationName == "compileClasspath"
+        resolveOperations[1].details.projectPath == ":"
+        resolveOperations[1].details.buildPath == ":my-composite-app"
+        resolveOperations[1].details.scriptConfiguration == false
+        resolveOperations[1].details.configurationDescription == "Compile classpath for source set 'main'."
+        resolveOperations[1].details.configurationVisible == false
         resolveOperations[1].details.configurationTransitive == true
-        resolveOperations[1].result.resolvedDependenciesCount == 2
+        resolveOperations[1].result.resolvedDependenciesCount == 1
     }
 
     @Unroll


### PR DESCRIPTION
Relates to #3873.

https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Fcomposite-build-operation-trace-quickfix