### PR TITLE
Upgrade kotlin-dsl {0.15.3 => 0.15.4}

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     libraries = [:]
 }
 
-versions.gradle_kotlin_dsl = '0.15.3'
+versions.gradle_kotlin_dsl = '0.15.4'
 versions.commons_io = '2.2'
 versions.groovy = '2.4.12'
 versions.bouncycastle = '1.58'


### PR DESCRIPTION
Including support for init scripts written in Kotlin (passed on the command line only, for now), Kotlin 1.2.21, better script compilation error reporting and the move from `kotlin-stdlib-jre8` to `kotlin-stdlib-jdk8`.