### PR TITLE
Suggest folks invoking 'gradle help' visit help.gradle.org

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -45,6 +45,8 @@ To see a list of command-line options, run gradle --help
 
 To see more detail about a task, run gradle help --task <task>
 
+For troubleshooting, visit https://help.gradle.org
+
 BUILD SUCCESSFUL"""
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/configuration/Help.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/configuration/Help.java
@@ -90,6 +90,10 @@ public class Help extends DefaultTask {
         output.text("To see more detail about a task, run ");
         metaData.describeCommand(output.withStyle(UserInput), "help --task <task>");
         output.println();
+        output.println();
+        output.text("For troubleshooting, visit ");
+        output.withStyle(UserInput).text("https://help.gradle.org");
+        output.println();
     }
 
     @Option(option = "task", description = "The task to show help for.")


### PR DESCRIPTION
### Context
Folks who invoke `gradle help` may be looking for more than a brief command-line reference. This gives them a place to start for troubleshooting.

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
