### PR TITLE
Upgrade HttpClient version to 4.5.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,8 @@ versions.commons_io = '2.2'
 versions.groovy = '2.4.12'
 versions.bouncycastle = '1.58'
 versions.maven = '3.0.4'
-versions.httpclient = '4.4.1'
+versions.httpclient = '4.5.5'
+versions.httpcore = '4.4.9'
 
 libraries.ant = 'org.apache.ant:ant:1.9.9'
 libraries.asm =  'org.ow2.asm:asm:6.0'
@@ -333,7 +334,7 @@ allprojects { currentProject ->
                             it.removeAll { it.group == 'commons-logging' }
                             add(libraries.jcl_to_slf4j)
                             it.findAll { it.group == 'commons-codec' }.each { changeVersionInMetadata it, '1.6' }
-                            it.findAll { it.name == 'httpcore' }.each { changeVersionInMetadata it, '4.4.4' }
+                            it.findAll { it.name == 'httpcore' }.each { changeVersionInMetadata it, versions.httpcore }
                             add(libraries.jcifs)
                         }
                     }
@@ -341,7 +342,7 @@ allprojects { currentProject ->
                         withDependencies {
                             it.removeAll { it.group == 'commons-logging' }
                             it.findAll { it.group == 'commons-codec' }.each { changeVersionInMetadata it, '1.6' }
-                            it.findAll { it.name == 'httpcore' }.each { changeVersionInMetadata it, '4.4.4' }
+                            it.findAll { it.name == 'httpcore' }.each { changeVersionInMetadata it, versions.httpcore }
                         }
                     }
                 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -75,7 +75,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
     testCompile libraries.commons_httpclient
-    testCompile 'org.apache.httpcomponents:httpmime:4.5.5'
+    testCompile "org.apache.httpcomponents:httpmime:${versions.httpclient}"
     testCompile project(":core")
 }
 

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -75,7 +75,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
     testCompile libraries.commons_httpclient
-    testCompile 'org.apache.httpcomponents:httpmime:4.4.1'
+    testCompile 'org.apache.httpcomponents:httpmime:4.5.5'
     testCompile project(":core")
 }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -184,6 +184,10 @@ Putting processors on the compile classpath or using an explicit `-processorpath
 
 The `java-base` plugin will now add an `<sourceSetName>AnnotationProcessor` configuration for each source set. This might break when the user already defined such a configuration. We recommend removing your own and using the configuration provided by `java-base`. 
 
+### HttpClient library upgraded to version 4.5.5
+
+Gradle has been upgraded to embed HttpClient version 4.5.5 over 4.4.1.
+
 <!--
 ### Example breaking change
 -->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -199,7 +199,7 @@ Use `StartParameter.buildCacheEnabled` instead.
 
 ### HttpClient library upgraded to version 4.5.5
 
-Gradle has been upgraded to embed HttpClient version 4.5.5 over 4.4.1.
+Gradle has been upgraded to embed [HttpClient version 4.5.5](https://archive.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt) over 4.4.1.
 
 <!--
 ### Example breaking change


### PR DESCRIPTION
### Context

Upgrades to the latest version of HttpClient to fix a security vulnerability.