### PR TITLE
Recommend folks use build scans for profiling.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProfilingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProfilingIntegrationTest.groovy
@@ -45,5 +45,6 @@ allprojects {
         document.text().contains("build fooTask")
         document.text().contains("-x barTask")
         output.contains("See the profiling report at:")
+        output.contains("A fine-grained performance profile is available: use the --scan option.")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/profile/ReportGeneratingProfileListener.java
+++ b/subprojects/core/src/main/java/org/gradle/profile/ReportGeneratingProfileListener.java
@@ -52,6 +52,10 @@ public class ReportGeneratingProfileListener extends BuildAdapter implements Pro
         textOutput.println();
         String reportUrl = new ConsoleRenderer().asClickableFileUrl(reportFile);
         textOutput.formatln("See the profiling report at: %s", reportUrl);
+        textOutput.text("A fine-grained performance profile is available: use the ");
+        textOutput.withStyle(StyledTextOutput.Style.UserInput).text("--scan");
+        textOutput.text(" option.");
+        textOutput.println();
     }
 }
 


### PR DESCRIPTION
Build scans are better than --profile in every way, so recommend
use of --scan after profile report URL

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
