### PR TITLE
Allow a dependency to be declared on a branch of a source dependency

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
@@ -18,6 +18,8 @@ package org.gradle.api.artifacts;
 import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
+import javax.annotation.Nullable;
+
 /**
  * A configurable version constraint. This is exposed to the build author, so that one can express
  * more constraints on a version,
@@ -27,6 +29,21 @@ import org.gradle.internal.HasInternalProtocol;
 @Incubating
 @HasInternalProtocol
 public interface MutableVersionConstraint extends VersionConstraint {
+    /**
+     * Returns the branch to select versions from. When not {@code null}, select only versions that were built from the given branch.
+     *
+     * @since 4.6
+     */
+    @Nullable
+    String getBranch();
+
+    /**
+     * Specifies the branch to select versions from.
+     *
+     * @param branch The branch, possibly null.
+     * @since 4.6
+     */
+    void setBranch(@Nullable String branch);
 
     /**
      * Sets the preferred version of this module. Any other rejection/strict constraint will be overriden.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -27,6 +28,14 @@ import java.util.List;
  */
 @Incubating
 public interface VersionConstraint {
+    /**
+     * The branch to select versions from. When not {@code null} selects only those versions that were built from the specified branch.
+     *
+     * @since 4.6
+     */
+    @Nullable
+    String getBranch();
+
     /**
      * The preferred version of a module. The preferred version of a module can typically be upgraded during dependency resolution,
      * unless further constraints are added.

--- a/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VersionControlSystem.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VersionControlSystem.java
@@ -18,6 +18,7 @@ package org.gradle.vcs.internal;
 import org.gradle.api.Incubating;
 import org.gradle.vcs.VersionControlSpec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Set;
 
@@ -47,4 +48,10 @@ public interface VersionControlSystem {
      * Returns the default revision for this VCS.
      */
     VersionRef getHead(VersionControlSpec spec);
+
+    /**
+     * Returns the given branch or null.
+     */
+    @Nullable
+    VersionRef getBranch(VersionControlSpec spec, String branch);
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -78,7 +78,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:","org:foo:1.1")
+                edge("org:foo","org:foo:1.1")
                 module("org:foo:1.1")
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -94,7 +94,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB:', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     module('org.test:moduleB:1.0')
                 }
@@ -144,7 +144,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB:', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     module('org.test:moduleB:1.0')
                 }
@@ -391,7 +391,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB:', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     module('org.test:moduleB:1.0')
                 }
@@ -519,7 +519,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleC:', 'org.test:moduleC:1.0')
+                edge('org.test:moduleC', 'org.test:moduleC:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     module("org.test:moduleB:1.0") {
                         module('org.test:moduleC:1.0')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -64,7 +64,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA:", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0")
             }
         }
     }
@@ -93,7 +93,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                         noArtifacts()
                     }
                 }
-                edge("group:moduleA:", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0")
             }
         }
     }
@@ -123,7 +123,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA:", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0")
             }
         }
 
@@ -141,7 +141,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     }
                     noArtifacts()
                 }
-                edge("group:moduleA:", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0")
             }
         }
     }
@@ -180,10 +180,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }
-                edge("group:moduleA:", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0")
             }
         }
-
     }
 
     def "a parent pom is not a bom"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.dependencies;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.VersionConstraint;
 
 public abstract class AbstractVersionConstraint implements VersionConstraint {
@@ -24,13 +25,16 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
         if (this == o) {
             return true;
         }
-        if (o == null) {
+        if (o == null || o.getClass() != getClass()) {
             return false;
         }
 
         AbstractVersionConstraint that = (AbstractVersionConstraint) o;
 
-        if (getPreferredVersion() != null ? !getPreferredVersion().equals(that.getPreferredVersion()) : that.getPreferredVersion() != null) {
+        if (!Objects.equal(getPreferredVersion(), that.getPreferredVersion())) {
+            return false;
+        }
+        if (!Objects.equal(getBranch(), that.getBranch())) {
             return false;
         }
         return getRejectedVersions().equals(that.getRejectedVersions());
@@ -38,13 +42,13 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
 
     @Override
     public int hashCode() {
-        int result = getPreferredVersion() != null ? getPreferredVersion().hashCode() : 0;
+        int result = getPreferredVersion().hashCode();
         result = 31 * result + getRejectedVersions().hashCode();
         return result;
     }
 
     @Override
     public String toString() {
-        return getPreferredVersion() + (getRejectedVersions().isEmpty() ? "" : " (rejects: " + Joiner.on(" - ").join(getRejectedVersions()) + ")");
+        return getPreferredVersion() + (getRejectedVersions().isEmpty() ? "" : " (rejects: " + Joiner.on(" - ").join(getRejectedVersions()) + ")") + (getBranch() == null ? "" : " (branch: " + getBranch() + ")");
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -20,15 +20,25 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint implements ImmutableVersionConstraint {
     private static final DefaultImmutableVersionConstraint EMPTY = new DefaultImmutableVersionConstraint("");
     private final String preferredVersion;
     private final ImmutableList<String> rejectedVersions;
+    @Nullable
+    private final String requiredBranch;
 
     public DefaultImmutableVersionConstraint(String preferredVersion,
                                              List<String> rejectedVersions) {
+        this(preferredVersion, rejectedVersions, null);
+    }
+
+    public DefaultImmutableVersionConstraint(String preferredVersion,
+                                             List<String> rejectedVersions,
+                                             @Nullable
+                                             String requiredBranch) {
         if (preferredVersion == null) {
             throw new IllegalArgumentException("Preferred version must not be null");
         }
@@ -42,6 +52,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         }
         this.preferredVersion = preferredVersion;
         this.rejectedVersions = ImmutableList.copyOf(rejectedVersions);
+        this.requiredBranch = requiredBranch;
     }
 
     public DefaultImmutableVersionConstraint(String preferredVersion) {
@@ -50,6 +61,13 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         }
         this.preferredVersion = preferredVersion;
         this.rejectedVersions = ImmutableList.of();
+        this.requiredBranch = null;
+    }
+
+    @Nullable
+    @Override
+    public String getBranch() {
+        return requiredBranch;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.gradle.api.InvalidUserDataException;
-import com.google.common.base.Strings;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.VersionConstraintInternal;
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,6 +33,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 
 public class DefaultMutableVersionConstraint extends AbstractVersionConstraint implements VersionConstraintInternal {
     private String prefer;
+    private String branch;
     private final List<String> rejects = Lists.newArrayListWithExpectedSize(1);
 
     public DefaultMutableVersionConstraint(VersionConstraint versionConstraint) {
@@ -68,7 +70,18 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     @Override
     public ImmutableVersionConstraint asImmutable() {
         String v = prefer == null ? "" : prefer;
-        return new DefaultImmutableVersionConstraint(v, rejects);
+        return new DefaultImmutableVersionConstraint(v, rejects, branch);
+    }
+
+    @Nullable
+    @Override
+    public String getBranch() {
+        return branch;
+    }
+
+    @Override
+    public void setBranch(String branch) {
+        this.branch = branch;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -37,6 +37,7 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -57,6 +58,7 @@ import org.gradle.vcs.internal.spec.AbstractVersionControlSpec;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -103,8 +105,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                     selectedVersion = selectVersionFromRepository(spec, versionControlSystem, depSelector.getVersionConstraint());
                 }
                 if (selectedVersion == null) {
-                    result.failed(new ModuleVersionResolveException(depSelector,
-                        "Could not resolve " + depSelector.toString() + ". " + spec.getDisplayName() + " does not contain a version matching " + depSelector.getVersion()));
+                    result.failed(new ModuleVersionNotFoundException(depSelector, Collections.singleton(spec.getDisplayName())));
                     return;
                 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -42,8 +42,15 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         builder.append(group);
         builder.append(":");
         builder.append(module);
-        builder.append(":");
-        builder.append(versionConstraint.getPreferredVersion());
+        if (versionConstraint.getPreferredVersion().length() > 0) {
+            builder.append(":");
+            builder.append(versionConstraint.getPreferredVersion());
+        }
+        if (versionConstraint.getBranch() != null) {
+            builder.append(" (branch: ");
+            builder.append(versionConstraint.getBranch());
+            builder.append(")");
+        }
         return builder.toString();
     }
 
@@ -67,11 +74,11 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     public boolean matchesStrictly(ComponentIdentifier identifier) {
         assert identifier != null : "identifier cannot be null";
 
-        if(identifier instanceof ModuleComponentIdentifier) {
-            ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier)identifier;
+        if (identifier instanceof ModuleComponentIdentifier) {
+            ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier) identifier;
             return module.equals(moduleComponentIdentifier.getModule())
-                    && group.equals(moduleComponentIdentifier.getGroup())
-                    && versionConstraint.getPreferredVersion().equals(moduleComponentIdentifier.getVersion());
+                && group.equals(moduleComponentIdentifier.getGroup())
+                && versionConstraint.getPreferredVersion().equals(moduleComponentIdentifier.getVersion());
         }
 
         return false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.resolve;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 
@@ -32,16 +31,16 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
         super(selector, message);
     }
 
-    public ModuleVersionNotFoundException(ModuleVersionSelector selector, String message) {
-        super(selector, message);
-    }
-
     public ModuleVersionNotFoundException(ModuleComponentSelector selector, Collection<String> attemptedLocations, Collection<String> unmatchedVersions, Collection<String> rejectedVersions) {
         super(selector, format(selector, attemptedLocations, unmatchedVersions, rejectedVersions));
     }
 
     public ModuleVersionNotFoundException(ModuleVersionIdentifier id, Collection<String> attemptedLocations) {
         super(id, format(id, attemptedLocations));
+    }
+
+    public ModuleVersionNotFoundException(ModuleComponentSelector selector, Collection<String> attemptedLocations) {
+        super(selector, format(selector, attemptedLocations));
     }
 
     private static String format(ModuleComponentSelector selector, Collection<String> locations, Collection<String> unmatchedVersions, Collection<String> rejectedVersions) {
@@ -66,6 +65,13 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
     private static String format(ModuleVersionIdentifier id, Collection<String> locations) {
         StringBuilder builder = new StringBuilder();
         builder.append(String.format("Could not find %s.", id));
+        addLocations(builder, locations);
+        return builder.toString();
+    }
+
+    private static String format(ModuleComponentSelector selector, Collection<String> locations) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("Could not find any version that matches %s.", selector));
         addLocations(builder, locations);
         return builder.toString();
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionCause
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
+import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -234,10 +235,10 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
     }
 
     private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {
-        return DefaultModuleComponentSelector.newSelector(group, module, new DefaultMutableVersionConstraint(version))
+        return DefaultModuleComponentSelector.newSelector(group, module, new DefaultImmutableVersionConstraint(version))
     }
 
     private static ModuleVersionSelector newVersionSelector(String group, String name, String version) {
-        return DefaultModuleVersionSelector.newSelector(group, name, new DefaultMutableVersionConstraint(version))
+        return DefaultModuleVersionSelector.newSelector(group, name, new DefaultImmutableVersionConstraint(version))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyDescriptorFactoryTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyDescriptorFactoryTest.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.VersionConstraintInternal;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
@@ -65,10 +66,13 @@ public class ExternalModuleDependencyDescriptorFactoryTest extends AbstractDepen
 
         assertEquals(moduleDependency.isChanging(), dependencyMetaData.isChanging());
         assertEquals(moduleDependency.isForce(), dependencyMetaData.isForce());
+        assertEquals(moduleDependency.getGroup(), moduleDependency.getGroup());
+        assertEquals(moduleDependency.getName(), moduleDependency.getName());
+        assertEquals(moduleDependency.getVersion(), moduleDependency.getVersion());
         assertEquals(moduleDependency.getGroup(), selector.getGroup());
         assertEquals(moduleDependency.getName(), selector.getModule());
         assertEquals(moduleDependency.getVersion(), selector.getVersion());
-        assertEquals(moduleDependency.getVersionConstraint(), selector.getVersionConstraint());
+        assertEquals(((VersionConstraintInternal)moduleDependency.getVersionConstraint()).asImmutable(), selector.getVersionConstraint());
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData);
     }
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1456,7 +1456,7 @@ foo:foo:1.0
          org.gradle.usage = java-api
    ]
 
-org:foo: -> $selected
+org:foo -> $selected
    variant "default" [
       Requested attributes not found in the selected variant:
          org.gradle.usage = java-api
@@ -1509,7 +1509,7 @@ org:foo: -> $selected
          org.gradle.usage = java-api
    ]
 
-org:foo: -> $selected
+org:foo -> $selected
    variant "default" [
       Requested attributes not found in the selected variant:
          org.gradle.usage = java-api
@@ -1607,7 +1607,7 @@ org:foo:$displayVersion -> $selected
 \\--- org:bom:1.0
      \\--- compileClasspath
 
-org:leaf: -> 1.0
+org:leaf -> 1.0
    variant "compile" [
       org.gradle.usage = java-api
    ]

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -130,12 +130,12 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
                         module("org.hamcrest:hamcrest-core:1.3")
                     }.noArtifacts()
                 }
-                edge("org.springframework.boot:spring-boot-test-autoconfigure:", "org.springframework.boot:spring-boot-test-autoconfigure:$bomVersion", springBootTestAutoconfigureDeps).byReason(reason1)
-                edge("org.springframework.boot:spring-boot-test:", "org.springframework.boot:spring-boot-test:$bomVersion", springBootTestDeps).byReason(reason2)
-                edge("org.springframework.boot:spring-boot-autoconfigure:", "org.springframework.boot:spring-boot-autoconfigure:$bomVersion", springBootAutoconfigureDeps).byReason(reason2)
-                edge("org.springframework.boot:spring-boot:", "org.springframework.boot:spring-boot:$bomVersion", springBootDeps).byReason(reason2)
-                edge("org.springframework:spring-test:", "org.springframework:spring-test:4.3.12.RELEASE", springTestDeps).byReason(reason2)
-                edge("junit:junit:", "junit:junit:4.12", junitDeps).byReason(reason2)
+                edge("org.springframework.boot:spring-boot-test-autoconfigure", "org.springframework.boot:spring-boot-test-autoconfigure:$bomVersion", springBootTestAutoconfigureDeps).byReason(reason1)
+                edge("org.springframework.boot:spring-boot-test", "org.springframework.boot:spring-boot-test:$bomVersion", springBootTestDeps).byReason(reason2)
+                edge("org.springframework.boot:spring-boot-autoconfigure", "org.springframework.boot:spring-boot-autoconfigure:$bomVersion", springBootAutoconfigureDeps).byReason(reason2)
+                edge("org.springframework.boot:spring-boot", "org.springframework.boot:spring-boot:$bomVersion", springBootDeps).byReason(reason2)
+                edge("org.springframework:spring-test", "org.springframework:spring-test:4.3.12.RELEASE", springTestDeps).byReason(reason2)
+                edge("junit:junit", "junit:junit:4.12", junitDeps).byReason(reason2)
             }
         }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -149,7 +149,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         def result = runner("dependencies", "--configuration", "compile").build()
 
         then:
-        result.output.contains('org.springframework:spring-core: -> 4.0.3.RELEASE')
+        result.output.contains('org.springframework:spring-core -> 4.0.3.RELEASE')
     }
 
     @Issue('https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-gradle-plugin/1.5.7.RELEASE')

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -169,44 +169,6 @@ class GitVcsIntegrationTest extends AbstractVcsIntegrationTest {
         gitCheckout.file('.git').assertExists()
     }
 
-    def 'handle missing version by adding tag to git repository'() {
-        given:
-        settingsFile << """
-            sourceControl {
-                vcsMappings {
-                    withModule("org.test:dep") {
-                        from(GitVersionControlSpec) {
-                            url = "${repo.url}"
-                        }
-                    }
-                }
-            }
-        """
-        def commit = repo.commit('initial commit')
-        repo.createLightWeightTag('1.3.0')
-
-        def javaFile = file('dep/src/main/java/Dep.java')
-        javaFile.replace('class', 'interface')
-        repo.commit('Changed Dep to an interface')
-
-        buildFile.replace('latest.integration', '1.4.0')
-
-        when:
-        fails('assemble')
-
-        then:
-        failureCauseContains("Could not resolve org.test:dep:1.4.0. Git Repository at file:")
-        failureCauseContains("does not contain a version matching 1.4.0")
-
-        when:
-        javaFile.replace('interface', 'class')
-        repo.commit('Switch it back to a class.')
-        repo.createLightWeightTag('1.4.0')
-
-        then:
-        succeeds('assemble')
-    }
-
     def 'can handle conflicting versions'() {
         given:
         settingsFile << """

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -392,7 +392,7 @@ Required by:
         then:
         fixture.expectGraph {
             root(":", "test:consumer:1.2") {
-                edge("test:test:", "project :test", "test:test:2.0") {
+                edge("test:test", "project :test", "test:test:2.0") {
                 }
             }
         }
@@ -408,7 +408,7 @@ Required by:
         then:
         fixture.expectGraph {
             root(":", "test:consumer:1.2") {
-                edge("test:test:", "project :test", "test:test:3.0") {
+                edge("test:test", "project :test", "test:test:3.0") {
                 }
             }
         }
@@ -423,7 +423,7 @@ Required by:
         then:
         fixture.expectGraph {
             root(":", "test:consumer:1.2") {
-                edge("test:test:", "project :test", "test:test:3.0") {
+                edge("test:test", "project :test", "test:test:3.0") {
                 }
             }
         }
@@ -447,8 +447,7 @@ Required by:
 
         then:
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':compile'.")
-        // TODO - include branch in error message
-        failure.assertHasCause("""Could not find any version that matches test:test:.
+        failure.assertHasCause("""Could not find any version that matches test:test (branch: release).
 Searched in the following locations:
     Git Repository at ${repo.url}
 Required by:
@@ -466,7 +465,7 @@ Required by:
         then:
         fixture.expectGraph {
             root(":", "test:consumer:1.2") {
-                edge("test:test:", "project :test", "test:test:2.0") {
+                edge("test:test", "project :test", "test:test:2.0") {
                 }
             }
         }
@@ -481,7 +480,7 @@ Required by:
         then:
         fixture.expectGraph {
             root(":", "test:consumer:1.2") {
-                edge("test:test:", "project :test", "test:test:2.0") {
+                edge("test:test", "project :test", "test:test:2.0") {
                 }
             }
         }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/VcsMappingsIntegrationTest.groovy
@@ -143,7 +143,7 @@ class VcsMappingsIntegrationTest extends AbstractVcsIntegrationTest {
         fails('assemble')
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compileClasspath'.")
-        failure.assertHasCause("Could not list available versions for 'Git Repository at https://bad.invalid'.")
+        failure.assertHasCause("Could not locate default branch for 'Git Repository at https://bad.invalid'.")
     }
 
     def "can define and use source repositories with all {}"() {

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
@@ -79,7 +79,17 @@ public class DefaultVersionControlSystemFactory implements VersionControlSystemF
             try {
                 return delegate.getHead(spec);
             } catch (Exception e) {
-                throw new GradleException(String.format("Could not list available versions for '%s'.", spec.getDisplayName()), e);
+                throw new GradleException(String.format("Could not locate default branch for '%s'.", spec.getDisplayName()), e);
+            }
+        }
+
+        @Nullable
+        @Override
+        public VersionRef getBranch(VersionControlSpec spec, String branch) {
+            try {
+                return delegate.getBranch(spec, branch);
+            } catch (Exception e) {
+                throw new GradleException(String.format("Could not locate branch '%s' for '%s'.", branch, spec.getDisplayName()), e);
             }
         }
 

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
@@ -22,6 +22,7 @@ import org.gradle.util.GFileUtils;
 import org.gradle.vcs.VersionControlSpec;
 import org.gradle.vcs.internal.spec.DirectoryRepositorySpec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
@@ -35,6 +36,12 @@ public class SimpleVersionControlSystem implements VersionControlSystem {
     @Override
     public VersionRef getHead(VersionControlSpec spec) {
         return new DefaultVersionRef();
+    }
+
+    @Nullable
+    @Override
+    public VersionRef getBranch(VersionControlSpec spec, String branch) {
+        return null;
     }
 
     @Override

--- a/subprojects/version-control/src/testFixtures/groovy/org/gradle/vcs/fixtures/GitHttpRepository.java
+++ b/subprojects/version-control/src/testFixtures/groovy/org/gradle/vcs/fixtures/GitHttpRepository.java
@@ -88,7 +88,7 @@ public class GitHttpRepository implements TestRule, GitRepository {
         server.expect(server.get(backingRepo.getName() + "/info/refs", getRefsAction()));
     }
 
-    public void expectCloneHead() {
+    public void expectCloneSomething() {
         server.expect(server.get(backingRepo.getName() + "/info/refs", getRefsAction()));
         server.expect(server.post(backingRepo.getName() + "/git-upload-pack", new ErroringAction<HttpExchange>() {
             @Override


### PR DESCRIPTION
### Context

This change adds a `branch` property to a dependency declaration. When specified, the dependency (constraint) will select only versions of the target component that were built from the specified branch. This is currently implemented only for source dependencies, but should at some point also apply to binary dependencies.

The API is only intended to be a placeholder and will likely be reworked as more/better constraints are added to select versions based on criteria other than matching on version property.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
