### PR TITLE
Let GradleBuildPerformanceTest use a retry rule

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -73,8 +73,8 @@ class GradleBuildPerformanceTest extends Specification {
         }
     }
 
-    def warmupBuilds = 10
-    def measuredBuilds = 20
+    def warmupBuilds = 20
+    def measuredBuilds = 40
 
     @Unroll
     def "#tasks on the gradle build comparing the build"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -21,10 +21,12 @@ import org.gradle.performance.fixture.BuildExperimentRunner
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.CrossBuildPerformanceTestRunner
 import org.gradle.performance.fixture.GradleSessionProvider
+import org.gradle.performance.fixture.PerformanceTestRetryRule
 import org.gradle.performance.results.BaselineVersion
 import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.gradle.performance.results.CrossBuildResultsStore
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.testing.internal.util.RetryRule
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
@@ -48,6 +50,9 @@ import spock.lang.Unroll
  */
 @Category(PerformanceRegressionTest)
 class GradleBuildPerformanceTest extends Specification {
+
+    @Rule
+    RetryRule retry = new PerformanceTestRetryRule()
 
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()


### PR DESCRIPTION
Too much variance, see [this graph](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/10818878:id/report-performance-performance-tests.zip%21/report/tests/help-on-the-gradle-build-comparing-the-build.html).