### PR TITLE
Fix deserialization of components after cache expiry

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionResultApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionResultApiIntegrationTest.groovy
@@ -324,8 +324,9 @@ baz:1.0 requested
                            println "\${it.cause} : \${it.description}"
                         }
                     }
-                    println 'Waiting 10s for the cache to expire'
-                    Thread.sleep(10100) // must be > 10s
+                    println 'Waiting for the cache to expire'
+                    // see org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.CachedStoreFactory
+                    Thread.sleep(800) // must be > cache expiry
                     println 'Read result again'
                     result.allComponents {
                         it.selectionReason.descriptions.each {
@@ -335,6 +336,7 @@ baz:1.0 requested
                 }
             }
         """
+        executer.withArgument('-Dorg.gradle.api.internal.artifacts.ivyservice.resolveengine.store.cacheExpiryMs=500')
 
         when:
         run 'resolveTwice'

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializer.java
@@ -61,4 +61,8 @@ public class ComponentResultSerializer implements Serializer<ComponentResult> {
         encoder.writeString(value.getVariantName());
         attributeContainerSerializer.write(encoder, value.getVariantAttributes());
     }
+
+    void reset() {
+        reasonSerializer.reset();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializer.java
@@ -35,10 +35,7 @@ public class ComponentSelectionReasonSerializer implements Serializer<ComponentS
 
     private final BiMap<String, Integer> descriptions = HashBiMap.create();
 
-    private OperationType lastOperationType = OperationType.read;
-
     public ComponentSelectionReason read(Decoder decoder) throws IOException {
-        prepareForOperation(OperationType.read);
         List<ComponentSelectionDescriptor> descriptions = readDescriptions(decoder);
         return VersionSelectionReasons.of(descriptions);
     }
@@ -66,7 +63,6 @@ public class ComponentSelectionReasonSerializer implements Serializer<ComponentS
     }
 
     public void write(Encoder encoder, ComponentSelectionReason value) throws IOException {
-        prepareForOperation(OperationType.write);
         List<ComponentSelectionDescriptor> descriptions = value.getDescriptions();
         encoder.writeSmallInt(descriptions.size());
         for (ComponentSelectionDescriptor description : descriptions) {
@@ -91,21 +87,7 @@ public class ComponentSelectionReasonSerializer implements Serializer<ComponentS
         }
     }
 
-    /**
-     * This serializer assumes that we are using it alternatively for writes, then reads, in cycles.
-     * After each cycle completed, state has to be reset.
-     *
-     * @param operationType the current operation type
-     */
-    private void prepareForOperation(OperationType operationType) {
-        if (operationType != lastOperationType) {
-            descriptions.clear();
-            lastOperationType = operationType;
-        }
-    }
-
-    private enum OperationType {
-        read,
-        write
+    public void reset() {
+        descriptions.clear();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializer.java
@@ -59,4 +59,8 @@ public class DependencyResultSerializer {
             componentSelectionReasonSerializer.write(encoder, value.getReason());
         }
     }
+
+    public void reset() {
+        componentSelectionReasonSerializer.reset();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -79,6 +79,8 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
 
     @Override
     public void start(final DependencyGraphNode root) {
+        componentResultSerializer.reset();
+        dependencyResultSerializer.reset();
     }
 
     @Override
@@ -189,6 +191,8 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
             try {
                 DefaultResolutionResultBuilder builder = new DefaultResolutionResultBuilder();
                 Map<Long, ComponentSelector> selectors = new HashMap<Long, ComponentSelector>();
+                componentResultSerializer.reset();
+                dependencyResultSerializer.reset();
                 while (true) {
                     type = decoder.readByte();
                     valuesRead++;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/CachedStoreFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/CachedStoreFactory.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class CachedStoreFactory<T> implements Closeable {
 
     private static final Logger LOG = Logging.getLogger(CachedStoreFactory.class);
+    private static final int CACHE_SIZE = Integer.getInteger("org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.cacheSize", 100);
+    private static final int CACHE_EXPIRY = Integer.getInteger("org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.cacheExpiryMs", 10000);
 
     private final Cache<Object, T> cache;
     private final Stats stats;
@@ -40,7 +42,7 @@ public class CachedStoreFactory<T> implements Closeable {
 
     public CachedStoreFactory(String displayName) {
         this.displayName = displayName;
-        cache = CacheBuilder.newBuilder().maximumSize(100).expireAfterAccess(10000, TimeUnit.MILLISECONDS).build();
+        cache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).expireAfterAccess(CACHE_EXPIRY, TimeUnit.MILLISECONDS).build();
         stats = new Stats();
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
@@ -68,6 +68,7 @@ class ComponentSelectionReasonSerializerTest extends SerializerSpec {
         def reason = VersionSelectionReasons.of(Arrays.asList(reasons))
         def result = serialize(reason, serializer)
         assert result == reason
+        serializer.reset()
     }
 
     private static ComponentSelectionReasonInternal withReason(String reason) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor
+import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.serialize.SerializerSpec
 
 class ComponentSelectionReasonSerializerTest extends SerializerSpec {
@@ -68,11 +69,16 @@ class ComponentSelectionReasonSerializerTest extends SerializerSpec {
         def reason = VersionSelectionReasons.of(Arrays.asList(reasons))
         def result = serialize(reason, serializer)
         assert result == reason
-        serializer.reset()
     }
 
     private static ComponentSelectionReasonInternal withReason(String reason) {
         VersionSelectionReasons.of([VersionSelectionReasons.SELECTED_BY_RULE.withReason(reason)])
     }
 
+    @Override
+    def <T> T serialize(T value, Serializer<T> serializer) {
+        def bytes = toBytes(value, serializer)
+        serializer.reset()
+        return fromBytes(bytes, serializer)
+    }
 }


### PR DESCRIPTION
### Context

The result of graph resolution is stored on disk, and cached in memory for 10s after it has been accessed (for example, by calling `configurations.conf.incoming.resolutionResult.allComponents { ... }`.

However, after those 10s, it has to be read again from disk. The problem is that the serializer is stateful, and assumed cycles of write/read/write/read. Not, typically, write/read/read.

This PR fixes the problem by handling the reset of the serializer state externally.
