### PR TITLE
Moved call to remoteProcessor.processTestClass() into cricital section

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -84,11 +84,11 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
                 JULRedirector.checkDeprecatedProperty(options);
                 remoteProcessor = forkProcess();
             }
+
+            remoteProcessor.processTestClass(testClass);
         } finally {
             lock.unlock();
         }
-
-        remoteProcessor.processTestClass(testClass);
     }
 
     RemoteTestClassProcessor forkProcess() {


### PR DESCRIPTION
Fix for https://builds.gradle.org/viewLog.html?buildId=11002556&buildTypeId=Gradle_Check_Quick_Java8_Oracle_Linux_testingJvm