### PR TITLE
Fix GradleBuildPerformanceTest retry

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -31,10 +31,8 @@ import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Unroll
 
 /**
  * Test Gradle's build performance against current Gradle.
@@ -82,41 +80,39 @@ class GradleBuildPerformanceTest extends Specification {
     def warmupBuilds = 20
     def measuredBuilds = 40
 
-    @Unroll
-    @Ignore("IllegalException: Multiple specifications with display name 'baseline build' on retry")
-    def "#tasks on the gradle build comparing the build"() {
+    def baselineBuildName = 'baseline build'
+    def currentBuildName = 'current build'
 
-        given:
+    def setup() {
         runner.testGroup = 'gradle build'
-        runner.testId = testName.methodName
 
-        and:
-        def baselineBuildName = 'baseline build'
-        def currentBuildName = 'current build'
-
-        and:
         runner.baseline {
             displayName baselineBuildName
             projectName 'gradleBuildBaseline'
             warmUpCount warmupBuilds
             invocationCount measuredBuilds
             invocation {
-                tasksToRun(tasks)
+                tasksToRun("help")
                 useDaemon()
             }
         }
 
-        and:
         runner.buildSpec {
             displayName currentBuildName
             projectName 'gradleBuildCurrent'
             warmUpCount warmupBuilds
             invocationCount measuredBuilds
             invocation {
-                tasksToRun(tasks)
+                tasksToRun("help")
                 useDaemon()
             }
         }
+    }
+
+    def "help on the gradle build comparing the build"() {
+
+        given:
+        runner.testId = testName.methodName
 
         when:
         def results = runner.run()
@@ -134,9 +130,6 @@ class GradleBuildPerformanceTest extends Specification {
         if (baselineResults.fasterThan(currentResults)) {
             throw new AssertionError(speedStats)
         }
-
-        where:
-        tasks << ['help']
     }
 
     private static BaselineVersion buildBaselineResults(CrossBuildPerformanceResults results, String name) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -65,27 +65,36 @@ class GradleBuildPerformanceTest extends Specification {
     @Shared
     def resultStore = new CrossBuildResultsStore()
 
-    def runner = new CrossBuildPerformanceTestRunner(
-        new BuildExperimentRunner(new GradleSessionProvider(buildContext)),
-        resultStore,
-        buildContext) {
-
-        @Override
-        protected void defaultSpec(BuildExperimentSpec.Builder builder) {
-            super.defaultSpec(builder)
-            builder.workingDirectory = tmpDir.testDirectory
-        }
-    }
+    CrossBuildPerformanceTestRunner runner
 
     def warmupBuilds = 20
     def measuredBuilds = 40
 
-    def baselineBuildName = 'baseline build'
-    def currentBuildName = 'current build'
-
     def setup() {
-        runner.testGroup = 'gradle build'
+        runner = new CrossBuildPerformanceTestRunner(
+            new BuildExperimentRunner(new GradleSessionProvider(buildContext)),
+            resultStore,
+            buildContext) {
 
+            @Override
+            protected void defaultSpec(BuildExperimentSpec.Builder builder) {
+                super.defaultSpec(builder)
+                builder.workingDirectory = tmpDir.testDirectory
+            }
+        }
+        runner.testGroup = 'gradle build'
+    }
+
+    def "help on the gradle build comparing the build"() {
+
+        given:
+        runner.testId = testName.methodName
+
+        and:
+        def baselineBuildName = 'baseline build'
+        def currentBuildName = 'current build'
+
+        and:
         runner.baseline {
             displayName baselineBuildName
             projectName 'gradleBuildBaseline'
@@ -97,6 +106,7 @@ class GradleBuildPerformanceTest extends Specification {
             }
         }
 
+        and:
         runner.buildSpec {
             displayName currentBuildName
             projectName 'gradleBuildCurrent'
@@ -107,12 +117,6 @@ class GradleBuildPerformanceTest extends Specification {
                 useDaemon()
             }
         }
-    }
-
-    def "help on the gradle build comparing the build"() {
-
-        given:
-        runner.testId = testName.methodName
 
         when:
         def results = runner.run()


### PR DESCRIPTION
by moving runner specs declaration out of the test method
because RetryRule is a MethodRule and reuse the setup test instance.