### PR TITLE
Fix bugs when integrating with running Vintage engine on Spock 

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -160,7 +160,7 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
                         return true;
                     }
                 }
-                if (isVintageDynamicTest(descriptor, source.get())) {
+                if (isVintageDynamicLeafTest(descriptor, source.get())) {
                     return shouldRunVintageDynamicTest(descriptor);
                 }
             }

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -80,12 +80,12 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     }
 
     private boolean isLeafTest(TestIdentifier identifier) {
-        return identifier.isTest();
+        return identifier.isTest() && !isVintageDynamicTestClass(identifier);
     }
 
     @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-        if (isLeafMethodOrFailedContainer(testIdentifier, testExecutionResult)) {
+        if (isLeafTestOrFailedContainer(testIdentifier, testExecutionResult)) {
             if (!isLeafTest(testIdentifier)) {
                 // only leaf methods triggered start events previously
                 // so here we need to add the missing start events
@@ -121,7 +121,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         currentRunningTestClass.end(className(testIdentifier));
     }
 
-    private boolean isLeafMethodOrFailedContainer(TestIdentifier testIdentifier, TestExecutionResult result) {
+    private boolean isLeafTestOrFailedContainer(TestIdentifier testIdentifier, TestExecutionResult result) {
         // Generally, there're 2 kinds of identifier:
         // 1. A container (test engine/class/repeated tests). It is not tracked unless it fails/aborts.
         // 2. A test "leaf" method. It's always tracked.
@@ -135,10 +135,10 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     private TestDescriptorInternal getDescriptor(final TestIdentifier test) {
         if (isMethod(test)) {
             return new DefaultTestDescriptor(idGenerator.generateId(), className(test), test.getDisplayName());
-        } else if (isVintageDynamicTest(test)) {
+        } else if (isVintageDynamicLeafTest(test)) {
             UniqueId uniqueId = UniqueId.parse(test.getUniqueId());
             return new DefaultTestDescriptor(idGenerator.generateId(), vintageDynamicClassName(uniqueId), vintageDynamicMethodName(uniqueId));
-        } else if (isClass(test)) {
+        } else if (isClass(test) || isVintageDynamicTestClass(test)) {
             return new DefaultTestDescriptor(idGenerator.generateId(), className(test), "classMethod");
         } else {
             return new DefaultTestDescriptor(idGenerator.generateId(), className(test), test.getDisplayName());

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/VintageTestNameAdapter.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/VintageTestNameAdapter.java
@@ -27,19 +27,27 @@ import java.util.List;
 
 class VintageTestNameAdapter {
     private static final String VINTAGE_DESCRIPTOR_CLASS_NAME = "VintageTestDescriptor";
+    private static final String VINTAGE_ENGINE = "[engine:junit-vintage]";
 
-    static boolean isVintageEngine(TestIdentifier testIdentifier) {
-        return testIdentifier.getUniqueId().contains("[engine:junit-vintage]");
+    static boolean isVintageDynamicLeafTest(TestIdentifier test) {
+        return test.getParentId().isPresent()
+            && !VINTAGE_ENGINE.equals(test.getParentId().get())
+            && isClassAndTest(test);
     }
 
-    static boolean isVintageDynamicTest(TestIdentifier test) {
-        return isVintageEngine(test)
-            && test.getSource().isPresent()
+    private static boolean isClassAndTest(TestIdentifier test) {
+        return test.getSource().isPresent()
             && test.getSource().get() instanceof ClassSource
             && test.isTest();
     }
 
-    static boolean isVintageDynamicTest(TestDescriptor test, TestSource source) {
+    static boolean isVintageDynamicTestClass(TestIdentifier test) {
+        return test.getParentId().isPresent()
+            && VINTAGE_ENGINE.equals(test.getParentId().get())
+            && isClassAndTest(test);
+    }
+
+    static boolean isVintageDynamicLeafTest(TestDescriptor test, TestSource source) {
         return test.isTest()
             && source instanceof ClassSource
             && VINTAGE_DESCRIPTOR_CLASS_NAME.equals(test.getClass().getSimpleName());

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.junit
 
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 
@@ -79,5 +80,43 @@ class TestSpec extends Specification {
 """
         expect:
         succeeds("test")
+    }
+
+    def 'can run spock with @Unroll'() {
+        given:
+        file("build.gradle") << """
+apply plugin: 'groovy'
+
+repositories {
+    ${jcenterRepository()}
+}
+
+dependencies {
+    testCompile localGroovy()
+    testCompile '$dependencyNotation', 'org.spockframework:spock-core:1.0-groovy-2.4@jar'
+}
+"""
+        file('src/test/groovy/UnrollTest.groovy') << '''
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class UnrollTest extends Specification {
+    @Unroll
+    def "can test #type"() {
+        expect: type
+
+        where:
+        type << ['1', '2']
+    }
+}
+'''
+        when:
+        succeeds('test')
+
+        then:
+        new DefaultTestExecutionResult(testDirectory)
+            .testClass("UnrollTest").assertTestCount(2, 0, 0)
+            .assertTestPassed('can test 1')
+            .assertTestPassed('can test 2')
     }
 }


### PR DESCRIPTION
Vintage engine will trigger events with type 'TEST' for both test class
and test method, which might cause test hang unexpectedly. This PR identifies
these different test events and fixes this issue.