### PR TITLE
Replace Guava by JDK primitives in `ScriptFileResolver`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/DefaultScriptFileResolver.java
@@ -15,18 +15,23 @@
  */
 package org.gradle.internal.scripts;
 
+import org.gradle.scripts.ScriptingLanguage;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+
 import static org.gradle.internal.FileUtils.hasExtension;
 
 public class DefaultScriptFileResolver implements ScriptFileResolver {
 
+    private static final String[] EXTENSIONS = scriptingLanguageExtensions();
+
     @Override
     public File resolveScriptFile(File dir, String basename) {
-        for (String extension : ScriptingLanguages.EXTENSIONS) {
+        for (String extension : EXTENSIONS) {
             File candidate = new File(dir, basename + extension);
             if (candidate.isFile()) {
                 return candidate;
@@ -51,11 +56,20 @@ public class DefaultScriptFileResolver implements ScriptFileResolver {
     }
 
     private boolean hasScriptExtension(File file) {
-        for (String extension : ScriptingLanguages.EXTENSIONS) {
+        for (String extension : EXTENSIONS) {
             if (hasExtension(file, extension)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static String[] scriptingLanguageExtensions() {
+        List<ScriptingLanguage> scriptingLanguages = ScriptingLanguages.all();
+        String[] extensions = new String[scriptingLanguages.size()];
+        for (int i = 0; i < extensions.length; i++) {
+            extensions[i] = scriptingLanguages.get(i).getExtension();
+        }
+        return extensions;
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptingLanguages.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/ScriptingLanguages.java
@@ -15,10 +15,12 @@
  */
 package org.gradle.internal.scripts;
 
-import com.google.common.collect.ImmutableList;
-
 import org.gradle.scripts.ScriptingLanguage;
 
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,18 +28,17 @@ import java.util.List;
  */
 public final class ScriptingLanguages {
 
-    private static final ImmutableList<ScriptingLanguage> ALL =
-        ImmutableList.of(
-            scriptingLanguage(".gradle", null),
-            scriptingLanguage(".gradle.kts", "org.gradle.kotlin.dsl.provider.KotlinScriptPluginFactory"));
-
-    static final ImmutableList<String> EXTENSIONS = extensionsOf(ALL);
+    private static final List<ScriptingLanguage> ALL =
+        Collections.unmodifiableList(
+            Arrays.asList(
+                scriptingLanguage(".gradle", null),
+                scriptingLanguage(".gradle.kts", "org.gradle.kotlin.dsl.provider.KotlinScriptPluginFactory")));
 
     public static List<ScriptingLanguage> all() {
         return ALL;
     }
 
-    private static ScriptingLanguage scriptingLanguage(final String extension, final String scriptPluginFactory) {
+    private static ScriptingLanguage scriptingLanguage(final String extension, @Nullable final String scriptPluginFactory) {
         return new ScriptingLanguage() {
             @Override
             public String getExtension() {
@@ -49,13 +50,5 @@ public final class ScriptingLanguages {
                 return scriptPluginFactory;
             }
         };
-    }
-
-    private static ImmutableList<String> extensionsOf(List<ScriptingLanguage> scriptingLanguages) {
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
-        for (ScriptingLanguage language : scriptingLanguages) {
-            builder.add(language.getExtension());
-        }
-        return builder.build();
     }
 }


### PR DESCRIPTION
That code is used by the command-line launcher so we should try to minimize
its dependencies and avoid expensive classloading chains.