### PR TITLE
Fix multi-version testing build logic

### DIFF
--- a/gradle/distributionTesting.gradle.kts
+++ b/gradle/distributionTesting.gradle.kts
@@ -44,8 +44,8 @@ tasks.withType<DistributionTest> {
         systemProperties[integTestVersionsSysProp] = "latest"
     }
 
-    fun ifProperty(name: String, then: String): String? =
-        then.takeIf { hasProperty(name) && property(name).toString().isNotEmpty() }
+    fun Project.ifProperty(name: String, then: String): String? =
+        then.takeIf { findProperty(name) != null }
 
     systemProperties["org.gradle.integtest.native.toolChains"] =
         ifProperty("testAllPlatforms", "all") ?: "default"


### PR DESCRIPTION
There was a large drop in the number of tests here: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Platform_Java7_Oracle_Linux_codeQuality&tab=buildTypeStatistics&branch_Gradle_Check_Platform_Java7_Oracle_Linux=master

Here's the build before the drop: https://e.grdev.net/s/u6qcp7eglzys4/tests/byProject?toggled=W1swXSxbMCwwXSxbMCwwLDBdXQ
Here's the build after the drop: https://e.grdev.net/s/qrn4n4234iwoi/tests/byProject?toggled=W1swXSxbMCwwXSxbMCwwLDFdLFswLDAsMSwwXV0

Receiver of `hasProperty(name)` and `property(name)` was the task hence not seeing the project properties. Fixed by making the `ifProperty()` utility method an extension on `Project`.

Simplified `ifProperty()` expression along the way.