### PR TITLE
Move content from feature preview document to user guide

### DIFF
--- a/subprojects/dependency-management/preview-features.adoc
+++ b/subprojects/dependency-management/preview-features.adoc
@@ -1,40 +1,5 @@
 # Gradle 5.0 Feature Previews
 
-## Enhanced support for Maven repositories
-
-These improvements can change the resolution result for certain Gradle configurations. Thus we consider them to be _potentially breaking changes_. As such, these improvements are opt-in for the Gradle 4.x stream of releases, but are scheduled to become the default in Gradle 5.0.
-
-[NOTE]
-Activate this feature in Gradle 4.6+ by setting `org.gradle.advancedpomsupport=true` in _gradle.properties_.
-
-### Maven `optional` dependencies
-
-Whenever a POM file contains a dependency declaration with `<optional>true</optional>`, Gradle will create a _dependency constraint_. This constraint will produce the expected result for an optional dependency: if the dependency module is brought in by another, non-optional, dependency declaration, then the constraint will apply when choosing the version for that dependency (e.g., if the optional dependency defines a higher version, that one is chosen).
-
-### Maven BOM files and `<dependencyManagement>`
-
-Gradle now provides support for "Maven BOM" files, which are effectively POM files that use `<dependencyManagement>` to control the dependency versions of direct and transitive dependencies. The BOM support in Gradle works similar to the use of `<scope>import</scope>` when depending on a BOM in Maven, but is done via a regular dependency declaration on the BOM:
-
-```
-dependencies {
-  implementation 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE'
-}
-```
-
-When Gradle discovers a dependency on a Maven BOM file, all dependencies declared in the `<dependencyManagement>` block are treated as Gradle _dependency constraints_. This means that any `<dependencyManagement>` versions defined in the BOM file can impact the resolved graph. Gradle treats any POM file with `<packaging>pom</packaging>` as BOM file: if a dependency resolves to a Maven module with `pom` packaging, then a _dependency constraint_ will be produced for every dependency declared in a `dependencyManagement` block.
-
-Note one major difference between the handling of BOM files in Maven and Gradle: a dependency on a BOM is just a regular dependency, and can be published and resolved transitively just like any other dependency. This is different from Maven, where a BOM is _imported_ into the build, and downstream consumers do not automatically benefit from the dependency constraints defined. For example, if project A depends on project B, and project B _imports_ the BOM for project C, then a dependency declared in project A will not use the versions defined in project C.
-
-### Runtime scoped dependencies are not included in Java compile classpath
-
-Since Gradle 1.0, `runtime` scoped dependencies have been included in the Java compile classpath. While this often works fine, it has a number of drawbacks:
-
-- It's easy to publish a compile-time dependency with `runtime` scope, causing issues for non-Gradle consumers
-- The compile classpath is much larger than it needs to be, slowing down compilation
-- The compile classpath includes `runtime` files that do not impact compilation, resulting in unnecessary re-compilation when these files change.
-
-With Gradle 5.0, we intend to change this behaviour. A Maven POM will be considered to define an `api` and `runtime` variant for a Java library, with the `api` variant only including `compile` scoped dependencies. The Java compile classpath will use the `api` variant for each resolved dependency, while the Java runtime classpath will use the `runtime` variant. The net result is that `runtime` scoped dependencies will no longer be available in the compile classpath.
-
 ## New Gradle `.module` metadata format
 
 In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a new module metadata format, that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
@@ -58,9 +23,3 @@ The `.module` files are used to automatically publish the `api` and `runtime` va
 If this feature preview is activated, Gradle automatically searches for a `.module` file for each dependency in a Maven or Ivy repository. If the file is found, it is preferred over the `pom`/`ivy.xml` file.
 
 If a `.module` file is found, _dependency constraints_ and _version constraints_ of the dependency are consumed from that file and are honored during dependency resolution.
-
-### Gradle does not search for `.jar` file when metadata files are missing
-
-With this feature preview, Gradle expects a `.module` or a  `.pom`/`ivy.xml` file for each regular Maven or Ivy module. Previously, Gradle also searched for a `.jar` file in repositories in the absence of any metadata file. This was to cover the unusual case that the module was published without any metadata file. If the jar file was discovered, it was considered to be a module with no dependencies.
-
-This behaviour is no longer active with this feature preview and will no longer be the default in Gradle 5.0. This reduces the number of network requests and makes module discovery less magical. It is still possible to opt into support for such _artifact only modules_ by configuring the `metadataSources` for a repository.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -21,9 +21,35 @@ With [dependency constraints](userguide/managing_transitive_dependencies.html#se
 
 In the example, the version of `commons-codec` that is brought in transitively is `1.9`. With the constraint, we express that we need at lease `1.11` and Gradle will now pick that version during dependency resolution.
 
-### Advanced POM support (preview)
+### Improved POM support: optional dependencies
 
-Gradle now supports [additional features for modules with POM metadata](https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/preview-features.adoc). This includes support for _optional dependencies_, _BOM import_ and _compile/runtime scope separation_. 
+Gradle now creates a dependency constraint for each dependency declaration in a POM file with `<optional>true</optional>`. This constraint will produce the expected result for an optional dependency: if the dependency module is brought in by another, non-optional, dependency declaration, then the constraint will apply when choosing the version for that dependency (e.g., if the optional dependency defines a higher version, that one is chosen).
+
+_Note:_ This is a _Gradle 5.0 feature preview_, which means it is a potentially breaking change that will be activated by default in Gradle 5.0. It can be turned on in Gradle 4.6+ by setting `org.gradle.advancedpomsupport=true` in _gradle.properties_.
+
+### Improved POM support: BOM import
+
+Gradle now [provides support](userguide/managing_transitive_dependencies.html#sec:bom_import) for importing [bill of materials (BOM) files](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies), which are effectively `.pom` files that use `<dependencyManagement>` to control the dependency versions of direct and transitive dependencies. It works by declaring a dependency on a BOM.
+
+    dependencies {
+        implementation 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE'
+    
+        implementation 'com.google.code.gson:gson'
+        implementation 'dom4j:dom4j'
+    }
+
+Here, for example, the versions of `gson` and `dom4j` are provided by the Spring Boot BOM.
+
+_Note:_ This is a _Gradle 5.0 feature preview_, which means it is a potentially breaking change that will be activated by default in Gradle 5.0. It can be turned on in Gradle 4.6+ by setting `org.gradle.advancedpomsupport=true` in _gradle.properties_.
+
+### Improved POM support: compile/runtime scope separation
+
+Since Gradle 1.0, `runtime` scoped dependencies have been included in the Java compile classpath, which has some drawbacks:
+
+- The compile classpath is much larger than it needs to be, slowing down compilation.
+- The compile classpath includes `runtime` files that do not impact compilation, resulting in unnecessary re-compilation when these files change.
+
+Now, the Java and Java Library plugins both honor the separation of compile and runtime scopes. Meaning that the compile classpath only includes `compile` scoped dependencies, while the runtime classpath adds the `runtime` scoped dependencies as well. This is in particular useful if you develop and publish Java libraries with Gradle where the api/implementation dependencies separation is reflected in the published scopes.
 
 _Note:_ This is a _Gradle 5.0 feature preview_, which means it is a potentially breaking change that will be activated by default in Gradle 5.0. It can be turned on in Gradle 4.6+ by setting `org.gradle.advancedpomsupport=true` in _gradle.properties_.
 

--- a/subprojects/docs/src/docs/userguide/javaLibraryPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaLibraryPlugin.adoc
@@ -55,6 +55,12 @@ Dependencies appearing in the `api` configurations will be transitively exposed 
 The `compile` configuration still exists but should not be used as it will not offer the guarantees that the `api` and `implementation` configurations provide.
 ====
 
+If your build consumes a published module with POM metadata, the Java and Java Library plugins both honor api and implementation separation through the scopes used in the pom. Meaning that the compile classpath only includes `compile` scoped dependencies, while the runtime classpath adds the `runtime` scoped dependencies as well. While this often does not have an effect for modules published with Maven, it can have a big impact for modules developed with the Java Library plugin and published with Gradle.
+
+[NOTE]
+====
+Separating compile and runtime scope of modules is active by default in Gradle 5.0+. In Gradle 4.6+, you need to activate it by by setting `org.gradle.advancedpomsupport=true` in gradle.properties.
+====
 
 [[sec:java_library_recognizing_dependencies]]
 === Recognizing API and implementation dependencies

--- a/subprojects/docs/src/docs/userguide/managingTransitiveDependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/managingTransitiveDependencies.adoc
@@ -30,6 +30,13 @@ Dependency constraints allow you to define the version or the version range of b
 
 In the example, all versions are omitted from the dependency declaration. Instead, the versions are defined in the constraints block. The version definition for `commons-codec:1.11` is only taken into account if `commons-codec` is brought in as transitive dependency, since `commons-codec` is not defined as dependency in the project. Otherwise, the constraint has no effect.
 
+Dependency constraints themselves can also be added transitively. If a modules's metadata is defined in a `.pom` file that contains dependency entries with `<optional>true</optional>`, Gradle will create a dependency constraint for each of these so-called _optional dependencies_. This leads to a similar resolution behavior as provided by Maven: if the corresponding module is brought in by another, non-optional, dependency declaration, then the constraint will apply when choosing the version for that module (e.g., if the optional dependency defines a higher version, that one is chosen).
+
+[NOTE]
+====
+Support for _optional dependencies_ from pom files is active by default with Gradle 5.0+. For using it in Gradle 4.6+, you need to activate it by by setting `org.gradle.advancedpomsupport=true` in gradle.properties.
+====
+
 [[sec:excluding_transitive_module_dependencies]]
 === Excluding transitive module dependencies
 
@@ -140,3 +147,23 @@ A project can decide to disable transitive dependency resolution completely. You
     <sourcefile file="build.gradle" snippet="transitive-per-configuration"/>
 </sample>
 ++++
+
+[[sec:bom_import]]
+=== Importing dependency constraints from Maven BOMs
+
+Gradle provides support for importing https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies[bill of materials (BOM) files], which are effectively `.pom` files that use `<dependencyManagement>` to control the dependency versions of direct and transitive dependencies. The BOM support in Gradle works similar to using `<scope>import</scope>` when depending on a BOM in Maven. In Gradle however, it is done via a regular dependency declaration on the BOM:
+
+++++
+<sample id="importing-dependency-constraints-from-bom" dir="userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM" title="Depend on a BOM to import it's dependency constraints">
+    <sourcefile file="build.gradle" snippet="dependency-on-bom"/>
+</sample>
+++++
+
+In the example, the versions of `gson` and `dom4j` are provided by the Spring Boot BOM. This way, if you are developing for a platform like Spring Boot,  you do not have to declare any versions yourself but can rely on the versions the platform provides.
+
+Gradle treats all entries in the `<dependencyManagement>` block of a BOM similar to <<sec:dependency_constraints,Gradle's dependency constraints>>. This means that any version defined in the `<dependencyManagement>` block can impact the dependency resolution result. In order to qualify as a BOM, a `.pom` file needs to have `<packaging>pom</packaging>` set.
+
+[NOTE]
+====
+Importing dependency constraints from Maven BOMs is active by default with Gradle 5.0+. For using it in Gradle 4.6+, you need to activate it by by setting `org.gradle.advancedpomsupport=true` in gradle.properties.
+====

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM/build.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'java-library'
+
+repositories {
+    mavenCentral()
+}
+
+//START SNIPPET dependency-on-bom
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE'
+
+    implementation 'com.google.code.gson:gson'
+    implementation 'dom4j:dom4j'
+}
+//END SNIPPET dependency-on-bom
+
+//Note: dom4j also bring ins xml-apis as transitive dependency
+task copyLibs(type: Copy) {
+    from configurations.compileClasspath
+    into "$buildDir/libs"
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM/gradle.properties
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.advancedpomsupport=true

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dependency-on-bom'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesManagingTransitiveDependenciesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesManagingTransitiveDependenciesIntegrationTest.groovy
@@ -151,6 +151,19 @@ class SamplesManagingTransitiveDependenciesIntegrationTest extends AbstractInteg
         assertSingleLib('guava-23.0.jar')
     }
 
+    @UsesSample("userguide/dependencyManagement/managingTransitiveDependencies/importingDependencyConstraintsFromBOM")
+    def "can import dependency versions from a bom"() {
+        executer.inDirectory(sample.dir)
+
+        when:
+        succeeds(COPY_LIBS_TASK_NAME)
+
+        then:
+        def libs = listFilesInBuildLibsDir()
+        libs.size() == 3
+        libs.any { it.name == 'gson-2.8.2.jar' || it.name == 'dom4j-1.6.1.jar' || it.name == 'xml-apis-1.4.01.jar'}
+    }
+
     private TestFile[] listFilesInBuildLibsDir() {
         sample.dir.file('build/libs').listFiles()
     }


### PR DESCRIPTION
To make it sustainable and easy to discover for users. The content
is reworded to fit into the existing documentation and with the new
terminology definitions. Some explanations are moved to the release
notes, which previously linked to the preview document, to better
illustrate the features there.

Features documented:
- optional dependencies
- BOM support
- compile/runtime scope separation
- metadata sources (was already added to documentation earlier,
  therefore it can also be removed from the preview doc)
