### PR TITLE
Enable Kotlin DSL tests on Windows

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyKotlinIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyKotlinIntegrationTest.groovy
@@ -24,9 +24,8 @@ import org.gradle.util.Requires
 import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption
 import static org.gradle.internal.scan.config.fixtures.BuildScanAutoApplyFixture.PUBLISHING_BUILD_SCAN_MESSAGE_PREFIX
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
-import static org.gradle.util.TestPrecondition.NOT_WINDOWS
 
-@Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+@Requires([KOTLIN_SCRIPT])
 class BuildScanAutoApplyKotlinIntegrationTest extends KotlinScriptIntegrationTest {
 
     private final BuildScanAutoApplyFixture fixture = new BuildScanAutoApplyFixture(testDirectory, mavenRepo)

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -19,14 +19,14 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import spock.lang.IgnoreIf
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
-import static org.gradle.util.TestPrecondition.NOT_WINDOWS
 
-@Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+@Requires([KOTLIN_SCRIPT])
 class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     @Override
@@ -40,6 +40,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
     }
 
     @IgnoreIf({GradleContextualExecuter.parallel})
+    @LeaksFileHandles
     def "tasks stay cached after buildSrc with custom Kotlin task is rebuilt"() {
         withKotlinBuildSrc()
         file("buildSrc/src/main/kotlin/CustomTask.kt") << customKotlinTask()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.Requires
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
-import static org.gradle.util.TestPrecondition.NOT_WINDOWS
 
-@Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+@Requires([KOTLIN_SCRIPT])
 class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
     @Override
@@ -55,6 +55,7 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
         result.output.contains('it works!')
     }
 
+    @LeaksFileHandles
     def 'can apply Groovy script from url'() {
         given:
         executer.requireOwnGradleUserHomeDir() //we need an empty external resource cache

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
-@Requires([TestPrecondition.KOTLIN_SCRIPT, TestPrecondition.NOT_WINDOWS])
+@Requires([TestPrecondition.KOTLIN_SCRIPT])
 class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractIntegrationSpec {
 
     @Override

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
@@ -356,7 +356,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         }
     }
 
-    @Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+    @Requires([KOTLIN_SCRIPT])
     def "generates events for nested script plugin applications of different types"() {
         given:
         def scriptPluginGroovy1 = file('scriptPluginGroovy1.gradle')

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
@@ -24,7 +24,6 @@ import org.gradle.tooling.ProjectConnection
 import org.gradle.util.Requires
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
-import static org.gradle.util.TestPrecondition.NOT_WINDOWS
 
 @ToolingApiVersion(">=2.5")
 @TargetGradleVersion(">=4.2")
@@ -108,7 +107,7 @@ class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
         task.child('Execute doLast {} action for :custom')
     }
 
-    @Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+    @Requires([KOTLIN_SCRIPT])
     def "task actions defined in doFirst and doLast blocks of Kotlin build scripts have informative names"() {
         given:
         buildFileKts << """
@@ -145,7 +144,7 @@ class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
         task.child('Execute One last thing... for :custom')
     }
 
-    @Requires([KOTLIN_SCRIPT, NOT_WINDOWS])
+    @Requires([KOTLIN_SCRIPT])
     def "task actions defined in doFirst and doLast blocks of Kotlin build scripts can be named"() {
         given:
         buildFileKts << """


### PR DESCRIPTION
And annotate offending tests with `@LeaksFileHandles`.

See gradle/kotlin-dsl#166