### PR TITLE
Close build cache service when last composite finishes

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -21,9 +21,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.TestBuildCache
 import org.gradle.internal.operations.trace.BuildOperationTrace
-import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
-
 /**
  * Tests build cache configuration within composite builds and buildSrc.
  */
@@ -32,7 +30,9 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
     def operations = new BuildOperationsFixture(executer, testDirectoryProvider)
 
     def setup() {
-        executer.withBuildCacheEnabled()
+        executer.beforeExecute {
+            withBuildCacheEnabled()
+        }
     }
 
     def "can configure with settings.gradle"() {
@@ -113,7 +113,6 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
         ]
     }
 
-    @ToBeImplemented
     @Issue("https://github.com/gradle/gradle/issues/4216")
     def "build cache service is closed only after all included builds are finished"() {
         def localCache = new TestBuildCache(file("local-cache"))
@@ -146,17 +145,14 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
         """
 
         expect:
-        withBuildCache().succeeds '--parallel'
+        succeeds()
 
         when:
         ['i1', 'i2'].each {
             file("$it/src/test/java/DummyTest.java") << "public class DummyTest {}"
         }
         then:
-        executer.withStackTraceChecksDisabled() // FIXME: There should be no stack traces
-        withBuildCache().succeeds '--parallel'
-        output.contains('Failed to store cache entry')
-        output.contains('NullPointerException')
+        succeeds()
     }
 
     private static String customTaskCode(String val = "foo") {

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -21,6 +21,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.TestBuildCache
 import org.gradle.internal.operations.trace.BuildOperationTrace
+import org.gradle.util.ToBeImplemented
+import spock.lang.Issue
+
 /**
  * Tests build cache configuration within composite builds and buildSrc.
  */
@@ -108,6 +111,52 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
             ":": mainCache.cacheDir,
             ":buildSrc": buildSrcCache.cacheDir
         ]
+    }
+
+    @ToBeImplemented
+    @Issue("https://github.com/gradle/gradle/issues/4216")
+    def "build cache service is closed only after all included builds are finished"() {
+        def localCache = new TestBuildCache(file("local-cache"))
+
+        buildTestFixture.withBuildInSubDir()
+        ['i1', 'i2'].each {
+            multiProjectBuild(it, ['first', 'second']) {
+                buildFile << """
+                gradle.startParameter.setTaskNames(['build'])
+                println gradle
+                allprojects {
+                    apply plugin: 'java-library'
+                }
+                """
+            }
+        }
+
+        settingsFile << localCache.localCacheConfiguration() << """
+            includeBuild "i1"
+            includeBuild "i2"
+        """
+        buildFile << """             
+            apply plugin: 'java'
+            println gradle
+            gradle.startParameter.setTaskNames(['build'])
+            processResources {
+                dependsOn gradle.includedBuild('i1').task(':processResources')
+                dependsOn gradle.includedBuild('i2').task(':processResources')
+            }
+        """
+
+        expect:
+        withBuildCache().succeeds '--parallel'
+
+        when:
+        ['i1', 'i2'].each {
+            file("$it/src/test/java/DummyTest.java") << "public class DummyTest {}"
+        }
+        then:
+        executer.withStackTraceChecksDisabled() // FIXME: There should be no stack traces
+        withBuildCache().succeeds '--parallel'
+        output.contains('Failed to store cache entry')
+        output.contains('NullPointerException')
     }
 
     private static String customTaskCode(String val = "foo") {


### PR DESCRIPTION
`buildFinished` events for the root build can happen before `buildFinished` events from included builds (#4199).
This causes #4216 when using composite builds, since the build cache is shared between included builds.

Instead of fixing #4216 by using separate build cache services for each included build (#4231), we use a reference counting approach. I.e. the `buildFinished` event only closes the build cache service if no build is using it any more.

Sharing the same service has two advantages:
- The same process only uses one build cache service for the same cache directory at the same time, which makes locking of the directory build cache easier.
- The configuration of the build cache service is finalized at most twice (`buildSrc` and root build), making it easier for the build scan plugin to capture the cache configuration.