### PR TITLE
Separate Dependency Constraint and Dependency declarations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -319,6 +319,28 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     DependencySet getAllDependencies();
 
     /**
+     * Gets the set of dependency constraints directly contained in this configuration
+     * (ignoring superconfigurations).
+     *
+     * @return the set of dependency constraints
+     *
+     * @since 4.6
+     */
+    @Incubating
+    DependencyConstraintSet getDependencyConstraints();
+
+    /**
+     * <p>Gets the complete set of dependency constraints including those contributed by
+     * superconfigurations.</p>
+     *
+     * @return the (read-only) set of dependency constraints
+     *
+     * @since 4.6
+     */
+    @Incubating
+    DependencyConstraintSet getAllDependencyConstraints();
+
+    /**
      * Returns the artifacts of this configuration excluding the artifacts of extended configurations.
      *
      * @return The set.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -51,13 +51,4 @@ public interface DependencyConstraint extends ModuleVersionSelector {
      * @since 4.6
      */
     void because(String reason);
-
-    /**
-     * Creates and returns a new dependency constraint with the property values of this one.
-     *
-     * @return The copy. Never returns null.
-     *
-     * @since 4.6
-     */
-    DependencyConstraint copy();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -18,22 +18,46 @@ package org.gradle.api.artifacts;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents a constraints over all, including transitive, dependencies.
  *
  * @since 4.5
  */
 @Incubating
-public interface DependencyConstraint extends Dependency {
+public interface DependencyConstraint extends ModuleVersionSelector {
 
     /**
-     * Configures the version constraint for this dependency.
+     * Configures the version constraint for this dependency constraint.
+     *
      * @param configureAction the configuration action for the module version
      */
     void version(Action<? super MutableVersionConstraint> configureAction);
 
     /**
-     * Returns the version constraint.
+     * Returns a reason why this dependency constraint should be used, in particular with regards to its version. The dependency report will use it to explain why a specific dependency was selected, or why a
+     * specific dependency version was used.
+     *
+     * @return a reason to use this dependency constraint
+     * @since 4.6
      */
-    VersionConstraint getVersionConstraint();
+    @Nullable
+    String getReason();
+
+    /**
+     * Sets the reason why this dependency constraint should be used.
+     *
+     * @since 4.6
+     */
+    void because(String reason);
+
+    /**
+     * Creates and returns a new dependency constraint with the property values of this one.
+     *
+     * @return The copy. Never returns null.
+     *
+     * @since 4.6
+     */
+    DependencyConstraint copy();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.artifacts;
 
-
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Incubating;
 
 /**
- * Implementations of this interface always describe direct dependencies and not
- * constraints may optionally considered as dependency.
+ * A set of dependency constraint definitions that are associated with a configuration.
  *
- * @since 4.5
+ * @since 4.6
  */
 @Incubating
-public interface DirectDependency extends Dependency {
+public interface DependencyConstraintSet extends DomainObjectSet<DependencyConstraint> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -32,7 +32,7 @@ import static groovy.lang.Closure.DELEGATE_FIRST;
  * <p>
  * For examples on configuring the exclude rules please refer to {@link #exclude(java.util.Map)}.
  */
-public interface ModuleDependency extends DirectDependency {
+public interface ModuleDependency extends Dependency {
     /**
      * Adds an exclude rule to exclude transitive dependencies of this dependency.
      * <p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
@@ -64,6 +64,16 @@ public interface ResolvableDependencies extends ArtifactView {
     DependencySet getDependencies();
 
     /**
+     * Returns the set of dependency constraints which will be considered during resolution.
+     *
+     * @return the dependency constraints. Never null.
+     *
+     * @since 4.6
+     */
+    @Incubating
+    DependencyConstraintSet getDependencyConstraints();
+
+    /**
      * Adds an action to be executed before the dependencies in this set are resolved.
      *
      * @param action The action to execute.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/SelfResolvingDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/SelfResolvingDependency.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * repository.
  */
 @HasInternalProtocol
-public interface SelfResolvingDependency extends DirectDependency, Buildable {
+public interface SelfResolvingDependency extends Dependency, Buildable {
     /**
      * Resolves this dependency. A {@link org.gradle.api.artifacts.ProjectDependency} is resolved with transitive equals true
      * by this method.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractDependency.java
@@ -16,11 +16,11 @@
 
 package org.gradle.api.internal.artifacts.dependencies;
 
-import org.gradle.api.artifacts.DirectDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.DependencyResolveContext;
 import org.gradle.api.internal.artifacts.ResolvableDependency;
 
-public abstract class AbstractDependency implements ResolvableDependency, DirectDependency {
+public abstract class AbstractDependency implements ResolvableDependency, Dependency {
     private String reason;
 
     protected void copyTo(AbstractDependency target) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -20,6 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.CachingDependencyResolveContext;
 import org.gradle.api.internal.artifacts.DependencyResolveContext;
@@ -104,8 +105,12 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     public void resolve(DependencyResolveContext context) {
         boolean transitive = isTransitive() && context.isTransitive();
         if (transitive) {
-            for (Dependency dependency : findProjectConfiguration().getAllDependencies()) {
+            Configuration projectConfiguration = findProjectConfiguration();
+            for (Dependency dependency : projectConfiguration.getAllDependencies()) {
                 context.add(dependency);
+            }
+            for (DependencyConstraint dependencyConstraint : projectConfiguration.getAllDependencyConstraints()) {
+                context.add(dependencyConstraint);
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -63,7 +63,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.1","org:foo:1.0")
+                edgeFromConstraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
@@ -116,7 +116,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.1","org:foo:1.0")
+                edgeFromConstraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
@@ -148,7 +148,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.1","org:foo:1.0")
+                edgeFromConstraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -135,7 +135,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 module("org:bar:1.0") {
                     edge("org:foo:1.0", "org:foo:1.1").byConflictResolution()
                 }
-                module("org:foo:1.1")
+                edgeFromConstraint("org:foo:1.1", "org:foo:1.1")
             }
         }
     }
@@ -168,7 +168,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 module("org:bar:1.0") {
                     edge("org:foo:[1.0,1.2]", "org:foo:1.1").byReason('tested versions')
                 }
-                edge("org:foo:[1.0,1.1]", "org:foo:1.1").byReason('tested versions')
+                edgeFromConstraint("org:foo:[1.0,1.1]", "org:foo:1.1").byReason('tested versions')
             }
         }
     }
@@ -412,6 +412,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:foo:1.1") {
+                    graph.constraints.add(delegate)
                     artifact(classifier: 'shaded')
                 }
                 module("org:bar:1.0") {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -172,7 +172,7 @@ task checkDeps
 """
         then:
         fails 'checkDeps'
-        failure.assertThatCause(Matchers.startsWith("Cannot convert the provided notation to an object of type DirectDependency: 100."))
+        failure.assertThatCause(Matchers.startsWith("Cannot convert the provided notation to an object of type Dependency: 100."))
     }
 
     def "fails gracefully for single null notation"() {
@@ -190,7 +190,7 @@ task checkDeps
 """
         then:
         fails 'checkDeps'
-        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type DirectDependency"))
+        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type Dependency"))
     }
 
     def "fails gracefully for null notation in list"() {
@@ -208,7 +208,7 @@ task checkDeps
 """
         then:
         fails 'checkDeps'
-        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type DirectDependency"))
+        failure.assertThatCause(Matchers.startsWith("Cannot convert a null value to an object of type Dependency"))
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3271")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.Describable;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.DependencyConstraintSet;
+import org.gradle.api.internal.DelegatingDomainObjectSet;
+
+import java.util.Collection;
+
+public class DefaultDependencyConstraintSet extends DelegatingDomainObjectSet<DependencyConstraint> implements DependencyConstraintSet {
+    private final Describable displayName;
+
+    public DefaultDependencyConstraintSet(Describable displayName, DomainObjectSet<DependencyConstraint> backingSet) {
+        super(backingSet);
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+        return displayName.getDisplayName();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends DependencyConstraint> dependencyConstraints) {
+        boolean added = false;
+        for (DependencyConstraint dependencyConstraint : dependencyConstraints) {
+            added |= add(dependencyConstraint);
+        }
+        return added;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.artifacts;
 
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.ClientModule;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
-import org.gradle.api.artifacts.DirectDependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryDelegate;
@@ -30,12 +30,12 @@ import org.gradle.internal.typeconversion.NotationParser;
 import java.util.Map;
 
 public class DefaultDependencyFactory implements DependencyFactory {
-    private final NotationParser<Object, DirectDependency> dependencyNotationParser;
+    private final NotationParser<Object, Dependency> dependencyNotationParser;
     private final NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser;
     private final NotationParser<Object, ClientModule> clientModuleNotationParser;
     private final ProjectDependencyFactory projectDependencyFactory;
 
-    public DefaultDependencyFactory(NotationParser<Object, DirectDependency> dependencyNotationParser,
+    public DefaultDependencyFactory(NotationParser<Object, Dependency> dependencyNotationParser,
                                     NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser,
                                     NotationParser<Object, ClientModule> clientModuleNotationParser,
                                     ProjectDependencyFactory projectDependencyFactory) {
@@ -45,7 +45,7 @@ public class DefaultDependencyFactory implements DependencyFactory {
         this.projectDependencyFactory = projectDependencyFactory;
     }
 
-    public DirectDependency createDependency(Object dependencyNotation) {
+    public Dependency createDependency(Object dependencyNotation) {
         return dependencyNotationParser.parseNotation(dependencyNotation);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -60,6 +60,7 @@ import org.gradle.api.internal.artifacts.DefaultResolverResults;
 import org.gradle.api.internal.artifacts.ExcludeRuleNotationConverter;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
@@ -713,7 +714,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
         DomainObjectSet<DependencyConstraint> copiedDependencyConstraints = copiedConfiguration.getDependencyConstraints();
         for (DependencyConstraint dependencyConstraint : dependencyConstraints) {
-            copiedDependencyConstraints.add(dependencyConstraint.copy());
+            copiedDependencyConstraints.add(((DefaultDependencyConstraint)dependencyConstraint).copy());
         }
         return copiedConfiguration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -118,7 +118,6 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         this.reason = reason;
     }
 
-    @Override
     public DependencyConstraint copy() {
         DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(group, name, versionConstraint);
         constraint.reason = reason;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -18,10 +18,11 @@ package org.gradle.api.internal.artifacts.dependencies;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.internal.artifacts.ModuleVersionSelectorStrictSpec;
 
 import javax.annotation.Nullable;
 
@@ -81,8 +82,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         return contentEquals(that);
     }
 
-    @Override
-    public boolean contentEquals(Dependency dependency) {
+    private boolean contentEquals(DependencyConstraint dependency) {
         if (this == dependency) {
             return true;
         }
@@ -91,13 +91,6 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         }
         DefaultDependencyConstraint that = (DefaultDependencyConstraint) dependency;
         return StringUtils.equals(group, that.getGroup()) && StringUtils.equals(name, that.getName()) && versionConstraint.equals(that.versionConstraint);
-    }
-
-    @Override
-    public DependencyConstraint copy() {
-        DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(group, name, versionConstraint);
-        constraint.reason = reason;
-        return constraint;
     }
 
     @Override
@@ -111,6 +104,11 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     }
 
     @Override
+    public boolean matchesStrictly(ModuleVersionIdentifier identifier) {
+        return new ModuleVersionSelectorStrictSpec(this).isSatisfiedBy(identifier);
+    }
+
+    @Override
     public String getReason() {
         return reason;
     }
@@ -118,5 +116,12 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     @Override
     public void because(String reason) {
         this.reason = reason;
+    }
+
+    @Override
+    public DependencyConstraint copy() {
+        DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(group, name, versionConstraint);
+        constraint.reason = reason;
+        return constraint;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -20,7 +20,6 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.internal.metaobject.MethodAccess;
@@ -71,7 +70,7 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
 
     private DependencyConstraint doAdd(Configuration configuration, Object dependencyNotation, @Nullable Action<? super DependencyConstraint> configureAction) {
         DependencyConstraint dependency = doCreate(dependencyNotation, configureAction);
-        configuration.getDependencies().add(dependency);
+        configuration.getDependencyConstraints().add(dependency);
         return dependency;
     }
 
@@ -80,11 +79,11 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
         return dynamicMethods;
     }
 
-    private class DependencyConstraintAdder implements DynamicAddDependencyMethods.DependencyAdder {
+    private class DependencyConstraintAdder implements DynamicAddDependencyMethods.DependencyAdder<DependencyConstraint> {
         @Override
-        public Dependency add(Configuration configuration, Object dependencyNotation, Closure configureClosure) {
+        public DependencyConstraint add(Configuration configuration, Object dependencyNotation, Closure configureClosure) {
             DependencyConstraint dependencyConstraint = ConfigureUtil.configure(configureClosure, dependencyFactory.createDependencyConstraint(dependencyNotation));
-            configuration.getDependencies().add(dependencyConstraint);
+            configuration.getDependencyConstraints().add(dependencyConstraint);
             return dependencyConstraint;
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -209,7 +209,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         transforms.registerTransform(registrationAction);
     }
 
-    private class DirectDependencyAdder implements DynamicAddDependencyMethods.DependencyAdder {
+    private class DirectDependencyAdder implements DynamicAddDependencyMethods.DependencyAdder<Dependency> {
 
         @Override
         public Dependency add(Configuration configuration, Object dependencyNotation, @Nullable Closure configureAction) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.util.CollectionUtils;
@@ -63,7 +62,7 @@ class DynamicAddDependencyMethods implements MethodAccess {
         }
     }
 
-    interface DependencyAdder {
-        Dependency add(Configuration configuration, Object dependencyNotation, Closure configureAction);
+    interface DependencyAdder<T> {
+        T add(Configuration configuration, Object dependencyNotation, Closure configureAction);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -58,7 +58,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
-        if (configuration.getAllDependencies().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty() && configuration.getAllDependencyConstraints().isEmpty()) {
             emptyGraph(configuration, result);
         } else {
             delegate.resolveBuildDependencies(configuration, result);
@@ -67,7 +67,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty() && configuration.getAllDependencyConstraints().isEmpty()) {
             emptyGraph(configuration, results);
         } else {
             delegate.resolveGraph(configuration, results);
@@ -85,7 +85,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty() && configuration.getAllDependencyConstraints().isEmpty()) {
             results.artifactsResolved(new EmptyResolvedConfiguration(), new EmptyResults());
         } else {
             delegate.resolveArtifacts(configuration, results);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -58,7 +58,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
-        if (configuration.getAllDependencies().isEmpty() && configuration.getAllDependencyConstraints().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty()) {
             emptyGraph(configuration, result);
         } else {
             delegate.resolveBuildDependencies(configuration, result);
@@ -67,7 +67,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty() && configuration.getAllDependencyConstraints().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty()) {
             emptyGraph(configuration, results);
         } else {
             delegate.resolveGraph(configuration, results);
@@ -85,7 +85,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty() && configuration.getAllDependencyConstraints().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty()) {
             results.artifactsResolved(new EmptyResolvedConfiguration(), new EmptyResults());
         } else {
             delegate.resolveArtifacts(configuration, results);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
-import org.gradle.internal.component.local.model.DslOriginDependencyMetadataWrapper;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
@@ -48,9 +47,8 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
     public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint());
-        LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
+        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, null,
             Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true, dependencyConstraint.getReason());
-        return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependencyConstraint);
     }
 
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -46,6 +46,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         configuration.runDependencyActions();
 
         addDependencies(metaData, configuration);
+        addDependencyConstraints(metaData, configuration);
         addExcludeRules(metaData, configuration);
     }
 
@@ -58,12 +59,16 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
             } else if (dependency instanceof FileCollectionDependency) {
                 final FileCollectionDependency fileDependency = (FileCollectionDependency) dependency;
                 configurationMetadata.addFiles(new DefaultLocalFileDependencyMetadata(fileDependency));
-            } else if (dependency instanceof DependencyConstraint) {
-                DependencyConstraint dependencyConstraint = (DependencyConstraint) dependency;
-                configurationMetadata.addDependency(dependencyDescriptorFactory.createDependencyConstraintDescriptor(configurationMetadata.getComponentId(), configuration.getName(), attributes, dependencyConstraint));
             } else {
                 throw new IllegalArgumentException("Cannot convert dependency " + dependency + " to local component dependency metadata.");
             }
+        }
+    }
+
+    private void addDependencyConstraints(BuildableLocalConfigurationMetadata configurationMetadata, ConfigurationInternal configuration) {
+        AttributeContainerInternal attributes = configuration.getAttributes();
+        for (DependencyConstraint dependencyConstraint : configuration.getDependencyConstraints()) {
+            configurationMetadata.addDependency(dependencyDescriptorFactory.createDependencyConstraintDescriptor(configurationMetadata.getComponentId(), configuration.getName(), attributes, dependencyConstraint));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
@@ -42,7 +42,9 @@ public class ResolvedConfigurationDependencyGraphVisitor implements DependencyAr
         for (DependencyGraphEdge dependency : node.getIncomingEdges()) {
             if (dependency.getFrom() == root) {
                 Dependency moduleDependency = dependency.getOriginalDependency();
-                builder.addFirstLevelDependency(moduleDependency, node);
+                if (moduleDependency != null) {
+                    builder.addFirstLevelDependency(moduleDependency, node);
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.notations;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.DirectDependency;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
@@ -31,9 +31,9 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
 public class DependencyNotationParser {
-    public static NotationParser<Object, DirectDependency> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, ClassPathRegistry classPathRegistry, FileLookup fileLookup, RuntimeShadedJarFactory runtimeShadedJarFactory, CurrentGradleInstallation currentGradleInstallation) {
+    public static NotationParser<Object, Dependency> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, ClassPathRegistry classPathRegistry, FileLookup fileLookup, RuntimeShadedJarFactory runtimeShadedJarFactory, CurrentGradleInstallation currentGradleInstallation) {
         return NotationParserBuilder
-            .toType(DirectDependency.class)
+            .toType(Dependency.class)
             .fromCharSequence(new DependencyStringNotationConverter<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
             .converter(new DependencyMapNotationConverter<DefaultExternalModuleDependency>(instantiator, DefaultExternalModuleDependency.class))
             .fromType(FileCollection.class, new DependencyFilesNotationConverter(instantiator))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.DependencyConstraint
-import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.DependencyConstraintSet
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.AsmBackedClassGenerator
 import spock.lang.Specification
@@ -33,7 +33,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
     private def configurationContainer = Mock(ConfigurationContainer)
     private def dependencyFactory = Mock(DependencyFactory)
     private def configuration = Mock(Configuration)
-    private def dependencySet = Mock(DependencySet)
+    private def dependencyConstraintSet = Mock(DependencyConstraintSet)
 
     private DefaultDependencyConstraintHandler dependencyConstraintHandler = new AsmBackedClassGenerator().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory)
 
@@ -41,7 +41,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration
         _ * configurationContainer.getByName(TEST_CONF_NAME) >> configuration
         _ * configurationContainer.getByName(UNKNOWN_TEST_CONF_NAME) >> { throw new UnknownDomainObjectException("") }
-        _ * configuration.dependencies >> dependencySet
+        _ * configuration.dependencyConstraints >> dependencyConstraintSet
     }
 
     void "creates and adds a dependency constraint from some notation"() {
@@ -55,7 +55,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
 
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
-        1 * dependencySet.add(dependencyConstraint)
+        1 * dependencyConstraintSet.add(dependencyConstraint)
     }
 
     void "creates, configures and adds a dependency constraint from some notation"() {
@@ -72,7 +72,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
         1 * dependencyConstraint.version(_ as Action<VersionConstraint>)
-        1 * dependencySet.add(dependencyConstraint)
+        1 * dependencyConstraintSet.add(dependencyConstraint)
     }
 
     void "creates a dependency constraint from some notation"() {
@@ -115,7 +115,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
 
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
-        1 * dependencySet.add(dependencyConstraint)
+        1 * dependencyConstraintSet.add(dependencyConstraint)
 
     }
 
@@ -130,7 +130,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
 
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> dependencyConstraint
-        1 * dependencySet.add(dependencyConstraint)
+        1 * dependencyConstraintSet.add(dependencyConstraint)
         1 * dependencyConstraint.version(_ as Action<VersionConstraint>)
     }
 
@@ -147,8 +147,8 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> constraint1
         1 * dependencyFactory.createDependencyConstraint("someOther") >> constraint2
-        1 * dependencySet.add(constraint1)
-        1 * dependencySet.add(constraint2)
+        1 * dependencyConstraintSet.add(constraint1)
+        1 * dependencyConstraintSet.add(constraint2)
     }
 
     void "can use dynamic method to add multiple dependency constraint from nested lists"() {
@@ -164,8 +164,8 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> constraint1
         1 * dependencyFactory.createDependencyConstraint("someOther") >> constraint2
-        1 * dependencySet.add(constraint1)
-        1 * dependencySet.add(constraint2)
+        1 * dependencyConstraintSet.add(constraint1)
+        1 * dependencyConstraintSet.add(constraint2)
     }
 
     void "dynamic method fails for unknown configuration"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.ClientModule
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
-import org.gradle.api.artifacts.DirectDependency
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.VersionConstraint
@@ -58,7 +58,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates and adds a dependency from some notation"() {
-        DirectDependency dependency = Mock()
+        Dependency dependency = Mock()
 
         when:
         def result = dependencyHandler.add(TEST_CONF_NAME, "someNotation")
@@ -89,7 +89,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates a dependency from some notation"() {
-        DirectDependency dependency = Mock()
+        Dependency dependency = Mock()
 
         when:
         def result = dependencyHandler.create("someNotation")
@@ -122,7 +122,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "can use dynamic method to add dependency"() {
-        DirectDependency dependency = Mock()
+        Dependency dependency = Mock()
 
         when:
         def result = dependencyHandler.someConf("someNotation")
@@ -152,8 +152,8 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "can use dynamic method to add multiple dependencies"() {
-        DirectDependency dependency1 = Mock()
-        DirectDependency dependency2 = Mock()
+        Dependency dependency1 = Mock()
+        Dependency dependency2 = Mock()
 
         when:
         def result = dependencyHandler.someConf("someNotation", "someOther")
@@ -169,8 +169,8 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "can use dynamic method to add multiple dependencies from nested lists"() {
-        DirectDependency dependency1 = Mock()
-        DirectDependency dependency2 = Mock()
+        Dependency dependency1 = Mock()
+        Dependency dependency2 = Mock()
 
         when:
         def result = dependencyHandler.someConf([["someNotation"], ["someOther"]])
@@ -274,7 +274,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates gradle api dependency"() {
-        DirectDependency dependency = Mock()
+        Dependency dependency = Mock()
 
         when:
         def result = dependencyHandler.gradleApi()
@@ -287,7 +287,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates Gradle test-kit dependency"() {
-        DirectDependency dependency = Mock()
+        Dependency dependency = Mock()
 
         when:
         def result = dependencyHandler.gradleTestKit()
@@ -300,7 +300,7 @@ class DefaultDependencyHandlerTest extends Specification {
     }
 
     void "creates local groovy dependency"() {
-        DirectDependency dependency = Mock()
+        Dependency dependency = Mock()
 
         when:
         def result = dependencyHandler.localGroovy()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyConstraintSet
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
@@ -32,6 +33,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
     def delegate = Mock(ConfigurationResolver)
     def configuration = Stub(ConfigurationInternal)
     def dependencies = Stub(DependencySet)
+    def dependencyConstraints = Stub(DependencyConstraintSet)
     def componentIdentifierFactory = Mock(ComponentIdentifierFactory)
     def results = new DefaultResolverResults()
     def moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
@@ -44,7 +46,9 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
 
         given:
         dependencies.isEmpty() >> true
+        dependencyConstraints.isEmpty() >> true
         configuration.getAllDependencies() >> dependencies
+        configuration.getAllDependencyConstraints() >> dependencyConstraints
 
         when:
         dependencyResolver.resolveBuildDependencies(configuration, results)
@@ -70,7 +74,9 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
 
         given:
         dependencies.isEmpty() >> true
+        dependencyConstraints.isEmpty() >> true
         configuration.getAllDependencies() >> dependencies
+        configuration.getAllDependencyConstraints() >> dependencyConstraints
 
         when:
         dependencyResolver.resolveGraph(configuration, results)
@@ -98,7 +104,9 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
     def "returns empty result when no dependencies"() {
         given:
         dependencies.isEmpty() >> true
+        dependencyConstraints.isEmpty() >> true
         configuration.getAllDependencies() >> dependencies
+        configuration.getAllDependencyConstraints() >> dependencyConstraints
 
         when:
         dependencyResolver.resolveGraph(configuration, results)

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -262,7 +262,7 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
-                    dependencyConstraints: configurations.implementation.allDependencies.withType(DependencyConstraint),
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: configurations.implementation.attributes))
 
             dependencies {
@@ -371,7 +371,7 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
-                    dependencyConstraints: configurations.implementation.allDependencies.withType(DependencyConstraint),
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: configurations.implementation.attributes))
 
             dependencies {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
@@ -41,7 +41,7 @@ class DefaultUsageContext implements UsageContext, Named {
         this.attributes = configuration.getAttributes();
         this.artifacts = artifacts;
         this.dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
-        this.dependencyConstraints = configuration.getAllDependencies().withType(DependencyConstraint.class);
+        this.dependencyConstraints = configuration.getAllDependencyConstraints();
     }
 
     DefaultUsageContext(String name, Usage usage, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Set<? extends ModuleDependency> dependencies, Set<? extends DependencyConstraint> dependencyConstraints) {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -225,7 +225,7 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
-                    dependencyConstraints: configurations.implementation.allDependencies.withType(DependencyConstraint),
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: configurations.implementation.attributes))
 
             dependencies {
@@ -334,7 +334,7 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
-                    dependencyConstraints: configurations.implementation.allDependencies.withType(DependencyConstraint),
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: configurations.implementation.attributes))
 
             dependencies {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
@@ -235,12 +234,12 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         runtimeUsage.dependencies.size() == 2
         runtimeUsage.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         runtimeUsage.dependencyConstraints.size() == 2
-        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies.withType(DependencyConstraint)
+        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencyConstraints
 
         apiUsage.dependencies.size() == 1
         apiUsage.dependencies == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         apiUsage.dependencyConstraints.size() == 1
-        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencies.withType(DependencyConstraint)
+        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
     }
 
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -357,18 +357,6 @@ public class ModuleMetadataFileGenerator {
         jsonWriter.endArray();
     }
 
-    private void writeDependencyConstraints(UsageContext variant, JsonWriter jsonWriter) throws IOException {
-        if (variant.getDependencyConstraints().isEmpty()) {
-            return;
-        }
-        jsonWriter.name("dependencyConstraints");
-        jsonWriter.beginArray();
-        for (DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
-            writeDependency(dependencyConstraint, jsonWriter);
-        }
-        jsonWriter.endArray();
-    }
-
     private void writeDependency(Dependency dependency, JsonWriter jsonWriter) throws IOException {
         jsonWriter.beginObject();
         if (dependency instanceof ProjectDependency) {
@@ -387,8 +375,6 @@ public class ModuleMetadataFileGenerator {
             VersionConstraint vc;
             if (dependency instanceof ModuleVersionSelector) {
                 vc = ((ExternalDependency) dependency).getVersionConstraint();
-            } else if (dependency instanceof DependencyConstraint) {
-                vc = ((DependencyConstraint) dependency).getVersionConstraint();
             } else {
                 vc = DefaultImmutableVersionConstraint.of(Strings.nullToEmpty(dependency.getVersion()));
             }
@@ -398,6 +384,33 @@ public class ModuleMetadataFileGenerator {
             writeExcludes((ModuleDependency) dependency, jsonWriter);
         }
         String reason = dependency.getReason();
+        if (StringUtils.isNotEmpty(reason)) {
+            jsonWriter.name("reason");
+            jsonWriter.value(reason);
+        }
+        jsonWriter.endObject();
+    }
+
+    private void writeDependencyConstraints(UsageContext variant, JsonWriter jsonWriter) throws IOException {
+        if (variant.getDependencyConstraints().isEmpty()) {
+            return;
+        }
+        jsonWriter.name("dependencyConstraints");
+        jsonWriter.beginArray();
+        for (DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
+            writeDependencyConstraint(dependencyConstraint, jsonWriter);
+        }
+        jsonWriter.endArray();
+    }
+
+    private void writeDependencyConstraint(DependencyConstraint dependencyConstraint, JsonWriter jsonWriter) throws IOException {
+        jsonWriter.beginObject();
+        jsonWriter.name("group");
+        jsonWriter.value(dependencyConstraint.getGroup());
+        jsonWriter.name("module");
+        jsonWriter.value(dependencyConstraint.getName());
+        writeVersionConstraint(dependencyConstraint.getVersionConstraint(), jsonWriter);
+        String reason = dependencyConstraint.getReason();
         if (StringUtils.isNotEmpty(reason)) {
             jsonWriter.name("reason");
             jsonWriter.value(reason);


### PR DESCRIPTION
**UPDATED**

Separate DependencyConstraint and Dependency declarations

The interfaces for declaring these two different things were coupled in the initial implementation - to reuse all functionality based on the Dependency interface directly. This interface is used internally to pass dependency declarations through the resolution process. However, this is only due to remembering the first level dependencies for the "old" results API (Configuration.resolvedConfiguration()).

These implementation specifics should not bleed into the API.

A dependency declaration defines a *requirement*:
>  I require module/project X

A dependency constraint defines a *constraint*:
>  If I must use X, I can only work with versions matching the constraint

Only if we look at external dependencies, constraints and external dependencies share the ability to declare a *version constraint*. Therefore, both now extend `ModuleVersionSelector`.

Now, dependency constraints are removed as "first level dependencies" from the result. This is fine as the dependency itself is still in the result graph - when there is a constraint, there is always at least one other edge.