### PR TITLE
Revert: Add scope to maven dependency key

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 48),
+    META_DATA(ROOT, "metadata", 51),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -469,17 +469,7 @@ public class PomReader implements PomParent {
     }
 
     public PomDependencyMgt findDependencyDefaults(MavenDependencyKey dependencyKey) {
-        PomDependencyMgt candidate = getDependencyMgt().get(dependencyKey);
-        if (candidate != null) {
-            return getDependencyMgt().get(dependencyKey);
-        }
-        // lenient matching that ignores the scopes
-        for (MavenDependencyKey key : getDependencyMgt().keySet()) {
-            if (key.equalsWithoutScope(dependencyKey)) {
-                return getDependencyMgt().get(key);
-            }
-        }
-        return null;
+        return getDependencyMgt().get(dependencyKey);
     }
 
     public void resolveGAV() {
@@ -502,7 +492,7 @@ public class PomReader implements PomParent {
         }
 
         public MavenDependencyKey getId() {
-            return new MavenDependencyKey(getGroupId(), getArtifactId(), getType(), getClassifier(), getScope());
+            return new MavenDependencyKey(getGroupId(), getArtifactId(), getType(), getClassifier());
         }
 
         /* (non-Javadoc)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKey.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKey.java
@@ -23,14 +23,12 @@ public class MavenDependencyKey {
     private final String artifactId;
     private final String type;
     private final String classifier;
-    private final String scope;
 
-    public MavenDependencyKey(String groupId, String artifactId, String type, String classifier, String scope) {
+    public MavenDependencyKey(String groupId, String artifactId, String type, String classifier) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.type = type;
         this.classifier = classifier;
-        this.scope = scope;
     }
 
     public String getGroupId() {
@@ -49,10 +47,6 @@ public class MavenDependencyKey {
         return classifier;
     }
 
-    public String getScope() {
-        return scope;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -63,10 +57,6 @@ public class MavenDependencyKey {
         }
 
         MavenDependencyKey that = (MavenDependencyKey) o;
-        return equalsWithoutScope(that) && Objects.equal(scope, that.scope);
-    }
-
-    public boolean equalsWithoutScope(MavenDependencyKey that) {
         return Objects.equal(groupId, that.groupId)
             && Objects.equal(artifactId, that.artifactId)
             && Objects.equal(classifier, that.classifier)
@@ -75,7 +65,7 @@ public class MavenDependencyKey {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(groupId, artifactId, classifier, type, scope);
+        return Objects.hashCode(groupId, artifactId, classifier, type);
     }
 
     @Override
@@ -83,11 +73,8 @@ public class MavenDependencyKey {
         StringBuilder key = new StringBuilder();
         key.append(groupId).append(KEY_SEPARATOR).append(artifactId).append(KEY_SEPARATOR).append(type);
 
-        if (classifier != null) {
+        if(classifier != null) {
             key.append(KEY_SEPARATOR).append(classifier);
-        }
-        if (scope != null) {
-            key.append(KEY_SEPARATOR).append(scope);
         }
 
         return key.toString();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.48'
-        cacheLayout.version == VersionNumber.parse("2.48.0")
-        cacheLayout.formattedVersion == '2.48'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.48')
+        cacheLayout.key == 'metadata-2.51'
+        cacheLayout.version == VersionNumber.parse("2.51.0")
+        cacheLayout.formattedVersion == '2.51'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.51')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
@@ -254,6 +254,81 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         depRuntime.scope == MavenScope.Runtime
     }
 
+    def "if two dependencyManagement entries for the same dependency are combined, the closest wins a conflict"() {
+        given:
+        def parent = tmpDir.file("parent.xml") << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-one</groupId>
+    <artifactId>parent</artifactId>
+    <version>version-one</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>group-two</groupId>
+                <artifactId>artifact-two</artifactId>
+                <version>1.2</version>
+                $scopeInParent
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+"""
+
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-one</groupId>
+    <artifactId>artifact-one</artifactId>
+    <version>version-one</version>
+
+    <parent>
+        <groupId>group-one</groupId>
+        <artifactId>parent</artifactId>
+        <version>version-one</version>
+    </parent>
+    
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>group-two</groupId>
+                <artifactId>artifact-two</artifactId>
+                $versionInChild
+                $scopeInChild
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+"""
+        and:
+        parseContext.getMetaDataArtifact(_, MAVEN_POM) >> asResource(parent)
+
+        when:
+        parsePom()
+
+        then:
+        metadata.dependencies.size() == 1
+        def depCompile = metadata.dependencies[0]
+        depCompile.selector == moduleId('group-two', 'artifact-two', selectedVersion)
+        depCompile.scope == selectedScope
+
+        where:
+        scopeInParent            | scopeInChild          | versionInChild           | selectedVersion | selectedScope
+        ""                       | "<scope>test</scope>" | "<version>1.1</version>" | "1.1"           | MavenScope.Test
+        "<scope>compile</scope>" | "<scope>test</scope>" | "<version>1.1</version>" | "1.1"           | MavenScope.Test
+        "<scope>test</scope>"    | ""                    | "<version>1.1</version>" | "1.1"           | MavenScope.Compile
+        ""                       | "<scope>test</scope>" | ""                       | ""              | MavenScope.Test
+        "<scope>compile</scope>" | "<scope>test</scope>" | ""                       | ""              | MavenScope.Test
+        "<scope>test</scope>"    | ""                    | ""                       | ""              | MavenScope.Compile
+    }
+
     def "uses empty version if parent pom dependency management section does not provide default values for dependency"() {
         given:
         def parent = tmpDir.file("parent.xml") << """

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderProfileTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderProfileTest.groovy
@@ -176,9 +176,9 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         !pomReader.properties.containsKey('prop1')
         !pomReader.properties.containsKey('prop3')
         pomReader.properties['prop2'] == 'myproperty2'
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-four', 'artifact-four', 'jar', null, null))
-        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-four', 'artifact-four', 'jar', null))
+        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
     }
 
     def "cannot use POM property to set profile ID"() {
@@ -373,7 +373,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -424,7 +424,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -469,7 +469,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -525,8 +525,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyDep1 = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyDep2 = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyDep1 = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyDep2 = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 2
@@ -563,7 +563,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
@@ -606,7 +606,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
@@ -657,7 +657,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -705,8 +705,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -761,7 +761,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -824,8 +824,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 2
@@ -891,8 +891,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -964,7 +964,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey key = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1005,8 +1005,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 2
@@ -1048,7 +1048,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1110,9 +1110,9 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
-        MavenDependencyKey keyArtifactFour = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null, null)
+        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyArtifactFour = new MavenDependencyKey('group-four', 'artifact-four', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 3
@@ -1163,7 +1163,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1204,7 +1204,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1246,7 +1246,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1290,7 +1290,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -1336,7 +1336,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -1379,7 +1379,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
 
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1429,7 +1429,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1495,8 +1495,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyArtifactTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyArtifactThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 2
@@ -1563,7 +1563,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -1668,7 +1668,7 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -1834,8 +1834,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
-        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -1891,8 +1891,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         activePomProfiles.size() == 1
         activePomProfiles[0].id == 'profile-1'
         pomReader.properties['prop1'] == 'myproperty1'
-        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
-        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null), 'version-three')
+        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null), 'version-three')
     }
 
     def "activates profile for negated property if system property is provided"() {
@@ -1946,8 +1946,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         activePomProfiles.size() == 1
         activePomProfiles[0].id == 'profile-1'
         pomReader.properties['prop1'] == 'myproperty1'
-        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
-        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null), 'version-three')
+        pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null), 'version-three')
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -2002,8 +2002,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
-        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
     }
 
     def "does not activate profile if property value is not declared and system property is set with any value"() {
@@ -2056,8 +2056,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         List<PomProfile> activePomProfiles = pomReader.parseActivePomProfiles()
         activePomProfiles.size() == 0
         !pomReader.properties.containsKey('prop1')
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null))
-        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null))
+        !pomReader.dependencies.containsKey(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null))
 
         cleanup:
         System.clearProperty(customPropertyName)
@@ -2194,10 +2194,10 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
         !pomReader.properties.containsKey('prop4')
         pomReader.properties['prop2'] == 'myproperty2'
         pomReader.properties['prop3'] == 'myproperty3'
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-one', 'jar', null, null))
-        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-four', 'jar', null, null))
-        assertResolvedPomDependencyManagement(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null), 'version-three')
-        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null), 'version-three')
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-one', 'jar', null))
+        !pomReader.dependencyMgt.containsKey(new MavenDependencyKey('group-two', 'artifact-four', 'jar', null))
+        assertResolvedPomDependencyManagement(new MavenDependencyKey('group-two', 'artifact-two', 'jar', null), 'version-three')
+        assertResolvedPomDependency(new MavenDependencyKey('group-three', 'artifact-three', 'jar', null), 'version-three')
     }
 
     def "parse POM with multiple active profiles activated by absence of system property"() {
@@ -2313,8 +2313,8 @@ class PomReaderProfileTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -151,7 +151,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -182,7 +182,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencies().size() == 1
@@ -225,7 +225,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
 
         then:
         pomReader.getDependencies().size() == 1
@@ -268,9 +268,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
-        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test', null)
-        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client', null)
+        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
+        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test')
+        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client')
 
         then:
         pomReader.getDependencies().size() == 3
@@ -300,7 +300,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -333,7 +333,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -377,7 +377,7 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
+        MavenDependencyKey key = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -421,9 +421,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar', null)
-        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test', null)
-        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client', null)
+        MavenDependencyKey dependencyJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'jar', 'myjar')
+        MavenDependencyKey dependencyTestJarkey = new MavenDependencyKey('group-two', 'artifact-two', 'test-jar', 'test')
+        MavenDependencyKey dependencyEjbClientKey = new MavenDependencyKey('group-two', 'artifact-two', 'ejb-client', 'client')
 
         then:
         pomReader.getDependencyMgt().size() == 3
@@ -636,9 +636,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
-        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null)
 
         then:
         pomReader.getDependencies().size() == 3
@@ -681,9 +681,9 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null, null)
-        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-three', 'artifact-three', 'jar', null)
+        MavenDependencyKey keyGroupFour = new MavenDependencyKey('group-four', 'artifact-four', 'ejb-client', null)
 
         then:
         pomReader.getDependencyMgt().size() == 3
@@ -724,8 +724,8 @@ class PomReaderTest extends AbstractPomReaderTest {
 </project>
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1
@@ -782,8 +782,8 @@ class PomReaderTest extends AbstractPomReaderTest {
 """
         pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
         pomReader.setPomParent(parentPomReader)
-        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null, null)
-        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null, null)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        MavenDependencyKey keyGroupThree = new MavenDependencyKey('group-two', 'artifact-three', 'jar', null)
 
         then:
         pomReader.getDependencyMgt().size() == 1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKeyTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/data/MavenDependencyKeyTest.groovy
@@ -23,33 +23,29 @@ import static org.gradle.util.Matchers.strictlyEquals
 
 class MavenDependencyKeyTest extends Specification {
     @Unroll
-    def "can compare with other instance (#groupId, #artifactId, #type, #classifier, #scope)"() {
+    def "can compare with other instance (#groupId, #artifactId, #type, #classifier)"() {
         expect:
-        MavenDependencyKey key1 = new MavenDependencyKey('group-one', 'artifact-one', 'jar', 'sources', 'runtime')
-        MavenDependencyKey key2 = new MavenDependencyKey(groupId, artifactId, type, classifier, scope)
+        MavenDependencyKey key1 = new MavenDependencyKey('group-one', 'artifact-one', 'jar', 'sources')
+        MavenDependencyKey key2 = new MavenDependencyKey(groupId, artifactId, type, classifier)
         strictlyEquals(key1, key2) == equality
         (key1.hashCode() == key2.hashCode()) == hashCode
         (key1.toString() == key2.toString()) == stringRepresentation
-        key1.equalsWithoutScope(key2) == equalityWithoutScope
-        key2.equalsWithoutScope(key1) == equalityWithoutScope
 
         where:
-        groupId     | artifactId     | type  | classifier | scope     | equality | hashCode | stringRepresentation | equalityWithoutScope
-        'group-one' | 'artifact-one' | 'jar' | null       | null      | false    | false    | false                | false
-        'group-one' | 'artifact-one' | 'jar' | 'sources'  | null      | false    | false    | false                | true
-        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'compile' | false    | false    | false                 | true
-        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'runtime' | true     | true     | true                 | true
+        groupId     | artifactId     | type  | classifier | equality | hashCode | stringRepresentation
+        'group-one' | 'artifact-one' | 'jar' | null       | false    | false    | false
+        'group-one' | 'artifact-one' | 'jar' | 'sources'  | true     | true     | true
     }
 
     @Unroll
-    def "builds String representation (#groupId, #artifactId, #type, #classifier, #scope)"() {
+    def "builds String representation (#groupId, #artifactId, #type, #classifier)"() {
         expect:
-        MavenDependencyKey key = new MavenDependencyKey(groupId, artifactId, type, classifier, scope)
+        MavenDependencyKey key = new MavenDependencyKey(groupId, artifactId, type, classifier)
         key.toString() == stringRepresentation
 
         where:
-        groupId     | artifactId     | type  | classifier | scope     | stringRepresentation
-        'group-one' | 'artifact-one' | 'jar' | null       | null      | 'group-one:artifact-one:jar'
-        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'runtime' | 'group-one:artifact-one:jar:sources:runtime'
+        groupId     | artifactId     | type  | classifier | stringRepresentation
+        'group-one' | 'artifact-one' | 'jar' | null       | 'group-one:artifact-one:jar'
+        'group-one' | 'artifact-one' | 'jar' | 'sources'  | 'group-one:artifact-one:jar:sources'
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -145,7 +145,9 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public VersionNumber getArtifactCacheLayoutVersion() {
-        if (isSameOrNewer("4.5-rc-1")) {
+        if (isSameOrNewer("4.5.1-rc-1")) {
+            return VersionNumber.parse("2.51");
+        } else if (isSameOrNewer("4.5-rc-1")) {
             return VersionNumber.parse("2.48");
         } else if (isSameOrNewer("4.4-rc-1")) {
             return VersionNumber.parse("2.36");

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -537,7 +537,10 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 expectFiles "bar-1.0.jar"
             }
             withoutModuleMetadata {
-                expectFiles "bar-1.0.jar"
+                // To allow this, we would need to support multiple dependency management entries with different scopes
+                // for the same module. This is not supported by Maven and an attempt to implement it in Gradle failed.
+                // See: https://github.com/gradle/gradle/issues/4202
+                expectFiles "bar-1.1.jar"
             }
         }
         resolveRuntimeArtifacts(javaLibrary) {


### PR DESCRIPTION
This reverts a82cf4a, which caused the #4202 regression in `4.5`. After investigating, it turned out the the original use case that it was supposed to solve (see commit comment a82cf4a) conflicts with existing behaviour. 

We can accept not to support the use case with pom metadata. It is supported with Gradle module metadata. Hence we revert the change. See: https://github.com/gradle/gradle/pull/4244/files#diff-00c096f4d1b67345691179afbdc0c14d

This also requires to increases the cache layout version, as this is now a new combination of changes. When we merge this back from release to master, the layout version needs to be increased again for master.