### PR TITLE
Deprecate Play 2.2 support

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -213,6 +213,10 @@ buildCache {
 
 Putting processors on the compile classpath or using an explicit `-processorpath` compiler argument has been deprecated and will be removed in Gradle 5.0. Annotation processors should be added to the `annotationProcessor` configuration instead. If you don't want any processing, but your compile classpath contains a processor unintentionally (e.g. as part of some library you use), use the `-proc:none` compiler argument to ignore it.
 
+### Play 2.2 is deprecated
+
+Play 2.2 is very old and deprecated now. Please try later version of [Play](https://www.playframework.com/).
+
 ## Potential breaking changes
 
 ### Added annotationProcessor configurations

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -213,9 +213,9 @@ buildCache {
 
 Putting processors on the compile classpath or using an explicit `-processorpath` compiler argument has been deprecated and will be removed in Gradle 5.0. Annotation processors should be added to the `annotationProcessor` configuration instead. If you don't want any processing, but your compile classpath contains a processor unintentionally (e.g. as part of some library you use), use the `-proc:none` compiler argument to ignore it.
 
-### Play 2.2 is deprecated
+### Play 2.2 is deprecated in Play plugin
 
-Play 2.2 is very old and deprecated now. Please try later version of [Play](https://www.playframework.com/).
+The use of Play 2.2 with the the Play plugin has been deprecated and will be removed with Gradle 5.0. It is highly recommended to upgrade to a newer version of [Play](https://www.playframework.com/).
 
 ## Potential breaking changes
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformIntegrationTest.groovy
@@ -27,6 +27,8 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
+import static org.gradle.play.integtest.fixtures.PlayMultiVersionIntegrationTest.isPlay22
+
 public class PlayPlatformIntegrationTest extends AbstractIntegrationSpec {
     PlayApp playApp = new BasicPlayApp()
 
@@ -56,6 +58,9 @@ model {
     }
 }
 """
+        if (isPlay22(playVersion)) {
+            executer.expectDeprecationWarning()
+        }
 
         succeeds("stage")
 
@@ -124,6 +129,9 @@ model {
 }
 """
         then:
+        if (isPlay22(playVersion)) {
+            executer.expectDeprecationWarning()
+        }
         fails "assemble"
 
         and:

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/Play23RoutesCompileIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/Play23RoutesCompileIntegrationTest.groovy
@@ -17,7 +17,10 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.play.integtest.fixtures.PlayCoverage
+
+import static org.gradle.play.integtest.fixtures.PlayMultiVersionIntegrationTest.isPlay22
 
 @TargetCoverage({ PlayCoverage.PLAY23_OR_EARLIER })
 class Play23RoutesCompileIntegrationTest extends AbstractRoutesCompileIntegrationTest {
@@ -39,6 +42,14 @@ class Play23RoutesCompileIntegrationTest extends AbstractRoutesCompileIntegratio
     @Override
     def getOtherRoutesFileNames() {
         return []
+    }
+
+    @Override
+    protected ExecutionResult succeeds(String... tasks) {
+        if (isPlay22(version)) {
+            executer.expectDeprecationWarning()
+        }
+        return super.succeeds(tasks)
     }
 
     def "trying to use injected router with older versions of Play produces reasonable error"() {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/Play23RoutesCompileIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/Play23RoutesCompileIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.play.integtest.fixtures.PlayCoverage
 
@@ -50,6 +51,14 @@ class Play23RoutesCompileIntegrationTest extends AbstractRoutesCompileIntegratio
             executer.expectDeprecationWarning()
         }
         return super.succeeds(tasks)
+    }
+
+    @Override
+    protected ExecutionFailure fails(String... tasks) {
+        if (isPlay22(version)) {
+            executer.expectDeprecationWarning()
+        }
+        return super.fails(tasks)
     }
 
     def "trying to use injected router with older versions of Play produces reasonable error"() {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/TwirlCompileIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/TwirlCompileIntegrationTest.groovy
@@ -321,6 +321,8 @@ Binaries
 
     @Unroll
     def "has reasonable error if Twirl template is configured incorrectly with (#template)"() {
+        given:
+        executer.noDeprecationChecks()
         buildFile << """
             model {
                 components {
@@ -336,7 +338,7 @@ Binaries
         """
 
         when:
-        fails("components")
+        result = executer.withTasks('components').runWithFailure()
         then:
         result.error.contains(errorMessage)
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/TwirlVersionIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/TwirlVersionIntegrationTest.groovy
@@ -36,6 +36,7 @@ class TwirlVersionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "changing between twirl-incompatible versions of play causes Twirl to recompile" () {
+        executer.expectDeprecationWarning()
         withPlayVersion("2.2.1")
         withTemplateSource(file("app", "views", "index.scala.html"))
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/platform/PlayMajorVersion.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/platform/PlayMajorVersion.java
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.language.scala.ScalaPlatform;
 import org.gradle.play.platform.PlayPlatform;
 import org.gradle.util.CollectionUtils;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.VersionNumber;
 
 import java.util.List;
@@ -43,8 +44,8 @@ public enum PlayMajorVersion {
     public void validateCompatible(ScalaPlatform scalaPlatform) {
         if (!compatibleScalaVersions.contains(scalaPlatform.getScalaCompatibilityVersion())) {
             throw new InvalidUserDataException(
-                    String.format("Play versions %s are not compatible with Scala platform %s. Compatible Scala platforms are %s.",
-                            name, scalaPlatform.getScalaCompatibilityVersion(), compatibleScalaVersions));
+                String.format("Play versions %s are not compatible with Scala platform %s. Compatible Scala platforms are %s.",
+                    name, scalaPlatform.getScalaCompatibilityVersion(), compatibleScalaVersions));
         }
     }
 
@@ -60,6 +61,9 @@ public enum PlayMajorVersion {
     public static PlayMajorVersion forPlayVersion(String playVersion) {
         VersionNumber versionNumber = VersionNumber.parse(playVersion);
         if (versionNumber.getMajor() == 2) {
+            if (versionNumber.getMinor() == 2) {
+                DeprecationLogger.nagUserWith("Play 2.2 support " + DeprecationLogger.getDeprecationMessage() + ". Please upgrade your Play.");
+            }
             int index = versionNumber.getMinor() - 2;
             if (index < 0 || index >= values().length) {
                 throw invalidVersion(playVersion);

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionIntegrationTest.groovy
@@ -19,7 +19,28 @@ package org.gradle.play.integtest.fixtures
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.executer.ExecutionFailure
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 
 @TargetCoverage({ JavaVersion.current().isJava8Compatible() ? PlayCoverage.ALL : PlayCoverage.PLAY23_OR_EARLIER })
 abstract class PlayMultiVersionIntegrationTest extends MultiVersionIntegrationSpec {
+
+    static boolean isPlay22(def version) {
+        return version.toString().startsWith('2.2')
+    }
+
+    protected ExecutionFailure fails(String... tasks) {
+        if (isPlay22(version)) {
+            executer.expectDeprecationWarning()
+        }
+        return super.fails(tasks)
+    }
+
+    protected ExecutionResult succeeds(String... tasks) {
+        if (isPlay22(version)) {
+            executer.expectDeprecationWarning()
+        }
+        return super.succeeds(tasks)
+    }
+
 }


### PR DESCRIPTION
### Context

As a follow-up of #3353 , we need to deprecate Play 2.2 before removing it.