### PR TITLE
WIP: Collect failures from included builds in a composite build

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildFailureCollectionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildFailureCollectionIntegrationTest.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.build.BuildTestFile
+
+class CompositeBuildFailureCollectionIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    BuildTestFile buildB
+    BuildTestFile buildC
+    BuildTestFile buildD
+
+    def setup() {
+        buildB = singleProjectBuild('buildB') {
+            buildFile << javaProject()
+            file('src/test/java/SampleTestB.java') << junitTestClass('SampleTestB')
+        }
+
+        buildC = multiProjectBuild('buildC', ['sub1', 'sub2', 'sub3']) {
+            buildFile << """
+                allprojects {
+                    ${javaProject()}
+                }
+
+                test.dependsOn 'sub1:test', 'sub2:test', 'sub3:test'
+            """
+            file('sub1/src/test/java/SampleTestC_Sub1.java') << junitTestClass('SampleTestC_Sub1')
+            file('sub2/src/test/java/SampleTestC_Sub2.java') << junitTestClass('SampleTestC_Sub2')
+            file('sub3/src/test/java/SampleTestC_Sub3.java') << junitTestClass('SampleTestC_Sub3')
+        }
+
+        buildD = singleProjectBuild('buildD') {
+            buildFile << javaProject()
+            file('src/test/java/SampleTestD.java') << junitTestClass('SampleTestD')
+        }
+
+        includedBuilds << buildB << buildC << buildD
+
+        buildA.buildFile << """
+            test.dependsOn gradle.includedBuilds*.task(':test')
+        """
+    }
+
+    def "can collect all test failures"() {
+        when:
+        execute(buildA, 'test', '--continue')
+
+        then:
+        noExceptionThrown()
+    }
+
+    private String javaProject() {
+        """
+            apply plugin: 'java'
+
+            ${mavenCentralRepository()}
+            
+            dependencies {
+                testCompile 'junit:junit:4.12'
+            }
+        """
+    }
+
+    static String junitTestClass(String className) {
+        """
+            import org.junit.Test;
+            import static org.junit.Assert.assertTrue;
+            
+            public class $className {
+                @Test
+                public void testSuccess() {
+                    assertTrue(true);
+                }
+            
+                @Test
+                public void testFailure() {
+                    throw new RuntimeException("Failure!");
+                }
+            }
+        """
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildFailureCollectionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildFailureCollectionIntegrationTest.groovy
@@ -55,12 +55,22 @@ class CompositeBuildFailureCollectionIntegrationTest extends AbstractCompositeBu
         """
     }
 
-    def "can collect all test failures"() {
+    def "can collect all build failures"() {
         when:
-        execute(buildA, 'test', '--continue')
+        fails(buildA, 'test', ['--continue'])
 
         then:
-        noExceptionThrown()
+        assertTaskExecuted(":buildB", ":test")
+        assertTaskExecuted(":buildC", ":sub1:test")
+        assertTaskExecuted(":buildC", ":sub2:test")
+        assertTaskExecuted(":buildC", ":sub3:test")
+        assertTaskExecuted(":buildD", ":test")
+        errorOutput.contains('Multiple build failures')
+        errorOutput.contains("Execution failed for task ':buildB:test'")
+        errorOutput.contains("Execution failed for task ':buildC:sub1:test'")
+        errorOutput.contains("Execution failed for task ':buildC:sub2:test'")
+        errorOutput.contains("Execution failed for task ':buildC:sub3:test'")
+        errorOutput.contains("Execution failed for task ':buildD:test'")
     }
 
     private String javaProject() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildFailureCollectionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildFailureCollectionIntegrationTest.groovy
@@ -68,11 +68,11 @@ class CompositeBuildFailureCollectionIntegrationTest extends AbstractCompositeBu
         assertTaskExecuted(":buildC", ":sub2:test")
         assertTaskExecuted(":buildC", ":sub3:test")
         assertTaskExecuted(":buildD", ":test")
-        errorOutput.contains("Execution failed for task ':buildB:test'")
-        errorOutput.contains("Execution failed for task ':buildC:sub1:test'")
-        errorOutput.contains("Execution failed for task ':buildC:sub2:test'")
-        errorOutput.contains("Execution failed for task ':buildC:sub3:test'")
-        errorOutput.contains("Execution failed for task ':buildD:test'")
+        assertTaskExecutionFailureMessage(errorOutput, ':buildB:test')
+        assertTaskExecutionFailureMessage(errorOutput, ':buildC:sub1:test')
+        assertTaskExecutionFailureMessage(errorOutput,':buildC:sub2:test')
+        assertTaskExecutionFailureMessage(errorOutput,':buildC:sub3:test')
+        assertTaskExecutionFailureMessage(errorOutput,':buildD:test')
     }
 
     def "can collect build failure in root and included build"() {
@@ -98,10 +98,10 @@ class CompositeBuildFailureCollectionIntegrationTest extends AbstractCompositeBu
 
         then:
         !errorOutput.contains('Multiple build failures')
-        errorOutput.contains("Execution failed for task ':test'")
-        errorOutput.contains("Execution failed for task ':buildC:sub1:test'")
-        errorOutput.contains("Execution failed for task ':buildC:sub2:test'")
-        errorOutput.contains("Execution failed for task ':buildC:sub3:test'")
+        assertTaskExecutionFailureMessage(errorOutput, ':test')
+        assertTaskExecutionFailureMessage(errorOutput, ':buildC:sub1:test')
+        assertTaskExecutionFailureMessage(errorOutput, ':buildC:sub2:test')
+        assertTaskExecutionFailureMessage(errorOutput, ':buildC:sub3:test')
     }
 
     private String javaProject() {
@@ -133,5 +133,9 @@ class CompositeBuildFailureCollectionIntegrationTest extends AbstractCompositeBu
                 }
             }
         """
+    }
+
+    static void assertTaskExecutionFailureMessage(String errorOutput, String taskPath) {
+        assert errorOutput.contains("Execution failed for task '$taskPath'")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
@@ -22,10 +22,17 @@ import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.execution.taskgraph.BuildFailureState;
 
 import java.util.Set;
 
 public class SelectedTaskExecutionAction implements BuildExecutionAction {
+    private final BuildFailureState buildFailureState;
+
+    public SelectedTaskExecutionAction(BuildFailureState buildFailureState) {
+        this.buildFailureState = buildFailureState;
+    }
+
     public void execute(BuildExecutionContext context) {
         GradleInternal gradle = context.getGradle();
         TaskGraphExecuter taskGraph = gradle.getTaskGraph();
@@ -37,9 +44,9 @@ public class SelectedTaskExecutionAction implements BuildExecutionAction {
         taskGraph.execute();
     }
 
-    private static class ContinueOnFailureHandler implements TaskFailureHandler {
+    private class ContinueOnFailureHandler implements TaskFailureHandler {
         public void onTaskFailure(Task task) {
-            // Do nothing
+            buildFailureState.addFailure(task.getState().getFailure());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/BuildFailureState.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/BuildFailureState.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BuildFailureState {
+
+    private final List<Throwable> collectedFailures = new ArrayList<Throwable>();
+
+    public void addFailure(Throwable failure) {
+        collectedFailures.add(failure);
+    }
+
+    public List<Throwable> getFailures() {
+        return Collections.unmodifiableList(new ArrayList<Throwable>(collectedFailures));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfoFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfoFactory.java
@@ -50,6 +50,8 @@ public class TaskInfoFactory {
     }
 
     private static class TaskResourceTaskInfo extends TaskInfo {
+        private Exception caughtException;
+
         public TaskResourceTaskInfo(TaskInternal task) {
             super(task);
             doNotRequire();
@@ -63,7 +65,18 @@ public class TaskInfoFactory {
         @Override
         public boolean isComplete() {
             IncludedBuildTaskResource task = (IncludedBuildTaskResource) getTask();
-            return task.isComplete();
+
+            try {
+                return task.isComplete();
+            } catch (Exception e) {
+                caughtException = e;
+                return true;
+            }
+        }
+
+        @Override
+        public Throwable getTaskFailure() {
+            return caughtException != null ? caughtException : super.getTaskFailure();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -123,11 +123,11 @@ public class DefaultGradleLauncher implements GradleLauncher {
     @Override
     public void finishBuild() {
         if (stage != null) {
-            Throwable failure = analyzeBuildFailureState();
-            finishBuild(new BuildResult(stage.name(), gradle, failure));
+            Throwable collectedFailure = analyzeBuildFailureState();
+            finishBuild(new BuildResult(stage.name(), gradle, collectedFailure));
 
-            if (failure != null) {
-                throw new ReportedException(failure);
+            if (collectedFailure != null) {
+                throw new ReportedException(collectedFailure);
             }
         }
     }
@@ -160,9 +160,10 @@ public class DefaultGradleLauncher implements GradleLauncher {
             runTasks();
             finishBuild();
         } catch (Throwable t) {
-            Throwable failure = exceptionAnalyser.transform(t);
-            finishBuild(new BuildResult(upTo.name(), gradle, failure));
-            throw new ReportedException(failure);
+            Throwable collectedFailure = analyzeBuildFailureState();
+            Throwable exceptionToBeThrown = collectedFailure != null ? collectedFailure : t;
+            finishBuild(new BuildResult(upTo.name(), gradle, exceptionToBeThrown));
+            throw new ReportedException(exceptionToBeThrown);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -160,10 +160,9 @@ public class DefaultGradleLauncher implements GradleLauncher {
             runTasks();
             finishBuild();
         } catch (Throwable t) {
-            Throwable collectedFailure = analyzeBuildFailureState();
-            Throwable exceptionToBeThrown = collectedFailure != null ? collectedFailure : t;
-            finishBuild(new BuildResult(upTo.name(), gradle, exceptionToBeThrown));
-            throw new ReportedException(exceptionToBeThrown);
+            Throwable failure = exceptionAnalyser.transform(t);
+            finishBuild(new BuildResult(upTo.name(), gradle, failure));
+            throw new ReportedException(failure);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -30,6 +30,7 @@ import org.gradle.configuration.BuildConfigurer;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
+import org.gradle.execution.taskgraph.BuildFailureState;
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.ProjectEvaluationLogger;
@@ -195,7 +196,8 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             gradle.getServices().get(BuildConfigurationActionExecuter.class),
             gradle.getServices().get(BuildExecuter.class),
             serviceRegistry,
-            servicesToStop
+            servicesToStop,
+            serviceRegistry.get(BuildFailureState.class)
         );
         nestedBuildFactory.setParent(gradleLauncher);
         return gradleLauncher;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -51,6 +51,7 @@ import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.VersionStrategy;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
+import org.gradle.execution.taskgraph.BuildFailureState;
 import org.gradle.groovy.scripts.internal.DefaultScriptSourceHasher;
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher;
 import org.gradle.initialization.BuildRequestMetaData;
@@ -258,5 +259,9 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
 
     CleanupActionFactory createCleanupActionFactory(BuildOperationExecutor buildOperationExecutor) {
         return new CleanupActionFactory(buildOperationExecutor);
+    }
+
+    BuildFailureState createBuildFailureState() {
+        return new BuildFailureState();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -50,6 +50,7 @@ import org.gradle.execution.TaskNameResolvingBuildConfigurationAction;
 import org.gradle.execution.TaskSelector;
 import org.gradle.execution.commandline.CommandLineTaskConfigurer;
 import org.gradle.execution.commandline.CommandLineTaskParser;
+import org.gradle.execution.taskgraph.BuildFailureState;
 import org.gradle.execution.taskgraph.DefaultTaskGraphExecuter;
 import org.gradle.execution.taskgraph.TaskPlanExecutor;
 import org.gradle.initialization.BuildCancellationToken;
@@ -125,10 +126,10 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return new CommandLineTaskParser(new CommandLineTaskConfigurer(optionReader), taskSelector);
     }
 
-    BuildExecuter createBuildExecuter(StyledTextOutputFactory textOutputFactory) {
+    BuildExecuter createBuildExecuter(StyledTextOutputFactory textOutputFactory, BuildFailureState buildFailureState) {
         return new DefaultBuildExecuter(
             asList(new DryRunBuildExecutionAction(textOutputFactory),
-                new SelectedTaskExecutionAction()));
+                new SelectedTaskExecutionAction(buildFailureState)));
     }
 
     BuildConfigurationActionExecuter createBuildConfigurationActionExecuter(CommandLineTaskParser commandLineTaskParser, TaskSelector taskSelector, ProjectConfigurer projectConfigurer) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/SelectedTaskExecutionActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/SelectedTaskExecutionActionTest.groovy
@@ -19,10 +19,12 @@ import org.gradle.StartParameter
 import org.gradle.api.Task
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.tasks.TaskState
+import org.gradle.execution.taskgraph.BuildFailureState
 import spock.lang.Specification
 
 class SelectedTaskExecutionActionTest extends Specification {
-    final SelectedTaskExecutionAction action = new SelectedTaskExecutionAction()
+    final BuildFailureState buildFailureState = new BuildFailureState()
+    final SelectedTaskExecutionAction action = new SelectedTaskExecutionAction(buildFailureState)
     final BuildExecutionContext context = Mock()
     final TaskGraphExecuter executer = Mock()
     final GradleInternal gradleInternal = Mock()
@@ -43,6 +45,7 @@ class SelectedTaskExecutionActionTest extends Specification {
 
         then:
         1 * executer.execute()
+        buildFailureState.failures.empty
     }
 
     def "executes selected tasks when continue specified"() {
@@ -55,6 +58,7 @@ class SelectedTaskExecutionActionTest extends Specification {
         then:
         1 * executer.useFailureHandler(!null)
         1 * executer.execute()
+        buildFailureState.failures.empty
     }
 
     def "adds failure handler that does not abort execution when continue specified"() {
@@ -70,6 +74,7 @@ class SelectedTaskExecutionActionTest extends Specification {
         then:
         1 * executer.useFailureHandler(!null) >> { handler = it[0] }
         1 * executer.execute() >> { handler.onTaskFailure(brokenTask(failure)) }
+        buildFailureState.failures.size() == 1
     }
 
     def brokenTask(Throwable failure) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -28,11 +28,12 @@ import org.gradle.api.internal.changedetection.state.TaskHistoryStore
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.composite.internal.IncludedBuildControllers
 import org.gradle.configuration.BuildConfigurer
 import org.gradle.execution.BuildConfigurationActionExecuter
 import org.gradle.execution.BuildExecuter
 import org.gradle.execution.TaskGraphExecuter
-import org.gradle.composite.internal.IncludedBuildControllers
+import org.gradle.execution.taskgraph.BuildFailureState
 import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.operations.TestBuildOperationExecutor
@@ -76,6 +77,7 @@ class DefaultGradleLauncherSpec extends Specification {
     private ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
     private WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
     private BuildScopeServices buildServices = Mock(BuildScopeServices.class)
+    private BuildFailureState buildFailureState = new BuildFailureState()
     private Stoppable otherService = Mock(Stoppable)
     private IncludedBuildControllers includedBuildControllers = Mock()
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -131,7 +133,7 @@ class DefaultGradleLauncherSpec extends Specification {
         return new DefaultGradleLauncher(gradleMock, initScriptHandlerMock, settingsLoaderMock, buildLoaderMock,
             buildConfigurerMock, exceptionAnalyserMock, buildBroadcaster,
             modelListenerMock, buildCompletionListener, buildOperationExecutor, buildConfigurationActionExecuter, buildExecuter,
-            buildServices, [otherService])
+            buildServices, [otherService], buildFailureState)
     }
 
     void testRun() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleScopeServicesTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.execution.DefaultBuildExecuter
 import org.gradle.execution.ProjectConfigurer
 import org.gradle.execution.TaskGraphExecuter
 import org.gradle.execution.TaskSelector
+import org.gradle.execution.taskgraph.BuildFailureState
 import org.gradle.execution.taskgraph.DefaultTaskGraphExecuter
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
@@ -81,6 +82,7 @@ public class GradleScopeServicesTest extends Specification {
         parent.get(WorkerLeaseRegistry) >> Stub(WorkerLeaseRegistry)
         parent.get(ParallelismConfigurationManager) >> new ParallelismConfigurationManagerFixture(DefaultParallelismConfiguration.DEFAULT)
         parent.get(StyledTextOutputFactory) >> new TestStyledTextOutputFactory()
+        parent.get(BuildFailureState) >> new BuildFailureState()
         gradle.getStartParameter() >> startParameter
         pluginRegistryParent.createChild(_, _, _) >> pluginRegistryChild
     }


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle/issues/4064 for more context. Currently causes other, existing integration tests to fail: https://builds.gradle.org/viewLog.html?buildId=10904331&tab=buildResultsDiv&buildTypeId=Gradle_Check_Quick_Java8_Oracle_Linux_compositeBuilds