### PR TITLE
Upgrade Kotlin DSL {0.15.5 => 0.15.6}

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ buildTypes {
 }
 
 ext {
-    gradle_kotlin_dsl_version = '0.15.5'
+    gradle_kotlin_dsl_version = '0.15.6'
     jvm = org.gradle.internal.jvm.Jvm.current()
     javaVersion = JavaVersion.current()
     isCiServer = System.getenv().containsKey("CI")


### PR DESCRIPTION
Compiled against the latest `Settings` API in order to expose
`Settings#enableFeaturePreview`.

See gradle/kotlin-dsl#718