### PR TITLE
Ignore nested class in JUnit platform test

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
 import org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.junit.TestClassExecutionListener;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.time.Clock;
@@ -72,11 +73,14 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
     }
 
     private class CollectAllTestClassesExecutor implements Action<String> {
-        private final List<String> testClasses = new ArrayList<>();
+        private final List<Class<?>> testClasses = new ArrayList<>();
 
         @Override
         public void execute(String testClassName) {
-            testClasses.add(testClassName);
+            Class<?> klass = loadClass(testClassName);
+            if (isTopClass(klass)) {
+                testClasses.add(klass);
+            }
         }
 
         private void processAllTestClasses() {
@@ -87,7 +91,20 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
 
     }
 
-    private LauncherDiscoveryRequest createLauncherDiscoveryRequest(List<String> testClasses) {
+    private boolean isTopClass(Class<?> klass) {
+        return klass.getEnclosingClass() == null;
+    }
+
+    private Class<?> loadClass(String className) {
+        try {
+            ClassLoader applicationClassloader = Thread.currentThread().getContextClassLoader();
+            return Class.forName(className, false, applicationClassloader);
+        } catch (ClassNotFoundException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    private LauncherDiscoveryRequest createLauncherDiscoveryRequest(List<Class<?>> testClasses) {
         List<DiscoverySelector> classSelectors = testClasses.stream()
             .map(DiscoverySelectors::selectClass)
             .collect(Collectors.toList());

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformUserGuideIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformUserGuideIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing.junitplatform
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.hamcrest.Matchers
+import spock.lang.Unroll
 
 import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
 
@@ -112,7 +113,14 @@ public class LifecycleTest {
         'annotations' | ''                                                         | '@TestInstance(Lifecycle.PER_CLASS)'
     }
 
-    def 'can perform nested tests'() {
+    @Unroll
+    def 'can perform nested tests with #maxParallelForks'() {
+        given:
+        buildFile << """
+test {
+    maxParallelForks = ${maxParallelForks}
+}
+"""
         file('src/test/java/org/gradle/TestingAStackDemo.java') << '''
 package org.gradle;
 import static org.junit.jupiter.api.Assertions.*;
@@ -186,6 +194,9 @@ class TestingAStackDemo {
             .assertTestPassed('throws EmptyStackException when popped')
         result.testClass('org.gradle.TestingAStackDemo$WhenNew$AfterPushing').assertTestCount(1, 0, 0)
             .assertTestPassed('it is no longer empty')
+
+        where:
+        maxParallelForks << [1, 3]
     }
 
     def 'can support dependency injection'() {


### PR DESCRIPTION
### Context

In current Gradle & JUnit 5 integration, we push all test classes to JUnit Platform runner. However, if `maxParallelForks > 1`, it's possible to push `Outer.class` to one worker process and `Outer$Nested.class` to another class. This will result in that tests in nested class are executed multiple times, e.g. https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested

In this PR, we examine all test classes and discard nested classes. See the tests in this PR.

 