### PR TITLE
Allow the C++/Swift dependency API to be used to declare dependency on an upstream branch

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VersionControlSystem.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VersionControlSystem.java
@@ -47,7 +47,7 @@ public interface VersionControlSystem {
     /**
      * Returns the default revision for this VCS.
      */
-    VersionRef getHead(VersionControlSpec spec);
+    VersionRef getDefaultBranch(VersionControlSpec spec);
 
     /**
      * Returns the given branch or null.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentDependencies.java
@@ -16,7 +16,9 @@
 
 package org.gradle.language;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 
 /**
  * Allows the implementation dependencies of a component to be specified.
@@ -26,9 +28,17 @@ import org.gradle.api.Incubating;
 @Incubating
 public interface ComponentDependencies {
     /**
-     * Adds an implementation dependency to this component.
+     * Adds an implementation dependency to this component. An implementation dependency is not visible to consumers that are compiled against this component.
      *
      * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
      */
     void implementation(Object notation);
+
+    /**
+     * Adds an implementation dependency to this component. An implementation dependency is not visible to consumers that are compiled against this component.
+     *
+     * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+     * @param action The action to run to configure the dependency.
+     */
+    void implementation(Object notation, Action<? super ExternalModuleDependency> action);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/LibraryDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/LibraryDependencies.java
@@ -16,7 +16,9 @@
 
 package org.gradle.language;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 
 /**
  * Allows the API and implementation dependencies of a library to be specified.
@@ -26,9 +28,17 @@ import org.gradle.api.Incubating;
 @Incubating
 public interface LibraryDependencies extends ComponentDependencies {
     /**
-     * Adds an API dependency to this library.
+     * Adds an API dependency to this library. An API dependency is made visible to consumers that are compiled against this component.
      *
      * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
      */
     void api(Object notation);
+
+    /**
+     * Adds an API dependency to this library. An API dependency is made visible to consumers that are compiled against this component.
+     *
+     * @param notation The dependency notation, as per {@link org.gradle.api.artifacts.dsl.DependencyHandler#create(Object)}.
+     * @param action The action to run to configure the dependency.
+     */
+    void api(Object notation, Action<? super ExternalModuleDependency> action);
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultComponentDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultComponentDependencies.java
@@ -16,8 +16,10 @@
 
 package org.gradle.language.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.language.ComponentDependencies;
 
@@ -45,5 +47,12 @@ public class DefaultComponentDependencies implements ComponentDependencies {
     @Override
     public void implementation(Object notation) {
         implementation.getDependencies().add(getDependencyHandler().create(notation));
+    }
+
+    @Override
+    public void implementation(Object notation, Action<? super ExternalModuleDependency> action) {
+        ExternalModuleDependency dependency = (ExternalModuleDependency) getDependencyHandler().create(notation);
+        action.execute(dependency);
+        implementation.getDependencies().add(dependency);
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultLibraryDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultLibraryDependencies.java
@@ -16,8 +16,10 @@
 
 package org.gradle.language.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.language.LibraryDependencies;
 
 import javax.inject.Inject;
@@ -41,5 +43,12 @@ public class DefaultLibraryDependencies extends DefaultComponentDependencies imp
     @Override
     public void api(Object notation) {
         apiDependencies.getDependencies().add(getDependencyHandler().create(notation));
+    }
+
+    @Override
+    public void api(Object notation, Action<? super ExternalModuleDependency> action) {
+        ExternalModuleDependency dependency = (ExternalModuleDependency) getDependencyHandler().create(notation);
+        action.execute(dependency);
+        apiDependencies.getDependencies().add(dependency);
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultLibraryDependenciesTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultLibraryDependenciesTest.groovy
@@ -16,32 +16,36 @@
 
 package org.gradle.language.internal
 
+import org.gradle.api.Action
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import spock.lang.Specification
 
-
 class DefaultLibraryDependenciesTest extends Specification {
-    def "can add api dependency"() {
-        def configurations = Stub(ConfigurationContainer)
-        def dependencyFactory = Mock(DependencyHandler)
-        def apiDeps = Mock(Configuration)
-        def deps = Mock(DependencySet)
-        def dep = Stub(Dependency)
+    def configurations = Stub(ConfigurationContainer)
+    def dependencyFactory = Mock(DependencyHandler)
+    def apiDeps = Mock(Configuration)
+    def deps = Mock(DependencySet)
+    DefaultLibraryDependencies dependencies
 
-        given:
+    def setup() {
         configurations.create("api") >> apiDeps
         apiDeps.dependencies >> deps
 
-        def dependencies = new DefaultLibraryDependencies(configurations, "impl", "api") {
+        dependencies = new DefaultLibraryDependencies(configurations, "impl", "api") {
             @Override
             protected DependencyHandler getDependencyHandler() {
                 return dependencyFactory
             }
         }
+    }
+
+    def "can add api dependency"() {
+        def dep = Stub(Dependency)
 
         when:
         dependencies.api("a:b:c")
@@ -51,4 +55,16 @@ class DefaultLibraryDependenciesTest extends Specification {
         1 * deps.add(dep)
     }
 
+    def "can add and configure api dependency"() {
+        def dep = Stub(ExternalModuleDependency)
+        def action = Mock(Action)
+
+        when:
+        dependencies.api("a:b:c", action)
+
+        then:
+        1 * dependencyFactory.create("a:b:c") >> dep
+        1 * action.execute(dep)
+        1 * deps.add(dep)
+    }
 }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -68,7 +68,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         fixture.prepare()
     }
 
-    def "selects and builds from HEAD for latest.integration selector"() {
+    def "selects and builds from master for latest.integration selector"() {
         given:
         buildFile << """
             dependencies { compile 'test:test:latest.integration' }
@@ -342,7 +342,7 @@ Required by:
     }
 
     @Unroll
-    def "static selector cannot reference branch #selector"() {
+    def "static selector cannot reference #selector"() {
         given:
         buildFile << """
             dependencies { compile 'test:test:${selector}' }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/ParallelVersionControlSpec.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/ParallelVersionControlSpec.groovy
@@ -53,7 +53,7 @@ class ParallelVersionControlSpec extends AbstractIntegrationSpec {
                     def spec = new DefaultGitVersionControlSpec(project.gradle.startParameter, project.gradle.classLoaderScope)
                     spec.url = url
                     def system = versionControlSystemFactory.create(spec)
-                    def ref = system.getHead(spec)
+                    def ref = system.getDefaultBranch(spec)
                     system.populate(outputDir, ref, spec)
                     assert new File(outputDir, 'repo/.git').exists()
                 }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
@@ -88,7 +88,7 @@ public class GitVersionControlSystem implements VersionControlSystem {
     }
 
     @Override
-    public VersionRef getHead(VersionControlSpec spec) {
+    public VersionRef getDefaultBranch(VersionControlSpec spec) {
         GitVersionControlSpec gitSpec = cast(spec);
         Collection<Ref> refs;
         try {
@@ -99,11 +99,11 @@ public class GitVersionControlSystem implements VersionControlSystem {
             throw wrapGitCommandException("ls-remote", gitSpec.getUrl(), null, e);
         }
         for (Ref ref : refs) {
-            if (ref.getName().equals("HEAD")) {
+            if (ref.getName().equals("refs/heads/master")) {
                 return GitVersionRef.from(ref);
             }
         }
-        throw new UnsupportedOperationException("Git repository has no HEAD reference");
+        throw new UnsupportedOperationException("Git repository has no master branch");
     }
 
     @Nullable

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/DefaultVersionControlSystemFactory.java
@@ -75,9 +75,9 @@ public class DefaultVersionControlSystemFactory implements VersionControlSystemF
         }
 
         @Override
-        public VersionRef getHead(VersionControlSpec spec) {
+        public VersionRef getDefaultBranch(VersionControlSpec spec) {
             try {
-                return delegate.getHead(spec);
+                return delegate.getDefaultBranch(spec);
             } catch (Exception e) {
                 throw new GradleException(String.format("Could not locate default branch for '%s'.", spec.getDisplayName()), e);
             }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/SimpleVersionControlSystem.java
@@ -30,11 +30,11 @@ import java.util.Set;
 public class SimpleVersionControlSystem implements VersionControlSystem {
     @Override
     public Set<VersionRef> getAvailableVersions(VersionControlSpec spec) {
-        return Sets.newHashSet(getHead(spec));
+        return Sets.newHashSet(getDefaultBranch(spec));
     }
 
     @Override
-    public VersionRef getHead(VersionControlSpec spec) {
+    public VersionRef getDefaultBranch(VersionControlSpec spec) {
         return new DefaultVersionRef();
     }
 

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -238,12 +238,12 @@ class GitVersionControlSystemSpec extends Specification {
         versionMap['v1.0.1'] == c1.id.name
     }
 
-    def 'can get HEAD of repository'() {
+    def 'default branch of repo is master'() {
         given:
-        def version = gitVcs.getHead(repoSpec)
+        def version = gitVcs.getDefaultBranch(repoSpec)
 
         expect:
-        version.version == 'HEAD'
+        version.version == 'master'
         version.canonicalId == c2.id.name
     }
 }


### PR DESCRIPTION
### Context

The C++ and Swift models use a slightly more statically typed API for declaring dependencies than `DependencyHandler`. This change allows a dependency declaration to be configured using an action/closure through this API, to match what is possible through `DependencyHandler`.

This change also changes source dependency resolution to interpret `latest.integration` to mean 'master branch' rather than 'HEAD'.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
