### PR TITLE
Avoid duplicate `REQUESTED` selection reason

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionResultApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionResultApiIntegrationTest.groovy
@@ -293,6 +293,62 @@ baz:1.0 requested
         useReason << [true, false]
     }
 
+    @Unroll
+    def "direct dependency reasons are not mis-showing up as a separate REQUESTED and do not overwrite selection by rule"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+        mavenRepo.module("org", "bar", "1.0").publish()
+
+        buildFile << """
+
+            repositories {
+               maven { url "${mavenRepo.uri}" }
+            }
+
+            configurations {
+                conf
+            }
+            dependencies {
+                conf("org:foo:1.0") {
+                    if ($useReason) { because("This is a direct dependency reason") }
+                }
+            }
+            
+            configurations.all {
+                resolutionStrategy.eachDependency {
+                    if (requested.name == 'foo') {
+                        because("fix comes from component selection rule").useTarget("org:bar:1.0")
+                    }
+                }
+            }
+            
+            task checkWithApi {
+                doLast {
+                    def result = configurations.conf.incoming.resolutionResult
+                    result.allComponents {
+                        if (it.id instanceof ModuleComponentIdentifier) {
+                            println "Module \$it.id"
+                            it.selectionReason.descriptions.each {
+                                println "   \$it.cause : \$it.description"
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        run 'checkWithApi'
+
+        then:
+        outputContains("""Module org:bar:1.0
+   REQUESTED : ${useReason?'This is a direct dependency reason':'requested'}
+   SELECTED_BY_RULE : fix comes from component selection rule
+""")
+        where:
+        useReason << [true, false]
+    }
+
     void "expired cache entry doesn't break reading reasons from cache"() {
         given:
         mavenRepo.module("org", "foo", "1.0").publish()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -50,7 +50,7 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
     private final List<NodeState> nodes = Lists.newLinkedList();
     private final Long resultId;
     private final ModuleResolveState module;
-    private final ComponentSelectionReasonInternal selectionReason = VersionSelectionReasons.requested();
+    private final ComponentSelectionReasonInternal selectionReason = VersionSelectionReasons.empty();
     private volatile ComponentResolveMetadata metaData;
 
     private ModuleState state = ModuleState.Selectable;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -40,6 +41,9 @@ public class VersionSelectionReasons {
         return new DefaultComponentSelectionReason(REQUESTED);
     }
 
+    public static ComponentSelectionReasonInternal empty() {
+        return new DefaultComponentSelectionReason(Collections.<ComponentSelectionDescriptor>emptyList());
+    }
 
     public static ComponentSelectionReason root() {
         return new DefaultComponentSelectionReason(ROOT);
@@ -126,6 +130,11 @@ public class VersionSelectionReasons {
         @Override
         public ComponentSelectionReasonInternal addCause(ComponentSelectionDescriptor description) {
             if (!descriptions.contains(description)) {
+                ComponentSelectionCause cause = description.getCause();
+                if (descriptions.isEmpty() && cause != ComponentSelectionCause.REQUESTED && cause != ComponentSelectionCause.ROOT) {
+                    // initial reason must always be either root or requested
+                    descriptions.add(REQUESTED);
+                }
                 descriptions.add((ComponentSelectionDescriptorInternal) description);
             }
             return this;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
@@ -78,6 +78,7 @@ class DependencyResultSerializerTest extends Specification {
         encoder.flush()
         Map<ModuleComponentSelector, ModuleVersionResolveException> map = new HashMap<>()
         map.put(requested, failure)
+        serializer.reset()
         def out = serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(bytes.toByteArray())), [4L: requested], map)
 
         then:


### PR DESCRIPTION
### Context

This is similar to the fix in #4301, but this time for direct dependencies
instead of constraints.

