### PR TITLE
Correctly recognize JUnit Vintage test descriptor

### DIFF
--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -29,7 +29,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JUnitTestEventAdapter extends RunListener {
-    private static final Pattern DESCRIPTOR_PATTERN = Pattern.compile("(.*)\\((.*)\\)", Pattern.DOTALL);
+    private static final Pattern DESCRIPTOR_PATTERN = Pattern.compile("(.*)\\((.*)\\)(\\[\\d+])?", Pattern.DOTALL);
     private final IdGenerator<?> idGenerator;
     private final GenericJUnitTestEventAdapter<Description> adapter;
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapterTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapterTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junit
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JUnitTestEventAdapterTest extends Specification {
+    @Unroll
+    def 'can recognize JUnit4 description #description'() {
+        expect:
+        JUnitTestEventAdapter.methodName(description) == methodName
+        JUnitTestEventAdapter.className(description) == className
+
+        where:
+        description                 | className                   | methodName
+        'ok(org.gradle.Test)'       | 'org.gradle.Test'           | 'ok'
+        'ok(org.gradle.Test)[0]'    | 'org.gradle.Test'           | 'ok'
+        'this is not a description' | 'this is not a description' | null
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4358

If a test class has two method descriptor with same name, Vintage Engine
will name them as "testMethod(org.gradle.TestClass)[0]", which can't
be recognized by our regular expression. This PR updates the regular expression to recognize it.