### PR TITLE
Improve accuracy of generated Swift PM manifest

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VcsResolver.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/internal/VcsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,29 +16,20 @@
 
 package org.gradle.vcs.internal;
 
-import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.invocation.Gradle;
-import org.gradle.vcs.VcsMapping;
 import org.gradle.vcs.VersionControlSpec;
 
 import javax.annotation.Nullable;
 
-public interface VcsMappingsStore {
-    VcsResolver asResolver();
+public interface VcsResolver {
+    /**
+     * Returns the VCS to use to search for matches to the given selector, or null if no such VCS.
+     */
+    @Nullable
+    VersionControlSpec locateVcsFor(ModuleComponentSelector selector);
 
-    void addRule(Action<? super VcsMapping> rule, Gradle gradle);
-
-    VcsResolver NO_OP = new VcsResolver() {
-        @Nullable
-        @Override
-        public VersionControlSpec locateVcsFor(ModuleComponentSelector selector) {
-            return null;
-        }
-
-        @Override
-        public boolean hasRules() {
-            return false;
-        }
-    };
+    /**
+     * Does this resolver do anything?
+     */
+    boolean hasRules();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
@@ -23,7 +23,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.scan.BuildScanRequest;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.vcs.internal.VcsMappingsStore;
+import org.gradle.vcs.internal.VcsResolver;
 
 /**
  * Wiring of the objects that provide the build scan config integration.
@@ -54,8 +54,8 @@ public class BuildScanConfigServices {
         return new Factory<BuildScanConfig.Attributes>() {
             @Override
             public BuildScanConfig.Attributes create() {
-                VcsMappingsStore vcsMappings = ((GradleInternal) gradle).getServices().get(VcsMappingsStore.class);
-                final boolean hasRules = vcsMappings.hasRules();
+                VcsResolver vcsResolver = ((GradleInternal) gradle).getServices().get(VcsResolver.class);
+                final boolean hasRules = vcsResolver.hasRules();
                 return new BuildScanConfig.Attributes() {
                     @Override
                     public boolean isRootProjectHasVcsMappings() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelector.java
@@ -25,6 +25,10 @@ public class LatestVersionSelector extends AbstractStringVersionSelector {
         selectorStatus = selector.substring("latest.".length());
     }
 
+    public String getSelectorStatus() {
+        return selectorStatus;
+    }
+
     public boolean isDynamic() {
         return true;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/SubVersionSelector.java
@@ -26,6 +26,10 @@ public class SubVersionSelector extends AbstractStringVersionSelector {
         prefix = selector.substring(0, selector.length() - 1);
     }
 
+    public String getPrefix() {
+        return prefix;
+    }
+
     public boolean isDynamic() {
         return true;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -47,9 +47,7 @@ import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.util.CollectionUtils;
 import org.gradle.vcs.VersionControlSpec;
-import org.gradle.vcs.internal.VcsMappingFactory;
-import org.gradle.vcs.internal.VcsMappingInternal;
-import org.gradle.vcs.internal.VcsMappingsStore;
+import org.gradle.vcs.internal.VcsResolver;
 import org.gradle.vcs.internal.VcsWorkingDirectoryRoot;
 import org.gradle.vcs.internal.VersionControlSystem;
 import org.gradle.vcs.internal.VersionControlSystemFactory;
@@ -67,21 +65,19 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
     private final ProjectDependencyResolver projectDependencyResolver;
     private final ServiceRegistry serviceRegistry;
     private final LocalComponentRegistry localComponentRegistry;
-    private final VcsMappingsStore vcsMappingsStore;
-    private final VcsMappingFactory vcsMappingFactory;
+    private final VcsResolver vcsResolver;
     private final VersionControlSystemFactory versionControlSystemFactory;
     private final VersionSelectorScheme versionSelectorScheme;
     private final VersionComparator versionComparator;
     private final File baseWorkingDir;
     private final Map<String, VersionRef> selectedVersionCache = new HashMap<String, VersionRef>();
 
-    public VcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirRoot, ProjectDependencyResolver projectDependencyResolver, ServiceRegistry serviceRegistry, LocalComponentRegistry localComponentRegistry, VcsMappingsStore vcsMappingsStore, VcsMappingFactory vcsMappingFactory, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
+    public VcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirRoot, ProjectDependencyResolver projectDependencyResolver, ServiceRegistry serviceRegistry, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
         this.baseWorkingDir = vcsWorkingDirRoot.getDir();
         this.projectDependencyResolver = projectDependencyResolver;
         this.serviceRegistry = serviceRegistry;
         this.localComponentRegistry = localComponentRegistry;
-        this.vcsMappingsStore = vcsMappingsStore;
-        this.vcsMappingFactory = vcsMappingFactory;
+        this.vcsResolver = vcsResolver;
         this.versionControlSystemFactory = versionControlSystemFactory;
         this.versionSelectorScheme = versionSelectorScheme;
         this.versionComparator = versionComparator;
@@ -89,16 +85,12 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
 
     @Override
     public void resolve(DependencyMetadata dependency, BuildableComponentIdResolveResult result) {
-        VcsMappingInternal vcsMappingInternal = getVcsMapping(dependency);
-
-        if (vcsMappingInternal != null) {
-            // Safe to cast because if it weren't a ModuleComponentSelector, vcsMappingInternal would be null.
+        if (dependency.getSelector() instanceof ModuleComponentSelector) {
             final ModuleComponentSelector depSelector = (ModuleComponentSelector) dependency.getSelector();
-            vcsMappingsStore.getVcsMappingRule().execute(vcsMappingInternal);
+            VersionControlSpec spec = vcsResolver.locateVcsFor(depSelector);
 
             // TODO: Need failure handling, e.g., cannot clone repository
-            if (vcsMappingInternal.hasRepository()) {
-                VersionControlSpec spec = vcsMappingInternal.getRepository();
+            if (spec != null) {
                 VersionControlSystem versionControlSystem = versionControlSystemFactory.create(spec);
 
                 VersionRef selectedVersion = selectVersion(depSelector, spec, versionControlSystem);
@@ -124,12 +116,12 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                     }
                 });
                 if (entry == null) {
-                    result.failed(new ModuleVersionResolveException(vcsMappingInternal.getRequested(), spec.getDisplayName() + " did not contain a project publishing the specified dependency."));
+                    result.failed(new ModuleVersionResolveException(depSelector, spec.getDisplayName() + " did not contain a project publishing the specified dependency."));
                 } else {
                     LocalComponentMetadata componentMetaData = localComponentRegistry.getComponent(entry.right);
 
                     if (componentMetaData == null) {
-                        result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(includedBuild, entry.right.getProjectPath()), vcsMappingInternal.getRepository().getDisplayName() + " could not be resolved into a usable project."));
+                        result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(includedBuild, entry.right.getProjectPath()), spec.getDisplayName() + " could not be resolved into a usable project."));
                     } else {
                         result.resolved(componentMetaData);
                     }
@@ -196,13 +188,6 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
             return spec.getUniqueId() + ":b:" + constraint.getBranch();
         }
         return spec.getUniqueId() + ":v:" + constraint.getPreferredVersion();
-    }
-
-    private VcsMappingInternal getVcsMapping(DependencyMetadata dependency) {
-        if (vcsMappingsStore.hasRules() && dependency.getSelector() instanceof ModuleComponentSelector) {
-            return vcsMappingFactory.create(dependency.getSelector());
-        }
-        return null;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.LatestVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -158,15 +159,16 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
         }
 
         String version = constraint.getPreferredVersion();
-        if (version.equals("latest.integration")) {
+        VersionSelector versionSelector = versionSelectorScheme.parseSelector(version);
+        if (versionSelector instanceof LatestVersionSelector && ((LatestVersionSelector)versionSelector).getSelectorStatus().equals("integration")) {
             return versionControlSystem.getDefaultBranch(spec);
         }
 
-        VersionSelector versionSelector = versionSelectorScheme.parseSelector(version);
         if (versionSelector.requiresMetadata()) {
             // TODO - implement this by moving this resolver to live alongside the external resolvers
             return null;
         }
+
         Set<VersionRef> versions = versionControlSystem.getAvailableVersions(spec);
         Version bestVersion = null;
         VersionRef bestCandidate = null;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -15,6 +15,7 @@
  */
 
 package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy
+
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.artifacts.ComponentSelectionRules
@@ -28,10 +29,10 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConst
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
-import org.gradle.vcs.internal.VcsMappingsStore
 import org.gradle.internal.Actions
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.rules.NoInputsRuleAction
+import org.gradle.vcs.internal.VcsResolver
 import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
@@ -45,14 +46,14 @@ class DefaultResolutionStrategySpec extends Specification {
     def dependencySubstitutions = Mock(DependencySubstitutionsInternal)
     def globalDependencySubstitutions = Mock(DependencySubstitutionRules)
     def componentSelectorConverter = Mock(ComponentSelectorConverter)
-    def vcsMappingsInternal = Mock(VcsMappingsStore)
+    def vcsResolver = Mock(VcsResolver)
 
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock() {
         module(_, _) >> { args ->
             DefaultModuleIdentifier.newId(*args)
         }
     }
-    def strategy = new DefaultResolutionStrategy(cachePolicy, dependencySubstitutions, globalDependencySubstitutions, vcsMappingsInternal, moduleIdentifierFactory, componentSelectorConverter)
+    def strategy = new DefaultResolutionStrategy(cachePolicy, dependencySubstitutions, globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter)
 
     def "allows setting forced modules"() {
         expect:

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.swiftpm
+
+import org.gradle.vcs.fixtures.GitFileRepository
+
+
+class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
+    def "export fails when external dependency cannot be mapped to a git url"() {
+        given:
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+                id 'swift-library'
+            }
+            dependencies {
+                implementation 'dep:dep:1.0'
+            }
+"""
+
+        when:
+        fails("generateSwiftPmManifest")
+
+        then:
+        failure.assertHasCause("Cannot determine the Git URL for dependency on dep:dep.")
+    }
+
+    def "produces manifest for Swift component with source dependencies"() {
+        given:
+        def lib1Repo = GitFileRepository.init(testDirectory.file("repos/lib1"))
+        lib1Repo.file("build.gradle") << """
+            plugins {
+                id 'swift-library'
+                id 'swiftpm-export'
+            }
+        """
+        lib1Repo.file("settings.gradle") << "rootProject.name = 'lib1'"
+        lib1Repo.file("src/main/swift/Lib1.swift") << """
+            public class Lib1 {
+                public class func thing() { }
+            }
+"""
+        executer.inDirectory(lib1Repo.workTree).withTasks("generateSwiftPmManifest").run()
+        lib1Repo.commit("v1")
+        lib1Repo.createLightWeightTag("1.0.0")
+
+        and:
+        def lib2Repo = GitFileRepository.init(testDirectory.file("repos/lib2"))
+        lib2Repo.file("build.gradle") << """
+            plugins {
+                id 'swift-library'
+                id 'swiftpm-export'
+            }
+        """
+        lib2Repo.file("settings.gradle") << "rootProject.name = 'lib2'"
+        lib2Repo.file("src/main/swift/Lib2.swift") << """
+            public class Lib2 {
+                public class func thing() { }
+            }
+        """
+        executer.inDirectory(lib2Repo.workTree).withTasks("generateSwiftPmManifest").run()
+        lib2Repo.commit("v2")
+        lib2Repo.createLightWeightTag("2.0.0")
+
+        and:
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("test:lib1") {
+                        from(GitVersionControlSpec) {
+                            url = uri('${lib1Repo.url}')
+                        }
+                    }
+                    withModule("test:lib2") {
+                        from(GitVersionControlSpec) {
+                            url = uri('${lib2Repo.url}')
+                        }
+                    }
+                }
+            }
+"""
+        buildFile << """
+            plugins {
+                id 'swift-library'
+                id 'swiftpm-export'
+            }
+            dependencies {
+                api "test:lib1:1.0.0"
+                implementation "test:lib2:2.0.0"
+            }
+"""
+        file("src/main/swift/Lib.swift") << """
+            import Lib1
+            import Lib2
+            class Lib {
+                init() {
+                    Lib1.thing()
+                    Lib2.thing()
+                }
+            }
+        """
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").text == """// swift-tools-version:4.0
+//
+// GENERATED FILE - do not edit
+//
+import PackageDescription
+
+let package = Package(
+    name: "test",
+    products: [
+        .library(name: "test", type: .dynamic, targets: ["Test"]),
+    ],
+    dependencies: [
+        .package(url: "repos/lib2", from: "2.0.0"),
+        .package(url: "repos/lib1", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Test",
+            dependencies: [
+                .product(name: "lib2"),
+                .product(name: "lib1"),
+            ],
+            path: ".",
+            sources: [
+                "src/main/swift/Lib.swift",
+            ]
+        ),
+    ]
+)
+"""
+        swiftPmBuildSucceeds()
+
+        cleanup:
+        lib1Repo?.close()
+        lib2Repo?.close()
+    }
+
+    def "maps dependency on latest.integration to master branch"() {
+        given:
+        def lib1Repo = GitFileRepository.init(testDirectory.file("repo/lib1"))
+        lib1Repo.file("build.gradle") << """
+            plugins {
+                id 'swift-library'
+                id 'swiftpm-export'
+            }
+        """
+        lib1Repo.file("settings.gradle") << "rootProject.name = 'lib1'"
+        lib1Repo.file("src/main/swift/Lib1.swift") << """
+            public class Lib1 {
+                public class func thing() { }
+            }
+"""
+        executer.inDirectory(lib1Repo.workTree).withTasks("generateSwiftPmManifest").run()
+        lib1Repo.commit("v1")
+
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("dep:lib1") {
+                        from(GitVersionControlSpec) {
+                            url = uri('${lib1Repo.url}')
+                        }
+                    }
+                }
+            }
+        """
+        buildFile << """
+            plugins { 
+                id 'swiftpm-export' 
+                id 'swift-library'
+            }
+            dependencies {
+                implementation 'dep:lib1:latest.integration'
+            }
+        """
+        file("src/main/swift/Lib.swift") << """
+            import Lib1
+            class Lib {
+                init() {
+                    Lib1.thing()
+                }
+            }
+        """
+
+        when:
+        run("generateSwiftPmManifest")
+
+        then:
+        file("Package.swift").text.contains("""
+    dependencies: [
+        .package(url: "repo/lib1", .branch("master")),
+    ],
+""")
+        swiftPmBuildSucceeds()
+
+        cleanup:
+        lib1Repo?.close()
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerExportIntegrationTest.groovy
@@ -130,24 +130,4 @@ let package = Package(
 )
 """
     }
-
-    def "fails when external dependency cannot be mapped to a git url"() {
-        given:
-        buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
-                id 'swift-library'
-            }
-            dependencies {
-                implementation 'dep:dep:1.0'
-            }
-"""
-
-        when:
-        fails("generateSwiftPmManifest")
-
-        then:
-        failure.assertHasCause("Cannot determine the Git URL for dependency on dep:dep.")
-    }
-
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.swiftpm
 
 import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
-import org.gradle.vcs.fixtures.GitFileRepository
 
 class SwiftPackageManagerSwiftBuildExportIntegrationTest extends AbstractSwiftPackageManagerExportIntegrationTest {
 
@@ -312,121 +311,5 @@ let package = Package(
 )
 """
         swiftPmBuildSucceeds()
-    }
-
-    def "produces manifest for Swift component with source dependencies"() {
-        given:
-        def lib1Repo = GitFileRepository.init(testDirectory.file("repos/lib1"))
-        lib1Repo.file("build.gradle") << """
-            plugins {
-                id 'swift-library'
-                id 'swiftpm-export'
-            }
-        """
-        lib1Repo.file("settings.gradle") << "rootProject.name = 'lib1'"
-        lib1Repo.file("src/main/swift/Lib1.swift") << """
-            public class Lib1 {
-                public class func thing() { }
-            }
-"""
-        executer.inDirectory(lib1Repo.workTree).withTasks("generateSwiftPmManifest").run()
-        lib1Repo.commit("v1")
-        lib1Repo.createLightWeightTag("1.0.0")
-
-        and:
-        def lib2Repo = GitFileRepository.init(testDirectory.file("repos/lib2"))
-        lib2Repo.file("build.gradle") << """
-            plugins {
-                id 'swift-library'
-                id 'swiftpm-export'
-            }
-        """
-        lib2Repo.file("settings.gradle") << "rootProject.name = 'lib2'"
-        lib2Repo.file("src/main/swift/Lib2.swift") << """
-            public class Lib2 {
-                public class func thing() { }
-            }
-        """
-        executer.inDirectory(lib2Repo.workTree).withTasks("generateSwiftPmManifest").run()
-        lib2Repo.commit("v2")
-        lib2Repo.createLightWeightTag("2.0.0")
-
-        and:
-        settingsFile << """
-            sourceControl {
-                vcsMappings {
-                    withModule("test:lib1") {
-                        from(GitVersionControlSpec) {
-                            url = uri('${lib1Repo.url}')
-                        }
-                    }
-                    withModule("test:lib2") {
-                        from(GitVersionControlSpec) {
-                            url = uri('${lib2Repo.url}')
-                        }
-                    }
-                }
-            }
-"""
-        buildFile << """
-            plugins {
-                id 'swift-library'
-                id 'swiftpm-export'
-            }
-            dependencies {
-                api "test:lib1:1.0.0"
-                implementation "test:lib2:2.0.0"
-            }
-"""
-        file("src/main/swift/Lib.swift") << """
-            import Lib1
-            import Lib2
-            class Lib {
-                init() {
-                    Lib1.thing()
-                    Lib2.thing()
-                }
-            }
-        """
-
-        when:
-        run("generateSwiftPmManifest")
-
-        then:
-        file("Package.swift").text == """// swift-tools-version:4.0
-//
-// GENERATED FILE - do not edit
-//
-import PackageDescription
-
-let package = Package(
-    name: "test",
-    products: [
-        .library(name: "test", type: .dynamic, targets: ["Test"]),
-    ],
-    dependencies: [
-        .package(url: "repos/lib2", from: "2.0.0"),
-        .package(url: "repos/lib1", from: "1.0.0"),
-    ],
-    targets: [
-        .target(
-            name: "Test",
-            dependencies: [
-                .product(name: "lib2"),
-                .product(name: "lib1"),
-            ],
-            path: ".",
-            sources: [
-                "src/main/swift/Lib.swift",
-            ]
-        ),
-    ]
-)
-"""
-        swiftPmBuildSucceeds()
-
-        cleanup:
-        lib1Repo?.close()
-        lib2Repo?.close()
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/BranchDependency.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/BranchDependency.java
@@ -16,17 +16,17 @@
 
 package org.gradle.swiftpm.internal;
 
-import java.io.Serializable;
 import java.net.URI;
 
-abstract public class Dependency implements Serializable {
-    private final URI url;
+public class BranchDependency extends Dependency {
+    private final String branch;
 
-    public Dependency(URI url) {
-        this.url = url;
+    public BranchDependency(URI url, String branch) {
+        super(url);
+        this.branch = branch;
     }
 
-    public URI getUrl() {
-        return url;
+    public String getBranch() {
+        return branch;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/VersionDependency.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/VersionDependency.java
@@ -16,17 +16,38 @@
 
 package org.gradle.swiftpm.internal;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 
 public class VersionDependency extends Dependency {
-    private final String version;
+    private final String lowerBound;
+    private final String upperBound;
+    private final boolean upperInclusive;
 
     public VersionDependency(URI url, String version) {
         super(url);
-        this.version = version;
+        this.lowerBound = version;
+        this.upperBound = null;
+        upperInclusive = false;
     }
 
-    public String getVersion() {
-        return version;
+    public VersionDependency(URI url, String lowerBound, @Nullable String upperBound, boolean upperInclusive) {
+        super(url);
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.upperInclusive = upperInclusive;
+    }
+
+    public String getLowerBound() {
+        return lowerBound;
+    }
+
+    @Nullable
+    public String getUpperBound() {
+        return upperBound;
+    }
+
+    public boolean isUpperInclusive() {
+        return upperInclusive;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/VersionDependency.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/internal/VersionDependency.java
@@ -16,17 +16,17 @@
 
 package org.gradle.swiftpm.internal;
 
-import java.io.Serializable;
 import java.net.URI;
 
-abstract public class Dependency implements Serializable {
-    private final URI url;
+public class VersionDependency extends Dependency {
+    private final String version;
 
-    public Dependency(URI url) {
-        this.url = url;
+    public VersionDependency(URI url, String version) {
+        super(url);
+        this.version = version;
     }
 
-    public URI getUrl() {
-        return url;
+    public String getVersion() {
+        return version;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -35,11 +35,13 @@ import org.gradle.language.swift.SwiftVersion;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.swiftpm.Package;
 import org.gradle.swiftpm.internal.AbstractProduct;
+import org.gradle.swiftpm.internal.BranchDependency;
 import org.gradle.swiftpm.internal.DefaultExecutableProduct;
 import org.gradle.swiftpm.internal.DefaultLibraryProduct;
 import org.gradle.swiftpm.internal.DefaultPackage;
 import org.gradle.swiftpm.internal.DefaultTarget;
 import org.gradle.swiftpm.internal.Dependency;
+import org.gradle.swiftpm.internal.VersionDependency;
 import org.gradle.swiftpm.tasks.GenerateSwiftPackageManagerManifest;
 import org.gradle.vcs.VcsMapping;
 import org.gradle.vcs.VersionControlSpec;
@@ -206,10 +208,15 @@ public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
                     if (vcsSpec == null || !(vcsSpec instanceof GitVersionControlSpec)) {
                         throw new InvalidUserDataException(String.format("Cannot determine the Git URL for dependency on %s:%s.", dependency.getGroup(), dependency.getName()));
                     }
+                    GitVersionControlSpec gitSpec = (GitVersionControlSpec) vcsSpec;
+
                     // TODO - need to map version selector to Swift PM selector
                     String versionSelector = externalDependency.getVersion();
-                    GitVersionControlSpec gitSpec = (GitVersionControlSpec) vcsSpec;
-                    dependencies.add(new Dependency(gitSpec.getUrl(), versionSelector));
+                    if ("latest.integration".equals(versionSelector)) {
+                        dependencies.add(new BranchDependency(gitSpec.getUrl(), "master"));
+                    } else {
+                        dependencies.add(new VersionDependency(gitSpec.getUrl(), versionSelector));
+                    }
                     target.getRequiredProducts().add(externalDependency.getName());
                 }
             }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -205,11 +205,18 @@ public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
                     GitVersionControlSpec gitSpec = (GitVersionControlSpec) vcsSpec;
 
                     // TODO - need to map version selector to Swift PM selector
-                    String versionSelector = externalDependency.getVersion();
-                    if ("latest.integration".equals(versionSelector)) {
-                        dependencies.add(new BranchDependency(gitSpec.getUrl(), "master"));
+                    if (externalDependency.getVersionConstraint().getBranch() != null) {
+                        dependencies.add(new BranchDependency(gitSpec.getUrl(), externalDependency.getVersionConstraint().getBranch()));
+                        if (externalDependency.getVersion() != null) {
+                            throw new InvalidUserDataException(String.format("Cannot map a dependency on %s:%s that defines both a branch (%s) and a version constraint (%s).", externalDependency.getGroup(), externalDependency.getName(), externalDependency.getVersionConstraint().getBranch(), externalDependency.getVersion()));
+                        }
                     } else {
-                        dependencies.add(new VersionDependency(gitSpec.getUrl(), versionSelector));
+                        String versionSelector = externalDependency.getVersion();
+                        if ("latest.integration".equals(versionSelector)) {
+                            dependencies.add(new BranchDependency(gitSpec.getUrl(), "master"));
+                        } else {
+                            dependencies.add(new VersionDependency(gitSpec.getUrl(), versionSelector));
+                        }
                     }
                     target.getRequiredProducts().add(externalDependency.getName());
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -27,10 +27,12 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.swiftpm.Package;
 import org.gradle.swiftpm.internal.AbstractProduct;
+import org.gradle.swiftpm.internal.BranchDependency;
 import org.gradle.swiftpm.internal.DefaultLibraryProduct;
 import org.gradle.swiftpm.internal.DefaultPackage;
 import org.gradle.swiftpm.internal.DefaultTarget;
 import org.gradle.swiftpm.internal.Dependency;
+import org.gradle.swiftpm.internal.VersionDependency;
 
 import java.io.File;
 import java.io.IOException;
@@ -110,9 +112,16 @@ public class GenerateSwiftPackageManagerManifest extends DefaultTask {
                         } else {
                             writer.print(dependency.getUrl());
                         }
-                        writer.print("\", from: \"");
-                        writer.print(dependency.getVersion());
-                        writer.println("\"),");
+                        writer.print("\", ");
+                        if (dependency instanceof VersionDependency) {
+                            writer.print("from: \"");
+                            writer.print(((VersionDependency) dependency).getVersion());
+                            writer.println("\"),");
+                        } else {
+                            writer.print(".branch(\"");
+                            writer.print(((BranchDependency) dependency).getBranch());
+                            writer.println("\")),");
+                        }
                     }
                     writer.println("    ],");
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -114,14 +114,30 @@ public class GenerateSwiftPackageManagerManifest extends DefaultTask {
                         }
                         writer.print("\", ");
                         if (dependency instanceof VersionDependency) {
-                            writer.print("from: \"");
-                            writer.print(((VersionDependency) dependency).getVersion());
-                            writer.println("\"),");
+                            VersionDependency versionDependency = (VersionDependency) dependency;
+                            if (versionDependency.getUpperBound() == null) {
+                                writer.print("from: \"");
+                                writer.print(versionDependency.getLowerBound());
+                                writer.print("\"");
+                            } else if (versionDependency.isUpperInclusive()){
+                                writer.print("\"");
+                                writer.print(versionDependency.getLowerBound());
+                                writer.print("\"...\"");
+                                writer.print(versionDependency.getUpperBound());
+                                writer.print("\"");
+                            }  else {
+                                writer.print("\"");
+                                writer.print(versionDependency.getLowerBound());
+                                writer.print("\"..<\"");
+                                writer.print(versionDependency.getUpperBound());
+                                writer.print("\"");
+                            }
                         } else {
                             writer.print(".branch(\"");
                             writer.print(((BranchDependency) dependency).getBranch());
-                            writer.println("\")),");
+                            writer.print("\")");
                         }
+                        writer.println("),");
                     }
                     writer.println("    ],");
                 }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/VersionControlServices.java
@@ -60,8 +60,12 @@ public class VersionControlServices extends AbstractPluginServiceRegistry {
             return new DefaultVcsMappingFactory(decoratingInstantiator, new VersionControlSpecFactory(decoratingInstantiator, startParameter));
         }
 
-        VcsMappingsStore createVcsMappingsStore() {
-            return new DefaultVcsMappingsStore();
+        VcsMappingsStore createVcsMappingsStore(VcsMappingFactory mappingFactory) {
+            return new DefaultVcsMappingsStore(mappingFactory);
+        }
+
+        VcsResolver createVcsResolver(VcsMappingsStore mappingsStore) {
+            return mappingsStore.asResolver();
         }
     }
 

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/internal/DefaultVcsMappingStoreTest.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/internal/DefaultVcsMappingStoreTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.api.Action
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.internal.GradleInternal
+import org.gradle.testing.internal.util.Specification
+import org.gradle.vcs.VersionControlSpec
+
+class DefaultVcsMappingStoreTest extends Specification {
+    def factory = Mock(VcsMappingFactory)
+    def store = new DefaultVcsMappingsStore(factory)
+
+    def "does nothing when no rules defined"() {
+        def selector = Stub(ModuleComponentSelector)
+
+        when:
+        def spec = store.locateVcsFor(selector)
+
+        then:
+        spec == null
+        0 * factory._
+    }
+
+    def "does nothing when no rule accepts selector"() {
+        def selector = Stub(ModuleComponentSelector)
+        def mapping = new DefaultVcsMapping(selector, Stub(VersionControlSpecFactory))
+        def rule = Mock(Action)
+
+        store.addRule(rule, Stub(GradleInternal))
+
+        when:
+        def spec = store.locateVcsFor(selector)
+
+        then:
+        spec == null
+        1 * factory.create(selector) >> mapping
+        1 * rule.execute(mapping)
+        0 * _
+    }
+
+    def "returns repo defined by last rule that accepts selector"() {
+        def selector = Stub(ModuleComponentSelector)
+        def mapping = new DefaultVcsMapping(selector, Stub(VersionControlSpecFactory))
+        def rule = Mock(Action)
+        def rule2 = Mock(Action)
+        def vcsSpec = Stub(VersionControlSpec)
+        def build = Stub(GradleInternal)
+
+        store.addRule(rule, build)
+        store.addRule(rule2, build)
+
+        when:
+        def spec = store.locateVcsFor(selector)
+
+        then:
+        spec == vcsSpec
+        1 * factory.create(selector) >> mapping
+        1 * rule.execute(mapping) >> {
+            mapping.from(Stub(VersionControlSpec))
+        }
+        1 * rule2.execute(mapping) >> {
+            mapping.from(vcsSpec)
+        }
+        0 * _
+    }
+}


### PR DESCRIPTION
### Context

This change improves the mapping done by the 'swiftpm-export' plugin from Gradle dependency declarations to Swift PM dependency declarations in the generated Swift PM manifest.

Handles dependency on a branch, `latest.integration`, most version ranges and most `+` selectors. 

Improved error message for a dependency that cannot be mapped.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
