### PR TITLE
Various dependency management performance improvements

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.clientmodule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.Dependency;
@@ -179,7 +180,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
 
     private static class ClientModuleConfigurationMetadata extends DefaultConfigurationMetadata {
         ClientModuleConfigurationMetadata(ModuleComponentIdentifier componentId, String name, ModuleComponentArtifactMetadata artifact, List<ModuleDependencyMetadata> dependencies) {
-            super(componentId, name, true, true, ImmutableList.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of());
+            super(componentId, name, true, true, ImmutableSet.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of());
             setDependencies(dependencies);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -50,6 +50,7 @@ class EdgeState implements DependencyGraphEdge {
     private final ResolveState resolveState;
     private final ModuleExclusion transitiveExclusions;
     private final List<NodeState> targetNodes = Lists.newLinkedList();
+    private final boolean isTransitive;
 
     private ComponentState targetModuleRevision;
     private ModuleVersionResolveException targetNodeSelectionFailure;
@@ -62,6 +63,7 @@ class EdgeState implements DependencyGraphEdge {
         this.transitiveExclusions = transitiveExclusions;
         this.resolveState = resolveState;
         this.selector = resolveState.getSelector(dependencyState, dependencyState.getModuleIdentifier());
+        this.isTransitive = from.isTransitive() && dependencyMetadata.isTransitive();
     }
 
     @Override
@@ -99,7 +101,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     public boolean isTransitive() {
-        return from.isTransitive() && dependencyMetadata.isTransitive();
+        return isTransitive;
     }
 
     public void attachToTargetConfigurations() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -54,6 +54,7 @@ class EdgeState implements DependencyGraphEdge {
 
     private ComponentState targetModuleRevision;
     private ModuleVersionResolveException targetNodeSelectionFailure;
+    private ModuleExclusion cachedExclusions;
 
     EdgeState(NodeState from, DependencyState dependencyState, ModuleExclusion transitiveExclusions, ResolveState resolveState) {
         this.from = from;
@@ -160,12 +161,16 @@ class EdgeState implements DependencyGraphEdge {
 
     @Override
     public ModuleExclusion getExclusions() {
+        if (cachedExclusions != null) {
+            return cachedExclusions;
+        }
         List<ExcludeMetadata> excludes = dependencyMetadata.getExcludes();
         if (excludes.isEmpty()) {
             return transitiveExclusions;
         }
         ModuleExclusion edgeExclusions = resolveState.getModuleExclusions().excludeAny(ImmutableList.copyOf(excludes));
-        return resolveState.getModuleExclusions().intersect(edgeExclusions, transitiveExclusions);
+        cachedExclusions = resolveState.getModuleExclusions().intersect(edgeExclusions, transitiveExclusions);
+        return cachedExclusions;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesState.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.Maps;
-import org.gradle.api.artifacts.ModuleIdentifier;
 
 import java.util.Map;
 
@@ -26,18 +25,29 @@ import java.util.Map;
 public class PendingDependenciesState {
     private static final PendingDependencies NOT_PENDING = PendingDependencies.notPending();
 
-    private final Map<ModuleIdentifier, PendingDependencies> pendingDependencies = Maps.newHashMap();
+    private final Map<String, Map<String, PendingDependencies>> pendingDependencies = Maps.newHashMap();
 
-    public PendingDependencies getPendingDependencies(ModuleIdentifier module) {
-        PendingDependencies pendingDependencies = this.pendingDependencies.get(module);
+    public PendingDependencies getPendingDependencies(String group, String module) {
+        Map<String, PendingDependencies> pendingDependenciesForGroup = pendingDependenciesForGroup(group);
+        PendingDependencies pendingDependencies = pendingDependenciesForGroup.get(module);
         if (pendingDependencies == null) {
             pendingDependencies = PendingDependencies.pending();
-            this.pendingDependencies.put(module, pendingDependencies);
+            pendingDependenciesForGroup.put(module, pendingDependencies);
         }
         return pendingDependencies;
     }
 
-    public PendingDependencies notPending(ModuleIdentifier module) {
-        return pendingDependencies.put(module, NOT_PENDING);
+    public PendingDependencies notPending(String group, String module) {
+        Map<String, PendingDependencies> pendingDependenciesForGroup = pendingDependenciesForGroup(group);
+        return pendingDependenciesForGroup.put(module, NOT_PENDING);
+    }
+
+    private Map<String, PendingDependencies> pendingDependenciesForGroup(String group) {
+        Map<String, PendingDependencies> map = pendingDependencies.get(group);
+        if (map == null) {
+            map = Maps.newHashMap();
+            pendingDependencies.put(group, map);
+        }
+        return map;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -121,7 +122,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             return null;
         }
 
-        ImmutableList<String> hierarchy = constructHierarchy(descriptorConfiguration);
+        ImmutableSet<String> hierarchy = constructHierarchy(descriptorConfiguration);
         boolean transitive = descriptorConfiguration.isTransitive();
         boolean visible = descriptorConfiguration.isVisible();
         populated = createConfiguration(componentIdentifier, name, transitive, visible, hierarchy, variantMetadataRules);
@@ -129,13 +130,13 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         return populated;
     }
 
-    private ImmutableList<String> constructHierarchy(Configuration descriptorConfiguration) {
+    private ImmutableSet<String> constructHierarchy(Configuration descriptorConfiguration) {
         if (descriptorConfiguration.getExtendsFrom().isEmpty()) {
-            return ImmutableList.of(descriptorConfiguration.getName());
+            return ImmutableSet.of(descriptorConfiguration.getName());
         }
         Set<String> accumulator = new LinkedHashSet<String>();
         populateHierarchy(descriptorConfiguration, accumulator);
-        return ImmutableList.copyOf(accumulator);
+        return ImmutableSet.copyOf(accumulator);
     }
 
     private void populateHierarchy(Configuration metadata, Set<String> accumulator) {
@@ -149,7 +150,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     /**
      * Creates a {@link org.gradle.internal.component.model.ConfigurationMetadata} implementation for this component.
      */
-    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules);
+    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, VariantMetadataRules componentMetadataRules);
 
     /**
      * If there are no variants defined in the metadata, but the implementation knows how to provide variants it can do that here.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationDependencyMetadataWrapper.java
@@ -38,6 +38,8 @@ public class ConfigurationDependencyMetadataWrapper implements ModuleDependencyM
     private final ExternalDependencyDescriptor delegate;
     private final String reason;
 
+    private List<ExcludeMetadata> cachedExcludes;
+
     private ConfigurationDependencyMetadataWrapper(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor delegate, String reason) {
         this.configuration = configuration;
         this.componentId = componentId;
@@ -61,7 +63,11 @@ public class ConfigurationDependencyMetadataWrapper implements ModuleDependencyM
 
     @Override
     public List<ExcludeMetadata> getExcludes() {
-        return delegate.getConfigurationExcludes(configuration.getHierarchy());
+        if (cachedExcludes != null) {
+            return cachedExcludes;
+        }
+        cachedExcludes = delegate.getConfigurationExcludes(configuration.getHierarchy());
+        return cachedExcludes;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -43,7 +43,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
     private final boolean transitive;
     private final boolean visible;
-    private final ImmutableList<String> hierarchy;
+    private final ImmutableSet<String> hierarchy;
     private final VariantMetadataRules componentMetadataRules;
     private final ImmutableList<ExcludeMetadata> excludes;
     private final ImmutableAttributes attributes;
@@ -56,14 +56,14 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     private ImmutableAttributes computedAttributes;
 
     protected DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
-                                           ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                           ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                            VariantMetadataRules componentMetadataRules,
                                            ImmutableList<ExcludeMetadata> excludes) {
         this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, ImmutableAttributes.EMPTY, null);
     }
 
     private DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
-                                         ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                          VariantMetadataRules componentMetadataRules,
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes attributes,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -85,7 +86,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
     }
 
     @Override
-    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules) {
+    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, VariantMetadataRules componentMetadataRules) {
         ImmutableList<ModuleComponentArtifactMetadata> artifacts = filterArtifacts(name, hierarchy);
         ImmutableList<ExcludeMetadata> excludesForConfiguration = filterExcludes(hierarchy);
 
@@ -94,7 +95,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
         return configuration;
     }
 
-    private ImmutableList<ModuleComponentArtifactMetadata> filterArtifacts(String name, ImmutableList<String> hierarchy) {
+    private ImmutableList<ModuleComponentArtifactMetadata> filterArtifacts(String name, ImmutableSet<String> hierarchy) {
         Set<ModuleComponentArtifactMetadata> artifacts = new LinkedHashSet<ModuleComponentArtifactMetadata>();
         collectArtifactsFor(name, artifacts);
         for (String parent : hierarchy) {
@@ -119,7 +120,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
         }
     }
 
-    private ImmutableList<ExcludeMetadata> filterExcludes(ImmutableList<String> hierarchy) {
+    private ImmutableList<ExcludeMetadata> filterExcludes(ImmutableSet<String> hierarchy) {
         ImmutableList.Builder<ExcludeMetadata> filtered = ImmutableList.builder();
         for (Exclude exclude : excludes) {
             for (String config : exclude.getConfigurations()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
@@ -82,7 +83,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     }
 
     @Override
-    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> parents, VariantMetadataRules componentMetadataRules) {
+    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> parents, VariantMetadataRules componentMetadataRules) {
         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = getArtifactsForConfiguration(name);
         DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of());
         configuration.setDependencies(filterDependencies(configuration));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
@@ -194,11 +194,10 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
         if (excludes.isEmpty()) {
             return Collections.emptyList();
         }
-        Set<String> asSet = ImmutableSet.copyOf(configurations);
         List<ExcludeMetadata> rules = Lists.newArrayListWithCapacity(excludes.size());
         for (Exclude exclude : excludes) {
             Set<String> ruleConfigurations = exclude.getConfigurations();
-            if (include(ruleConfigurations, asSet)) {
+            if (include(ruleConfigurations, configurations)) {
                 rules.add(exclude);
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
@@ -191,10 +191,14 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
 
     @Override
     public List<ExcludeMetadata> getConfigurationExcludes(Collection<String> configurations) {
-        List<ExcludeMetadata> rules = Lists.newArrayList();
+        if (excludes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> asSet = ImmutableSet.copyOf(configurations);
+        List<ExcludeMetadata> rules = Lists.newArrayListWithCapacity(excludes.size());
         for (Exclude exclude : excludes) {
             Set<String> ruleConfigurations = exclude.getConfigurations();
-            if (include(ruleConfigurations, configurations)) {
+            if (include(ruleConfigurations, asSet)) {
                 rules.add(exclude);
             }
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -85,10 +85,10 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractModuleComponentResolve
         def md = metadata
 
         then:
-        md.getConfiguration("a").hierarchy == ["a"]
-        md.getConfiguration("b").hierarchy == ["b", "a"]
-        md.getConfiguration("c").hierarchy == ["c", "a"]
-        md.getConfiguration("d").hierarchy == ["d", "b", "a", "c"]
+        md.getConfiguration("a").hierarchy as List == ["a"]
+        md.getConfiguration("b").hierarchy as List  == ["b", "a"]
+        md.getConfiguration("c").hierarchy as List  == ["c", "a"]
+        md.getConfiguration("d").hierarchy as List  == ["d", "b", "a", "c"]
     }
 
     def "builds and caches artifacts for a configuration"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -75,7 +75,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         runtime.artifacts.name.name == ["runtime.jar"]
         runtime.excludes.empty
         def defaultConfig = immutable.getConfiguration("default")
-        defaultConfig.hierarchy == ["default", "runtime"]
+        defaultConfig.hierarchy as List == ["default", "runtime"]
         defaultConfig.transitive
         defaultConfig.visible
         defaultConfig.artifacts.name.name == ["api.jar", "runtime.jar"]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -48,13 +48,13 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         expect:
         def immutable = metadata.asImmutable()
         immutable.configurationNames == ["compile", "runtime", "test", "provided", "system", "optional", "master", "default", "javadoc", "sources"] as Set
-        immutable.getConfiguration("compile").hierarchy == ["compile"]
-        immutable.getConfiguration("runtime").hierarchy == ["runtime", "compile"]
-        immutable.getConfiguration("master").hierarchy == ["master"]
-        immutable.getConfiguration("test").hierarchy == ["test", "runtime", "compile"]
-        immutable.getConfiguration("default").hierarchy == ["default", "runtime", "compile", "master"]
-        immutable.getConfiguration("provided").hierarchy == ["provided"]
-        immutable.getConfiguration("optional").hierarchy == ["optional"]
+        immutable.getConfiguration("compile").hierarchy as List == ["compile"]
+        immutable.getConfiguration("runtime").hierarchy as List  == ["runtime", "compile"]
+        immutable.getConfiguration("master").hierarchy as List  == ["master"]
+        immutable.getConfiguration("test").hierarchy as List  == ["test", "runtime", "compile"]
+        immutable.getConfiguration("default").hierarchy as List  == ["default", "runtime", "compile", "master"]
+        immutable.getConfiguration("provided").hierarchy as List  == ["provided"]
+        immutable.getConfiguration("optional").hierarchy as List  == ["optional"]
     }
 
     def "default metadata"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/GradleFeaturePreviewsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/GradleFeaturePreviewsPerformanceTest.groovy
@@ -44,4 +44,24 @@ class GradleFeaturePreviewsPerformanceTest extends AbstractCrossBuildPerformance
         runner.run()
     }
 
+    def "resolveDependencies on large number of dependencies with advanced pom support"() {
+        def memory = '1g'
+
+        when:
+        runner.testGroup = "feature previews"
+        runner.buildSpec {
+            projectName(EXCLUDE_RULE_MERGING_TEST_PROJECT).displayName("advanced-pom-support").invocation {
+                tasksToRun("resolveDependencies").args("-Dorg.gradle.advancedpomsupport=true", '-PnoExcludes').gradleOpts("-Xms${memory}", "-Xmx${memory}")
+            }
+        }
+        runner.baseline {
+            projectName(EXCLUDE_RULE_MERGING_TEST_PROJECT).displayName("no-advanced-pom-support").invocation {
+                tasksToRun("resolveDependencies").args("-Dorg.gradle.advancedpomsupport=false", '-PnoExcludes').gradleOpts("-Xms${memory}", "-Xmx${memory}")
+            }
+        }
+
+        then:
+        runner.run()
+    }
+
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.regression.corefeature
+
+import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.WithExternalRepository
+import org.gradle.performance.fixture.BuildExperimentInvocationInfo
+import org.gradle.performance.fixture.BuildExperimentListener
+import org.gradle.performance.fixture.BuildExperimentSpec
+import org.gradle.performance.fixture.GradleInvocationSpec
+import org.gradle.performance.measure.MeasuredOperation
+
+class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
+
+    private final static TEST_PROJECT_NAME = 'excludeRuleMergingBuild'
+
+    def setup() {
+        runner.minimumVersion = '4.0'
+    }
+
+    def "resolve large dependency graph"() {
+        runner.testProject = TEST_PROJECT_NAME
+        startServer()
+
+        given:
+        def baseline = "4.6-20180125002142+0000"
+        runner.tasksToRun = ['resolveDependencies']
+        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
+        runner.targetVersions = [baseline]
+        runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", "-PnoExcludes"]
+        //runner.addBuildExperimentListener(createArgsTweaker(baseline))
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        cleanup:
+        stopServer()
+    }
+
+    def "resolve large dependency graph (parallel)"() {
+        runner.testProject = TEST_PROJECT_NAME
+        startServer()
+
+        given:
+        def baseline = "4.6-20180125002142+0000"
+        runner.tasksToRun = ['resolveDependencies']
+        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
+        runner.targetVersions = [baseline]
+        runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", "-PnoExcludes", "--parallel"]
+        //runner.addBuildExperimentListener(createArgsTweaker(baseline))
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        cleanup:
+        stopServer()
+    }
+
+    private static BuildExperimentListener createArgsTweaker(String baseline) {
+        new BuildExperimentListener() {
+            @Override
+            void beforeExperiment(BuildExperimentSpec experimentSpec, File projectDir) {
+                GradleInvocationSpec invocation = experimentSpec.invocation as GradleInvocationSpec
+                if (invocation.gradleDistribution.version.version != baseline) {
+                    invocation.args << '-Dorg.gradle.advancedpomsupport=true'
+                }
+            }
+
+            @Override
+            void beforeInvocation(BuildExperimentInvocationInfo invocationInfo) {
+
+            }
+
+            @Override
+            void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
+
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Context

This pull request implements several performance improvements in dependency management, as identified during the investigation of why enabling advanced POM support makes builds slower. They are not necessarily directly related to this, but were identified as hotspots in the analysis of flame graphs.

Each of the commits implement a performance improvement of its own.

The PR also adds a performance test based on the same project as the "exclude rule merging" performance test, but avoids the creation of excludes, making it more suitable to analyze the performance of dependency management in general.
