### PR TITLE
Fix constraints incorrectly showing up as "REQUESTED"

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -38,8 +38,6 @@ public interface DependencyGraphEdge extends DependencyResult {
 
     List<ComponentArtifactMetadata> getArtifacts(ConfigurationMetadata targetConfiguration);
 
-    Iterable<? extends DependencyGraphNode> getTargets();
-
     /**
      * The original dependency instance declared in the build script, if any.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
@@ -200,11 +199,6 @@ class EdgeState implements DependencyGraphEdge {
             return ((DslOriginDependencyMetadata) dependencyMetadata).getSource();
         }
         return null;
-    }
-
-    @Override
-    public Iterable<? extends DependencyGraphNode> getTargets() {
-        return targetNodes;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -110,6 +110,9 @@ class SelectorState implements DependencyGraphSelector {
         if (dependencyState.failure != null) {
             idResolveResult.failed(dependencyState.failure);
         } else {
+            if (dependencyMetadata.isPending()) {
+                idResolveResult.setSelectionDescription(CONSTRAINT);
+            }
             resolver.resolve(dependencyMetadata, idResolveResult);
         }
 
@@ -121,9 +124,6 @@ class SelectorState implements DependencyGraphSelector {
         selected = resolveState.getRevision(idResolveResult.getModuleVersionId());
         selected.selectedBy(this);
         selected.addCause(idResolveResult.getSelectionDescription());
-        if (dependencyMetadata.isPending()) {
-            selected.addCause(CONSTRAINT);
-        }
         if (dependencyState.getRuleDescriptor() != null) {
             selected.addCause(dependencyState.getRuleDescriptor());
         }
@@ -143,9 +143,6 @@ class SelectorState implements DependencyGraphSelector {
         }
         List<ComponentSelectionDescriptorInternal> descriptors = Lists.newArrayListWithCapacity(isConstraint && hasRuleDescriptor ? 3 : 2);
         descriptors.add(description);
-        if (isConstraint) {
-            descriptors.add(CONSTRAINT);
-        }
         if (hasRuleDescriptor) {
             descriptors.add(dependencyState.getRuleDescriptor());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resolve.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
@@ -95,7 +96,7 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
         metaData = null;
         id = null;
         moduleVersionId = null;
-        selectionDescription = VersionSelectionReasons.REQUESTED;
+        selectionDescription = selectionDescription == null || selectionDescription.getCause() != ComponentSelectionCause.CONSTRAINT ? VersionSelectionReasons.REQUESTED : VersionSelectionReasons.CONSTRAINT;
         versionConstraint = null;
     }
 


### PR DESCRIPTION
### Context

This pull request fixes the component selection reason whenever a constraint provides a custom message. While the dependency report showed properly both `via constraint` and the `custom message`, both actually came from 2 different descriptors, one being a `REQUESTED, custom message` instead of `CONSTRAINT, custom message`.
