### PR TITLE
Convert more native tasks to use Provider API types

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -62,6 +62,57 @@
             "changes": [
                 "org.gradle.plugins.ide.IdeWorkspace"
             ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.tasks.LinkSharedLibrary",
+            "member": "Class org.gradle.nativeplatform.tasks.LinkSharedLibrary",
+            "acceptation": "Made idiomatic for the Provider API",
+            "changes": [
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setOutputFile(java.io.File)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setOutputFile(org.gradle.api.provider.Provider)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setTargetPlatform(org.gradle.nativeplatform.platform.NativePlatform)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setToolChain(org.gradle.nativeplatform.toolchain.NativeToolChain)"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.tasks.LinkMachOBundle",
+            "member": "Class org.gradle.nativeplatform.tasks.LinkMachOBundle",
+            "acceptation": "Made idiomatic for the Provider API",
+            "changes": [
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setOutputFile(java.io.File)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setOutputFile(org.gradle.api.provider.Provider)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setTargetPlatform(org.gradle.nativeplatform.platform.NativePlatform)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setToolChain(org.gradle.nativeplatform.toolchain.NativeToolChain)"
+            ]
+        },
+        {
+            "type": "org.gradle.nativeplatform.tasks.LinkExecutable",
+            "member": "Class org.gradle.nativeplatform.tasks.LinkExecutable",
+            "acceptation": "Made idiomatic for the Provider API",
+            "changes": [
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setOutputFile(java.io.File)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setOutputFile(org.gradle.api.provider.Provider)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setTargetPlatform(org.gradle.nativeplatform.platform.NativePlatform)",
+                "org.gradle.nativeplatform.tasks.AbstractLinkTask.setToolChain(org.gradle.nativeplatform.toolchain.NativeToolChain)"
+            ]
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.AbstractNativePCHCompileTask",
+            "member": "Class org.gradle.language.nativeplatform.tasks.AbstractNativePCHCompileTask",
+            "acceptation": "Made idiomatic for the Provider API",
+            "changes": [
+                "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.setTargetPlatform(org.gradle.nativeplatform.platform.NativePlatform)",
+                "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.setToolChain(org.gradle.nativeplatform.toolchain.NativeToolChain)"
+            ]
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask",
+            "member": "Class org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask",
+            "acceptation": "Made idiomatic for the Provider API",
+            "changes": [
+                "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.setTargetPlatform(org.gradle.nativeplatform.platform.NativePlatform)",
+                "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.setToolChain(org.gradle.nativeplatform.toolchain.NativeToolChain)"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/dsl/org.gradle.nativeplatform.tasks.AbstractLinkTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.nativeplatform.tasks.AbstractLinkTask.xml
@@ -36,7 +36,7 @@
                 <td>linkerArgs</td>
             </tr>
             <tr>
-                <td>binaryFile</td>
+                <td>linkedFile</td>
             </tr>
             <tr>
                 <td>toolChain</td>

--- a/subprojects/docs/src/docs/dsl/org.gradle.nativeplatform.tasks.CreateStaticLibrary.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.nativeplatform.tasks.CreateStaticLibrary.xml
@@ -33,6 +33,9 @@
                 <td>toolChain</td>
             </tr>
             <tr>
+                <td>targetPlatform</td>
+            </tr>
+            <tr>
                 <td>staticLibArgs</td>
             </tr>
         </table>

--- a/subprojects/docs/src/docs/dsl/org.gradle.nativeplatform.tasks.InstallExecutable.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.nativeplatform.tasks.InstallExecutable.xml
@@ -27,10 +27,19 @@
                 <td>installDirectory</td>
             </tr>
             <tr>
-                <td>sourceFile</td>
+                <td>executableFile</td>
+            </tr>
+            <tr>
+                <td>runScriptFile</td>
             </tr>
             <tr>
                 <td>libs</td>
+            </tr>
+            <tr>
+                <td>toolChain</td>
+            </tr>
+            <tr>
+                <td>targetPlatform</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -62,9 +62,41 @@ From now on, Gradle [will cache forever that a `group:name` was absent](https://
 This has a positive performance on dependency resolution when multiple repositories are defined and dynamic versions are used.
 As before, using `--refresh-dependencies` will force a refresh, bypassing all caching.
 
-<!--
-### Example breaking change
--->
+### Changes to native compilation, linking and installation tasks
+
+To follow idiomatic [Provider API](userguide/lazy_configuration.html) practices, many tasks related to compiling and linking native libraries and applications have been converted to use the Provider API.
+
+Tasks extending `org.gradle.nativeplatform.tasks.AbstractLinkTask`, which include `org.gradle.nativeplatform.tasks.LinkExecutable` and `org.gradle.nativeplatform.tasks.LinkSharedLibrary`.
+
+- `getDestinationDir()` was replaced by `getDestinationDirectory()`.
+- `getBinaryFile()`, `getOutputFile()` was replaced by `getLinkedFile()`.
+- `setOutputFile(File)` was removed. Use `Property.set()` instead.
+- `setOutputFile(Provider)` was removed. Use `Property.set()` instead.
+- `getTargetPlatform()` was changed to return a `Property`.
+- `setTargetPlatform(NativePlatform)` was removed. Use `Property.set()` instead.
+- `getToolChain()` was changed to return a `Property`.
+- `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
+
+Task type `org.gradle.nativeplatform.tasks.CreateStaticLibrary`
+
+- `getOutputFile()` was changed to return a `Property`.
+- `setOutputFile(File)` was removed. Use `Property.set()` instead.
+- `setOutputFile(Provider)` was removed. Use `Property.set()` instead.
+- `getTargetPlatform()` was changed to return a `Property`.
+- `setTargetPlatform(NativePlatform)` was removed. Use `Property.set()` instead.
+- `getToolChain()` was changed to return a `Property`.
+- `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
+- `getStaticLibArgs()` was changed to return a `ListProperty`.
+- `setStaticLibArgs(List)` was removed. Use `ListProperty.set()` instead.
+
+Task type `org.gradle.nativeplatform.tasks.InstallExecutable`
+
+- `getPlatform()` replaced by `getTargetPlatform()`.
+- `setTargetPlatform(NativePlatform)` was removed. Use `Property.set()` instead.
+- `getToolChain()` was changed to return a `Property`.
+- `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
+
+Task types `org.gradle.nativeplatform.tasks.StripSymbols`, `org.gradle.nativeplatform.tasks.ExtractSymbols`, `org.gradle.language.swift.tasks.SwiftCompile`, and `org.gradle.nativeplatform.tasks.LinkMachOBundle` were changed in similar ways.
 
 ### Removed incubating method `BuildIdentifier.isCurrentBuild()`
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -96,7 +96,7 @@ Task type `org.gradle.nativeplatform.tasks.InstallExecutable`
 - `getToolChain()` was changed to return a `Property`.
 - `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
 
-Task types `org.gradle.nativeplatform.tasks.StripSymbols`, `org.gradle.nativeplatform.tasks.ExtractSymbols`, `org.gradle.language.swift.tasks.SwiftCompile`, and `org.gradle.nativeplatform.tasks.LinkMachOBundle` were changed in similar ways.
+Task types `org.gradle.language.assembler.tasks.Assemble`, `org.gradle.language.rc.tasks.WindowsResourceCompile`, `org.gradle.nativeplatform.tasks.StripSymbols`, `org.gradle.nativeplatform.tasks.ExtractSymbols`, `org.gradle.language.swift.tasks.SwiftCompile`, and `org.gradle.nativeplatform.tasks.LinkMachOBundle` were changed in similar ways.
 
 ### Removed incubating method `BuildIdentifier.isCurrentBuild()`
 

--- a/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
+++ b/subprojects/docs/src/samples/native-binaries/cpp-exe/build.gradle
@@ -20,7 +20,7 @@ model {
                 dependsOn binary.tasks.link
                 doFirst {
                     if (binary.toolChain in Gcc) {
-                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000)
+                        ["strip", binary.tasks.link.linkedFile].execute().waitForOrKill(1000)
                     }
                 }
             }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinary.java
@@ -208,7 +208,7 @@ public class NativeSpecVisualStudioTargetBinary implements VisualStudioTargetBin
     public File getOutputFile() {
         if (isExecutable()) {
             InstallExecutable installTask = getInstallTask();
-            return new File(installTask.getInstallDirectory().get().getAsFile(), "lib/" + installTask.getSourceFile().get().getAsFile().getName());
+            return new File(installTask.getInstallDirectory().get().getAsFile(), "lib/" + installTask.getExecutableFile().get().getAsFile().getName());
         } else {
             return binary.getPrimaryOutput();
         }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeParallelIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeParallelIntegrationTest.groovy
@@ -78,11 +78,11 @@ abstract class AbstractNativeParallelIntegrationTest extends AbstractInstalledTo
             tasks.matching { it.name == '${taskName}' }.all {  
                 def originalToolChain
                 doFirst {
-                    originalToolChain = toolChain
-                    setToolChain(new CallbackToolChain(toolChain, beforeOperations, afterOperations))
+                    originalToolChain = toolChain.get()
+                    toolChain = new CallbackToolChain(originalToolChain, beforeOperations, afterOperations)
                 }
                 doLast {
-                    toolChain.undecorateToolProviders()
+                    toolChain.get().undecorateToolProviders()
                     toolChain = originalToolChain
                 }
             }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -349,7 +349,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             apply plugin: 'cpp-application'
             application.binaries.get { !it.optimized }.configure {
                 compileTask.get().objectFileDir = layout.buildDirectory.dir("object-files")
-                linkTask.get().binaryFile = layout.buildDirectory.file("exe/some-app.exe")
+                linkTask.get().linkedFile = layout.buildDirectory.file("exe/some-app.exe")
                 installTask.get().installDirectory = layout.buildDirectory.dir("some-app")
             }
          """
@@ -767,7 +767,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
                 apply plugin: 'cpp-library'
                 library.binaries.get { !it.optimized }.configure {
                     def link = linkTask.get()
-                    link.binaryFile = layout.buildDirectory.file("shared/lib1_debug.dll")
+                    link.linkedFile = layout.buildDirectory.file("shared/lib1_debug.dll")
                     if (link.importLibrary.present) {
                         link.importLibrary = layout.buildDirectory.file("import/lib1_import.lib")
                     }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
@@ -308,7 +308,7 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
             library.binaries.get { !it.optimized }.configure { 
                 compileTask.get().objectFileDir = layout.buildDirectory.dir("object-files")
                 def link = linkTask.get()
-                link.binaryFile = layout.buildDirectory.file("shared/main.bin")
+                link.linkedFile = layout.buildDirectory.file("shared/main.bin")
                 if (link.importLibrary.present) {
                     link.importLibrary = layout.buildDirectory.file("import/main.lib")
                 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
@@ -380,7 +380,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest {
             application.binaries.configureEach {
                 compileTask.get().objectFileDir = layout.buildDirectory.dir("object-files")
                 compileTask.get().moduleFile = layout.buildDirectory.file("some-app.swiftmodule")
-                linkTask.get().binaryFile = layout.buildDirectory.file("exe/some-app.exe")
+                linkTask.get().linkedFile = layout.buildDirectory.file("exe/some-app.exe")
                 installTask.get().installDirectory = layout.buildDirectory.dir("some-app")
             }
          """

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -151,6 +151,29 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         outputs.recompiledClasses('main', 'sum', 'greeter', 'multiply')
     }
 
+    def 'changing macros rebuilds everything'() {
+        given:
+        def outputs = new CompilationOutputsFixture(file("build/obj/main/debug"), [ ".o" ])
+        def app = new SwiftApp()
+        settingsFile << "rootProject.name = 'app'"
+        app.writeToProject(testDirectory)
+        buildFile << """
+            apply plugin: 'swift-application'
+         """
+
+        outputs.snapshot { succeeds("compileDebugSwift") }
+
+        buildFile << """
+            tasks.withType(SwiftCompile) {
+                macros.add('NEWMACRO')
+            }
+        """
+
+        expect:
+        succeeds("compileDebugSwift")
+        outputs.recompiledClasses('main', 'sum', 'greeter', 'multiply')
+    }
+
     def 'changes to an unused dependency rebuilds everything'() {
         given:
         def outputs = new CompilationOutputsFixture(file("build/obj/main/debug"), [ ".o" ])

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftLibraryIntegrationTest.groovy
@@ -249,7 +249,7 @@ class SwiftLibraryIntegrationTest extends AbstractInstalledToolChainIntegrationS
             library.binaries.getByName('mainDebug').configure {
                 compileTask.get().objectFileDir = layout.buildDirectory.dir("object-files")
                 compileTask.get().moduleFile = layout.buildDirectory.file("some-lib.swiftmodule")
-                linkTask.get().binaryFile = layout.buildDirectory.file("some-lib/main.bin")
+                linkTask.get().linkedFile = layout.buildDirectory.file("some-lib/main.bin")
             }
          """
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/plugins/internal/AssembleTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/plugins/internal/AssembleTaskConfig.java
@@ -58,8 +58,8 @@ public class AssembleTaskConfig implements SourceTransformTaskConfig {
     private void configureAssembleTask(Assemble task, final NativeBinarySpecInternal binary, final LanguageSourceSetInternal sourceSet) {
         task.setDescription("Assembles the " + sourceSet + " of " + binary);
 
-        task.setToolChain(binary.getToolChain());
-        task.setTargetPlatform(binary.getTargetPlatform());
+        task.getToolChain().set(binary.getToolChain());
+        task.getTargetPlatform().set(binary.getTargetPlatform());
 
         task.source(sourceSet.getSource());
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
@@ -18,6 +18,8 @@ package org.gradle.language.assembler.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -50,19 +52,24 @@ import java.util.concurrent.Callable;
 public class Assemble extends DefaultTask {
     private ConfigurableFileCollection source;
     private ConfigurableFileCollection includes;
-    private NativeToolChainInternal toolChain;
-    private NativePlatformInternal targetPlatform;
+    private final Property<NativePlatform> targetPlatform;
+    private final Property<NativeToolChain> toolChain;
     private File objectFileDir;
     private List<String> assemblerArgs;
 
     @Inject
     public Assemble() {
+        ObjectFactory objectFactory = getProject().getObjects();
         source = getProject().files();
         includes = getProject().files();
+        this.targetPlatform = objectFactory.property(NativePlatform.class);
+        this.toolChain = objectFactory.property(NativeToolChain.class);
         getInputs().property("outputType", new Callable<String>() {
             @Override
             public String call() throws Exception {
-                return NativeToolChainInternal.Identifier.identify(toolChain, targetPlatform);
+                NativeToolChainInternal nativeToolChain = (NativeToolChainInternal) toolChain.get();
+                NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
+                return NativeToolChainInternal.Identifier.identify(nativeToolChain, nativePlatform);
             }
         });
     }
@@ -88,7 +95,9 @@ public class Assemble extends DefaultTask {
         spec.args(getAssemblerArgs());
         spec.setOperationLogger(operationLogger);
 
-        Compiler<AssembleSpec> compiler = toolChain.select(targetPlatform).newCompiler(AssembleSpec.class);
+        NativeToolChainInternal nativeToolChain = (NativeToolChainInternal) toolChain.get();
+        NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
+        Compiler<AssembleSpec> compiler = nativeToolChain.select(nativePlatform).newCompiler(AssembleSpec.class);
         WorkResult result = BuildOperationLoggingCompilerDecorator.wrap(compiler).execute(spec);
         setDidWork(result.getDidWork());
     }
@@ -119,27 +128,23 @@ public class Assemble extends DefaultTask {
     }
 
     /**
-     * The tool chain being used to build.
+     * The tool chain used for compilation.
+     *
+     * @since 4.6
      */
     @Internal
-    public NativeToolChain getToolChain() {
+    public Property<NativeToolChain> getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(NativeToolChain toolChain) {
-        this.toolChain = (NativeToolChainInternal) toolChain;
-    }
-
     /**
-     * The platform being targeted.
+     * The platform being compiled for.
+     *
+     * @since 4.6
      */
     @Nested
-    public NativePlatform getTargetPlatform() {
+    public Property<NativePlatform> getTargetPlatform() {
         return targetPlatform;
-    }
-
-    public void setTargetPlatform(NativePlatform targetPlatform) {
-        this.targetPlatform = (NativePlatformInternal) targetPlatform;
     }
 
     /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
@@ -130,7 +130,7 @@ public class Assemble extends DefaultTask {
     /**
      * The tool chain used for compilation.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -140,7 +140,7 @@ public class Assemble extends DefaultTask {
     /**
      * The platform being compiled for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -103,8 +103,8 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
                 if (binary.isOptimized()) {
                     compile.setOptimized(true);
                 }
-                compile.setTargetPlatform(currentPlatform);
-                compile.setToolChain(toolChain);
+                compile.getTargetPlatform().set(currentPlatform);
+                compile.getToolChain().set(toolChain);
                 compile.getObjectFileDir().set(buildDirectory.dir("obj/" + names.getDirName()));
 
                 binary.getObjectsDir().set(compile.getObjectFileDir());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
@@ -77,8 +77,8 @@ public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
     }
 
     private void configureCompileTaskCommon(AbstractNativeCompileTask task, final NativeBinarySpecInternal binary, final LanguageSourceSetInternal sourceSet) {
-        task.setToolChain(binary.getToolChain());
-        task.setTargetPlatform(binary.getTargetPlatform());
+        task.getToolChain().set(binary.getToolChain());
+        task.getTargetPlatform().set(binary.getTargetPlatform());
         task.setPositionIndependentCode(binary instanceof SharedLibraryBinarySpec);
 
         task.includes(((HeaderExportingSourceSet) sourceSet).getExportedHeaders().getSourceDirectories());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompilerBuilder.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompilerBuilder.java
@@ -18,17 +18,15 @@ package org.gradle.language.nativeplatform.internal.incremental;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
-import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 
 public interface IncrementalCompilerBuilder {
-    IncrementalCompiler newCompiler(TaskInternal task, FileCollection sourceFiles, FileCollection includeDirs);
+    IncrementalCompiler newCompiler(TaskInternal task, FileCollection sourceFiles, FileCollection includeDirs, Provider<Boolean> importAware);
 
     interface IncrementalCompiler {
         <T extends NativeCompileSpec> Compiler<T> createCompiler(Compiler<T> compiler);
-
-        void setToolChain(NativeToolChainInternal toolChain);
 
         /**
          * Returns a file collection that contains the header files required by the source files.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -151,7 +151,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     /**
      * The tool chain used for compilation.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -161,7 +161,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     /**
      * The platform being compiled for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
@@ -92,8 +92,8 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
     @Optional
     @Nested
     protected CompilerVersion getCompilerVersion() {
-        NativeToolChainInternal toolChain = (NativeToolChainInternal) getToolChain();
-        NativePlatformInternal targetPlatform = (NativePlatformInternal) getTargetPlatform();
+        NativeToolChainInternal toolChain = (NativeToolChainInternal) getToolChain().get();
+        NativePlatformInternal targetPlatform = (NativePlatformInternal) getTargetPlatform().get();
         PlatformToolProvider toolProvider = toolChain.select(targetPlatform);
         Compiler<? extends NativeCompileSpec> compiler = toolProvider.newCompiler(createCompileSpec().getClass());
         if (!(compiler instanceof VersionAwareCompiler)) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -182,7 +182,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 })));
                 link.getTargetPlatform().set(targetPlatform);
                 link.getToolChain().set(toolChain);
-                link.isDebuggable().set(executable.isDebuggable());
+                link.getDebuggable().set(executable.isDebuggable());
 
                 executable.getLinkTask().set(link);
                 executable.getDebuggerExecutableFile().set(link.getLinkedFile());
@@ -251,7 +251,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 link.getLinkedFile().set(runtimeFile);
                 link.getTargetPlatform().set(targetPlatform);
                 link.getToolChain().set(toolChain);
-                link.isDebuggable().set(library.isDebuggable());
+                link.getDebuggable().set(library.isDebuggable());
 
                 Provider<RegularFile> linkFile = link.getLinkedFile();
                 runtimeFile = link.getLinkedFile();

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -215,7 +215,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 install.getTargetPlatform().set(targetPlatform);
                 install.getToolChain().set(toolChain);
                 install.getInstallDirectory().set(buildDirectory.dir("install/" + names.getDirName()));
-                install.getSourceFile().set(executable.getExecutableFile());
+                install.getExecutableFile().set(executable.getExecutableFile());
                 install.lib(executable.getRuntimeLibraries());
 
                 executable.getInstallTask().set(install);

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -174,17 +174,18 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 link.source(executable.getObjects());
                 link.lib(executable.getLinkLibraries());
                 final PlatformToolProvider toolProvider = executable.getPlatformToolProvider();
-                link.setOutputFile(buildDirectory.file(providers.provider(new Callable<String>() {
+                link.getLinkedFile().set(buildDirectory.file(providers.provider(new Callable<String>() {
                     @Override
                     public String call() {
                         return toolProvider.getExecutableName("exe/" + names.getDirName() + executable.getBaseName().get());
                     }
                 })));
-                link.setTargetPlatform(targetPlatform);
-                link.setToolChain(toolChain);
-                link.setDebuggable(executable.isDebuggable());
+                link.getTargetPlatform().set(targetPlatform);
+                link.getToolChain().set(toolChain);
+                link.isDebuggable().set(executable.isDebuggable());
 
                 executable.getLinkTask().set(link);
+                executable.getDebuggerExecutableFile().set(link.getLinkedFile());
 
                 if (executable.isDebuggable() && executable.isOptimized() && toolProvider.requiresDebugBinaryStripping()) {
                     Provider<RegularFile> symbolLocation = buildDirectory.file(providers.provider(new Callable<String>() {
@@ -204,15 +205,15 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                     ExtractSymbols extractSymbols = extractSymbols(link, names, tasks, toolChain, targetPlatform, symbolLocation);
                     executable.getOutputs().from(extractSymbols.getSymbolFile());
                 } else {
-                    executable.getExecutableFile().set(link.getBinaryFile());
+                    executable.getExecutableFile().set(link.getLinkedFile());
                 }
 
                 // Add an install task
                 // TODO - should probably not add this for all executables?
                 // TODO - add stripped symbols to the installation
                 final InstallExecutable install = tasks.create(names.getTaskName("install"), InstallExecutable.class);
-                install.setPlatform(link.getTargetPlatform());
-                install.setToolChain(link.getToolChain());
+                install.getTargetPlatform().set(targetPlatform);
+                install.getToolChain().set(toolChain);
                 install.getInstallDirectory().set(buildDirectory.dir("install/" + names.getDirName()));
                 install.getSourceFile().set(executable.getExecutableFile());
                 install.lib(executable.getRuntimeLibraries());
@@ -247,13 +248,13 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                         return toolProvider.getSharedLibraryName("lib/" + names.getDirName() + library.getBaseName().get());
                     }
                 }));
-                link.setOutputFile(runtimeFile);
-                link.setTargetPlatform(targetPlatform);
-                link.setToolChain(toolChain);
-                link.setDebuggable(library.isDebuggable());
+                link.getLinkedFile().set(runtimeFile);
+                link.getTargetPlatform().set(targetPlatform);
+                link.getToolChain().set(toolChain);
+                link.isDebuggable().set(library.isDebuggable());
 
-                Provider<RegularFile> linkFile = link.getBinaryFile();
-                runtimeFile = link.getBinaryFile();
+                Provider<RegularFile> linkFile = link.getLinkedFile();
+                runtimeFile = link.getLinkedFile();
 
                 if (toolProvider.producesImportLibrary()) {
                     Provider<RegularFile> importLibrary = buildDirectory.file(providers.provider(new Callable<String>() {
@@ -294,7 +295,7 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
             }
         });
     }
-    
+
     private void addTasksForComponentWithStaticLibrary(final TaskContainer tasks, final ProviderFactory providers, final DirectoryProperty buildDirectory, SoftwareComponentContainer components) {
         components.withType(ConfigurableComponentWithStaticLibrary.class, new Action<ConfigurableComponentWithStaticLibrary>() {
             @Override
@@ -305,15 +306,15 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
                 final CreateStaticLibrary createTask = tasks.create(names.getTaskName("create"), CreateStaticLibrary.class);
                 createTask.source(library.getObjects());
                 final PlatformToolProvider toolProvider = library.getPlatformToolProvider();
-                Provider<RegularFile> runtimeFile = buildDirectory.file(providers.provider(new Callable<String>() {
+                Provider<RegularFile> linktimeFile = buildDirectory.file(providers.provider(new Callable<String>() {
                     @Override
                     public String call() {
                         return toolProvider.getStaticLibraryName("lib/" + names.getDirName() + library.getBaseName().get());
                     }
                 }));
-                createTask.setOutputFile(runtimeFile);
-                createTask.setTargetPlatform(library.getTargetPlatform());
-                createTask.setToolChain(library.getToolChain());
+                createTask.getOutputFile().set(linktimeFile);
+                createTask.getTargetPlatform().set(library.getTargetPlatform());
+                createTask.getToolChain().set(library.getToolChain());
 
                 // Wire the task into the library model
                 library.getLinkFile().set(createTask.getBinaryFile());
@@ -419,20 +420,20 @@ public class NativeBasePlugin implements Plugin<ProjectInternal> {
 
     private StripSymbols stripSymbols(AbstractLinkTask link, Names names, TaskContainer tasks, NativeToolChain toolChain, NativePlatform currentPlatform, Provider<RegularFile> strippedLocation) {
         StripSymbols stripSymbols = tasks.create(names.getTaskName("stripSymbols"), StripSymbols.class);
-        stripSymbols.getBinaryFile().set(link.getBinaryFile());
+        stripSymbols.getBinaryFile().set(link.getLinkedFile());
         stripSymbols.getOutputFile().set(strippedLocation);
-        stripSymbols.setTargetPlatform(currentPlatform);
-        stripSymbols.setToolChain(toolChain);
+        stripSymbols.getTargetPlatform().set(currentPlatform);
+        stripSymbols.getToolChain().set(toolChain);
 
         return stripSymbols;
     }
 
     private ExtractSymbols extractSymbols(AbstractLinkTask link, Names names, TaskContainer tasks, NativeToolChain toolChain, NativePlatform currentPlatform, Provider<RegularFile> symbolLocation) {
         ExtractSymbols extractSymbols = tasks.create(names.getTaskName("extractSymbols"), ExtractSymbols.class);
-        extractSymbols.getBinaryFile().set(link.getBinaryFile());
+        extractSymbols.getBinaryFile().set(link.getLinkedFile());
         extractSymbols.getSymbolFile().set(symbolLocation);
-        extractSymbols.setTargetPlatform(currentPlatform);
-        extractSymbols.setToolChain(toolChain);
+        extractSymbols.getTargetPlatform().set(currentPlatform);
+        extractSymbols.getToolChain().set(toolChain);
 
         return extractSymbols;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/plugins/internal/WindowsResourcesCompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/plugins/internal/WindowsResourcesCompileTaskConfig.java
@@ -61,8 +61,8 @@ public class WindowsResourcesCompileTaskConfig implements SourceTransformTaskCon
     private void configureResourceCompileTask(WindowsResourceCompile task, final NativeBinarySpecInternal binary, final WindowsResourceSet sourceSet) {
         task.setDescription("Compiles resources of the " + sourceSet + " of " + binary);
 
-        task.setToolChain(binary.getToolChain());
-        task.setTargetPlatform(binary.getTargetPlatform());
+        task.getToolChain().set(binary.getToolChain());
+        task.getTargetPlatform().set(binary.getTargetPlatform());
 
         task.includes(sourceSet.getExportedHeaders().getSourceDirectories());
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -75,7 +76,7 @@ public class WindowsResourceCompile extends DefaultTask {
         source = getProject().files();
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
-        incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes);
+        incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes, Providers.FALSE);
         getInputs().property("outputType", new Callable<String>() {
             @Override
             public String call() throws Exception {

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -19,6 +19,8 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -58,8 +60,8 @@ import java.util.concurrent.Callable;
 @Incubating
 public class WindowsResourceCompile extends DefaultTask {
 
-    private NativeToolChainInternal toolChain;
-    private NativePlatformInternal targetPlatform;
+    private final Property<NativePlatform> targetPlatform;
+    private final Property<NativeToolChain> toolChain;
     private File outputDir;
     private ConfigurableFileCollection includes;
     private ConfigurableFileCollection source;
@@ -68,13 +70,18 @@ public class WindowsResourceCompile extends DefaultTask {
     private final IncrementalCompilerBuilder.IncrementalCompiler incrementalCompiler;
 
     public WindowsResourceCompile() {
+        ObjectFactory objectFactory = getProject().getObjects();
         includes = getProject().files();
         source = getProject().files();
+        this.targetPlatform = objectFactory.property(NativePlatform.class);
+        this.toolChain = objectFactory.property(NativeToolChain.class);
         incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes);
         getInputs().property("outputType", new Callable<String>() {
             @Override
             public String call() throws Exception {
-                return NativeToolChainInternal.Identifier.identify(toolChain, targetPlatform);
+                NativeToolChainInternal nativeToolChain = (NativeToolChainInternal) toolChain.get();
+                NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
+                return NativeToolChainInternal.Identifier.identify(nativeToolChain, nativePlatform);
             }
         });
     }
@@ -103,7 +110,9 @@ public class WindowsResourceCompile extends DefaultTask {
         spec.setIncrementalCompile(inputs.isIncremental());
         spec.setOperationLogger(operationLogger);
 
-        PlatformToolProvider platformToolProvider = toolChain.select(targetPlatform);
+        NativeToolChainInternal nativeToolChain = (NativeToolChainInternal) toolChain.get();
+        NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
+        PlatformToolProvider platformToolProvider = nativeToolChain.select(nativePlatform);
         WorkResult result = doCompile(spec, platformToolProvider);
         setDidWork(result.getDidWork());
     }
@@ -118,26 +127,22 @@ public class WindowsResourceCompile extends DefaultTask {
 
     /**
      * The tool chain used for compilation.
+     *
+     * @since 4.6
      */
     @Internal
-    public NativeToolChain getToolChain() {
+    public Property<NativeToolChain> getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(NativeToolChain toolChain) {
-        this.toolChain = (NativeToolChainInternal) toolChain;
-    }
-
     /**
-     * The platform being targeted.
+     * The platform being compiled for.
+     *
+     * @since 4.6
      */
     @Nested
-    public NativePlatform getTargetPlatform() {
+    public Property<NativePlatform> getTargetPlatform() {
         return targetPlatform;
-    }
-
-    public void setTargetPlatform(NativePlatform targetPlatform) {
-        this.targetPlatform = (NativePlatformInternal) targetPlatform;
     }
 
     /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -129,7 +129,7 @@ public class WindowsResourceCompile extends DefaultTask {
     /**
      * The tool chain used for compilation.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -139,7 +139,7 @@ public class WindowsResourceCompile extends DefaultTask {
     /**
      * The platform being compiled for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -39,8 +39,6 @@ import org.gradle.language.swift.SwiftVersion;
 import org.gradle.language.swift.internal.DefaultSwiftBinary;
 import org.gradle.language.swift.internal.DefaultSwiftComponent;
 import org.gradle.language.swift.tasks.SwiftCompile;
-import org.gradle.nativeplatform.platform.NativePlatform;
-import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.nativeplatform.toolchain.internal.xcode.MacOSSdkPathLocator;
 import org.gradle.nativeplatform.toolchain.plugins.SwiftCompilerPlugin;
@@ -104,12 +102,10 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                 compile.getSourceCompatibility().set(binary.getSourceCompatibility());
                 binary.getModuleFile().set(compile.getModuleFile());
 
-                NativePlatform currentPlatform = binary.getTargetPlatform();
-                compile.setTargetPlatform(currentPlatform);
+                compile.getTargetPlatform().set(binary.getTargetPlatform());
 
                 // TODO - make this lazy
-                NativeToolChainInternal toolChain = binary.getToolChain();
-                compile.setToolChain(toolChain);
+                compile.getToolChain().set(binary.getToolChain());
 
                 binary.getCompileTask().set(compile);
                 binary.getObjectsDir().set(compile.getObjectFileDir());

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -82,8 +82,8 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                 SwiftCompile compile = tasks.create(names.getCompileTaskName("swift"), SwiftCompile.class);
                 compile.getModules().from(binary.getCompileModules());
                 compile.getSource().from(binary.getSwiftSource());
-                compile.isDebuggable().set(binary.isDebuggable());
-                compile.isOptimized().set(binary.isOptimized());
+                compile.getDebuggable().set(binary.isDebuggable());
+                compile.getOptimized().set(binary.isOptimized());
                 if (binary.isTestable()) {
                     compile.getCompilerArgs().add("-enable-testing");
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -84,12 +84,8 @@ public class SwiftBasePlugin implements Plugin<ProjectInternal> {
                 SwiftCompile compile = tasks.create(names.getCompileTaskName("swift"), SwiftCompile.class);
                 compile.getModules().from(binary.getCompileModules());
                 compile.getSource().from(binary.getSwiftSource());
-                if (binary.isDebuggable()) {
-                    compile.setDebuggable(true);
-                }
-                if (binary.isOptimized()) {
-                    compile.setOptimized(true);
-                }
+                compile.isDebuggable().set(binary.isDebuggable());
+                compile.isOptimized().set(binary.isOptimized());
                 if (binary.isTestable()) {
                     compile.getCompilerArgs().add("-enable-testing");
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -84,7 +84,7 @@ public class SwiftCompile extends DefaultTask {
     private final ConfigurableFileCollection source;
     private final Property<SwiftVersion> sourceCompatibility;
     private final ListProperty<String> macros;
-    private final Property<Boolean> debug;
+    private final Property<Boolean> debuggable;
     private final Property<Boolean> optimize;
     private final Property<NativePlatform> targetPlatform;
     private final Property<NativeToolChain> toolChain;
@@ -104,7 +104,7 @@ public class SwiftCompile extends DefaultTask {
         this.source = getProject().files();
         this.sourceCompatibility = objectFactory.property(SwiftVersion.class);
         this.macros = objectFactory.listProperty(String.class);
-        this.debug = objectFactory.property(Boolean.class);
+        this.debuggable = objectFactory.property(Boolean.class);
         this.optimize = objectFactory.property(Boolean.class);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
@@ -159,9 +159,29 @@ public class SwiftCompile extends DefaultTask {
      *
      * @since 4.6
      */
+    @Internal
+    public boolean isDebuggable() {
+        return debuggable.get();
+    }
+
+    /**
+     * Should the compiler generate debuggable code?
+     *
+     * @since 4.6
+     */
     @Input
-    public Property<Boolean> isDebuggable() {
-        return debug;
+    public Property<Boolean> getDebuggable() {
+        return debuggable;
+    }
+
+    /**
+     * Should the compiler generate debuggable code?
+     *
+     * @since 4.6
+     */
+    @Internal
+    public boolean isOptimized() {
+        return optimize.get();
     }
 
     /**
@@ -170,7 +190,7 @@ public class SwiftCompile extends DefaultTask {
      * @since 4.6
      */
     @Input
-    public Property<Boolean> isOptimized() {
+    public Property<Boolean> getOptimized() {
         return optimize;
     }
 
@@ -321,8 +341,8 @@ public class SwiftCompile extends DefaultTask {
         }
         spec.setMacros(macros);
         spec.args(getCompilerArgs().get());
-        spec.setDebuggable(isDebuggable().get());
-        spec.setOptimized(isOptimized().get());
+        spec.setDebuggable(getDebuggable().get());
+        spec.setOptimized(getOptimized().get());
         spec.setIncrementalCompile(isIncremental);
         spec.setOperationLogger(operationLogger);
         spec.setSourceCompatibility(sourceCompatibility.get());

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -113,7 +113,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * The tool chain used for compilation.
      *
-     * @since 4.4
+     * @since 4.6
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -123,7 +123,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * The platform being compiled for.
      *
-     * @since 4.4
+     * @since 4.6
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -113,7 +113,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * The tool chain used for compilation.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -123,7 +123,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * The platform being compiled for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {
@@ -147,7 +147,7 @@ public class SwiftCompile extends DefaultTask {
      *
      * <p>Macros do not have values in Swift; they are either present or absent.</p>
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Input
     public ListProperty<String> getMacros() {
@@ -157,7 +157,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * Should the compiler generate debuggable code?
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public boolean isDebuggable() {
@@ -167,7 +167,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * Should the compiler generate debuggable code?
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Input
     public Property<Boolean> getDebuggable() {
@@ -177,7 +177,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * Should the compiler generate debuggable code?
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public boolean isOptimized() {
@@ -187,7 +187,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * Should the compiler generate optimized code?
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Input
     public Property<Boolean> getOptimized() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
@@ -85,13 +85,13 @@ class   CppApplicationPluginTest extends Specification {
 
         def linkDebug = project.tasks.linkDebug
         linkDebug instanceof LinkExecutable
-        linkDebug.binaryFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("testApp"))
+        linkDebug.linkedFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("testApp"))
         linkDebug.debuggable
 
         def installDebug = project.tasks.installDebug
         installDebug instanceof InstallExecutable
         installDebug.installDirectory.get().asFile == projectDir.file("build/install/main/debug")
-        installDebug.runScript.name == OperatingSystem.current().getScriptName("testApp")
+        installDebug.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("testApp")
 
         def compileReleaseCpp = project.tasks.compileReleaseCpp
         compileReleaseCpp instanceof CppCompile
@@ -103,13 +103,13 @@ class   CppApplicationPluginTest extends Specification {
 
         def linkRelease = project.tasks.linkRelease
         linkRelease instanceof LinkExecutable
-        linkRelease.binaryFile.get().asFile == projectDir.file("build/exe/main/release/" + OperatingSystem.current().getExecutableName("testApp"))
+        linkRelease.linkedFile.get().asFile == projectDir.file("build/exe/main/release/" + OperatingSystem.current().getExecutableName("testApp"))
         linkRelease.debuggable
 
         def installRelease = project.tasks.installRelease
         installRelease instanceof InstallExecutable
         installRelease.installDirectory.get().asFile == projectDir.file("build/install/main/release")
-        installRelease.runScript.name == OperatingSystem.current().getScriptName("testApp")
+        installRelease.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("testApp")
     }
 
     def "output locations are calculated using base name defined on extension"() {
@@ -120,11 +120,11 @@ class   CppApplicationPluginTest extends Specification {
 
         then:
         def link = project.tasks.linkDebug
-        link.binaryFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("test_app"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("test_app"))
 
         def install = project.tasks.installDebug
         install.installDirectory.get().asFile == projectDir.file("build/install/main/debug")
-        install.runScript.name == OperatingSystem.current().getScriptName("test_app")
+        install.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("test_app")
     }
 
     def "output locations reflects changes to buildDir"() {
@@ -140,14 +140,14 @@ class   CppApplicationPluginTest extends Specification {
         compileCpp.objectFileDir.get().asFile == project.file("output/obj/main/debug")
 
         def link = project.tasks.linkDebug
-        link.outputFile == projectDir.file("output/exe/main/debug/" + OperatingSystem.current().getExecutableName("testApp"))
+        link.linkedFile.get().asFile == projectDir.file("output/exe/main/debug/" + OperatingSystem.current().getExecutableName("testApp"))
 
         def install = project.tasks.installDebug
-        install.destinationDir == project.file("output/install/main/debug")
-        install.executable == link.outputFile
+        install.installDirectory.get().asFile == project.file("output/install/main/debug")
+        install.executableFile.get().asFile == link.linkedFile.get().asFile
 
-        link.setOutputFile(project.file("exe"))
-        install.executable == link.outputFile
+        link.linkedFile.set(project.file("exe"))
+        install.executableFile.get().asFile == project.file("exe")
     }
 
     def "adds publications when maven-publish plugin is applied"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
@@ -91,7 +91,7 @@ class CppBasePluginTest extends Specification {
         then:
         def link = project.tasks[linkTask]
         link instanceof LinkExecutable
-        link.binaryFile.get().asFile == projectDir.file("build/exe/$exeDir" + OperatingSystem.current().getExecutableName("test_app"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/$exeDir" + OperatingSystem.current().getExecutableName("test_app"))
 
         def install = project.tasks[installTask]
         install instanceof InstallExecutable
@@ -123,7 +123,7 @@ class CppBasePluginTest extends Specification {
         then:
         def link = project.tasks[taskName]
         link instanceof LinkSharedLibrary
-        link.binaryFile.get().asFile == projectDir.file("build/lib/${libDir}" + OperatingSystem.current().getSharedLibraryName("test_lib"))
+        link.linkedFile.get().asFile == projectDir.file("build/lib/${libDir}" + OperatingSystem.current().getSharedLibraryName("test_lib"))
 
         where:
         name        | taskName        | libDir

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
@@ -171,7 +171,7 @@ class CppLibraryPluginTest extends Specification {
 
         def linkDebug = project.tasks.linkDebugShared
         linkDebug instanceof LinkSharedLibrary
-        linkDebug.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/shared/" + OperatingSystem.current().getSharedLibraryName("testLib"))
+        linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/shared/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkDebug.debuggable
 
         def compileRelease = project.tasks.compileReleaseSharedCpp
@@ -183,7 +183,7 @@ class CppLibraryPluginTest extends Specification {
 
         def linkRelease = project.tasks.linkReleaseShared
         linkRelease instanceof LinkSharedLibrary
-        linkRelease.binaryFile.get().asFile == projectDir.file("build/lib/main/release/shared/" + OperatingSystem.current().getSharedLibraryName("testLib"))
+        linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/shared/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkRelease.debuggable
 
         and:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
@@ -135,7 +135,7 @@ class CppLibraryPluginTest extends Specification {
 
         def linkDebug = project.tasks.linkDebug
         linkDebug instanceof LinkSharedLibrary
-        linkDebug.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("testLib"))
+        linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkDebug.debuggable
 
         def compileReleaseCpp = project.tasks.compileReleaseCpp
@@ -148,7 +148,7 @@ class CppLibraryPluginTest extends Specification {
 
         def linkRelease = project.tasks.linkRelease
         linkRelease instanceof LinkSharedLibrary
-        linkRelease.binaryFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getSharedLibraryName("testLib"))
+        linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkRelease.debuggable
     }
 
@@ -272,7 +272,7 @@ class CppLibraryPluginTest extends Specification {
 
         then:
         def link = project.tasks.linkDebug
-        link.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("test_lib"))
+        link.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("test_lib"))
     }
 
     def "output locations reflects changes to buildDir"() {
@@ -288,7 +288,7 @@ class CppLibraryPluginTest extends Specification {
         compileCpp.objectFileDir.get().asFile == project.file("output/obj/main/debug")
 
         def link = project.tasks.linkDebug
-        link.outputFile == projectDir.file("output/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("testLib"))
+        link.linkedFile.get().asFile == projectDir.file("output/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("testLib"))
     }
 
     def "adds header zip task when maven-publish plugin is applied"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -205,10 +205,10 @@ class NativeBasePluginTest extends Specification {
         expect:
         def linkTask = project.tasks['linkWindowsDebug']
         linkTask instanceof LinkSharedLibrary
-        linkTask.binaryFile.get().asFile == projectDir.file("build/lib/windows/debug/test_lib.dll")
+        linkTask.linkedFile.get().asFile == projectDir.file("build/lib/windows/debug/test_lib.dll")
 
         and:
-        runtimeFileProp.get().asFile == linkTask.binaryFile.get().asFile
+        runtimeFileProp.get().asFile == linkTask.linkedFile.get().asFile
         linkTaskProp.get() == linkTask
     }
 
@@ -240,16 +240,16 @@ class NativeBasePluginTest extends Specification {
         expect:
         def linkTask = project.tasks['linkWindowsDebug']
         linkTask instanceof LinkSharedLibrary
-        linkTask.binaryFile.get().asFile == projectDir.file("build/lib/windows/debug/test_lib.dll")
+        linkTask.linkedFile.get().asFile == projectDir.file("build/lib/windows/debug/test_lib.dll")
 
         def stripTask = project.tasks['stripSymbolsWindowsDebug']
         stripTask instanceof StripSymbols
-        stripTask.binaryFile.get().asFile == linkTask.binaryFile.get().asFile
+        stripTask.binaryFile.get().asFile == linkTask.linkedFile.get().asFile
         stripTask.outputFile.get().asFile == projectDir.file("build/lib/windows/debug/stripped/test_lib.dll")
 
         def extractTask = project.tasks['extractSymbolsWindowsDebug']
         extractTask instanceof ExtractSymbols
-        extractTask.binaryFile.get().asFile == linkTask.binaryFile.get().asFile
+        extractTask.binaryFile.get().asFile == linkTask.linkedFile.get().asFile
         extractTask.symbolFile.get().asFile == projectDir.file("build/lib/windows/debug/stripped/test_lib.dll.pdb")
 
         and:
@@ -287,16 +287,21 @@ class NativeBasePluginTest extends Specification {
         expect:
         def linkTask = project.tasks['linkWindowsDebug']
         linkTask instanceof LinkExecutable
-        linkTask.binaryFile.get().asFile == projectDir.file("build/exe/windows/debug/test_app.exe")
+        linkTask.linkedFile.get().asFile == projectDir.file("build/exe/windows/debug/test_app.exe")
 
         def installTask = project.tasks['installWindowsDebug']
         installTask instanceof InstallExecutable
-        installTask.sourceFile.get().asFile == linkTask.binaryFile.get().asFile
+        installTask.executableFile.get().asFile == linkTask.linkedFile.get().asFile
         installTask.installDirectory.get().asFile == projectDir.file("build/install/windows/debug")
 
         and:
+<<<<<<< HEAD
         exeFileProp.get().asFile == linkTask.binaryFile.get().asFile
         debugExeFileProp.get().asFile == installTask.installedExecutable.get().asFile
+=======
+        exeFileProp.get().asFile == linkTask.linkedFile.get().asFile
+        debugExeFileProp.get().asFile == linkTask.linkedFile.get().asFile
+>>>>>>> Fix test failures
         linkTaskProp.get() == linkTask
 
         and:
@@ -338,26 +343,28 @@ class NativeBasePluginTest extends Specification {
         expect:
         def linkTask = project.tasks['linkWindowsDebug']
         linkTask instanceof LinkExecutable
-        linkTask.binaryFile.get().asFile == projectDir.file("build/exe/windows/debug/test_app.exe")
+        linkTask.linkedFile.get().asFile == projectDir.file("build/exe/windows/debug/test_app.exe")
 
         def stripTask = project.tasks['stripSymbolsWindowsDebug']
         stripTask instanceof StripSymbols
-        stripTask.binaryFile.get().asFile == linkTask.binaryFile.get().asFile
+        stripTask.binaryFile.get().asFile == linkTask.linkedFile.get().asFile
         stripTask.outputFile.get().asFile == projectDir.file("build/exe/windows/debug/stripped/test_app.exe")
 
         def extractTask = project.tasks['extractSymbolsWindowsDebug']
         extractTask instanceof ExtractSymbols
-        extractTask.binaryFile.get().asFile == linkTask.binaryFile.get().asFile
+        extractTask.binaryFile.get().asFile == linkTask.linkedFile.get().asFile
         extractTask.symbolFile.get().asFile == projectDir.file("build/exe/windows/debug/stripped/test_app.exe.pdb")
 
         def installTask = project.tasks['installWindowsDebug']
         installTask instanceof InstallExecutable
-        installTask.sourceFile.get().asFile == stripTask.outputFile.get().asFile
+        installTask.executableFile.get().asFile == stripTask.outputFile.get().asFile
         installTask.installDirectory.get().asFile == projectDir.file("build/install/windows/debug")
 
         and:
         exeFileProp.get().asFile == stripTask.outputFile.get().asFile
         debugExeFileProp.get().asFile == installTask.installedExecutable.get().asFile
+        debugExeFileProp.get().asFile == linkTask.linkedFile.get().asFile
+
         linkTaskProp.get() == linkTask
 
         and:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -295,13 +295,9 @@ class NativeBasePluginTest extends Specification {
         installTask.installDirectory.get().asFile == projectDir.file("build/install/windows/debug")
 
         and:
-<<<<<<< HEAD
-        exeFileProp.get().asFile == linkTask.binaryFile.get().asFile
-        debugExeFileProp.get().asFile == installTask.installedExecutable.get().asFile
-=======
         exeFileProp.get().asFile == linkTask.linkedFile.get().asFile
-        debugExeFileProp.get().asFile == linkTask.linkedFile.get().asFile
->>>>>>> Fix test failures
+        debugExeFileProp.get().asFile == installTask.installedExecutable.get().asFile
+
         linkTaskProp.get() == linkTask
 
         and:
@@ -363,7 +359,6 @@ class NativeBasePluginTest extends Specification {
         and:
         exeFileProp.get().asFile == stripTask.outputFile.get().asFile
         debugExeFileProp.get().asFile == installTask.installedExecutable.get().asFile
-        debugExeFileProp.get().asFile == linkTask.linkedFile.get().asFile
 
         linkTaskProp.get() == linkTask
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
@@ -88,13 +88,13 @@ class SwiftApplicationPluginTest extends Specification {
 
         def linkDebug = project.tasks.linkDebug
         linkDebug instanceof LinkExecutable
-        linkDebug.binaryFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("TestApp"))
+        linkDebug.linkedFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("TestApp"))
         linkDebug.debuggable
 
         def installDebug = project.tasks.installDebug
         installDebug instanceof InstallExecutable
         installDebug.installDirectory.get().asFile == projectDir.file("build/install/main/debug")
-        installDebug.runScript.name == OperatingSystem.current().getScriptName("TestApp")
+        installDebug.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("TestApp")
 
         def compileRelease = project.tasks.compileReleaseSwift
         compileRelease instanceof SwiftCompile
@@ -106,13 +106,13 @@ class SwiftApplicationPluginTest extends Specification {
 
         def linkRelease = project.tasks.linkRelease
         linkRelease instanceof LinkExecutable
-        linkRelease.binaryFile.get().asFile == projectDir.file("build/exe/main/release/" + OperatingSystem.current().getExecutableName("TestApp"))
+        linkRelease.linkedFile.get().asFile == projectDir.file("build/exe/main/release/" + OperatingSystem.current().getExecutableName("TestApp"))
         linkRelease.debuggable
 
         def installRelease = project.tasks.installRelease
         installRelease instanceof InstallExecutable
         installRelease.installDirectory.get().asFile == projectDir.file("build/install/main/release")
-        installRelease.runScript.name == OperatingSystem.current().getScriptName("TestApp")
+        installRelease.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("TestApp")
     }
 
     def "output file names are calculated from module name defined on extension"() {
@@ -127,11 +127,11 @@ class SwiftApplicationPluginTest extends Specification {
         compileSwift.moduleFile.get().asFile == projectDir.file("build/modules/main/debug/App.swiftmodule")
 
         def link = project.tasks.linkDebug
-        link.binaryFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("App"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("App"))
 
         def install = project.tasks.installDebug
         install.installDirectory.get().asFile == projectDir.file("build/install/main/debug")
-        install.runScript.name == OperatingSystem.current().getScriptName("App")
+        install.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("App")
     }
 
     def "output locations reflects changes to buildDir"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
@@ -148,13 +148,13 @@ class SwiftApplicationPluginTest extends Specification {
         compileSwift.moduleFile.get().asFile == projectDir.file("output/modules/main/debug/TestApp.swiftmodule")
 
         def link = project.tasks.linkDebug
-        link.outputFile == projectDir.file("output/exe/main/debug/" + OperatingSystem.current().getExecutableName("TestApp"))
+        link.linkedFile.get().asFile == projectDir.file("output/exe/main/debug/" + OperatingSystem.current().getExecutableName("TestApp"))
 
         def install = project.tasks.installDebug
-        install.destinationDir == project.file("output/install/main/debug")
-        install.executable == link.outputFile
+        install.installDirectory.get().asFile == project.file("output/install/main/debug")
+        install.executableFile.get().asFile == link.linkedFile.get().asFile
 
-        link.setOutputFile(project.file("exe"))
-        install.executable == link.outputFile
+        link.linkedFile.set(project.file("exe"))
+        install.executableFile.get().asFile == link.linkedFile.get().asFile
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -99,7 +99,7 @@ class SwiftBasePluginTest extends Specification {
         then:
         def link = project.tasks[linkTask]
         link instanceof LinkExecutable
-        link.binaryFile.get().asFile == projectDir.file("build/exe/$exeDir" + OperatingSystem.current().getExecutableName("test_app"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/$exeDir" + OperatingSystem.current().getExecutableName("test_app"))
 
         def install = project.tasks[installTask]
         install instanceof InstallExecutable
@@ -131,7 +131,7 @@ class SwiftBasePluginTest extends Specification {
         then:
         def link = project.tasks[taskName]
         link instanceof LinkSharedLibrary
-        link.binaryFile.get().asFile == projectDir.file("build/lib/${libDir}" + OperatingSystem.current().getSharedLibraryName("test_lib"))
+        link.linkedFile.get().asFile == projectDir.file("build/lib/${libDir}" + OperatingSystem.current().getSharedLibraryName("test_lib"))
 
         where:
         name        | taskName        | libDir

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
@@ -298,6 +298,6 @@ class SwiftLibraryPluginTest extends Specification {
         compileSwift.moduleFile.get().asFile == projectDir.file("output/modules/main/debug/TestLib.swiftmodule")
 
         def link = project.tasks.linkDebug
-        link.outputFile == projectDir.file("output/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
+        link.linkedFile.get().asFile == projectDir.file("output/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
@@ -134,7 +134,7 @@ class SwiftLibraryPluginTest extends Specification {
 
         def linkDebug = project.tasks.linkDebug
         linkDebug instanceof LinkSharedLibrary
-        linkDebug.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
+        linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkDebug.debuggable
 
         def compileRelease = project.tasks.compileReleaseSwift
@@ -147,7 +147,7 @@ class SwiftLibraryPluginTest extends Specification {
 
         def linkRelease = project.tasks.linkRelease
         linkRelease instanceof LinkSharedLibrary
-        linkRelease.binaryFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
+        linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkRelease.debuggable
     }
 
@@ -171,7 +171,7 @@ class SwiftLibraryPluginTest extends Specification {
 
         def linkDebug = project.tasks.linkDebugShared
         linkDebug instanceof LinkSharedLibrary
-        linkDebug.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/shared/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
+        linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/shared/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkDebug.debuggable
 
         def compileRelease = project.tasks.compileReleaseSharedSwift
@@ -184,7 +184,7 @@ class SwiftLibraryPluginTest extends Specification {
 
         def linkRelease = project.tasks.linkReleaseShared
         linkRelease instanceof LinkSharedLibrary
-        linkRelease.binaryFile.get().asFile == projectDir.file("build/lib/main/release/shared/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
+        linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/shared/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkRelease.debuggable
 
         and:
@@ -281,7 +281,7 @@ class SwiftLibraryPluginTest extends Specification {
         compileSwift.moduleFile.get().asFile == projectDir.file("build/modules/main/debug/Lib.swiftmodule")
 
         def link = project.tasks.linkDebug
-        link.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("Lib"))
+        link.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("Lib"))
     }
 
     def "output locations reflects changes to buildDir"() {

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
@@ -43,7 +43,7 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
                     def linkDebug = linkTask.get()
                     extract.toolChain = linkDebug.toolChain
                     extract.targetPlatform = linkDebug.targetPlatform
-                    extract.binaryFile.set linkDebug.binaryFile
+                    extract.binaryFile.set linkDebug.linkedFile
                 }
                 symbolFile.set file("build/symbols")
             }

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
@@ -43,7 +43,7 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
                     def linkDebug = linkTask.get()
                     strip.toolChain = linkDebug.toolChain
                     strip.targetPlatform = linkDebug.targetPlatform
-                    strip.binaryFile.set linkDebug.binaryFile
+                    strip.binaryFile.set linkDebug.linkedFile
                 }
                 outputFile.set file("build/stripped")
             }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/NativeExecutableFileSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/NativeExecutableFileSpec.java
@@ -18,7 +18,7 @@ package org.gradle.nativeplatform;
 
 import org.gradle.api.Incubating;
 import org.gradle.model.internal.core.UnmanagedStruct;
-import org.gradle.platform.base.ToolChain;
+import org.gradle.nativeplatform.toolchain.NativeToolChain;
 
 import java.io.File;
 
@@ -31,7 +31,7 @@ import java.io.File;
 public class NativeExecutableFileSpec {
 
     private File file;
-    private ToolChain toolChain;
+    private NativeToolChain toolChain;
 
     public File getFile() {
         return file;
@@ -41,11 +41,19 @@ public class NativeExecutableFileSpec {
         this.file = file;
     }
 
-    public ToolChain getToolChain() {
+    /**
+     * The Tool Chain that produces the native executable.
+     * @since 4.6
+     */
+    public NativeToolChain getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(ToolChain toolChain) {
+    /**
+     * Sets the Tool Chain that produces the native executable.
+     * @since 4.6
+     */
+    public void setToolChain(NativeToolChain toolChain) {
         this.toolChain = toolChain;
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/NativeExecutableFileSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/NativeExecutableFileSpec.java
@@ -43,7 +43,7 @@ public class NativeExecutableFileSpec {
 
     /**
      * The Tool Chain that produces the native executable.
-     * @since 4.6
+     * @since 4.7
      */
     public NativeToolChain getToolChain() {
         return toolChain;
@@ -51,7 +51,7 @@ public class NativeExecutableFileSpec {
 
     /**
      * Sets the Tool Chain that produces the native executable.
-     * @since 4.6
+     * @since 4.7
      */
     public void setToolChain(NativeToolChain toolChain) {
         this.toolChain = toolChain;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/NativeComponents.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/NativeComponents.java
@@ -81,7 +81,7 @@ public class NativeComponents {
                 installTask.setGroup(LifecycleBasePlugin.BUILD_GROUP);
                 installTask.getToolChain().set(executable.getToolChain());
                 installTask.getTargetPlatform().set(binary.getTargetPlatform());
-                installTask.getSourceFile().set(executable.getFile());
+                installTask.getExecutableFile().set(executable.getFile());
                 installTask.getInstallDirectory().set(installation.getDirectory());
                 //TODO:HH wire binary libs via executable
                 installTask.lib(new BinaryLibs(binary) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/NativeComponents.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/NativeComponents.java
@@ -57,9 +57,9 @@ public class NativeComponents {
             @Override
             public void execute(LinkExecutable linkTask) {
                 linkTask.setDescription("Links " + binary.getDisplayName());
-                linkTask.setToolChain(binary.getToolChain());
-                linkTask.setTargetPlatform(binary.getTargetPlatform());
-                linkTask.setOutputFile(executableFile);
+                linkTask.getToolChain().set(binary.getToolChain());
+                linkTask.getTargetPlatform().set(binary.getTargetPlatform());
+                linkTask.getLinkedFile().set(executableFile);
                 linkTask.getLinkerArgs().set(binary.getLinker().getArgs());
 
                 linkTask.lib(new BinaryLibs(binary) {
@@ -79,8 +79,8 @@ public class NativeComponents {
             public void execute(InstallExecutable installTask) {
                 installTask.setDescription("Installs a development image of " + binary.getDisplayName());
                 installTask.setGroup(LifecycleBasePlugin.BUILD_GROUP);
-                installTask.setToolChain(executable.getToolChain());
-                installTask.setPlatform(binary.getTargetPlatform());
+                installTask.getToolChain().set(executable.getToolChain());
+                installTask.getTargetPlatform().set(binary.getTargetPlatform());
                 installTask.getSourceFile().set(executable.getFile());
                 installTask.getInstallDirectory().set(installation.getDirectory());
                 //TODO:HH wire binary libs via executable

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -320,9 +320,9 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
                 @Override
                 public void execute(LinkSharedLibrary linkTask) {
                     linkTask.setDescription("Links " + binary.getDisplayName());
-                    linkTask.setToolChain(binary.getToolChain());
-                    linkTask.setTargetPlatform(binary.getTargetPlatform());
-                    linkTask.setOutputFile(binary.getSharedLibraryFile());
+                    linkTask.getToolChain().set(binary.getToolChain());
+                    linkTask.getTargetPlatform().set(binary.getTargetPlatform());
+                    linkTask.getLinkedFile().set(binary.getSharedLibraryFile());
                     linkTask.setInstallName(binary.getSharedLibraryFile().getName());
                     linkTask.getLinkerArgs().set(binary.getLinker().getArgs());
                     linkTask.getImportLibrary().set(binary.getSharedLibraryLinkFile());
@@ -344,10 +344,10 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
                 @Override
                 public void execute(CreateStaticLibrary task) {
                     task.setDescription("Creates " + binary.getDisplayName());
-                    task.setToolChain(binary.getToolChain());
-                    task.setTargetPlatform(binary.getTargetPlatform());
-                    task.setOutputFile(binary.getStaticLibraryFile());
-                    task.setStaticLibArgs(binary.getStaticLibArchiver().getArgs());
+                    task.getToolChain().set(binary.getToolChain());
+                    task.getTargetPlatform().set(binary.getTargetPlatform());
+                    task.getOutputFile().set(binary.getStaticLibraryFile());
+                    task.getStaticLibArgs().set(binary.getStaticLibArchiver().getArgs());
                 }
             });
         }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -17,12 +17,16 @@ package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
+import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -35,7 +39,9 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.Cast;
 import org.gradle.internal.operations.logging.BuildOperationLogger;
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory;
+import org.gradle.language.base.compile.CompilerVersion;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.language.base.internal.compile.VersionAwareCompiler;
 import org.gradle.language.base.internal.tasks.SimpleStaleClassCleaner;
 import org.gradle.nativeplatform.internal.BuildOperationLoggingCompilerDecorator;
 import org.gradle.nativeplatform.internal.LinkerSpec;
@@ -43,97 +49,84 @@ import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
-import java.io.File;
-import java.util.concurrent.Callable;
 
 /**
  * Base task for linking a native binary from object files and libraries.
  */
 @Incubating
 public abstract class AbstractLinkTask extends DefaultTask implements ObjectFilesToBinary {
-    private NativeToolChainInternal toolChain;
-    private NativePlatformInternal targetPlatform;
-    private boolean debuggable;
-    private final RegularFileProperty outputFile;
+    private final RegularFileProperty linkedFile;
+    private final DirectoryProperty destinationDirectory;
     private final ListProperty<String> linkerArgs;
     private final ConfigurableFileCollection source;
     private final ConfigurableFileCollection libs;
+    private final Property<Boolean> debuggable;
+    private final Property<NativePlatform> targetPlatform;
+    private final Property<NativeToolChain> toolChain;
 
     public AbstractLinkTask() {
-        libs = getProject().files();
-        source = getProject().files();
-        outputFile = newOutputFile();
-        linkerArgs = getProject().getObjects().listProperty(String.class);
-        getInputs().property("outputType", new Callable<String>() {
+        ObjectFactory objectFactory = getProject().getObjects();
+        this.libs = getProject().files();
+        this.source = getProject().files();
+        this.linkedFile = newOutputFile();
+        this.destinationDirectory = newOutputDirectory();
+        destinationDirectory.set(linkedFile.map(new Transformer<Directory, RegularFile>() {
             @Override
-            public String call() throws Exception {
-                return NativeToolChainInternal.Identifier.identify(toolChain, targetPlatform);
+            public Directory transform(RegularFile regularFile) {
+                // TODO: Get rid of destinationDirectory entirely and replace it with a
+                // collection of link outputs
+                DirectoryProperty dirProp = getProject().getLayout().directoryProperty();
+                dirProp.set(regularFile.getAsFile().getParentFile());
+                return dirProp.get();
             }
-        });
+        }));
+        this.linkerArgs = getProject().getObjects().listProperty(String.class);
+        this.debuggable = objectFactory.property(Boolean.class);
+        this.targetPlatform = objectFactory.property(NativePlatform.class);
+        this.toolChain = objectFactory.property(NativeToolChain.class);
     }
 
     /**
      * The tool chain used for linking.
+     *
+     * @since 4.6
      */
     @Internal
-    public NativeToolChain getToolChain() {
+    public Property<NativeToolChain> getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(NativeToolChain toolChain) {
-        this.toolChain = (NativeToolChainInternal) toolChain;
-    }
-
     /**
-     * The platform that the linked binary will run on.
+     * The platform being linked for.
+     *
+     * @since 4.6
      */
     @Nested
-    public NativePlatform getTargetPlatform() {
+    public Property<NativePlatform> getTargetPlatform() {
         return targetPlatform;
-    }
-
-    public void setTargetPlatform(NativePlatform targetPlatform) {
-        this.targetPlatform = (NativePlatformInternal) targetPlatform;
     }
 
     /**
      * Include the destination directory as an output, to pick up auxiliary files produced alongside the main output file
+     *
+     * @since 4.6
      */
     @OutputDirectory
-    public File getDestinationDir() {
-        return getOutputFile().getParentFile();
+    public DirectoryProperty getDestinationDirectory() {
+        return destinationDirectory;
     }
 
     /**
      * The file where the linked binary will be located.
      *
-     * @since 4.1
+     * @since 4.6
      */
     @OutputFile
-    public RegularFileProperty getBinaryFile() {
-        return outputFile;
-    }
-
-    @Internal
-    public File getOutputFile() {
-        return outputFile.getAsFile().getOrNull();
-    }
-
-    public void setOutputFile(File outputFile) {
-        this.outputFile.set(outputFile);
-    }
-
-    /**
-     * Sets the output file generated by the linking process via a {@link Provider}.
-     *
-     * @param outputFile the output file provider to use
-     * @see #setOutputFile(File)
-     * @since 4.1
-     */
-    public void setOutputFile(Provider<? extends RegularFile> outputFile) {
-        this.outputFile.set(outputFile);
+    public RegularFileProperty getLinkedFile() {
+        return linkedFile;
     }
 
     /**
@@ -149,20 +142,11 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * Create a debuggable binary?
      *
-     * @since 4.3
+     * @since 4.6
      */
     @Input
-    public boolean isDebuggable() {
+    public Property<Boolean> isDebuggable() {
         return debuggable;
-    }
-
-    /**
-     * Create a debuggable binary?
-     *
-     * @since 4.3
-     */
-    public void setDebuggable(boolean debuggable) {
-        this.debuggable = debuggable;
     }
 
     /**
@@ -204,6 +188,16 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         this.libs.from(libs);
     }
 
+    /**
+     * The linker used, including the type and the version.
+     *
+     * @since 4.6
+     */
+    @Nested
+    protected CompilerVersion getCompilerVersion() {
+        return ((VersionAwareCompiler)createCompiler()).getVersion();
+    }
+
     @Inject
     public BuildOperationLoggerFactory getOperationLoggerFactory() {
         throw new UnsupportedOperationException();
@@ -212,7 +206,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     @TaskAction
     public void link() {
         SimpleStaleClassCleaner cleaner = new SimpleStaleClassCleaner(getOutputs());
-        cleaner.setDestinationDir(getDestinationDir());
+        cleaner.setDestinationDir(getDestinationDirectory().get().getAsFile());
         cleaner.execute();
 
         if (getSource().isEmpty()) {
@@ -221,22 +215,31 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         }
 
         LinkerSpec spec = createLinkerSpec();
-        spec.setTargetPlatform(getTargetPlatform());
+        spec.setTargetPlatform(getTargetPlatform().get());
         spec.setTempDir(getTemporaryDir());
-        spec.setOutputFile(getOutputFile());
+        spec.setOutputFile(getLinkedFile().get().getAsFile());
 
         spec.objectFiles(getSource());
         spec.libraries(getLibs());
         spec.args(getLinkerArgs().get());
-        spec.setDebuggable(isDebuggable());
+        spec.setDebuggable(isDebuggable().get());
 
         BuildOperationLogger operationLogger = getOperationLoggerFactory().newOperationLogger(getName(), getTemporaryDir());
         spec.setOperationLogger(operationLogger);
 
-        Compiler<LinkerSpec> compiler = Cast.uncheckedCast(toolChain.select(targetPlatform).newCompiler(spec.getClass()));
+        Compiler<LinkerSpec> compiler = createCompiler();
         compiler = BuildOperationLoggingCompilerDecorator.wrap(compiler);
         WorkResult result = compiler.execute(spec);
         setDidWork(result.getDidWork());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Compiler<LinkerSpec> createCompiler() {
+        NativePlatformInternal targetPlatform = Cast.cast(NativePlatformInternal.class, this.targetPlatform.get());
+        NativeToolChainInternal toolChain = Cast.cast(NativeToolChainInternal.class, getToolChain().get());
+        PlatformToolProvider toolProvider = toolChain.select(targetPlatform);
+        Class<LinkerSpec> linkerSpecType = (Class<LinkerSpec>) createLinkerSpec().getClass();
+        return toolProvider.newCompiler(linkerSpecType);
     }
 
     protected abstract LinkerSpec createLinkerSpec();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -144,8 +144,18 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
      *
      * @since 4.6
      */
+    @Internal
+    public boolean isDebuggable() {
+        return debuggable.get();
+    }
+
+    /**
+     * Create a debuggable binary?
+     *
+     * @since 4.6
+     */
     @Input
-    public Property<Boolean> isDebuggable() {
+    public Property<Boolean> getDebuggable() {
         return debuggable;
     }
 
@@ -222,7 +232,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         spec.objectFiles(getSource());
         spec.libraries(getLibs());
         spec.args(getLinkerArgs().get());
-        spec.setDebuggable(isDebuggable().get());
+        spec.setDebuggable(getDebuggable().get());
 
         BuildOperationLogger operationLogger = getOperationLoggerFactory().newOperationLogger(getName(), getTemporaryDir());
         spec.setOperationLogger(operationLogger);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -92,7 +92,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * The tool chain used for linking.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -102,7 +102,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * The platform being linked for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {
@@ -112,7 +112,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * Include the destination directory as an output, to pick up auxiliary files produced alongside the main output file
      *
-     * @since 4.6
+     * @since 4.7
      */
     @OutputDirectory
     public DirectoryProperty getDestinationDirectory() {
@@ -122,7 +122,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * The file where the linked binary will be located.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @OutputFile
     public RegularFileProperty getLinkedFile() {
@@ -142,7 +142,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * Create a debuggable binary?
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public boolean isDebuggable() {
@@ -152,7 +152,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * Create a debuggable binary?
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Input
     public Property<Boolean> getDebuggable() {
@@ -201,7 +201,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     /**
      * The linker used, including the type and the version.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     protected CompilerVersion getCompilerVersion() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -19,9 +19,10 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.provider.Provider;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -41,12 +42,9 @@ import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
 
 /**
  * Assembles a static library from object files.
@@ -55,20 +53,18 @@ import java.util.concurrent.Callable;
 public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBinary {
 
     private final ConfigurableFileCollection source;
-    private NativeToolChainInternal toolChain;
-    private NativePlatformInternal targetPlatform;
-    private RegularFileProperty outputFile;
-    private List<String> staticLibArgs = new ArrayList<String>();
+    private final RegularFileProperty outputFile;
+    private final ListProperty<String> staticLibArgs;
+    private final Property<NativePlatform> targetPlatform;
+    private final Property<NativeToolChain> toolChain;
 
     public CreateStaticLibrary() {
-        source = getProject().files();
-        getInputs().property("outputType", new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return NativeToolChainInternal.Identifier.identify(toolChain, targetPlatform);
-            }
-        });
-        outputFile = newOutputFile();
+        ObjectFactory objectFactory = getProject().getObjects();
+        this.source = getProject().files();
+        this.outputFile = newOutputFile();
+        this.staticLibArgs = getProject().getObjects().listProperty(String.class);
+        this.targetPlatform = objectFactory.property(NativePlatform.class);
+        this.toolChain = objectFactory.property(NativeToolChain.class);
     }
 
     /**
@@ -92,68 +88,58 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
         throw new UnsupportedOperationException();
     }
 
+    // TODO: Need to track version/implementation of ar tool.
+
     @TaskAction
     public void link() {
 
         StaticLibraryArchiverSpec spec = new DefaultStaticLibraryArchiverSpec();
         spec.setTempDir(getTemporaryDir());
-        spec.setOutputFile(getOutputFile());
+        spec.setOutputFile(getOutputFile().get().getAsFile());
         spec.objectFiles(getSource());
-        spec.args(getStaticLibArgs());
+        spec.args(getStaticLibArgs().get());
 
         BuildOperationLogger operationLogger = getOperationLoggerFactory().newOperationLogger(getName(), getTemporaryDir());
         spec.setOperationLogger(operationLogger);
 
-        Compiler<StaticLibraryArchiverSpec> compiler = Cast.uncheckedCast(toolChain.select(targetPlatform).newCompiler(spec.getClass()));
+        Compiler<StaticLibraryArchiverSpec> compiler = createCompiler();
         WorkResult result = BuildOperationLoggingCompilerDecorator.wrap(compiler).execute(spec);
         setDidWork(result.getDidWork());
     }
 
+    private Compiler<StaticLibraryArchiverSpec> createCompiler() {
+        NativePlatformInternal targetPlatform = Cast.cast(NativePlatformInternal.class, this.targetPlatform.get());
+        NativeToolChainInternal toolChain = Cast.cast(NativeToolChainInternal.class, getToolChain().get());
+        PlatformToolProvider toolProvider = toolChain.select(targetPlatform);
+        return toolProvider.newCompiler(StaticLibraryArchiverSpec.class);
+    }
+
     /**
-     * The tool chain used for creating the static library.
+     * The tool chain used for linking.
+     *
+     * @since 4.6
      */
     @Internal
-    public NativeToolChain getToolChain() {
+    public Property<NativeToolChain> getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(NativeToolChain toolChain) {
-        this.toolChain = (NativeToolChainInternal) toolChain;
-    }
-
     /**
-      * The platform being targeted.
-      */
+     * The platform being linked for.
+     *
+     * @since 4.6
+     */
     @Nested
-    public NativePlatform getTargetPlatform() {
+    public Property<NativePlatform> getTargetPlatform() {
         return targetPlatform;
-    }
-
-    public void setTargetPlatform(NativePlatform targetPlatform) {
-        this.targetPlatform = (NativePlatformInternal) targetPlatform;
     }
 
     /**
      * The file where the output binary will be located.
      */
     @OutputFile
-    public File getOutputFile() {
-        return outputFile.get().getAsFile();
-    }
-
-    public void setOutputFile(File outputFile) {
-        this.outputFile.set(outputFile);
-    }
-
-    /**
-     * Sets the output file generated by the linking process via a {@link Provider}.
-     *
-     * @param outputFile the output file provider to use
-     * @see #setOutputFile(File)
-     * @since 4.5
-     */
-    public void setOutputFile(Provider<? extends RegularFile> outputFile) {
-        this.outputFile.set(outputFile);
+    public RegularFileProperty getOutputFile() {
+        return outputFile;
     }
 
     /**
@@ -167,14 +153,13 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
     }
 
     /**
-     * Additional arguments passed to the archiver.
+     * <em>Additional</em> arguments passed to the archiver.
+     *
+     * @since 4.6
      */
     @Input
-    public List<String> getStaticLibArgs() {
+    public ListProperty<String> getStaticLibArgs() {
         return staticLibArgs;
     }
 
-    public void setStaticLibArgs(List<String> staticLibArgs) {
-        this.staticLibArgs = staticLibArgs;
-    }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -117,7 +117,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
     /**
      * The tool chain used for linking.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -127,7 +127,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
     /**
      * The platform being linked for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {
@@ -155,7 +155,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
     /**
      * <em>Additional</em> arguments passed to the archiver.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Input
     public ListProperty<String> getStaticLibArgs() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
@@ -19,6 +19,8 @@ package org.gradle.nativeplatform.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
@@ -36,6 +38,7 @@ import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 /**
  * Extracts the debug symbols from a binary and stores them in a separate file.
@@ -44,14 +47,18 @@ import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
  */
 @Incubating
 public class ExtractSymbols extends DefaultTask {
-    private NativeToolChainInternal toolChain;
-    private NativePlatformInternal targetPlatform;
-    private RegularFileProperty binaryFile;
-    private RegularFileProperty symbolFile;
+    private final RegularFileProperty binaryFile;
+    private final RegularFileProperty symbolFile;
+    private final Property<NativePlatform> targetPlatform;
+    private final Property<NativeToolChain> toolChain;
 
     public ExtractSymbols() {
+        ObjectFactory objectFactory = getProject().getObjects();
+
         this.binaryFile = newInputFile();
         this.symbolFile = newOutputFile();
+        this.targetPlatform = objectFactory.property(NativePlatform.class);
+        this.toolChain = objectFactory.property(NativeToolChain.class);
     }
 
     /**
@@ -70,23 +77,27 @@ public class ExtractSymbols extends DefaultTask {
         return symbolFile;
     }
 
+    /**
+     * The tool chain used for extracting symbols.
+     *
+     * @since 4.6
+     */
     @Internal
-    public NativeToolChain getToolChain() {
+    public Property<NativeToolChain> getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(NativeToolChain toolChain) {
-        this.toolChain = (NativeToolChainInternal) toolChain;
-    }
-
+    /**
+     * The platform for the binary.
+     *
+     * @since 4.6
+     */
     @Nested
-    public NativePlatform getTargetPlatform() {
+    public Property<NativePlatform> getTargetPlatform() {
         return targetPlatform;
     }
 
-    public void setTargetPlatform(NativePlatform targetPlatform) {
-        this.targetPlatform = (NativePlatformInternal) targetPlatform;
-    }
+    // TODO: Need to track version/implementation of symbol extraction tool.
 
     @TaskAction
     public void extractSymbols() {
@@ -97,9 +108,16 @@ public class ExtractSymbols extends DefaultTask {
         spec.setSymbolFile(symbolFile.get().getAsFile());
         spec.setOperationLogger(operationLogger);
 
-        Compiler<SymbolExtractorSpec> symbolExtractor = Cast.uncheckedCast(toolChain.select(targetPlatform).newCompiler(spec.getClass()));
+        Compiler<SymbolExtractorSpec> symbolExtractor = createCompiler();
         symbolExtractor = BuildOperationLoggingCompilerDecorator.wrap(symbolExtractor);
         WorkResult result = symbolExtractor.execute(spec);
         setDidWork(result.getDidWork());
+    }
+
+    private Compiler<SymbolExtractorSpec> createCompiler() {
+        NativePlatformInternal targetPlatform = Cast.cast(NativePlatformInternal.class, this.targetPlatform.get());
+        NativeToolChainInternal toolChain = Cast.cast(NativeToolChainInternal.class, getToolChain().get());
+        PlatformToolProvider toolProvider = toolChain.select(targetPlatform);
+        return toolProvider.newCompiler(SymbolExtractorSpec.class);
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
@@ -80,7 +80,7 @@ public class ExtractSymbols extends DefaultTask {
     /**
      * The tool chain used for extracting symbols.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -90,7 +90,7 @@ public class ExtractSymbols extends DefaultTask {
     /**
      * The platform for the binary.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -89,7 +89,7 @@ public class InstallExecutable extends DefaultTask {
     /**
      * The tool chain used for linking.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -99,7 +99,7 @@ public class InstallExecutable extends DefaultTask {
     /**
      * The platform being linked for.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {
@@ -119,7 +119,8 @@ public class InstallExecutable extends DefaultTask {
     /**
      * The executable file to install.
      *
-     * @since 4.6
+     * @since 4.7
+     *
      */
     @Internal("Covered by inputFileIfExists")
     public RegularFileProperty getExecutableFile() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -73,6 +73,7 @@ public class InstallExecutable extends DefaultTask {
         ObjectFactory objectFactory = getProject().getObjects();
         this.workerLeaseService = workerLeaseService;
         this.libs = getProject().files();
+        this.installDirectory = newOutputDirectory();
         this.installedExecutable = newOutputFile();
         this.installedExecutable.set(getLibDirectory().map(new Transformer<RegularFile, Directory>() {
             @Override
@@ -80,7 +81,6 @@ public class InstallExecutable extends DefaultTask {
                 return directory.file(executable.getAsFile().get().getName());
             }
         }));
-        this.installDirectory = newOutputDirectory();
         this.executable = newInputFile();
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
@@ -44,12 +44,12 @@ public class LinkSharedLibrary extends AbstractLinkTask {
         importLibrary.set(getProject().getLayout().getProjectDirectory().file(getProject().getProviders().provider(new Callable<String>() {
             @Override
             public String call() throws Exception {
-                RegularFile binaryFile = getBinaryFile().getOrNull();
+                RegularFile binaryFile = getLinkedFile().getOrNull();
                 if (binaryFile == null) {
                     return null;
                 }
-                NativeToolChainInternal toolChain = (NativeToolChainInternal) getToolChain();
-                NativePlatformInternal targetPlatform = (NativePlatformInternal) getTargetPlatform();
+                NativeToolChainInternal toolChain = (NativeToolChainInternal) getToolChain().getOrNull();
+                NativePlatformInternal targetPlatform = (NativePlatformInternal) getTargetPlatform().getOrNull();
                 if (toolChain == null || targetPlatform == null) {
                     return null;
                 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
@@ -19,6 +19,8 @@ package org.gradle.nativeplatform.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
@@ -36,6 +38,7 @@ import org.gradle.nativeplatform.platform.NativePlatform;
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
+import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 /**
  * Strips the debug symbols from a binary
@@ -44,14 +47,18 @@ import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
  */
 @Incubating
 public class StripSymbols extends DefaultTask {
-    private NativeToolChainInternal toolChain;
-    private NativePlatformInternal targetPlatform;
-    private RegularFileProperty binaryFile;
-    private RegularFileProperty outputFile;
+    private final RegularFileProperty binaryFile;
+    private final RegularFileProperty outputFile;
+    private final Property<NativePlatform> targetPlatform;
+    private final Property<NativeToolChain> toolChain;
 
     public StripSymbols() {
+        ObjectFactory objectFactory = getProject().getObjects();
+
         this.binaryFile = newInputFile();
         this.outputFile = newOutputFile();
+        this.targetPlatform = objectFactory.property(NativePlatform.class);
+        this.toolChain = objectFactory.property(NativeToolChain.class);
     }
 
     /**
@@ -71,23 +78,27 @@ public class StripSymbols extends DefaultTask {
         return outputFile;
     }
 
+    /**
+     * The tool chain used for striping symbols.
+     *
+     * @since 4.6
+     */
     @Internal
-    public NativeToolChain getToolChain() {
+    public Property<NativeToolChain> getToolChain() {
         return toolChain;
     }
 
-    public void setToolChain(NativeToolChain toolChain) {
-        this.toolChain = (NativeToolChainInternal) toolChain;
-    }
-
+    /**
+     * The platform for the binary.
+     *
+     * @since 4.6
+     */
     @Nested
-    public NativePlatform getTargetPlatform() {
+    public Property<NativePlatform> getTargetPlatform() {
         return targetPlatform;
     }
 
-    public void setTargetPlatform(NativePlatform targetPlatform) {
-        this.targetPlatform = (NativePlatformInternal) targetPlatform;
-    }
+    // TODO: Need to track version/implementation of symbol strip tool.
 
     @TaskAction
     public void stripSymbols() {
@@ -98,9 +109,16 @@ public class StripSymbols extends DefaultTask {
         spec.setOutputFile(outputFile.get().getAsFile());
         spec.setOperationLogger(operationLogger);
 
-        Compiler<StripperSpec> symbolStripper = Cast.uncheckedCast(toolChain.select(targetPlatform).newCompiler(spec.getClass()));
+        Compiler<StripperSpec> symbolStripper = createCompiler();
         symbolStripper = BuildOperationLoggingCompilerDecorator.wrap(symbolStripper);
         WorkResult result = symbolStripper.execute(spec);
         setDidWork(result.getDidWork());
+    }
+
+    private Compiler<StripperSpec> createCompiler() {
+        NativePlatformInternal targetPlatform = Cast.cast(NativePlatformInternal.class, this.targetPlatform.get());
+        NativeToolChainInternal toolChain = Cast.cast(NativeToolChainInternal.class, getToolChain().get());
+        PlatformToolProvider toolProvider = toolChain.select(targetPlatform);
+        return toolProvider.newCompiler(StripperSpec.class);
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
@@ -81,7 +81,7 @@ public class StripSymbols extends DefaultTask {
     /**
      * The tool chain used for striping symbols.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Internal
     public Property<NativeToolChain> getToolChain() {
@@ -91,7 +91,7 @@ public class StripSymbols extends DefaultTask {
     /**
      * The platform for the binary.
      *
-     * @since 4.6
+     * @since 4.7
      */
     @Nested
     public Property<NativePlatform> getTargetPlatform() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
@@ -22,6 +22,7 @@ import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.compile.DefaultCompilerVersion;
 import org.gradle.language.base.internal.compile.VersionAwareCompiler;
+import org.gradle.nativeplatform.internal.BinaryToolSpec;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.nativeplatform.internal.LinkerSpec;
 import org.gradle.nativeplatform.internal.StaticLibraryArchiverSpec;
@@ -34,7 +35,6 @@ import org.gradle.nativeplatform.toolchain.internal.DefaultCommandLineToolInvoca
 import org.gradle.nativeplatform.toolchain.internal.DefaultMutableCommandLineToolContext;
 import org.gradle.nativeplatform.toolchain.internal.EmptySystemLibraries;
 import org.gradle.nativeplatform.toolchain.internal.MutableCommandLineToolContext;
-import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
 import org.gradle.nativeplatform.toolchain.internal.OutputCleaningCompiler;
 import org.gradle.nativeplatform.toolchain.internal.Stripper;
 import org.gradle.nativeplatform.toolchain.internal.SymbolExtractor;
@@ -119,7 +119,7 @@ class GccPlatformToolProvider extends AbstractPlatformToolProvider {
         return versionAwareCompiler(outputCleaningCompiler, ToolType.CPP_COMPILER);
     }
 
-    private <T extends NativeCompileSpec> VersionAwareCompiler<T> versionAwareCompiler(Compiler<T> compiler, ToolType toolType) {
+    private <T extends BinaryToolSpec> VersionAwareCompiler<T> versionAwareCompiler(Compiler<T> compiler, ToolType toolType) {
         SearchResult<GccMetadata> gccMetadata = getGccMetadata(toolType);
         return new VersionAwareCompiler<T>(compiler, new DefaultCompilerVersion(
             metadataProvider.getCompilerType().getIdentifier(),
@@ -187,7 +187,7 @@ class GccPlatformToolProvider extends AbstractPlatformToolProvider {
     @Override
     protected Compiler<LinkerSpec> createLinker() {
         GccCommandLineToolConfigurationInternal linkerTool = toolRegistry.getTool(ToolType.LINKER);
-        return new GccLinker(buildOperationExecutor, commandLineTool(linkerTool), context(linkerTool), useCommandFile, workerLeaseService);
+        return versionAwareCompiler(new GccLinker(buildOperationExecutor, commandLineTool(linkerTool), context(linkerTool), useCommandFile, workerLeaseService), ToolType.LINKER);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppPlatformToolProvider.java
@@ -27,6 +27,7 @@ import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.compile.DefaultCompilerVersion;
 import org.gradle.language.base.internal.compile.VersionAwareCompiler;
+import org.gradle.nativeplatform.internal.BinaryToolSpec;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.nativeplatform.internal.LinkerSpec;
 import org.gradle.nativeplatform.internal.StaticLibraryArchiverSpec;
@@ -145,8 +146,8 @@ class VisualCppPlatformToolProvider extends AbstractPlatformToolProvider {
         return versionAwareCompiler(outputCleaningCompiler);
     }
 
-    private <T extends NativeCompileSpec> VersionAwareCompiler<T> versionAwareCompiler(OutputCleaningCompiler<T> outputCleaningCompiler) {
-        return new VersionAwareCompiler<T>(outputCleaningCompiler, new DefaultCompilerVersion(VisualCppToolChain.DEFAULT_NAME, "Microsoft", visualCpp.getImplementationVersion()));
+    private <T extends BinaryToolSpec> VersionAwareCompiler<T> versionAwareCompiler(Compiler<T> outputCleaningCompiler) {
+            return new VersionAwareCompiler<T>(outputCleaningCompiler, new DefaultCompilerVersion(VisualCppToolChain.DEFAULT_NAME, "Microsoft", visualCpp.getImplementationVersion()));
     }
 
     @Override
@@ -176,7 +177,7 @@ class VisualCppPlatformToolProvider extends AbstractPlatformToolProvider {
     @Override
     protected Compiler<LinkerSpec> createLinker() {
         CommandLineToolInvocationWorker commandLineTool = tool("Linker", visualCpp.getLinkerExecutable());
-        return new LinkExeLinker(buildOperationExecutor, commandLineTool, context(commandLineToolConfigurations.get(ToolType.LINKER)), addLibraryPath(), workerLeaseService);
+        return versionAwareCompiler(new LinkExeLinker(buildOperationExecutor, commandLineTool, context(commandLineToolConfigurations.get(ToolType.LINKER)), addLibraryPath(), workerLeaseService));
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Action;
+import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.FileUtils;
@@ -37,6 +38,7 @@ import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolInvocation;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolInvocationWorker;
 import org.gradle.nativeplatform.toolchain.internal.compilespec.SwiftCompileSpec;
+import org.gradle.util.CollectionUtils;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.VersionNumber;
 
@@ -146,6 +148,13 @@ class SwiftCompiler extends AbstractCompiler<SwiftCompileSpec> {
                 if (spec.isOptimized()) {
                     genericArgs.add("-O");
                 }
+
+                genericArgs.addAll(CollectionUtils.collect(spec.getMacros().keySet(), new Transformer<String, String>() {
+                    @Override
+                    public String transform(String macro) {
+                        return "-D" + macro;
+                    }
+                }));
 
                 genericArgs.add("-swift-version");
                 genericArgs.add(String.valueOf(spec.getSourceCompatibility().getVersion()));

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftPlatformToolProvider.java
@@ -94,7 +94,8 @@ class SwiftPlatformToolProvider extends AbstractPlatformToolProvider {
     @Override
     protected Compiler<LinkerSpec> createLinker() {
         CommandLineToolConfigurationInternal linkerTool = (CommandLineToolConfigurationInternal) toolRegistry.getLinker();
-        return new SwiftLinker(buildOperationExecutor, commandLineTool(ToolType.LINKER, "swiftc"), context(linkerTool), workerLeaseService);
+        SwiftLinker swiftLinker = new SwiftLinker(buildOperationExecutor, commandLineTool(ToolType.LINKER, "swiftc"), context(linkerTool), workerLeaseService);
+        return new VersionAwareCompiler<LinkerSpec>(swiftLinker, new DefaultCompilerVersion("swiftc", swiftcMetaData.getVendor(), swiftcMetaData.getVersion()));
     }
 
     protected Compiler<SwiftCompileSpec> createSwiftCompiler() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/plugins/NativeComponentPluginTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/plugins/NativeComponentPluginTest.groovy
@@ -61,8 +61,8 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
         with(project.tasks.linkTestExecutable) {
             it instanceof LinkExecutable
             it == testExecutable.tasks.link
-            it.toolChain == testExecutable.toolChain
-            it.targetPlatform == testExecutable.targetPlatform
+            it.toolChain.get() == testExecutable.toolChain
+            it.targetPlatform.get() == testExecutable.targetPlatform
             it.linkerArgs.get() == testExecutable.linker.args
         }
 
@@ -91,8 +91,8 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
         with(project.tasks.linkTestSharedLibrary) {
             it instanceof LinkSharedLibrary
             it == sharedLibraryBinary.tasks.link
-            it.toolChain == sharedLibraryBinary.toolChain
-            it.targetPlatform == sharedLibraryBinary.targetPlatform
+            it.toolChain.get() == sharedLibraryBinary.toolChain
+            it.targetPlatform.get() == sharedLibraryBinary.targetPlatform
             it.linkerArgs.get() == sharedLibraryBinary.linker.args
         }
 
@@ -105,9 +105,9 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
         with(project.tasks.createTestStaticLibrary) {
             it instanceof CreateStaticLibrary
             it == staticLibraryBinary.tasks.createStaticLib
-            it.toolChain == staticLibraryBinary.toolChain
-            it.targetPlatform == staticLibraryBinary.targetPlatform
-            it.staticLibArgs == staticLibraryBinary.staticLibArchiver.args
+            it.toolChain.get() == staticLibraryBinary.toolChain
+            it.targetPlatform.get() == staticLibraryBinary.targetPlatform
+            it.staticLibArgs.get() == staticLibraryBinary.staticLibArchiver.args
         }
 
         and:

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/tasks/LinkSharedLibraryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/tasks/LinkSharedLibraryTest.groovy
@@ -37,15 +37,15 @@ class LinkSharedLibraryTest extends Specification {
         provider.producesImportLibrary() >> false
 
         when:
-        link.toolChain = toolChain
-        link.targetPlatform = platform
+        link.toolChain.set(toolChain)
+        link.targetPlatform.set(platform)
 
         then:
-        !link.binaryFile.present
+        !link.linkedFile.present
         !link.importLibrary.present
 
         when:
-        link.binaryFile = tmpDir.file("shared/lib.dll")
+        link.linkedFile = tmpDir.file("shared/lib.dll")
 
         then:
         !link.importLibrary.present
@@ -60,22 +60,22 @@ class LinkSharedLibraryTest extends Specification {
         provider.getImportLibraryName(_) >> { String n -> n.replace(".dll", ".lib") }
 
         when:
-        link.toolChain = toolChain
-        link.targetPlatform = platform
+        link.toolChain.set(toolChain)
+        link.targetPlatform.set(platform)
 
         then:
-        !link.binaryFile.present
+        !link.linkedFile.present
         !link.importLibrary.present
 
         when:
-        link.binaryFile = tmpDir.file("shared/lib.dll")
+        link.linkedFile = tmpDir.file("shared/lib.dll")
 
         then:
         link.importLibrary.get().asFile == tmpDir.file("shared/lib.lib")
 
         when:
-        link.importLibrary = tmpDir.file("import/lib_debug.lib")
-        link.binaryFile = tmpDir.file("ignore-me")
+        link.importLibrary.set(tmpDir.file("import/lib_debug.lib"))
+        link.linkedFile.set(tmpDir.file("ignore-me"))
 
         then:
         link.importLibrary.get().asFile == tmpDir.file("import/lib_debug.lib")

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
@@ -172,7 +172,7 @@ public class CppUnitTestPlugin implements Plugin<ProjectInternal> {
                                     return executable.getInstallDirectory().get().getAsFile().exists();
                                 }
                             });
-                            testTask.setExecutable(installTask.getRunScript());
+                            testTask.setExecutable(installTask.getRunScriptFile().get().getAsFile());
                             testTask.dependsOn(testComponent.getTestBinary().get().getInstallDirectory());
                             // TODO: Honor changes to build directory
                             testTask.setOutputDir(project.getLayout().getBuildDirectory().dir("test-results/" + executable.getNames().getDirName()).get().getAsFile());

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java
@@ -99,7 +99,7 @@ public class NativeBinariesTestPlugin implements Plugin<Project> {
             InstallExecutable installTask = (InstallExecutable) tasks.getInstall();
             RunTestExecutable runTask = (RunTestExecutable) tasks.getRun();
             runTask.getInputs().files(installTask.getOutputs().getFiles()).withPropertyName("installTask.outputs");
-            runTask.setExecutable(installTask.getRunScript().getPath());
+            runTask.setExecutable(installTask.getRunScriptFile().get().getAsFile().getPath());
             Project project = runTask.getProject();
             runTask.setOutputDir(namingScheme.getOutputDirectory(project.getBuildDir(), "test-results"));
         }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -185,7 +185,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
             link.getLinkedFile().set(exeLocation);
             link.getTargetPlatform().set(currentPlatform);
             link.getToolChain().set(toolChain);
-            link.isDebuggable().set(binary.isDebuggable());
+            link.getDebuggable().set(binary.isDebuggable());
 
             binary.getExecutableFile().set(link.getLinkedFile());
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -169,7 +169,7 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
             }));
 
             InstallXCTestBundle install = tasks.create(names.getTaskName("install"), InstallXCTestBundle.class);
-            install.getBundleBinaryFile().set(link.getBinaryFile());
+            install.getBundleBinaryFile().set(link.getLinkedFile());
             install.getInstallDirectory().set(project.getLayout().getBuildDirectory().dir("install/" + names.getDirName()));
             binary.getInstallDirectory().set(install.getInstallDirectory());
 
@@ -182,12 +182,12 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
                     return toolProvider.getExecutableName("exe/" + names.getDirName() + binary.getBaseName().get());
                 }
             }));
-            link.setOutputFile(exeLocation);
-            link.setTargetPlatform(currentPlatform);
-            link.setToolChain(toolChain);
-            link.setDebuggable(binary.isDebuggable());
+            link.getLinkedFile().set(exeLocation);
+            link.getTargetPlatform().set(currentPlatform);
+            link.getToolChain().set(toolChain);
+            link.isDebuggable().set(binary.isDebuggable());
 
-            binary.getExecutableFile().set(link.getBinaryFile());
+            binary.getExecutableFile().set(link.getLinkedFile());
 
             DefaultSwiftXCTestBundle bundle = (DefaultSwiftXCTestBundle) binary;
             bundle.getLinkTask().set(link);

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
@@ -118,7 +118,7 @@ class CppUnitTestPluginTest extends Specification {
 
         def link = project.tasks.linkTest
         link instanceof LinkExecutable
-        link.binaryFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("someAppTest"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("someAppTest"))
         link.debuggable
 
         def install = project.tasks.installTest
@@ -139,7 +139,7 @@ class CppUnitTestPluginTest extends Specification {
         compileCpp.objectFileDir.get().asFile == projectDir.file("output/obj/test")
 
         def link = project.tasks.linkTest
-        link.binaryFile.get().asFile == projectDir.file("output/exe/test/" + OperatingSystem.current().getExecutableName("someAppTest"))
+        link.linkedFile.get().asFile == projectDir.file("output/exe/test/" + OperatingSystem.current().getExecutableName("someAppTest"))
 
         def install = project.tasks.installTest
         install.installDirectory.get().asFile == project.file("output/install/test")

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPluginTest.groovy
@@ -42,9 +42,9 @@ class NativeBinariesTestPluginTest extends PlatformBaseSpecification {
                     testedBinary = library
                     tasks.create("run", RunTestExecutable) {}
                     tasks.create("install", InstallExecutable) {
-                        it.destinationDir = new File(".")
-                        it.executable = new File("exe")
-                        it.platform = Mock(NativePlatform) {
+                        it.installDirectory = new File(".")
+                        it.executableFile = new File("exe")
+                        it.targetPlatform = Mock(NativePlatform) {
                             getOperatingSystem() >> Mock(OperatingSystem) {
                                 getName() >> "test"
                             }

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -144,7 +144,7 @@ class XCTestConventionPluginTest extends Specification {
 
         def link = project.tasks.linkTest
         link instanceof LinkMachOBundle
-        link.binaryFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
         def install = project.tasks.installTest
@@ -176,7 +176,7 @@ class XCTestConventionPluginTest extends Specification {
 
         def link = project.tasks.linkTest
         link instanceof LinkExecutable
-        link.binaryFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
+        link.linkedFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
         def install = project.tasks.installTest
@@ -200,7 +200,7 @@ class XCTestConventionPluginTest extends Specification {
         compileSwift.objectFileDir.get().asFile == projectDir.file("output/obj/test")
 
         def link = project.tasks.linkTest
-        link.binaryFile.get().asFile == projectDir.file("output/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
+        link.linkedFile.get().asFile == projectDir.file("output/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
 
         def install = project.tasks.installTest
         install.installDirectory.get().asFile == project.file("output/install/test")


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
