### PR TITLE
Render warning upon use of continue on failure and explain limitation

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnFailureIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnFailureIntegrationTest.groovy
@@ -107,6 +107,7 @@ class CompositeBuildContinueOnFailureIntegrationTest extends AbstractCompositeBu
         fails(buildA, ":delegate")
 
         then:
+        outputContains("Using '--continue' with a composite build does not collect all failures.")
         // We attach the single failure in 'buildB' to every delegated task, so ':buildB:succeeds' appears to have failed
         // Thus ":delegateWithSuccess" is never executed.
         assertTaskExecutedOnce(":buildB", ":fails")
@@ -131,6 +132,7 @@ class CompositeBuildContinueOnFailureIntegrationTest extends AbstractCompositeBu
         fails(buildA, ":delegate")
 
         then:
+        outputContains("Using '--continue' with a composite build does not collect all failures.")
         outputContains("continueOnFailure = true")
 
         assertTaskExecutedOnce(":buildB", ":checkContinueFlag")
@@ -151,6 +153,7 @@ class CompositeBuildContinueOnFailureIntegrationTest extends AbstractCompositeBu
         execute(buildA, ":assemble")
 
         then:
+        outputContains("Using '--continue' with a composite build does not collect all failures.")
         outputContains("continueOnFailure = true")
 
         assertTaskExecutedOnce(":buildB", ":checkContinueFlag")

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization;
 
+import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.composite.internal.IncludedBuildRegistry;
@@ -28,14 +29,16 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
     private final BuildSourceBuilder buildSourceBuilder;
     private final NestedBuildFactory nestedBuildFactory;
     private final IncludedBuildRegistry includedBuildRegistry;
+    private final StartParameter startParameter;
 
     public DefaultSettingsLoaderFactory(ISettingsFinder settingsFinder, SettingsProcessor settingsProcessor, BuildSourceBuilder buildSourceBuilder,
-                                        NestedBuildFactory nestedBuildFactory, IncludedBuildRegistry includedBuildRegistry) {
+                                        NestedBuildFactory nestedBuildFactory, IncludedBuildRegistry includedBuildRegistry, StartParameter startParameter) {
         this.settingsFinder = settingsFinder;
         this.settingsProcessor = settingsProcessor;
         this.buildSourceBuilder = buildSourceBuilder;
         this.nestedBuildFactory = nestedBuildFactory;
         this.includedBuildRegistry = includedBuildRegistry;
+        this.startParameter = startParameter;
     }
 
     @Override
@@ -52,7 +55,8 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
         return new CompositeBuildSettingsLoader(
             defaultSettingsLoader(),
             nestedBuildFactory,
-            includedBuildRegistry);
+            includedBuildRegistry,
+            startParameter);
     }
 
     private SettingsLoader defaultSettingsLoader() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -119,8 +119,10 @@ public class StartParameterBuildOptions {
     }
 
     public static class ContinueOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
+        public static final String LONG_OPTION = "continue";
+
         public ContinueOption() {
-            super(null, CommandLineOptionConfiguration.create("continue", "Continue task execution after a task failure."));
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Continue task execution after a task failure."));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -320,7 +320,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 CachedClasspathTransformer cachedClasspathTransformer,
                                                                 CachingServiceLocator cachingServiceLocator,
-                                                                IncludedBuildRegistry includedBuildRegistry) {
+                                                                IncludedBuildRegistry includedBuildRegistry,
+                                                                StartParameter startParameter) {
         return new DefaultSettingsLoaderFactory(
             new DefaultSettingsFinder(buildLayoutFactory),
             settingsProcessor,
@@ -334,7 +335,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
                         BuildSrcProjectConfigurationAction.class,
                         cachingServiceLocator))),
             nestedBuildFactory,
-            includedBuildRegistry);
+            includedBuildRegistry,
+            startParameter);
     }
 
     protected InitScriptHandler createInitScriptHandler(ScriptPluginFactory scriptPluginFactory, ScriptHandlerFactory scriptHandlerFactory, BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/docs/src/docs/userguide/compositeBuilds.adoc
+++ b/subprojects/docs/src/docs/userguide/compositeBuilds.adoc
@@ -214,7 +214,7 @@ Limitations of the current implementation include:
 * No support for included builds that have publications that don't mirror the project default configuration. See <<included_build_substitution_limitations>>.
 * Native builds are not supported. (Binary dependencies are not yet supported for native builds).
 * Substituting plugins only works with the `buildscript` block but not with the `plugins` block.
-
+* The use of `--continue` does not collect all failures. It only reports the failure of the first failing build.
 
 Improvements we have planned for upcoming releases include:
 


### PR DESCRIPTION
### Context

Composite builds currently have the limitation of only collecting the first failure when using `--continue` (see https://github.com/gradle/gradle/issues/2520). This PR renders a warning to inform the user about the limitation. The limitation now also is documented in the user guide.

As a side note: I am going to look into problem 2 as well.