### PR TITLE
Prevent creating byte array copies when hashing hash codes

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasher.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasher.java
@@ -72,7 +72,7 @@ public class ConfigurableClassLoaderHierarchyHasher implements ClassLoaderHierar
             }
             HashCode hash = classLoaderHasher.getHash(cl);
             if (hash != null) {
-                hasher.putBytes(hash.toByteArray());
+                hasher.putHash(hash);
                 return true;
             }
             foundUnknown = true;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashUtil.java
@@ -80,7 +80,7 @@ public class HashUtil {
     }
 
     public static String compactStringFor(HashCode hashCode) {
-        return compactStringFor(hashCode.toByteArray());
+        return compactStringFor(hashCode.getBytes());
     }
 
     public static String compactStringFor(byte[] digest) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasherTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasherTest.groovy
@@ -75,7 +75,7 @@ class ConfigurableClassLoaderHierarchyHasherTest extends Specification {
             if (it instanceof String) {
                 hasher.putString(it)
             } else if (it instanceof HashCode) {
-                hasher.putBytes(it.toByteArray())
+                hasher.putHash(it)
             } else {
                 throw new AssertionError()
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractClasspathSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractClasspathSnapshotBuilder.java
@@ -36,7 +36,7 @@ public abstract class AbstractClasspathSnapshotBuilder implements VisitingFileCo
     private final StringInterner stringInterner;
     private final ResourceSnapshotterCacheService cacheService;
     private final JarHasher jarHasher;
-    private final byte[] jarHasherConfigurationHash;
+    private final HashCode jarHasherConfigurationHash;
 
     public AbstractClasspathSnapshotBuilder(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, StringInterner stringInterner) {
         this.builder = new CollectingFileCollectionSnapshotBuilder(TaskFilePropertyCompareStrategy.ORDERED, InputPathNormalizationStrategy.NONE, stringInterner);
@@ -46,7 +46,7 @@ public abstract class AbstractClasspathSnapshotBuilder implements VisitingFileCo
         this.jarHasher = new JarHasher();
         DefaultBuildCacheHasher hasher = new DefaultBuildCacheHasher();
         jarHasher.appendConfigurationToHasher(hasher);
-        this.jarHasherConfigurationHash = hasher.hash().toByteArray();
+        this.jarHasherConfigurationHash = hasher.hash();
     }
 
     protected abstract void visitNonJar(RegularFileSnapshot file);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingResourceHasher.java
@@ -32,14 +32,14 @@ import java.util.zip.ZipEntry;
 public class CachingResourceHasher implements ResourceHasher {
     private final ResourceHasher delegate;
     private final ResourceSnapshotterCacheService resourceSnapshotterCacheService;
-    private final byte[] delegateConfigurationHash;
+    private final HashCode delegateConfigurationHash;
 
     public CachingResourceHasher(ResourceHasher delegate, ResourceSnapshotterCacheService resourceSnapshotterCacheService) {
         this.delegate = delegate;
         this.resourceSnapshotterCacheService = resourceSnapshotterCacheService;
         BuildCacheHasher hasher = new DefaultBuildCacheHasher();
         delegate.appendConfigurationToHasher(hasher);
-        this.delegateConfigurationHash = hasher.hash().toByteArray();
+        this.delegateConfigurationHash = hasher.hash();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceSnapshotterCacheService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceSnapshotterCacheService.java
@@ -30,7 +30,7 @@ public class ResourceSnapshotterCacheService {
         this.persistentCache = persistentCache;
     }
 
-    public HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileHasher hasher, byte[] configurationHash) {
+    public HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileHasher hasher, HashCode configurationHash) {
         HashCode resourceHashCacheKey = resourceHashCacheKey(fileSnapshot, configurationHash);
 
         HashCode resourceHash = persistentCache.get(resourceHashCacheKey);
@@ -51,9 +51,9 @@ public class ResourceSnapshotterCacheService {
         return resourceHash;
     }
 
-    private HashCode resourceHashCacheKey(RegularFileSnapshot fileSnapshot, byte[] configurationHash) {
+    private static HashCode resourceHashCacheKey(RegularFileSnapshot fileSnapshot, HashCode configurationHash) {
         BuildCacheHasher hasher = new DefaultBuildCacheHasher();
-        hasher.putBytes(configurationHash);
+        hasher.putHash(configurationHash);
         hasher.putHash(fileSnapshot.getContent().getContentMd5());
         return hasher.hash();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultContentHasherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultContentHasherFactory.java
@@ -17,12 +17,12 @@
 package org.gradle.internal.hash;
 
 public class DefaultContentHasherFactory implements ContentHasherFactory {
-    private static final byte[] SIGNATURE = Hashing.md5().hashString(DefaultContentHasherFactory.class.getName()).toByteArray();
+    private static final HashCode SIGNATURE = Hashing.md5().hashString(DefaultContentHasherFactory.class.getName());
 
     @Override
     public Hasher create() {
         Hasher hasher = Hashing.md5().newHasher();
-        hasher.putBytes(SIGNATURE);
+        hasher.putHash(SIGNATURE);
         return hasher;
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheKeyBuilder.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheKeyBuilder.java
@@ -85,8 +85,8 @@ class DefaultCacheKeyBuilder implements CacheKeyBuilder {
 
     private HashCode combinedHashOf(Object[] components) {
         Hasher hasher = hashFunction.newHasher();
-        for (Object c : components) {
-            hasher.putBytes(hashOf(c).toByteArray());
+        for (Object component : components) {
+            hasher.putHash(hashOf(component));
         }
         return hasher.hash();
     }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheKeyBuilderTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheKeyBuilderTest.groovy
@@ -22,11 +22,11 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.HashFunction
-import org.gradle.internal.hash.HashValue
 import org.gradle.internal.hash.Hasher
 import spock.lang.Specification
 
 import static org.gradle.cache.internal.CacheKeyBuilder.CacheKeySpec
+import static org.gradle.internal.hash.HashUtil.compactStringFor
 
 class DefaultCacheKeyBuilderTest extends Specification {
 
@@ -64,7 +64,7 @@ class DefaultCacheKeyBuilderTest extends Specification {
         0 * _
 
         and:
-        key == "$prefix/${toCompactHash(stringHash)}"
+        key == "$prefix/${compactStringFor(stringHash)}"
     }
 
     def 'given a File component, it should hash it and append it to the prefix'() {
@@ -81,7 +81,7 @@ class DefaultCacheKeyBuilderTest extends Specification {
         0 * _
 
         and:
-        key == "$prefix/${toCompactHash(fileHash)}"
+        key == "$prefix/${compactStringFor(fileHash)}"
     }
 
     def 'given a ClassPath component, it should snapshot it and append it to the prefix'() {
@@ -98,7 +98,7 @@ class DefaultCacheKeyBuilderTest extends Specification {
         0 * _
 
         and:
-        key == "$prefix/${toCompactHash(classPathHash)}"
+        key == "$prefix/${compactStringFor(classPathHash)}"
     }
 
     def 'given a ClassLoader component, it should hash its hierarchy and append it to the prefix'() {
@@ -115,7 +115,7 @@ class DefaultCacheKeyBuilderTest extends Specification {
         0 * _
 
         and:
-        key == "$prefix/${toCompactHash(classLoaderHierarchyHash)}"
+        key == "$prefix/${compactStringFor(classLoaderHierarchyHash)}"
     }
 
     def 'given more than one component, it should combine their hashes together and append the combined hash to the prefix'() {
@@ -135,16 +135,13 @@ class DefaultCacheKeyBuilderTest extends Specification {
         1 * hashFunction.newHasher() >> hasher
         1 * hashFunction.hashString(string) >> stringHash
         1 * fileHasher.hash(file) >> fileHash
-        1 * hasher.putBytes(stringHash.toByteArray())
-        1 * hasher.putBytes(fileHash.toByteArray())
+        1 * hasher.putHash(stringHash)
+        1 * hasher.putHash(fileHash)
         1 * hasher.hash() >> combinedHash
         0 * _
 
         and:
-        key == "$prefix/${toCompactHash(combinedHash)}"
+        key == "$prefix/${compactStringFor(combinedHash)}"
     }
 
-    private static String toCompactHash(HashCode hash) {
-        return new HashValue(hash.toByteArray()).asCompactString()
-    }
 }


### PR DESCRIPTION
Should reduce garbage creation a little.
