### PR TITLE
Encourage use of --scan when invoking dependency reports

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1691,7 +1691,7 @@ org:leaf2:1.0
 
 (*) - dependencies omitted (listed previously)
 
-A web-based, searchable dependency tree is available: use the --scan option.
+A web-based, searchable dependency report is available by adding the --scan option.
 """
     }
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1652,4 +1652,46 @@ org:leaf -> 1.0
      \\--- compileClasspath"""
     }
 
+    def "mentions web-based dependency insight report available using build scans"() {
+        given:
+        mavenRepo.module("org", "leaf1").publish()
+        mavenRepo.module("org", "leaf2").publish()
+
+        mavenRepo.module("org", "middle").dependsOnModules("leaf1", "leaf2").publish()
+
+        mavenRepo.module("org", "top").dependsOnModules("middle", "leaf2").publish()
+
+        file("build.gradle") << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            configurations {
+                conf
+            }
+            dependencies {
+                conf 'org:top:1.0'
+            }
+            task insight(type: DependencyInsightReportTask) {
+                setDependencySpec { it.requested.module == 'leaf2' }
+                configuration = configurations.conf
+            }
+        """
+
+        when:
+        run "insight"
+
+        then:
+        output.contains """
+org:leaf2:1.0
+   variant "runtime"
++--- org:middle:1.0
+|    \\--- org:top:1.0
+|         \\--- conf
+\\--- org:top:1.0 (*)
+
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency tree is available: use the --scan option.
+"""
+    }
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -676,8 +676,7 @@ compile - Dependencies for source set 'main' (deprecated, use 'implementation ' 
 """
     }
 
-    def "reports external dependency replaced with project dependency"()
-    {
+    def "reports external dependency replaced with project dependency"() {
         mavenRepo.module("org.utils", "api",  '1.3').publish()
 
         file("settings.gradle") << "include 'client', 'api2', 'impl'"

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -370,10 +370,10 @@ conf
      |    +--- org:leaf1:1.0
      |    \\--- org:leaf2:1.0
      \\--- org:leaf2:1.0
-
+ 
 (*) - dependencies omitted (listed previously)
-
-A web-based, searchable dependency report is available by adding the  --scan option.
+ 
+A web-based, searchable dependency report is available by adding the --scan option.
 """
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -338,7 +338,7 @@ conf
 """
     }
 
-    def "mentions web-based dependency report after legend"() {
+    def "mentions web-bsed dependency report after legend"() {
         given:
         mavenRepo.module("org", "leaf1").publish()
         mavenRepo.module("org", "leaf2").publish()
@@ -363,18 +363,9 @@ conf
         run "dependencies"
 
         then:
-        output.contains """
-conf
-\\--- org:top:1.0
-     +--- org:middle:1.0
-     |    +--- org:leaf1:1.0
-     |    \\--- org:leaf2:1.0
-     \\--- org:leaf2:1.0
- 
-(*) - dependencies omitted (listed previously)
- 
-A web-based, searchable dependency report is available by adding the --scan option.
-"""
+        output.contains """(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option."""
     }
 
     def "shows selected versions in case of a multi-phase conflict"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -373,7 +373,7 @@ conf
 
 (*) - dependencies omitted (listed previously)
 
-A web-based, searchable dependency tree is available: use the --scan option.
+A web-based, searchable dependency report is available by adding the  --scan option.
 """
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -222,7 +222,7 @@ public class DependencyInsightReportTask extends DefaultTask {
         legendRenderer.printLegend();
 
         output.println();
-        output.text("A web-based, searchable dependency tree is available: use the ");
+        output.text("A web-based, searchable dependency report is available by adding the ");
         output.withStyle(UserInput).format("--%s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
         output.println(" option.");
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -41,6 +41,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.NodeRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
 import org.gradle.api.tasks.diagnostics.internal.insight.DependencyInsightReporter;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.graph.GraphRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
@@ -216,10 +217,14 @@ public class DependencyInsightReportTask extends DefaultTask {
             if (!last) {
                 output.println();
             }
-
         }
 
         legendRenderer.printLegend();
+
+        output.println();
+        output.text("A web-based, searchable dependency tree is available: use the ");
+        output.withStyle(UserInput).format("--%s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
+        output.println(" option.");
     }
 
     private static AttributeMatchDetails match(Attribute<?> actualAttribute, Object actualValue, AttributeContainerInternal requestedAttributes) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRenderer.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.SimpleNodeRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableModuleResult;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvableConfigurationResult;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.graph.GraphRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.util.GUtil;
@@ -112,6 +113,12 @@ public class AsciiDependencyReportRenderer extends TextReportRenderer implements
     @Override
     public void complete() {
         legendRenderer.printLegend();
+
+        getTextOutput().println();
+        getTextOutput().text("A web-based, searchable dependency report is available by adding the ");
+        getTextOutput().withStyle(UserInput).format("--%s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
+        getTextOutput().println(" option.");
+
         super.complete();
     }
 

--- a/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
@@ -7,3 +7,5 @@ commons-codec:commons-codec:1.6 -> 1.7
 \--- org.apache.httpcomponents:httpclient:4.3.6
      \--- org.eclipse.jgit:org.eclipse.jgit:4.9.2.201712150930-r
           \--- scm
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
@@ -3,3 +3,5 @@ org.ow2.asm:asm:6.0 (we require a JDK 9 compatible bytecode generator)
       org.gradle.usage = java-api
    ]
 \--- compileClasspath
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReport.out
@@ -12,3 +12,5 @@ scm
      |    +--- commons-logging:commons-logging:1.1.3
      |    \--- commons-codec:commons-codec:1.6
      \--- org.slf4j:slf4j-api:1.7.2
+
+A web-based, searchable dependency report is available by adding the --scan option.


### PR DESCRIPTION
Build scans are searchable, web-based, and persistent. 

Supersedes #4352 

