### PR TITLE
Add support for capabilities

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilitiesHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilitiesHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts.dsl;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * A capabilities handler can be used to declare the capabilities of a component, or other components.
+ * Capabilities represent the "same functionality" and can be used to explain that two components provide
+ * the same functionality, but not with the same implementation. A typical example is the implementation of
+ * an API (different logging bindings, for example).
+ *
+ * This supercedes {@link ComponentModuleMetadataHandler component replacement rules}.
+ *
+ * @since 4.7
+ *
+ */
+@Incubating
+public interface CapabilitiesHandler {
+    /**
+     * Configures a capability.
+     *
+     * @param identifier the identifier of the capability to configure
+     * @param configureAction the configuration of the capability
+     */
+    void capability(String identifier, Action<? super CapabilityHandler> configureAction);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilitiesHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilitiesHandler.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A capabilities handler can be used to declare the capabilities of a component, or other components.
@@ -30,12 +31,14 @@ import org.gradle.api.Incubating;
  *
  */
 @Incubating
+@HasInternalProtocol
 public interface CapabilitiesHandler {
     /**
      * Configures a capability.
      *
      * @param identifier the identifier of the capability to configure
      * @param configureAction the configuration of the capability
+     *
      */
     void capability(String identifier, Action<? super CapabilityHandler> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Incubating;
+import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A single capability handler. A capability is provided by one or more modules.
@@ -24,6 +25,7 @@ import org.gradle.api.Incubating;
  * @since 4.7
  */
 @Incubating
+@HasInternalProtocol
 public interface CapabilityHandler {
     /**
      * Declares that this capability is provided by a module.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts.dsl;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A single capability handler. A capability is provided by one or more modules.
+ * A component <i>may</i> express a preference, but this is not required.
+ *
+ * @since 4.7
+ */
+@Incubating
+public interface CapabilityHandler {
+    /**
+     * Declares that this capability is provided by a module.
+     * @param moduleIdentifier the module notation (group:name)
+     */
+    void providedBy(String moduleIdentifier);
+
+    /**
+     * Declares that from all modules which provide the capability, the consumer prefers
+     * to use the specified module. This is used to disambiguate whenever multiple modules
+     * supplying the same capability are found in a dependency graph.
+     *
+     * @param moduleIdentifer the module identifier of the preferred module for this capability
+     *
+     * @return the preference
+     */
+    Preference prefer(String moduleIdentifer);
+
+    /**
+     * Wraps information about the preferred choice whenever multiple modules provide the
+     * same capability.
+     *
+     * @since 4.7
+     */
+    @Incubating
+    interface Preference {
+        /**
+         * Declares a custom reason why this component is preferred.
+         * @param reason the reason why this component is preferred
+         * @return this preference
+         */
+        Preference because(String reason);
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
@@ -29,9 +29,10 @@ import org.gradle.internal.HasInternalProtocol;
 public interface CapabilityHandler {
     /**
      * Declares that this capability is provided by a module.
+     *
      * @param moduleIdentifier the module notation (group:name)
      */
-    void providedBy(String moduleIdentifier);
+    CapabilityHandler providedBy(String moduleIdentifier);
 
     /**
      * Declares that from all modules which provide the capability, the consumer prefers
@@ -39,24 +40,16 @@ public interface CapabilityHandler {
      * supplying the same capability are found in a dependency graph.
      *
      * @param moduleIdentifer the module identifier of the preferred module for this capability
-     *
      * @return the preference
      */
-    Preference prefer(String moduleIdentifer);
+    CapabilityHandler prefer(String moduleIdentifer);
 
     /**
-     * Wraps information about the preferred choice whenever multiple modules provide the
-     * same capability.
+     * Declares a custom reason why this component sets a preference.
+     * @param reason the reason why this component declares a preference
      *
-     * @since 4.7
+     * @return this preference
      */
-    @Incubating
-    interface Preference {
-        /**
-         * Declares a custom reason why this component is preferred.
-         * @param reason the reason why this component is preferred
-         * @return this preference
-         */
-        Preference because(String reason);
-    }
+    CapabilityHandler because(String reason);
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -448,4 +448,15 @@ public interface DependencyHandler {
      */
     @Incubating
     void registerTransform(Action<? super VariantTransform> registrationAction);
+
+
+    /**
+     * Configures the capabilities definitions for this handler.
+     *
+     * @param configureAction the configuration action
+     *
+     * @since 4.7
+     */
+    @Incubating
+    void capabilities(Action<? super CapabilitiesHandler> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -459,4 +459,14 @@ public interface DependencyHandler {
      */
     @Incubating
     void capabilities(Action<? super CapabilitiesHandler> configureAction);
+
+    /**
+     * Returns the capabilities definitions for this handler.
+     *
+     * @return the capabilities
+     *
+     * @since 4.7
+     */
+    @Incubating
+    CapabilitiesHandler getCapabilities();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CapabilitiesIntegrationTest.groovy
@@ -67,8 +67,8 @@ class CapabilitiesIntegrationTest extends AbstractModuleDependencyResolveTest {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module('cglib:cglib:3.2.5').byReason(customReason ?: 'capability cglib is provided by cglib:cglib-nodep and cglib:cglib')
-                edge('cglib:cglib-nodep:3.2.5', 'cglib:cglib:3.2.5').byReason(customReason ?: 'capability cglib is provided by cglib:cglib-nodep and cglib:cglib')
+                module('cglib:cglib:3.2.5').byReason(customReason ?: 'capability cglib is provided by cglib:cglib and cglib:cglib-nodep')
+                edge('cglib:cglib-nodep:3.2.5', 'cglib:cglib:3.2.5').byReason(customReason ?: 'capability cglib is provided by cglib:cglib and cglib:cglib-nodep')
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CapabilitiesIntegrationTest.groovy
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import spock.lang.Unroll
+
+class CapabilitiesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        buildFile << """
+            configurations { conf }
+        """
+        executer.withStackTraceChecksDisabled()
+    }
+
+    /**
+     * This use case corresponds to an external library which has 2 variants published at
+     * different coordinates, and using both at the same time is illegal. The libraries
+     * were not published using Gradle, so the consumer needs a way to express that and
+     * enforce the use of only one of them at the same time.
+     */
+    @Unroll
+    def "can choose between cglib and cglib-nodep by declaring capabilities"() {
+        given:
+        repository {
+            'cglib:cglib:3.2.5'()
+            'cglib:cglib-nodep:3.2.5'()
+        }
+
+        buildFile << """
+            dependencies {
+               conf "cglib:cglib-nodep:3.2.5"
+               conf "cglib:cglib:3.2.5"
+            
+               capabilities {
+                  capability('cglib') {
+                     providedBy 'cglib:cglib'
+                     providedBy 'cglib:cglib-nodep'
+                     prefer 'cglib:cglib' ${customReason?"because '$customReason'":""}
+                  }
+               }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'cglib:cglib:3.2.5' {
+                expectResolve()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('cglib:cglib:3.2.5').byReason(customReason?:'capability cglib is provided by cglib:cglib-nodep and cglib:cglib')
+                edge('cglib:cglib-nodep:3.2.5', 'cglib:cglib:3.2.5').byReason(customReason?:'capability cglib is provided by cglib:cglib-nodep and cglib:cglib')
+            }
+        }
+
+        where:
+        customReason << [null, 'avoids a conflict with ASM']
+    }
+
+    /**
+     * This use case corresponds to the case where a library maintainer publishes a library
+     * either as individual modules, or using a fatjar. It's illegal to have both the fat jar and
+     * individual modules on the classpath, so we need a way to declare that we prefer to use
+     * the fat jar.
+     *
+     * This is from the consumer point of view, fixing the fact the library doesn't declare capabilities.
+     */
+    def "can select groovy-all over individual groovy-whatever"() {
+        given:
+        repository {
+            'org.apache:groovy:1.0'()
+            'org.apache:groovy-json:1.0'()
+            'org.apache:groovy-xml:1.0'()
+            'org.apache:groovy-all:1.0'()
+
+            'org:a:1.0' {
+                dependsOn 'org.apache:groovy:1.0'
+                dependsOn 'org.apache:groovy-json:1.0'
+            }
+            'org:b:1.0' {
+                dependsOn 'org.apache:groovy-all:1.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+               conf "org:a:1.0"
+               conf "org:b:1.0"
+            
+               capabilities {
+                  capability('groovy') {
+                     providedBy 'org.apache:groovy'
+                     prefer 'org.apache:groovy-all'
+                  }
+                  capability('groovy-json') {
+                     providedBy 'org.apache:groovy-json'
+                     prefer 'org.apache:groovy-all'
+                  }
+               }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:1.0' {
+                expectResolve()
+            }
+            'org:b:1.0' {
+                expectResolve()
+            }
+            'org.apache:groovy:1.0' {
+                expectGetMetadata()
+            }
+            'org.apache:groovy-json:1.0' {
+                expectGetMetadata()
+            }
+            'org.apache:groovy-all:1.0' {
+                expectResolve()
+            }
+        }
+
+        then:
+        run ':checkDeps'
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:a:1.0') {
+                    edge('org.apache:groovy:1.0', 'org.apache:groovy-all:1.0')
+                    edge('org.apache:groovy-json:1.0', 'org.apache:groovy-all:1.0')
+                }
+                module('org:b:1.0') {
+                    edge('org.apache:groovy-all:1.0', 'org.apache:groovy-all:1.0')
+                }
+            }
+        }
+
+    }
+
+    /**
+     * This use case corresponds to the case where a library maintainer publishes a library
+     * either as individual modules, or using a fatjar. It's illegal to have both the fat jar and
+     * individual modules on the classpath, so we need a way to declare that we prefer to use
+     * the individual jars instead.
+     *
+     * It's worth mentioning that the _consumer_ must, in this case, make sure that all the features
+     * actually used in the fatjar version are replaced with their appropriate module.
+     *
+     * This is from the consumer point of view, fixing the fact the library doesn't declare capabilities.
+     */
+    def "can select individual groovy-whatever over individual groovy-all"() {
+        given:
+        repository {
+            'org.apache:groovy:1.0'()
+            'org.apache:groovy-json:1.0'()
+            'org.apache:groovy-xml:1.0'()
+            'org.apache:groovy-all:1.0'()
+
+            'org:a:1.0' {
+                dependsOn 'org.apache:groovy:1.0'
+                dependsOn 'org.apache:groovy-json:1.0'
+            }
+            'org:b:1.0' {
+                dependsOn 'org.apache:groovy-all:1.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+               conf "org:a:1.0"
+               conf "org:b:1.0"
+            
+               capabilities {
+                  capability('groovy-json') {
+                     providedBy 'org.apache:groovy-json'
+                     providedBy 'org.apache:groovy-all'
+                  
+                     prefer 'org.apache:groovy-json'
+                  }
+                  
+                  capability('groovy') {
+                     providedBy 'org.apache:groovy'
+                     providedBy 'org.apache:groovy-all'
+                  
+                     prefer 'org.apache:groovy'
+                  }
+               }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:1.0' {
+                expectResolve()
+            }
+            'org:b:1.0' {
+                expectResolve()
+            }
+            'org.apache:groovy:1.0' {
+                expectResolve()
+            }
+            'org.apache:groovy-json:1.0' {
+                expectResolve()
+            }
+        }
+
+        then:
+        run ':checkDeps'
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:a:1.0') {
+                    edge('org.apache:groovy:1.0', 'org.apache:groovy:1.0')
+                    edge('org.apache:groovy-json:1.0', 'org.apache:groovy-json:1.0')
+                }
+                module('org:b:1.0') {
+                    // this is not quite right, as we should replace with 2 edges
+                    // one option to do it is to construct "adhoc" modules, and select an adhoc target in "prefer"
+                    // where this adhoc target would have dependencies on groovy-json and groovy
+                    edge('org.apache:groovy-all:1.0', 'org.apache:groovy-json:1.0')
+                }
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactDependencyResolver.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
@@ -33,5 +34,6 @@ public interface ArtifactDependencyResolver {
                  DependencyGraphVisitor graphVisitor,
                  DependencyArtifactsVisitor artifactsVisitor,
                  AttributesSchemaInternal consumerSchema,
-                 ArtifactTypeRegistry artifactTypeRegistry);
+                 ArtifactTypeRegistry artifactTypeRegistry,
+                 CapabilitiesHandler capabilitiesHandler);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -32,11 +32,13 @@ import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.dsl.ComponentModuleMetadataContainer;
 import org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultCapabilitiesHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler;
@@ -237,8 +239,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 artifactTypeRegistry);
         }
 
-        CapabilitiesHandler createCapabilitiesHandler(Instantiator instantiator, ComponentModuleMetadataHandler componentModuleMetadataHandler, ImmutableModuleIdentifierFactory factory) {
-            return instantiator.newInstance(DefaultCapabilitiesHandler.class, componentModuleMetadataHandler, factory);
+        CapabilitiesHandlerInternal createCapabilitiesHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory factory) {
+            return instantiator.newInstance(DefaultCapabilitiesHandler.class, factory);
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {
@@ -249,8 +251,12 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory);
         }
 
-        DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-            return instantiator.newInstance(DefaultComponentModuleMetadataHandler.class, moduleIdentifierFactory);
+        ComponentModuleMetadataContainer createComponentModuleMetadataContainer(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+            return new ComponentModuleMetadataContainer(moduleIdentifierFactory);
+        }
+
+        DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ComponentModuleMetadataContainer container, CapabilitiesHandlerInternal capabilitiesHandler) {
+            return instantiator.newInstance(DefaultComponentModuleMetadataHandler.class, container, capabilitiesHandler);
         }
 
         ArtifactHandler createArtifactHandler(Instantiator instantiator, DependencyMetaDataProvider dependencyMetaDataProvider, ConfigurationContainerInternal configurationContainer, DomainObjectContext context) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.StartParameter;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
@@ -36,6 +37,7 @@ import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultCapabilitiesHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
@@ -209,8 +211,18 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return new DefaultArtifactTypeRegistry(instantiator, immutableAttributesFactory);
         }
 
-        DependencyHandler createDependencyHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory,
-                                                  ProjectFinder projectFinder, DependencyConstraintHandler dependencyConstraintHandler, ComponentMetadataHandler componentMetadataHandler, ComponentModuleMetadataHandler componentModuleMetadataHandler, ArtifactResolutionQueryFactory resolutionQueryFactory, AttributesSchema attributesSchema, VariantTransformRegistry artifactTransformRegistrations, ArtifactTypeRegistry artifactTypeRegistry) {
+        DependencyHandler createDependencyHandler(Instantiator instantiator,
+                                                  ConfigurationContainerInternal configurationContainer,
+                                                  DependencyFactory dependencyFactory,
+                                                  ProjectFinder projectFinder,
+                                                  DependencyConstraintHandler dependencyConstraintHandler,
+                                                  ComponentMetadataHandler componentMetadataHandler,
+                                                  ComponentModuleMetadataHandler componentModuleMetadataHandler,
+                                                  CapabilitiesHandler capabilitiesHandler,
+                                                  ArtifactResolutionQueryFactory resolutionQueryFactory,
+                                                  AttributesSchema attributesSchema,
+                                                  VariantTransformRegistry artifactTransformRegistrations,
+                                                  ArtifactTypeRegistry artifactTypeRegistry) {
             return instantiator.newInstance(DefaultDependencyHandler.class,
                 configurationContainer,
                 dependencyFactory,
@@ -218,10 +230,15 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 dependencyConstraintHandler,
                 componentMetadataHandler,
                 componentModuleMetadataHandler,
+                capabilitiesHandler,
                 resolutionQueryFactory,
                 attributesSchema,
                 artifactTransformRegistrations,
                 artifactTypeRegistry);
+        }
+
+        CapabilitiesHandler createCapabilitiesHandler(Instantiator instantiator, ComponentModuleMetadataHandler componentModuleMetadataHandler) {
+            return instantiator.newInstance(DefaultCapabilitiesHandler.class, componentModuleMetadataHandler);
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {
@@ -259,7 +276,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                        ArtifactTypeRegistry artifactTypeRegistry,
                                                        ComponentSelectorConverter componentSelectorConverter,
                                                        AttributeContainerSerializer attributeContainerSerializer,
-                                                       BuildIdentity buildIdentity) {
+                                                       BuildIdentity buildIdentity,
+                                                       CapabilitiesHandler capabilitiesHandler) {
             return new ErrorHandlingConfigurationResolver(
                     new ShortCircuitEmptyConfigurationResolver(
                         new DefaultConfigurationResolver(
@@ -280,7 +298,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                             artifactTypeRegistry,
                             componentSelectorConverter,
                             attributeContainerSerializer,
-                            buildIdentity),
+                            buildIdentity,
+                            capabilitiesHandler),
                         componentIdentifierFactory,
                         moduleIdentifierFactory,
                         buildIdentity));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -237,8 +237,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 artifactTypeRegistry);
         }
 
-        CapabilitiesHandler createCapabilitiesHandler(Instantiator instantiator, ComponentModuleMetadataHandler componentModuleMetadataHandler) {
-            return instantiator.newInstance(DefaultCapabilitiesHandler.class, componentModuleMetadataHandler);
+        CapabilitiesHandler createCapabilitiesHandler(Instantiator instantiator, ComponentModuleMetadataHandler componentModuleMetadataHandler, ImmutableModuleIdentifierFactory factory) {
+            return instantiator.newInstance(DefaultCapabilitiesHandler.class, componentModuleMetadataHandler, factory);
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -255,8 +255,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return new ComponentModuleMetadataContainer(moduleIdentifierFactory);
         }
 
-        DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ComponentModuleMetadataContainer container, CapabilitiesHandlerInternal capabilitiesHandler) {
-            return instantiator.newInstance(DefaultComponentModuleMetadataHandler.class, container, capabilitiesHandler);
+        DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ComponentModuleMetadataContainer container) {
+            return instantiator.newInstance(DefaultComponentModuleMetadataHandler.class, container);
         }
 
         ArtifactHandler createArtifactHandler(Instantiator instantiator, DependencyMetaDataProvider dependencyMetaDataProvider, ConfigurationContainerInternal configurationContainer, DomainObjectContext context) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -295,7 +295,8 @@ class DependencyManagementBuildScopeServices {
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 ComponentSelectorConverter componentSelectorConverter,
                                                                 FeaturePreviews featurePreviews,
-                                                                ImmutableAttributesFactory attributesFactory) {
+                                                                ImmutableAttributesFactory attributesFactory,
+                                                                ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
         return new DefaultArtifactDependencyResolver(
             buildOperationExecutor,
             resolverFactories,
@@ -305,7 +306,7 @@ class DependencyManagementBuildScopeServices {
             moduleExclusions,
             componentSelectorConverter,
             featurePreviews,
-            attributesFactory);
+            attributesFactory, moduleIdentifierFactory);
     }
 
     ProjectPublicationRegistry createProjectPublicationRegistry() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilitiesModuleReplacements.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilitiesModuleReplacements.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl;
+
+import com.google.common.base.Joiner;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilityInternal;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class CapabilitiesModuleReplacements implements ModuleReplacementsData {
+    private final ModuleReplacementsData delegate;
+    private final CapabilitiesHandlerInternal capabilitiesHandler;
+
+    public CapabilitiesModuleReplacements(ModuleReplacementsData delegate, CapabilitiesHandlerInternal capabilitiesHandler) {
+        this.delegate = delegate;
+        this.capabilitiesHandler = capabilitiesHandler;
+    }
+
+    @Nullable
+    @Override
+    public Replacement getReplacementFor(ModuleIdentifier sourceModule) {
+        Replacement replacement = delegate.getReplacementFor(sourceModule);
+        if (replacement == null && capabilitiesHandler.hasCapabilities()) {
+            Collection<? extends CapabilityInternal> capabilities = capabilitiesHandler.getCapabilities(sourceModule);
+            for (CapabilityInternal capability : capabilities) {
+                ModuleIdentifier prefer = capability.getPrefer();
+                if (prefer != null && !sourceModule.equals(prefer)) {
+                    replacement = createReplacementForCapability(capability, prefer);
+                    break;
+                }
+            }
+        }
+        return replacement;
+    }
+
+    private static Replacement createReplacementForCapability(CapabilityInternal capability, ModuleIdentifier prefer) {
+        String because = capability.getReason();
+        if (because == null) {
+            because = "capability " + capability.getCapabilityId() + " is provided by " + Joiner.on(" and ").join(capability.getProvidedBy());
+        }
+        return new Replacement(prefer, because);
+    }
+
+    @Override
+    public boolean participatesInReplacements(ModuleIdentifier moduleId) {
+        boolean participates = delegate.participatesInReplacements(moduleId);
+        if (!participates && capabilitiesHandler.hasCapabilities()) {
+            return capabilitiesHandler.getCapabilities(moduleId) != null;
+        }
+        return participates;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentModuleMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentModuleMetadataHandler.java
@@ -19,15 +19,12 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.ComponentModuleMetadata;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.ComponentModuleMetadataProcessor;
-import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 
 public class DefaultComponentModuleMetadataHandler implements ComponentModuleMetadataHandler, ComponentModuleMetadataProcessor {
     private final ComponentModuleMetadataContainer moduleMetadataContainer;
-    private final ModuleReplacementsData moduleReplacementsData;
 
-    public DefaultComponentModuleMetadataHandler(ComponentModuleMetadataContainer moduleMetadataContainer, CapabilitiesHandlerInternal capabilitiesHandler) {
+    public DefaultComponentModuleMetadataHandler(ComponentModuleMetadataContainer moduleMetadataContainer) {
         this.moduleMetadataContainer = moduleMetadataContainer;
-        this.moduleReplacementsData = new CapabilitiesModuleReplacements(this.moduleMetadataContainer, capabilitiesHandler);
     }
 
     public void module(Object moduleNotation, Action<? super ComponentModuleMetadata> rule) {
@@ -35,6 +32,6 @@ public class DefaultComponentModuleMetadataHandler implements ComponentModuleMet
     }
 
     public ModuleReplacementsData getModuleReplacements() {
-        return moduleReplacementsData;
+        return moduleMetadataContainer;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentModuleMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentModuleMetadataHandler.java
@@ -19,13 +19,15 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.ComponentModuleMetadata;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.ComponentModuleMetadataProcessor;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 
 public class DefaultComponentModuleMetadataHandler implements ComponentModuleMetadataHandler, ComponentModuleMetadataProcessor {
     private final ComponentModuleMetadataContainer moduleMetadataContainer;
+    private final ModuleReplacementsData moduleReplacementsData;
 
-    public DefaultComponentModuleMetadataHandler(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        this.moduleMetadataContainer = new ComponentModuleMetadataContainer(moduleIdentifierFactory);
+    public DefaultComponentModuleMetadataHandler(ComponentModuleMetadataContainer moduleMetadataContainer, CapabilitiesHandlerInternal capabilitiesHandler) {
+        this.moduleMetadataContainer = moduleMetadataContainer;
+        this.moduleReplacementsData = new CapabilitiesModuleReplacements(this.moduleMetadataContainer, capabilitiesHandler);
     }
 
     public void module(Object moduleNotation, Action<? super ComponentModuleMetadata> rule) {
@@ -33,6 +35,6 @@ public class DefaultComponentModuleMetadataHandler implements ComponentModuleMet
     }
 
     public ModuleReplacementsData getModuleReplacements() {
-        return moduleMetadataContainer;
+        return moduleReplacementsData;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
+
+public interface CapabilitiesHandlerInternal extends CapabilitiesHandler {
+    void convertToReplacementRules();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
@@ -15,8 +15,18 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.collect.Multimap;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 
+import java.util.Collection;
+
 public interface CapabilitiesHandlerInternal extends CapabilitiesHandler {
-    void convertToReplacementRules();
+    void recordCapabilities(ModuleIdentifier module, Multimap<String, ModuleIdentifier> capabilityToModules);
+
+    ModuleIdentifier getPreferred(String capability);
+
+    boolean hasCapabilities();
+
+    Collection<? extends CapabilityInternal> getCapabilities(ModuleIdentifier module);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
@@ -29,4 +29,6 @@ public interface CapabilitiesHandlerInternal extends CapabilitiesHandler {
     boolean hasCapabilities();
 
     Collection<? extends CapabilityInternal> getCapabilities(ModuleIdentifier module);
+
+    CapabilityInternal getCapability(String name);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilitiesHandlerInternal.java
@@ -15,9 +15,11 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 
 import java.util.Collection;
 
@@ -31,4 +33,6 @@ public interface CapabilitiesHandlerInternal extends CapabilitiesHandler {
     Collection<? extends CapabilityInternal> getCapabilities(ModuleIdentifier module);
 
     CapabilityInternal getCapability(String name);
+
+    ImmutableList<? extends CapabilityDescriptor> listCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilityInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilityInternal.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+
+import java.util.Set;
+
+public interface CapabilityInternal {
+    String getCapabilityId();
+    Set<ModuleIdentifier> getProvidedBy();
+    ModuleIdentifier getPrefer();
+    String getReason();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilityInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilityInternal.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import com.google.common.collect.ComparisonChain;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 
 import java.util.Comparator;
 import java.util.Set;
@@ -32,8 +33,34 @@ public interface CapabilityInternal {
         }
     };
 
+    /**
+     * @return the identifier of the capability
+     */
     String getCapabilityId();
+
+    /**
+     * @return the set of modules which provide this capability
+     */
     Set<ModuleIdentifier> getProvidedBy();
+
+    /**
+     * If 2+ modules on the graph provide the same capability, one of them needs
+     * to be preferred. If not null, tells which one to use.
+     *
+     * @return the module which should be preferred
+     */
     ModuleIdentifier getPrefer();
+
+    /**
+     * A human readable explanation why the preferred module should be used
+     * @return the reason why to use the preferred module
+     */
     String getReason();
+
+    /**
+     * This method is used whenever we have a project dependency, to convert from the internal
+     * representation of capabilities to their consumable form.
+     * @return a capability descriptor
+     */
+    CapabilityDescriptor toCapabilityDescriptor();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilityInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/CapabilityInternal.java
@@ -15,11 +15,23 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.collect.ComparisonChain;
 import org.gradle.api.artifacts.ModuleIdentifier;
 
+import java.util.Comparator;
 import java.util.Set;
 
 public interface CapabilityInternal {
+    Comparator<ModuleIdentifier> MODULE_IDENTIFIER_COMPARATOR = new Comparator<ModuleIdentifier>() {
+        @Override
+        public int compare(ModuleIdentifier o1, ModuleIdentifier o2) {
+            return ComparisonChain.start()
+                .compare(o1.getGroup(), o2.getGroup())
+                .compare(o1.getName(), o2.getName())
+                .result();
+        }
+    };
+
     String getCapabilityId();
     Set<ModuleIdentifier> getProvidedBy();
     ModuleIdentifier getPrefer();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandler.java
@@ -22,7 +22,6 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.ComponentModuleMetadata;
 import org.gradle.api.artifacts.ComponentModuleMetadataDetails;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 import org.gradle.api.artifacts.dsl.CapabilityHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -33,7 +32,7 @@ import org.gradle.internal.typeconversion.NotationParserBuilder;
 import java.util.Map;
 import java.util.Set;
 
-public class DefaultCapabilitiesHandler implements CapabilitiesHandler {
+public class DefaultCapabilitiesHandler implements CapabilitiesHandlerInternal {
     private final ComponentModuleMetadataHandler metadataHandler;
     private final Map<String, DefaultCapability> capabilities = Maps.newHashMap();
     private final NotationParser<Object, ModuleIdentifier> notationParser;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.ComponentModuleMetadata;
+import org.gradle.api.artifacts.ComponentModuleMetadataDetails;
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
+import org.gradle.api.artifacts.dsl.CapabilityHandler;
+import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
+
+import java.util.Map;
+import java.util.Set;
+
+public class DefaultCapabilitiesHandler implements CapabilitiesHandler {
+    private final ComponentModuleMetadataHandler metadataHandler;
+    private final Map<String, DefaultCapability> capabilities = Maps.newHashMap();
+
+    public DefaultCapabilitiesHandler(ComponentModuleMetadataHandler metadataHandler) {
+        this.metadataHandler = metadataHandler;
+    }
+
+    @Override
+    public void capability(String identifier, Action<? super CapabilityHandler> configureAction) {
+        DefaultCapability capability = capabilities.get(identifier);
+        if (capability == null) {
+            capability = new DefaultCapability(identifier);
+            capabilities.put(identifier, capability);
+        }
+        configureAction.execute(capability);
+    }
+
+    public void convertToReplacementRules() {
+        for (Map.Entry<String, DefaultCapability> capabilityEntry : capabilities.entrySet()) {
+            DefaultCapability capabilityValue = capabilityEntry.getValue();
+            final String prefer = capabilityValue.prefer;
+            if (prefer != null) {
+                final String because;
+                if (capabilityValue.reason != null) {
+                    because = capabilityValue.reason;
+                } else {
+                    because = "capability " + capabilityEntry.getKey() + " is provided by " + Joiner.on(" and ").join(capabilityValue.providedBy);
+                }
+
+                for (String module : capabilityValue.providedBy) {
+                    if (!module.equals(prefer)) {
+                        metadataHandler.module(module, new Action<ComponentModuleMetadata>() {
+                            @Override
+                            public void execute(ComponentModuleMetadata componentModuleMetadata) {
+                                ((ComponentModuleMetadataDetails) componentModuleMetadata).replacedBy(prefer, because);
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    private final static class DefaultCapability implements CapabilityHandler {
+        private final String id;
+        private final Set<String> providedBy = Sets.newHashSet();
+        private String prefer;
+        private String reason;
+
+        private DefaultCapability(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public void providedBy(String moduleIdentifier) {
+            providedBy.add(moduleIdentifier);
+        }
+
+        @Override
+        public Preference prefer(String moduleIdentifer) {
+            prefer = moduleIdentifer;
+            return new Preference() {
+                @Override
+                public Preference because(String reason) {
+                    DefaultCapability.this.reason = reason;
+                    return this;
+                }
+            };
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandler.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -23,6 +24,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.CapabilityHandler;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
@@ -81,6 +83,19 @@ public class DefaultCapabilitiesHandler implements CapabilitiesHandlerInternal {
     @Override
     public CapabilityInternal getCapability(String name) {
         return capabilities.get(name);
+    }
+
+    @Override
+    public ImmutableList<? extends CapabilityDescriptor> listCapabilities() {
+        Collection<DefaultCapability> values = capabilities.values();
+        if (values.isEmpty()) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<CapabilityDescriptor> view = new ImmutableList.Builder<CapabilityDescriptor>();
+        for (final DefaultCapability value : values) {
+            view.add(value.toCapabilityDescriptor());
+        }
+        return view.build();
     }
 
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.dsl.CapabilityHandler;
+import org.gradle.internal.typeconversion.NotationParser;
+
+import java.util.Set;
+
+class DefaultCapability implements CapabilityHandler, CapabilityInternal {
+    private final NotationParser<Object, ModuleIdentifier> notationParser;
+    private final String id;
+    private String reason;
+
+    final Set<ModuleIdentifier> providedBy = Sets.newTreeSet(MODULE_IDENTIFIER_COMPARATOR);
+    ModuleIdentifier prefer;
+
+    DefaultCapability(NotationParser<Object, ModuleIdentifier> notationParser, String id) {
+        this.id = id;
+        this.notationParser = notationParser;
+    }
+
+    @Override
+    public void providedBy(String moduleIdentifier) {
+        providedBy.add(notationParser.parseNotation(moduleIdentifier));
+    }
+
+    @Override
+    public Preference prefer(String moduleIdentifier) {
+        prefer = notationParser.parseNotation(moduleIdentifier);
+        providedBy.add(prefer); // implicit assumption made explicit
+        return new Preference() {
+            @Override
+            public Preference because(String reason) {
+                DefaultCapability.this.reason = reason;
+                return this;
+            }
+        };
+    }
+
+    @Override
+    public String getCapabilityId() {
+        return id;
+    }
+
+    @Override
+    public Set<ModuleIdentifier> getProvidedBy() {
+        return providedBy;
+    }
+
+    @Override
+    public ModuleIdentifier getPrefer() {
+        return prefer;
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
@@ -15,9 +15,12 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.CapabilityHandler;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
+import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.typeconversion.NotationParser;
 
 import java.util.Set;
@@ -71,5 +74,14 @@ class DefaultCapability implements CapabilityHandler, CapabilityInternal {
     @Override
     public String getReason() {
         return reason;
+    }
+
+    @Override
+    public CapabilityDescriptor toCapabilityDescriptor() {
+        ImmutableList.Builder<String> providers = new ImmutableList.Builder<String>();
+        for (ModuleIdentifier identifier : providedBy) {
+            providers.add(identifier.toString());
+        }
+        return new DefaultImmutableCapability(id, providers.build(), prefer == null ? null : prefer.toString(), reason);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
@@ -39,21 +39,22 @@ class DefaultCapability implements CapabilityHandler, CapabilityInternal {
     }
 
     @Override
-    public void providedBy(String moduleIdentifier) {
+    public CapabilityHandler providedBy(String moduleIdentifier) {
         providedBy.add(notationParser.parseNotation(moduleIdentifier));
+        return this;
     }
 
     @Override
-    public Preference prefer(String moduleIdentifier) {
+    public CapabilityHandler prefer(String moduleIdentifier) {
         prefer = notationParser.parseNotation(moduleIdentifier);
         providedBy.add(prefer); // implicit assumption made explicit
-        return new Preference() {
-            @Override
-            public Preference because(String reason) {
-                DefaultCapability.this.reason = reason;
-                return this;
-            }
-        };
+        return this;
+    }
+
+    @Override
+    public CapabilityHandler because(String reason) {
+        this.reason = reason;
+        return this;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
@@ -46,6 +47,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     private final DependencyFactory dependencyFactory;
     private final ProjectFinder projectFinder;
     private final DependencyConstraintHandler dependencyConstraintHandler;
+    private final CapabilitiesHandler capabilitiesHandler;
     private final ComponentMetadataHandler componentMetadataHandler;
     private final ComponentModuleMetadataHandler componentModuleMetadataHandler;
     private final ArtifactResolutionQueryFactory resolutionQueryFactory;
@@ -60,6 +62,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
                                     DependencyConstraintHandler dependencyConstraintHandler,
                                     ComponentMetadataHandler componentMetadataHandler,
                                     ComponentModuleMetadataHandler componentModuleMetadataHandler,
+                                    CapabilitiesHandler capabilitiesHandler,
                                     ArtifactResolutionQueryFactory resolutionQueryFactory,
                                     AttributesSchema attributesSchema,
                                     VariantTransformRegistry transforms,
@@ -70,6 +73,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         this.dependencyConstraintHandler = dependencyConstraintHandler;
         this.componentMetadataHandler = componentMetadataHandler;
         this.componentModuleMetadataHandler = componentModuleMetadataHandler;
+        this.capabilitiesHandler = capabilitiesHandler;
         this.resolutionQueryFactory = resolutionQueryFactory;
         this.attributesSchema = attributesSchema;
         this.transforms = transforms;
@@ -207,6 +211,11 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     @Override
     public void registerTransform(Action<? super VariantTransform> registrationAction) {
         transforms.registerTransform(registrationAction);
+    }
+
+    @Override
+    public void capabilities(Action<? super CapabilitiesHandler> configureAction) {
+        configureAction.execute(capabilitiesHandler);
     }
 
     private class DirectDependencyAdder implements DynamicAddDependencyMethods.DependencyAdder<Dependency> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -218,6 +218,11 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         configureAction.execute(capabilitiesHandler);
     }
 
+    @Override
+    public CapabilitiesHandler getCapabilities() {
+        return capabilitiesHandler;
+    }
+
     private class DirectDependencyAdder implements DynamicAddDependencyMethods.DependencyAdder<Dependency> {
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/NoOpCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/NoOpCapabilitiesHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.dsl.CapabilityHandler;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class NoOpCapabilitiesHandler implements CapabilitiesHandlerInternal {
+    public final static CapabilitiesHandlerInternal INSTANCE = new NoOpCapabilitiesHandler();
+
+    @Override
+    public void recordCapabilities(ModuleIdentifier module, Multimap<String, ModuleIdentifier> capabilityToModules) {
+    }
+
+    @Override
+    public ModuleIdentifier getPreferred(String capability) {
+        return null;
+    }
+
+    @Override
+    public boolean hasCapabilities() {
+        return false;
+    }
+
+    @Override
+    public Collection<? extends CapabilityInternal> getCapabilities(ModuleIdentifier module) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public CapabilityInternal getCapability(String name) {
+        return null;
+    }
+
+    @Override
+    public ImmutableList<? extends CapabilityDescriptor> listCapabilities() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public void capability(String identifier, Action<? super CapabilityHandler> configureAction) {
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ResolutionScopeCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ResolutionScopeCapabilitiesHandler.java
@@ -54,11 +54,11 @@ public class ResolutionScopeCapabilitiesHandler implements CapabilitiesHandlerIn
         if (capability == null) {
             capability = new DefaultCapability(notationParser, identifier);
             capabilities.put(identifier, capability);
-        }
-        CapabilityInternal buildScopeCapability = buildScopeCapabilities.getCapability(identifier);
-        if (buildScopeCapability != null) {
-            capability.prefer = buildScopeCapability.getPrefer();
-            capability.providedBy.addAll(buildScopeCapability.getProvidedBy());
+            CapabilityInternal buildScopeCapability = buildScopeCapabilities.getCapability(identifier);
+            if (buildScopeCapability != null) {
+                capability.prefer = buildScopeCapability.getPrefer();
+                capability.providedBy.addAll(buildScopeCapability.getProvidedBy());
+            }
         }
         configureAction.execute(capability);
         for (ModuleIdentifier moduleIdentifier : capability.getProvidedBy()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ResolutionScopeCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ResolutionScopeCapabilitiesHandler.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -23,6 +24,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.CapabilityHandler;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
@@ -103,6 +105,11 @@ public class ResolutionScopeCapabilitiesHandler implements CapabilitiesHandlerIn
             return buildScopeCapabilities.getCapability(name);
         }
         return capability;
+    }
+
+    @Override
+    public ImmutableList<? extends CapabilityDescriptor> listCapabilities() {
+        throw new UnsupportedOperationException("This method shouldn't be called on a resolution scope handler");
     }
 
     private static NotationParser<Object, ModuleIdentifier> parser(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 53),
+    META_DATA(ROOT, "metadata", 54),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -32,7 +32,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.changedetection.state.CoercingStringValueSnapshot;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
-import org.gradle.internal.component.external.model.Capability;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
@@ -221,13 +221,14 @@ public class ModuleMetadataParser {
         return dependencies;
     }
 
-    private ImmutableList<? extends Capability> consumeCapabilities(JsonReader reader) throws IOException {
-        ImmutableList.Builder<Capability> capabilities = ImmutableList.builder();
+    private ImmutableList<? extends CapabilityDescriptor> consumeCapabilities(JsonReader reader) throws IOException {
+        ImmutableList.Builder<CapabilityDescriptor> capabilities = ImmutableList.builder();
         reader.beginArray();
         while (reader.peek() != END_ARRAY) {
             reader.beginObject();
             String name = null;
             String prefer = null;
+            String reason = null;
             ImmutableList<String> providedBy = null;
             while (reader.peek() != END_OBJECT) {
                 String val = reader.nextName();
@@ -237,9 +238,11 @@ public class ModuleMetadataParser {
                     prefer = reader.nextString();
                 } else if (val.equals("providedBy")) {
                     providedBy = readStringArray(reader);
+                } else if (val.equals("reason")) {
+                    reason = reader.nextString();
                 }
             }
-            capabilities.add(new DefaultImmutableCapability(name, providedBy, prefer));
+            capabilities.add(new DefaultImmutableCapability(name, providedBy, prefer, reason));
             reader.endObject();
         }
         reader.endArray();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -37,7 +37,7 @@ import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.descriptor.DefaultExclude;
 import org.gradle.internal.component.external.descriptor.MavenScope;
-import org.gradle.internal.component.external.model.Capability;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.component.external.model.ComponentVariant;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
@@ -157,11 +157,12 @@ public class ModuleMetadataSerializer {
             }
         }
 
-        private void writeCapabilities(ImmutableList<? extends Capability> capabilities) throws IOException {
+        private void writeCapabilities(ImmutableList<? extends CapabilityDescriptor> capabilities) throws IOException {
             encoder.writeSmallInt(capabilities.size());
-            for (Capability capability : capabilities) {
+            for (CapabilityDescriptor capability : capabilities) {
                 encoder.writeString(capability.getName());
                 encoder.writeNullableString(capability.getPrefer());
+                encoder.writeNullableString(capability.getReason());
                 List<String> providedBy = capability.getProvidedBy();
                 encoder.writeSmallInt(providedBy.size());
                 for (String s : providedBy) {
@@ -433,18 +434,19 @@ public class ModuleMetadataSerializer {
             }
         }
 
-        private ImmutableList<Capability> readCapabilities() throws IOException {
+        private ImmutableList<CapabilityDescriptor> readCapabilities() throws IOException {
             int count = decoder.readSmallInt();
-            ImmutableList.Builder<Capability> capabilities = new ImmutableList.Builder<Capability>();
+            ImmutableList.Builder<CapabilityDescriptor> capabilities = new ImmutableList.Builder<CapabilityDescriptor>();
             for (int i=0; i<count; i++) {
                 String name = decoder.readString();
                 String prefer = decoder.readNullableString();
+                String reason = decoder.readNullableString();
                 int providedCount = decoder.readSmallInt();
                 ImmutableList.Builder<String> providedBy = new ImmutableList.Builder<String>();
                 for (int j=0; j<providedCount; j++) {
                     providedBy.add(decoder.readString());
                 }
-                capabilities.add(new DefaultImmutableCapability(name, providedBy.build(), prefer));
+                capabilities.add(new DefaultImmutableCapability(name, providedBy.build(), prefer, reason));
             }
             return capabilities.build();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -23,6 +23,8 @@ import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.NoOpCapabilitiesHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -64,7 +66,8 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ProjectInternal project = projectFinder.findProject(module.getProjectPath());
         AttributesSchemaInternal schema = project == null ? null : (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
-        metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema);
+        CapabilitiesHandlerInternal capabilities = project == null ? NoOpCapabilitiesHandler.INSTANCE : (CapabilitiesHandlerInternal) project.getDependencies().getCapabilities();
+        metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema, capabilities);
         localComponentMetadataBuilder.addConfigurations(metaData, configurationsProvider.getAll());
         holder.cachedValue = metaData;
         return metaData;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -63,7 +64,7 @@ public class DefaultProjectLocalComponentProvider implements ProjectLocalCompone
         Module module = project.getModule();
         ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ComponentIdentifier componentIdentifier = newProjectId(project);
-        DefaultLocalComponentMetadata metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), (AttributesSchemaInternal) project.getDependencies().getAttributesSchema());
+        DefaultLocalComponentMetadata metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), (AttributesSchemaInternal) project.getDependencies().getAttributesSchema(), (CapabilitiesHandlerInternal) project.getDependencies().getCapabilities());
         metaDataBuilder.addConfigurations(metaData, project.getConfigurations().withType(ConfigurationInternal.class));
         return metaData;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ConflictResolverDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ConflictResolverDetails.java
@@ -15,10 +15,14 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
+
 import javax.annotation.Nullable;
 import java.util.Collection;
 
 public interface ConflictResolverDetails<T extends ComponentResolutionState> {
+    Collection<ModuleIdentifier> getParticipants();
+
     Collection<? extends T> getCandidates();
 
     void select(T candidate);
@@ -27,8 +31,6 @@ public interface ConflictResolverDetails<T extends ComponentResolutionState> {
 
     @Nullable
     T getSelected();
-
-    boolean isRestart();
 
     @Nullable
     Throwable getFailure();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
@@ -23,6 +24,7 @@ import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultCapabilitiesHandler;
 import org.gradle.api.internal.artifacts.ivyservice.clientmodule.ClientModuleResolver;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.CachingDependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator;
@@ -81,8 +83,9 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     }
 
     @Override
-    public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchemaInternal consumerSchema, ArtifactTypeRegistry artifactTypeRegistry) {
+    public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchemaInternal consumerSchema, ArtifactTypeRegistry artifactTypeRegistry, CapabilitiesHandler capabilitiesHandler) {
         LOGGER.debug("Resolving {}", resolveContext);
+        ((DefaultCapabilitiesHandler)capabilitiesHandler).convertToReplacementRules();
         ComponentResolversChain resolvers = createResolvers(resolveContext, repositories, metadataHandler, artifactTypeRegistry);
         DependencyGraphBuilder builder = createDependencyGraphBuilder(resolvers, resolveContext.getResolutionStrategy(), metadataHandler, edgeFilter, consumerSchema, moduleExclusions, buildOperationExecutor);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
-import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultCapabilitiesHandler;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.ivyservice.clientmodule.ClientModuleResolver;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.CachingDependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator;
@@ -85,7 +85,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     @Override
     public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchemaInternal consumerSchema, ArtifactTypeRegistry artifactTypeRegistry, CapabilitiesHandler capabilitiesHandler) {
         LOGGER.debug("Resolving {}", resolveContext);
-        ((DefaultCapabilitiesHandler)capabilitiesHandler).convertToReplacementRules();
+        ((CapabilitiesHandlerInternal)capabilitiesHandler).convertToReplacementRules();
         ComponentResolversChain resolvers = createResolvers(resolveContext, repositories, metadataHandler, artifactTypeRegistry);
         DependencyGraphBuilder builder = createDependencyGraphBuilder(resolvers, resolveContext.getResolutionStrategy(), metadataHandler, edgeFilter, consumerSchema, moduleExclusions, buildOperationExecutor);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultCapabilitiesModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultCapabilitiesModuleConflictResolver.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
+
+import java.util.Collection;
+
+/**
+ * This conflict resolver is trying to resolve conflicts based on the capabilities of the conflicting modules.
+ * If more than one module is in conflict and that they provide the same capability, it tries to find if
+ * there's a preferred module for the capability, in which case it's going to be selected.
+ */
+class DefaultCapabilitiesModuleConflictResolver implements ModuleConflictResolver {
+    private final CapabilitiesHandlerInternal capabilitiesHandler;
+
+    DefaultCapabilitiesModuleConflictResolver(CapabilitiesHandlerInternal capabilitiesHandler) {
+        this.capabilitiesHandler = capabilitiesHandler;
+    }
+
+    @Override
+    public <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details) {
+        if (capabilitiesHandler.hasCapabilities()) {
+            // todo CC: can be optimized further, if needed, by only creating the multimap if there's actually at least one capability provided by more than one module
+            Collection<? extends T> candidates = details.getCandidates();
+            Multimap<String, ModuleIdentifier> capabilitiesToCandidates = LinkedHashMultimap.create();
+            for (T candidate : candidates) {
+                ModuleIdentifier module = candidate.getId().getModule();
+                capabilitiesHandler.recordCapabilities(module, capabilitiesToCandidates);
+            }
+            if (capabilitiesToCandidates.isEmpty()) {
+                return;
+            }
+            tryPreferredCapabilityProvider(details, candidates, capabilitiesToCandidates);
+        }
+    }
+
+    private <T extends ComponentResolutionState> void tryPreferredCapabilityProvider(ConflictResolverDetails<T> details, Collection<? extends T> candidates, Multimap<String, ModuleIdentifier> capabilitiesToCandidates) {
+        for (String capability : capabilitiesToCandidates.keySet()) {
+            Collection<ModuleIdentifier> allModulesProvidingCapability = capabilitiesToCandidates.get(capability);
+            int inConflict = 0;
+            for (ModuleIdentifier participant : details.getParticipants()) {
+                if (allModulesProvidingCapability.contains(participant)) {
+                    inConflict++;
+                }
+            }
+            if (inConflict > 1) {
+                // there's a conflict between different modules with the same capability
+                ModuleIdentifier preferred = capabilitiesHandler.getPreferred(capability);
+                if (preferred == null) {
+                    throw new RuntimeException("Cannot choose between " + Joiner.on(" or ").join(details.getParticipants()) + " because they provide the same capability: " + capability);
+                }
+                // todo: handle case when there are more than one capabilities
+                for (T candidate : candidates) {
+                    if (candidate.getId().getModule().equals(preferred)) {
+                        details.select(candidate);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultCapabilitiesModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultCapabilitiesModuleConflictResolver.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * This conflict resolver is trying to resolve conflicts based on the capabilities of the conflicting modules.
@@ -68,10 +69,15 @@ class DefaultCapabilitiesModuleConflictResolver implements ModuleConflictResolve
                     throw new RuntimeException("Cannot choose between " + Joiner.on(" or ").join(details.getParticipants()) + " because they provide the same capability: " + capability);
                 }
                 // todo: handle case when there are more than one capabilities
-                for (T candidate : candidates) {
-                    if (candidate.getId().getModule().equals(preferred)) {
-                        details.select(candidate);
-                        return;
+                for (Iterator<? extends T> iterator = candidates.iterator(); iterator.hasNext(); ) {
+                    T candidate = iterator.next();
+                    if (!candidate.getId().getModule().equals(preferred)) {
+                        // this resolver doesn't select a version, it only removes the ones which are not valid
+                        // we do this because we still want version conflict to happen after this one, so it
+                        // only narrows the selection.
+                        // however, this should probably be handled in a different way, recognizing that resolvers
+                        // may cooperate to find the best solution
+                        iterator.remove();
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CapabilitiesValidatingGraphVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CapabilitiesValidatingGraphVisitor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilityInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.ResolutionScopeCapabilitiesHandler;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A dependency graph visitor which validates that all modules in the graph which provide the same
+ * capability are not in conflict. We have to do the validation late, because it's possible to
+ * discover new capabilities, and more importantly preferences for capabilities, as the graph is
+ * built (we don't know in advance what capabilities are going to be brought by transitive dependencies
+ * and it's possible for a module to express a preference for a capability).
+ */
+public class CapabilitiesValidatingGraphVisitor implements DependencyGraphVisitor {
+    private final DependencyGraphVisitor delegate;
+    private final ResolutionScopeCapabilitiesHandler capabilitiesHandler;
+
+    private final Map<ModuleIdentifier, Collection<? extends CapabilityInternal>> seenModulesToCapabilities = Maps.newHashMap();
+
+    public CapabilitiesValidatingGraphVisitor(DependencyGraphVisitor delegate, ResolutionScopeCapabilitiesHandler capabilitiesHandler) {
+        this.delegate = delegate;
+        this.capabilitiesHandler = capabilitiesHandler;
+    }
+
+    @Override
+    public void start(DependencyGraphNode root) {
+        delegate.start(root);
+    }
+
+    @Override
+    public void visitNode(DependencyGraphNode node) {
+        delegate.visitNode(node);
+        ModuleIdentifier module = node.getOwner().getModuleVersion().getModule();
+        if (capabilitiesHandler.hasCapabilities()) {
+            Collection<? extends CapabilityInternal> capabilities = capabilitiesHandler.getCapabilities(module);
+            if (!capabilities.isEmpty()) {
+                seenModulesToCapabilities.put(module, capabilities);
+            }
+        }
+    }
+
+    @Override
+    public void visitSelector(DependencyGraphSelector selector) {
+        delegate.visitSelector(selector);
+    }
+
+    @Override
+    public void visitEdges(DependencyGraphNode node) {
+        delegate.visitEdges(node);
+    }
+
+    @Override
+    public void finish(DependencyGraphNode root) {
+        delegate.finish(root);
+        for (Map.Entry<ModuleIdentifier, Collection<? extends CapabilityInternal>> entry : seenModulesToCapabilities.entrySet()) {
+            Collection<? extends CapabilityInternal> capabilities = entry.getValue();
+            // for each capability of this module, we must check if there's at least one other module in the graph
+            // which provides the same capability, in which case a preference should have been set
+            Set<ModuleIdentifier> seen = Sets.newTreeSet(CapabilityInternal.MODULE_IDENTIFIER_COMPARATOR);
+            for (CapabilityInternal capability : capabilities) {
+                if (capability.getPrefer() == null) {
+                    for (ModuleIdentifier provider : capability.getProvidedBy()) {
+                        if (seenModulesToCapabilities.containsKey(provider)) {
+                            seen.add(provider);
+                        }
+                    }
+                }
+                if (seen.size() > 1) {
+                    // at least 2 modules provide the same capability, and they do not agree
+                    throw new RuntimeException("Cannot choose between " + Joiner.on(" or ").join(seen) + " because they provide the same capability: " + capability.getCapabilityId());
+                }
+                seen.clear();
+            }
+        }
+    }
+}
+

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
@@ -74,6 +75,7 @@ public class DependencyGraphBuilder {
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
     private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory attributesFactory;
+    private final CapabilitiesHandlerInternal capabilitiesHandler;
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
@@ -83,7 +85,8 @@ public class DependencyGraphBuilder {
                                   BuildOperationExecutor buildOperationExecutor, ModuleReplacementsData moduleReplacementsData,
                                   DependencySubstitutionApplicator dependencySubstitutionApplicator, ComponentSelectorConverter componentSelectorConverter,
                                   FeaturePreviews featurePreviews,
-                                  ImmutableAttributesFactory attributesFactory) {
+                                  ImmutableAttributesFactory attributesFactory,
+                                  CapabilitiesHandlerInternal capabilitiesHandler) {
         this.idResolver = componentIdResolver;
         this.metaDataResolver = componentMetaDataResolver;
         this.moduleResolver = resolveContextToComponentResolver;
@@ -97,6 +100,7 @@ public class DependencyGraphBuilder {
         this.componentSelectorConverter = componentSelectorConverter;
         this.featurePreviews = featurePreviews;
         this.attributesFactory = attributesFactory;
+        this.capabilitiesHandler = capabilitiesHandler;
     }
 
     public void resolve(final ResolveContext resolveContext, final DependencyGraphVisitor modelVisitor) {
@@ -105,7 +109,7 @@ public class DependencyGraphBuilder {
         DefaultBuildableComponentResolveResult rootModule = new DefaultBuildableComponentResolveResult();
         moduleResolver.resolve(resolveContext, rootModule);
 
-        final ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleExclusions, moduleReplacementsData, componentSelectorConverter, attributesFactory, dependencySubstitutionApplicator);
+        ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleExclusions, moduleReplacementsData, componentSelectorConverter, attributesFactory, dependencySubstitutionApplicator, capabilitiesHandler);
         conflictHandler.registerResolver(new DirectDependencyForcingResolver(resolveState.getRoot().getComponent()));
 
         traverseGraph(resolveState);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -33,7 +33,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Modul
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.external.model.Capability;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -174,9 +174,9 @@ class EdgeState implements DependencyGraphEdge {
      * @param targetConfiguration the selected configuration
      */
     private void discoverAndApplyCapabilities(ConfigurationMetadata targetConfiguration) {
-        ImmutableList<? extends Capability> capabilities = targetConfiguration.getCapabilities();
+        ImmutableList<? extends CapabilityDescriptor> capabilities = targetConfiguration.getCapabilities();
         CapabilitiesHandlerInternal capabilitiesHandler = resolveState.getCapabilitiesHandler();
-        for (final Capability capability : capabilities) {
+        for (final CapabilityDescriptor capability : capabilities) {
             final String prefer = capability.getPrefer();
             capabilitiesHandler.capability(capability.getName(), new Action<CapabilityHandler>() {
                 @Override
@@ -188,7 +188,10 @@ class EdgeState implements DependencyGraphEdge {
                         handler.providedBy(provider);
                     }
                     if (prefer != null) {
-                        handler.prefer(prefer);
+                        CapabilityHandler.Preference preference = handler.prefer(prefer);
+                        if (capability.getReason() != null) {
+                            preference.because(capability.getReason());
+                        }
                     }
                     if (!Objects.equal(affected.getPrefer(), oldPreferred) || !Objects.equal(affected.getProvidedBy(), oldProvided)) {
                         resetSelectionForAffectedCapabilities(affected);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -201,7 +201,7 @@ class EdgeState implements DependencyGraphEdge {
             }
 
             private void trySetPreference(CapabilityHandler handler, CapabilityInternal affected, ModuleIdentifier oldPreferred) {
-                CapabilityHandler.Preference preference = handler.prefer(prefer);
+                CapabilityHandler preference = handler.prefer(prefer);
                 if (capability.getReason() != null) {
                     preference.because(capability.getReason());
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -93,7 +93,7 @@ class ModuleResolveState implements CandidateModule {
     }
 
     public void select(ComponentState selected) {
-        assert this.selected == null;
+//        assert this.selected == null;
         this.selected = selected;
         for (ComponentState version : versions.values()) {
             version.evict();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -64,12 +65,14 @@ class ResolveState {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final ImmutableAttributesFactory attributesFactory;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
+    private final CapabilitiesHandlerInternal capabilitiesHandler;
 
     public ResolveState(IdGenerator<Long> idGenerator, ComponentResolveResult rootResult, String rootConfigurationName, DependencyToComponentIdResolver idResolver,
                         ComponentMetaDataResolver metaDataResolver, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema,
                         ModuleExclusions moduleExclusions, ModuleReplacementsData moduleReplacementsData,
                         ComponentSelectorConverter componentSelectorConverter, ImmutableAttributesFactory attributesFactory,
-                        DependencySubstitutionApplicator dependencySubstitutionApplicator) {
+                        DependencySubstitutionApplicator dependencySubstitutionApplicator,
+                        CapabilitiesHandlerInternal capabilitiesHandler) {
         this.idGenerator = idGenerator;
         this.idResolver = idResolver;
         this.metaDataResolver = metaDataResolver;
@@ -80,6 +83,7 @@ class ResolveState {
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributesFactory = attributesFactory;
         this.dependencySubstitutionApplicator = dependencySubstitutionApplicator;
+        this.capabilitiesHandler = capabilitiesHandler;
         ComponentState rootVersion = getRevision(rootResult.getId());
         rootVersion.setMetaData(rootResult.getMetaData());
         final ResolvedConfigurationIdentifier id = new ResolvedConfigurationIdentifier(rootVersion.getId(), rootConfigurationName);
@@ -205,5 +209,9 @@ class ResolveState {
 
     public DependencySubstitutionApplicator getDependencySubstitutionApplicator() {
         return dependencySubstitutionApplicator;
+    }
+
+    public CapabilitiesHandlerInternal getCapabilitiesHandler() {
+        return capabilitiesHandler;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CompositeConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CompositeConflictResolver.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver;
@@ -77,8 +78,8 @@ class CompositeConflictResolver implements ModuleConflictResolver {
         }
 
         @Override
-        public boolean isRestart() {
-            return delegate.isRestart();
+        public Collection<ModuleIdentifier> getParticipants() {
+            return delegate.getParticipants();
         }
 
         @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictContainer.java
@@ -57,15 +57,15 @@ class ConflictContainer<K, T> {
             return null;
         }
         elements.put(target, candidates);
+        Collection<K> replacementSource = targetToSource.get(target);
         if (replacedBy != null) {
             targetToSource.put(replacedBy, target);
-            if (elements.containsKey(replacedBy)) {
+            if (replacementSource.isEmpty() && elements.containsKey(replacedBy)) {
                 //1) we've seen the replacement, register new conflict and return
                 return registerConflict(target, replacedBy);
             }
         }
 
-        Collection<K> replacementSource = targetToSource.get(target);
         if (!replacementSource.isEmpty()) {
             //2) new module is a replacement to a module we've seen already, register conflict and return
             return registerConflict(replacementSource, target);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolverDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolverDetails.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
 
@@ -22,25 +23,23 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 
 public class DefaultConflictResolverDetails<T extends ComponentResolutionState> implements ConflictResolverDetails<T> {
-    private final Collection<? extends T> participants;
+    private final Collection<ModuleIdentifier> participants;
+    private final Collection<? extends T> candidates;
     private T selected;
     private Throwable failure;
-    private boolean restart;
 
-    public DefaultConflictResolverDetails(Collection<? extends T> participants) {
+    public DefaultConflictResolverDetails(Collection<ModuleIdentifier> participants, Collection<? extends T> candidates) {
         this.participants = participants;
+        this.candidates = candidates;
     }
 
     @Override
     public Collection<? extends T> getCandidates() {
-        return participants;
+        return candidates;
     }
 
     @Override
     public void select(T candidate) {
-        if (restart) {
-            throw new IllegalStateException("Cannot select a candidate if another candidate has been queued for restart");
-        }
         selected = candidate;
     }
 
@@ -54,9 +53,10 @@ public class DefaultConflictResolverDetails<T extends ComponentResolutionState> 
         return selected;
     }
 
+
     @Override
-    public boolean isRestart() {
-        return restart;
+    public Collection<ModuleIdentifier> getParticipants() {
+        return participants;
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -57,6 +57,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue contentHash;
     private final ImmutableAttributes attributes;
+    private final ImmutableList<? extends Capability> capabilities;
 
     // Configurations are built on-demand, but only once.
     private final Map<String, DefaultConfigurationMetadata> configurations = Maps.newHashMap();
@@ -75,6 +76,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         attributesFactory = metadata.getAttributesFactory();
         attributes = extractAttributes(metadata);
         variants = metadata.getVariants();
+        capabilities = metadata.getCapabilities();
     }
 
     private static ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
@@ -98,6 +100,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         attributesFactory = metadata.getAttributesFactory();
         attributes = metadata.attributes;
         variants = metadata.variants;
+        capabilities = metadata.capabilities;
     }
 
     /**
@@ -165,7 +168,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         }
         List<VariantBackedConfigurationMetadata> configurations = new ArrayList<VariantBackedConfigurationMetadata>(variants.size());
         for (ComponentVariant variant : variants) {
-            configurations.add(new VariantBackedConfigurationMetadata(getComponentId(), variant, attributes, attributesFactory, variantMetadataRules));
+            configurations.add(new VariantBackedConfigurationMetadata(getComponentId(), variant, attributes, attributesFactory, variantMetadataRules, capabilities));
         }
         return ImmutableList.copyOf(configurations);
     }
@@ -261,6 +264,11 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
+    public ImmutableList<? extends Capability> getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -279,6 +287,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             && Objects.equal(configurationDefinitions, that.configurationDefinitions)
             && Objects.equal(attributes, that.attributes)
             && Objects.equal(variants, that.variants)
+            && Objects.equal(capabilities, that.capabilities)
             && Objects.equal(contentHash, that.contentHash);
     }
 
@@ -294,6 +303,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             configurationDefinitions,
             attributes,
             variants,
+            capabilities,
             contentHash);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -57,7 +57,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue contentHash;
     private final ImmutableAttributes attributes;
-    private final ImmutableList<? extends Capability> capabilities;
+    private final ImmutableList<? extends CapabilityDescriptor> capabilities;
 
     // Configurations are built on-demand, but only once.
     private final Map<String, DefaultConfigurationMetadata> configurations = Maps.newHashMap();
@@ -264,7 +264,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
-    public ImmutableList<? extends Capability> getCapabilities() {
+    public ImmutableList<? extends CapabilityDescriptor> getCapabilities() {
         return capabilities;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -65,6 +65,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
 
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
+    private ImmutableList<? extends Capability> capabilities = ImmutableList.of();
 
     AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier) {
         this.attributesFactory = attributesFactory;
@@ -255,6 +256,15 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         return attributesFactory;
     }
 
+    @Override
+    public ImmutableList<? extends Capability> getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    public void setCapabilities(ImmutableList<? extends Capability> capabilities) {
+        this.capabilities = capabilities;
+    }
 
     protected static class MutableVariantImpl implements MutableComponentVariant {
         private final String name;
@@ -529,4 +539,5 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
                 files);
         }
     }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -65,7 +65,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
 
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
-    private ImmutableList<? extends Capability> capabilities = ImmutableList.of();
+    private ImmutableList<? extends CapabilityDescriptor> capabilities = ImmutableList.of();
 
     AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier) {
         this.attributesFactory = attributesFactory;
@@ -257,12 +257,12 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
     }
 
     @Override
-    public ImmutableList<? extends Capability> getCapabilities() {
+    public ImmutableList<? extends CapabilityDescriptor> getCapabilities() {
         return capabilities;
     }
 
     @Override
-    public void setCapabilities(ImmutableList<? extends Capability> capabilities) {
+    public void setCapabilities(ImmutableList<? extends CapabilityDescriptor> capabilities) {
         this.capabilities = capabilities;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/Capability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/Capability.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import java.util.List;
+
+public interface Capability {
+    String getName();
+    List<String> getProvidedBy();
+    String getPrefer();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/CapabilityDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/CapabilityDescriptor.java
@@ -17,8 +17,9 @@ package org.gradle.internal.component.external.model;
 
 import java.util.List;
 
-public interface Capability {
+public interface CapabilityDescriptor {
     String getName();
     List<String> getProvidedBy();
     String getPrefer();
+    String getReason();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -165,4 +165,8 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
         return new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, attributes, configDependencies);
     }
 
+    @Override
+    public ImmutableList<? extends Capability> getCapabilities() {
+        return ImmutableList.of();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -166,7 +166,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     }
 
     @Override
-    public ImmutableList<? extends Capability> getCapabilities() {
+    public ImmutableList<? extends CapabilityDescriptor> getCapabilities() {
         return ImmutableList.of();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultImmutableCapability.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class DefaultImmutableCapability implements Capability {
+    private final String name;
+    private final ImmutableList<String> providedBy;
+    private final String prefer;
+
+    public DefaultImmutableCapability(String name, ImmutableList<String> providedBy, String prefer) {
+        this.name = name;
+        this.providedBy = providedBy;
+        this.prefer = prefer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultImmutableCapability that = (DefaultImmutableCapability) o;
+        return Objects.equal(name, that.name)
+            && Objects.equal(providedBy, that.providedBy)
+            && Objects.equal(prefer, that.prefer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, providedBy, prefer);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public List<String> getProvidedBy() {
+        return providedBy;
+    }
+
+    @Override
+    public String getPrefer() {
+        return prefer;
+    }
+
+    @Override
+    public String toString() {
+        return "Capability '" + name + "' provided by " + providedBy + (prefer == null ? "" : " prefers " + prefer);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultImmutableCapability.java
@@ -20,15 +20,17 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
-public class DefaultImmutableCapability implements Capability {
+public class DefaultImmutableCapability implements CapabilityDescriptor {
     private final String name;
     private final ImmutableList<String> providedBy;
     private final String prefer;
+    private final String reason;
 
-    public DefaultImmutableCapability(String name, ImmutableList<String> providedBy, String prefer) {
+    public DefaultImmutableCapability(String name, ImmutableList<String> providedBy, String prefer, String reason) {
         this.name = name;
         this.providedBy = providedBy;
         this.prefer = prefer;
+        this.reason = reason;
     }
 
     @Override
@@ -42,12 +44,13 @@ public class DefaultImmutableCapability implements Capability {
         DefaultImmutableCapability that = (DefaultImmutableCapability) o;
         return Objects.equal(name, that.name)
             && Objects.equal(providedBy, that.providedBy)
-            && Objects.equal(prefer, that.prefer);
+            && Objects.equal(prefer, that.prefer)
+            && Objects.equal(reason, that.reason);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, providedBy, prefer);
+        return Objects.hashCode(name, providedBy, prefer, reason);
     }
 
     @Override
@@ -66,7 +69,12 @@ public class DefaultImmutableCapability implements Capability {
     }
 
     @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
     public String toString() {
-        return "Capability '" + name + "' provided by " + providedBy + (prefer == null ? "" : " prefers " + prefer);
+        return "Capability '" + name + "' provided by " + providedBy + (prefer == null ? "" : " prefers " + prefer) + (reason == null ? "" : " because " + reason);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
@@ -64,4 +64,5 @@ public interface ModuleComponentResolveMetadata extends ComponentResolveMetadata
 
     ImmutableAttributesFactory getAttributesFactory();
 
+    ImmutableList<? extends Capability> getCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
@@ -64,5 +64,5 @@ public interface ModuleComponentResolveMetadata extends ComponentResolveMetadata
 
     ImmutableAttributesFactory getAttributesFactory();
 
-    ImmutableList<? extends Capability> getCapabilities();
+    ImmutableList<? extends CapabilityDescriptor> getCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.external.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
@@ -95,4 +96,14 @@ public interface MutableModuleComponentResolveMetadata {
      * Returns the metadata rules container for this module
      */
     VariantMetadataRules getVariantMetadataRules();
+
+    /**
+     * Returns the list of capabilities this component declares. A component may declare capabilities
+     * for other components.
+     *
+     * @return the capability list this component declares.
+     */
+    ImmutableList<? extends Capability> getCapabilities();
+
+    void setCapabilities(ImmutableList<? extends Capability> capabilities);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -103,7 +103,7 @@ public interface MutableModuleComponentResolveMetadata {
      *
      * @return the capability list this component declares.
      */
-    ImmutableList<? extends Capability> getCapabilities();
+    ImmutableList<? extends CapabilityDescriptor> getCapabilities();
 
-    void setCapabilities(ImmutableList<? extends Capability> capabilities);
+    void setCapabilities(ImmutableList<? extends CapabilityDescriptor> capabilities);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -46,11 +46,17 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     private final ImmutableList<GradleDependencyMetadata> dependencies;
     private final VariantMetadataRules variantMetadataRules;
     private final ImmutableAttributes componentLevelAttributes;
+    private final ImmutableList<? extends Capability> capabilities;
 
     private List<GradleDependencyMetadata> calculatedDependencies;
     private ImmutableAttributesFactory attributesFactory;
 
-    VariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules) {
+    VariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId,
+                                       ComponentVariant variant,
+                                       ImmutableAttributes componentLevelAttributes,
+                                       ImmutableAttributesFactory attributesFactory,
+                                       VariantMetadataRules variantMetadataRules,
+                                       ImmutableList<? extends Capability> capabilities) {
         this.componentId = componentId;
         this.variant = new RuleAwareVariant(variant);
         this.attributesFactory = attributesFactory;
@@ -66,6 +72,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
             dependencies.add(new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()), true, dependencyConstraint.getReason()));
         }
         this.dependencies = ImmutableList.copyOf(dependencies);
+        this.capabilities = capabilities;
     }
 
     @Override
@@ -126,6 +133,11 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     @Override
     public ComponentArtifactMetadata artifact(IvyArtifactName artifact) {
         return new DefaultModuleComponentArtifactMetadata(componentId, artifact);
+    }
+
+    @Override
+    public ImmutableList<? extends Capability> getCapabilities() {
+        return capabilities;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -46,7 +46,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     private final ImmutableList<GradleDependencyMetadata> dependencies;
     private final VariantMetadataRules variantMetadataRules;
     private final ImmutableAttributes componentLevelAttributes;
-    private final ImmutableList<? extends Capability> capabilities;
+    private final ImmutableList<? extends CapabilityDescriptor> capabilities;
 
     private List<GradleDependencyMetadata> calculatedDependencies;
     private ImmutableAttributesFactory attributesFactory;
@@ -56,7 +56,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
                                        ImmutableAttributes componentLevelAttributes,
                                        ImmutableAttributesFactory attributesFactory,
                                        VariantMetadataRules variantMetadataRules,
-                                       ImmutableList<? extends Capability> capabilities) {
+                                       ImmutableList<? extends CapabilityDescriptor> capabilities) {
         this.componentId = componentId;
         this.variant = new RuleAwareVariant(variant);
         this.attributesFactory = attributesFactory;
@@ -136,7 +136,7 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     }
 
     @Override
-    public ImmutableList<? extends Capability> getCapabilities() {
+    public ImmutableList<? extends CapabilityDescriptor> getCapabilities() {
         return capabilities;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.Capability;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -455,6 +456,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             }
 
             return new MissingLocalArtifactMetadata(componentIdentifier, ivyArtifactName);
+        }
+
+        @Override
+        public ImmutableList<? extends Capability> getCapabilities() {
+            return ImmutableList.of();
         }
 
         private boolean include(DefaultLocalConfigurationMetadata configuration) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -31,12 +31,13 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.Capability;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -62,13 +63,15 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     private final ComponentIdentifier componentIdentifier;
     private final String status;
     private final AttributesSchemaInternal attributesSchema;
+    private final CapabilitiesHandlerInternal capabilitiesHandler;
     private ImmutableList<ConfigurationMetadata> consumableConfigurations;
 
-    public DefaultLocalComponentMetadata(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, String status, AttributesSchemaInternal attributesSchema) {
+    public DefaultLocalComponentMetadata(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, String status, AttributesSchemaInternal attributesSchema, CapabilitiesHandlerInternal capabilitiesHandler) {
         this.id = id;
         this.componentIdentifier = componentIdentifier;
         this.status = status;
         this.attributesSchema = attributesSchema;
+        this.capabilitiesHandler = capabilitiesHandler;
     }
 
     @Override
@@ -80,7 +83,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
      * Creates a copy of this metadata, transforming the artifacts and dependencies of this component.
      */
     public DefaultLocalComponentMetadata copy(ComponentIdentifier componentIdentifier, Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifacts, Transformer<LocalOriginDependencyMetadata, LocalOriginDependencyMetadata> dependencies) {
-        DefaultLocalComponentMetadata copy = new DefaultLocalComponentMetadata(id, componentIdentifier, status, attributesSchema);
+        DefaultLocalComponentMetadata copy = new DefaultLocalComponentMetadata(id, componentIdentifier, status, attributesSchema, capabilitiesHandler);
         for (DefaultLocalConfigurationMetadata configuration : allConfigurations.values()) {
             copy.addConfiguration(configuration.getName(), configuration.description, configuration.extendsFrom, configuration.hierarchy, configuration.visible, configuration.transitive, configuration.attributes, configuration.canBeConsumed, configuration.canBeResolved);
         }
@@ -459,8 +462,8 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         }
 
         @Override
-        public ImmutableList<? extends Capability> getCapabilities() {
-            return ImmutableList.of();
+        public ImmutableList<? extends CapabilityDescriptor> getCapabilities() {
+            return capabilitiesHandler.listCapabilities();
         }
 
         private boolean include(DefaultLocalConfigurationMetadata configuration) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.Capability;
 import org.gradle.internal.component.external.model.MavenDependencyDescriptor;
 
 import java.util.Collection;
@@ -87,4 +88,6 @@ public interface ConfigurationMetadata extends HasAttributes {
      * (For external module components, we just instantiate a new artifact metadata).
      */
     ComponentArtifactMetadata artifact(IvyArtifactName artifact);
+
+    ImmutableList<? extends Capability> getCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.Capability;
+import org.gradle.internal.component.external.model.CapabilityDescriptor;
 import org.gradle.internal.component.external.model.MavenDependencyDescriptor;
 
 import java.util.Collection;
@@ -89,5 +89,5 @@ public interface ConfigurationMetadata extends HasAttributes {
      */
     ComponentArtifactMetadata artifact(IvyArtifactName artifact);
 
-    ImmutableList<? extends Capability> getCapabilities();
+    ImmutableList<? extends CapabilityDescriptor> getCapabilities();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandlerTest.groovy
@@ -16,14 +16,12 @@
 
 package org.gradle.api.internal.artifacts.dsl.dependencies
 
-import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import spock.lang.Specification
 
 class DefaultCapabilitiesHandlerTest extends Specification {
-    def componentModuleMetadataHandler = Mock(ComponentModuleMetadataHandler)
     def moduleFactory = new DefaultImmutableModuleIdentifierFactory()
-    def capabilities = new DefaultCapabilitiesHandler(componentModuleMetadataHandler, moduleFactory)
+    def capabilities = new DefaultCapabilitiesHandler(moduleFactory)
 
     def "can declare a capability"() {
         given:
@@ -39,29 +37,5 @@ class DefaultCapabilitiesHandlerTest extends Specification {
             assert it.is(c)
             it.prefer 'foo:bar'
         }
-    }
-
-    def "converts capabilities to rules"() {
-        given:
-        capabilities.capability('foo') {
-            it.providedBy('foo:bar')
-            it.providedBy('foo:baz')
-        }
-
-        when:
-        capabilities.convertToReplacementRules()
-
-        then:
-        0 * componentModuleMetadataHandler.module(_, _)
-
-        when:
-        capabilities.capability('foo') {
-            it.prefer('foo:bar')
-        }
-        capabilities.convertToReplacementRules()
-
-        then:
-        1 * componentModuleMetadataHandler.module(moduleFactory.module('foo', 'baz'), _)
-        0 * _
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandlerTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl.dependencies
+
+import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
+import spock.lang.Specification
+
+class DefaultCapabilitiesHandlerTest extends Specification {
+    def componentModuleMetadataHandler = Mock(ComponentModuleMetadataHandler)
+    def capabilities = new DefaultCapabilitiesHandler(componentModuleMetadataHandler)
+
+    def "can declare a capability"() {
+        given:
+        def c
+        expect:
+        capabilities.capability('foo') {
+            c = it
+            it.providedBy 'foo:bar'
+        }
+
+        and:
+        capabilities.capability('foo') {
+            assert it.is(c)
+            it.prefer 'foo:bar'
+        }
+    }
+
+    def "converts capabilities to rules"() {
+        given:
+        capabilities.capability('foo') {
+            it.providedBy('foo:bar')
+            it.providedBy('foo:baz')
+        }
+
+        when:
+        capabilities.convertToReplacementRules()
+
+        then:
+        0 * componentModuleMetadataHandler.module(_, _)
+
+        when:
+        capabilities.capability('foo') {
+            it.prefer('foo:bar')
+        }
+        capabilities.convertToReplacementRules()
+
+        then:
+        1 * componentModuleMetadataHandler.module('foo:baz', _)
+        0 * _
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapabilitiesHandlerTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.api.internal.artifacts.dsl.dependencies
 
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
+import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import spock.lang.Specification
 
 class DefaultCapabilitiesHandlerTest extends Specification {
     def componentModuleMetadataHandler = Mock(ComponentModuleMetadataHandler)
-    def capabilities = new DefaultCapabilitiesHandler(componentModuleMetadataHandler)
+    def moduleFactory = new DefaultImmutableModuleIdentifierFactory()
+    def capabilities = new DefaultCapabilitiesHandler(componentModuleMetadataHandler, moduleFactory)
 
     def "can declare a capability"() {
         given:
@@ -59,7 +61,7 @@ class DefaultCapabilitiesHandlerTest extends Specification {
         capabilities.convertToReplacementRules()
 
         then:
-        1 * componentModuleMetadataHandler.module('foo:baz', _)
+        1 * componentModuleMetadataHandler.module(moduleFactory.module('foo', 'baz'), _)
         0 * _
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
@@ -47,7 +48,7 @@ class DefaultDependencyHandlerTest extends Specification {
     private DependencySet dependencySet = Mock()
 
     private DefaultDependencyHandler dependencyHandler = new AsmBackedClassGenerator().newInstance(DefaultDependencyHandler,
-        configurationContainer, dependencyFactory, projectFinder, Stub(DependencyConstraintHandler), Stub(ComponentMetadataHandler), Stub(ComponentModuleMetadataHandler), Stub(ArtifactResolutionQueryFactory),
+        configurationContainer, dependencyFactory, projectFinder, Stub(DependencyConstraintHandler), Stub(ComponentMetadataHandler), Stub(ComponentModuleMetadataHandler), Stub(CapabilitiesHandler), Stub(ArtifactResolutionQueryFactory),
         Stub(AttributesSchema), Stub(VariantTransformRegistry), Stub(Factory))
 
     void setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.53'
-        cacheLayout.version == VersionNumber.parse("2.53.0")
-        cacheLayout.formattedVersion == '2.53'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.53')
+        cacheLayout.key == 'metadata-2.54'
+        cacheLayout.version == VersionNumber.parse("2.54.0")
+        cacheLayout.formattedVersion == '2.54'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.54')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.Attribute
@@ -24,6 +25,8 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionCon
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.descriptor.DefaultExclude
+import org.gradle.internal.component.external.model.Capability
+import org.gradle.internal.component.external.model.DefaultImmutableCapability
 import org.gradle.internal.component.external.model.MutableComponentVariant
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
 import org.gradle.internal.component.model.Exclude
@@ -94,6 +97,29 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.setAttributes(attributes(foo: 'bar', 'org.gradle.status': 'release'))
+        0 * _
+    }
+
+    def "parses component metadata capabilities"() {
+        def metadata = Mock(MutableModuleComponentResolveMetadata)
+        def capabilities = ImmutableList.<Capability>of(
+            new DefaultImmutableCapability("slf4j binding", ImmutableList.of("foo", "bar"), "foo"),
+            new DefaultImmutableCapability("cap", ImmutableList.of("blah"), null)
+        )
+
+        when:
+        parser.parse(resource('''
+    { 
+        "formatVersion": "0.3", 
+        "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v", "capabilities": [
+            {"name": "slf4j binding", "providedBy": ["foo", "bar"], "prefer": "foo" },
+            {"name": "cap", "providedBy": ["blah"] }] },
+        "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
+    }
+'''), metadata)
+
+        then:
+        1 * metadata.setCapabilities(capabilities)
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionCon
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.descriptor.DefaultExclude
-import org.gradle.internal.component.external.model.Capability
+import org.gradle.internal.component.external.model.CapabilityDescriptor
 import org.gradle.internal.component.external.model.DefaultImmutableCapability
 import org.gradle.internal.component.external.model.MutableComponentVariant
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
@@ -102,9 +102,10 @@ class ModuleMetadataParserTest extends Specification {
 
     def "parses component metadata capabilities"() {
         def metadata = Mock(MutableModuleComponentResolveMetadata)
-        def capabilities = ImmutableList.<Capability>of(
-            new DefaultImmutableCapability("slf4j binding", ImmutableList.of("foo", "bar"), "foo"),
-            new DefaultImmutableCapability("cap", ImmutableList.of("blah"), null)
+        def capabilities = ImmutableList.<CapabilityDescriptor>of(
+            new DefaultImmutableCapability("slf4j binding", ImmutableList.of("foo", "bar"), "foo", null),
+            new DefaultImmutableCapability("cap", ImmutableList.of("blah"), null, null),
+            new DefaultImmutableCapability("cap2", ImmutableList.of("blah"), null, "because")
         )
 
         when:
@@ -113,7 +114,9 @@ class ModuleMetadataParserTest extends Specification {
         "formatVersion": "0.3", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v", "capabilities": [
             {"name": "slf4j binding", "providedBy": ["foo", "bar"], "prefer": "foo" },
-            {"name": "cap", "providedBy": ["blah"] }] },
+            {"name": "cap", "providedBy": ["blah"] },
+            {"name": "cap2", "providedBy": ["blah"], "reason": "because" }
+            ] },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
 '''), metadata)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -35,7 +35,7 @@ import spock.lang.Specification
 abstract class AbstractConflictResolverTest extends Specification {
 
     List<ComponentResolutionState> participants = []
-    ConflictResolverDetails<ComponentResolutionState> details = new DefaultConflictResolverDetails(participants)
+    ConflictResolverDetails<ComponentResolutionState> details = new DefaultConflictResolverDetails([], participants)
 
     ModuleConflictResolver resolver
     TestComponent root = new TestComponent(DefaultModuleVersionIdentifier.newId('', 'root', ''))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -108,7 +108,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements, capabilitiesHandler), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory(), capabilitiesHandler)
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -555,7 +555,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements, capabilitiesHandler), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory(), capabilitiesHandler)
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
@@ -98,6 +99,7 @@ class DependencyGraphBuilderTest extends Specification {
             DefaultModuleIdentifier.newId(selector.group, selector.module)
         }
     }
+    def capabilitiesHandler = Mock(CapabilitiesHandlerInternal)
 
     DependencyGraphBuilder builder
 
@@ -106,7 +108,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements, capabilitiesHandler), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -553,7 +555,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements, capabilitiesHandler), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.featurePreviews(), TestUtil.attributesFactory())
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
 import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal
+import org.gradle.api.internal.artifacts.dsl.dependencies.NoOpCapabilitiesHandler
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
@@ -1001,14 +1002,14 @@ class DependencyGraphBuilderTest extends Specification {
     def revision(String name, String revision = '1.0') {
         // TODO Shouldn't really be using the local component implementation here
         def id = newId("group", name, revision)
-        def metaData = new DefaultLocalComponentMetadata(id, DefaultModuleComponentIdentifier.newId(id), "release", attributesSchema)
+        def metaData = new DefaultLocalComponentMetadata(id, DefaultModuleComponentIdentifier.newId(id), "release", attributesSchema, NoOpCapabilitiesHandler.INSTANCE)
         metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, attributes, true, true)
         metaData.addArtifacts("default", [new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip"))])
         return metaData
     }
 
     def project(String name, String revision = '1.0', List<String> extraConfigs = []) {
-        def metaData = new DefaultLocalComponentMetadata(newId("group", name, revision), newProjectId(":${name}"), "release", attributesSchema)
+        def metaData = new DefaultLocalComponentMetadata(newId("group", name, revision), newProjectId(":${name}"), "release", attributesSchema, NoOpCapabilitiesHandler.INSTANCE)
         metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, attributes, true, true)
         extraConfigs.each { String config ->
             metaData.addConfiguration(config, "${config}Config", ["default"] as Set<String>, ["default", config] as Set<String>, true, true, attributes, true, true)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
-import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver
@@ -31,8 +30,7 @@ class DefaultConflictHandlerTest extends Specification {
 
     def resolver = Mock(ModuleConflictResolver)
     def replacements = Mock(ModuleReplacementsData)
-    def capabilitiesHandler = Mock(CapabilitiesHandlerInternal)
-    @Subject handler = new DefaultConflictHandler(resolver, replacements, capabilitiesHandler)
+    @Subject handler = new DefaultConflictHandler(resolver, replacements)
     def details = Mock(ConflictResolverDetails)
 
     def "registers unconflicted modules"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver
@@ -30,7 +31,8 @@ class DefaultConflictHandlerTest extends Specification {
 
     def resolver = Mock(ModuleConflictResolver)
     def replacements = Mock(ModuleReplacementsData)
-    @Subject handler = new DefaultConflictHandler(resolver, replacements)
+    def capabilitiesHandler = Mock(CapabilitiesHandlerInternal)
+    @Subject handler = new DefaultConflictHandler(resolver, replacements, capabilitiesHandler)
     def details = Mock(ConflictResolverDetails)
 
     def "registers unconflicted modules"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant
+import org.gradle.api.internal.artifacts.dsl.dependencies.NoOpCapabilitiesHandler
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributeContainerInternal
@@ -40,7 +41,7 @@ import spock.lang.Specification
 class DefaultLocalComponentMetadataTest extends Specification {
     def id = DefaultModuleVersionIdentifier.newId("group", "module", "version")
     def componentIdentifier = DefaultModuleComponentIdentifier.newId(id)
-    def metadata = new DefaultLocalComponentMetadata(id, componentIdentifier, "status", Mock(AttributesSchemaInternal))
+    def metadata = new DefaultLocalComponentMetadata(id, componentIdentifier, "status", Mock(AttributesSchemaInternal), NoOpCapabilitiesHandler.INSTANCE)
 
     def "can lookup configuration after it has been added"() {
         when:

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-capabilities.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-capabilities.module
@@ -1,0 +1,25 @@
+{
+    "formatVersion": "0.3",
+    "component": {
+        "group": "org.gradle.test",
+        "module": "publishTest",
+        "version": "1.9",
+        "capabilities": [
+            {
+                "name": "slf4j binding",
+                "providedBy": [
+                    "foo",
+                    "bar"
+                ],
+                "prefer": "foo"
+            },
+            {
+                "name": "groovy",
+                "providedBy": [
+                    "org.codehaus.groovy:groovy",
+                    "org.codehaus.groovy:groovy-all"
+                ]
+            }
+        ]
+    }
+}

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.test.fixtures.HttpModule
 import org.gradle.test.fixtures.HttpRepository
 import org.gradle.test.fixtures.Module
+import org.gradle.test.fixtures.gradle.CapabilitySpec
 import org.gradle.test.fixtures.gradle.FileSpec
 import org.gradle.test.fixtures.ivy.IvyModule
 import org.gradle.test.fixtures.maven.MavenModule
@@ -40,6 +41,7 @@ class ModuleVersionSpec {
     private final Map<String, String> componentLevelAttributes = [:]
     private List<InteractionExpectation> expectGetMetadata = [InteractionExpectation.NONE]
     private List<ArtifactExpectation> expectGetArtifact = []
+    private Map<String, CapabilitySpec> capabilities = [:].withDefault { new CapabilitySpec(it) }
 
     static class ArtifactExpectation {
         final InteractionExpectation type
@@ -104,6 +106,12 @@ class ModuleVersionSpec {
 
     void expectGetVariantArtifacts(String variant) {
         expectGetArtifact << new ArtifactExpectation(InteractionExpectation.GET, new VariantArtifacts(variant))
+    }
+
+    void capability(String name, Closure<?> config) {
+        config.resolveStrategy = Closure.DELEGATE_FIRST
+        config.delegate = capabilities[name]
+        config()
     }
 
     void attribute(String key, String value) {
@@ -312,6 +320,11 @@ class ModuleVersionSpec {
                 } else {
                     module.dependencyConstraint(it)
                 }
+            }
+        }
+        if (capabilities) {
+            capabilities.values().each {
+                module.addCapability(it)
             }
         }
         if (withModule) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -145,7 +145,9 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public VersionNumber getArtifactCacheLayoutVersion() {
-        if (isSameOrNewer("4.6-rc-1")) {
+        if (isSameOrNewer("4.7-rc-1")) {
+            return VersionNumber.parse("2.54");
+        } else if (isSameOrNewer("4.6-rc-1")) {
             return VersionNumber.parse("2.53");
         } else if (isSameOrNewer("4.5.1-rc-1")) {
             return VersionNumber.parse("2.51");

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
@@ -22,6 +22,7 @@ import org.apache.tools.zip.ZipOutputStream
 import org.gradle.internal.IoActions
 import org.gradle.internal.hash.HashUtil
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.gradle.CapabilitySpec
 
 abstract class AbstractModule implements Module {
     /**
@@ -32,6 +33,7 @@ abstract class AbstractModule implements Module {
     private boolean hasModuleMetadata
 
     Map<String, String> attributes = [:]
+    List<CapabilitySpec> capabilities = []
 
     /**
      * @param cl A closure that is passed a writer to use to generate the content.
@@ -123,5 +125,10 @@ abstract class AbstractModule implements Module {
 
     boolean isHasModuleMetadata() {
         hasModuleMetadata
+    }
+
+    @Override
+    void addCapability(CapabilitySpec spec) {
+        capabilities << spec
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.test.fixtures
 
+import org.gradle.test.fixtures.gradle.CapabilitySpec
 import org.gradle.test.fixtures.gradle.VariantMetadataSpec
 
 /**
@@ -38,4 +39,6 @@ interface Module {
     void withVariant(String name, @DelegatesTo(value=VariantMetadataSpec.class, strategy = Closure.DELEGATE_FIRST) groovy.lang.Closure<?> action)
 
     Map<String, String> getAttributes()
+
+    void addCapability(CapabilitySpec spec);
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/CapabilitySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/CapabilitySpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.gradle
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class CapabilitySpec {
+    final String name
+    List<String> providedBy = []
+    String prefer
+
+    CapabilitySpec(String name) {
+        this.name = name
+    }
+
+    void providedBy(String id) {
+        providedBy << id
+    }
+
+    void prefer(String id) {
+        prefer = id
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -25,13 +25,15 @@ class GradleFileModuleAdapter {
     private final String version
     private final List<VariantMetadataSpec> variants
     private final Map<String, String> attributes
+    private final List<CapabilitySpec> capabilities
 
-    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadataSpec> variants, Map<String, String> attributes = [:]) {
+    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadataSpec> variants, Map<String, String> attributes, List<CapabilitySpec> capabilities) {
         this.group = group
         this.module = module
         this.version = version
         this.variants = variants
         this.attributes = attributes
+        this.capabilities = capabilities
     }
 
     void publishTo(TestFile moduleDir) {
@@ -41,7 +43,7 @@ class GradleFileModuleAdapter {
         jsonBuilder {
             formatVersion '0.3'
             builtBy {
-                gradle { }
+                gradle {}
             }
             component {
                 group this.group
@@ -52,6 +54,13 @@ class GradleFileModuleAdapter {
                         "$key" value
                     }
                 }
+                capabilities(this.capabilities.collect { c ->
+                    { ->
+                        name c.name
+                        providedBy c.providedBy
+                        if (c.prefer) { prefer c.prefer }
+                    }
+                })
             }
             variants(this.variants.collect { v ->
                 { ->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -405,7 +405,8 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.artifacts ?: defaultArtifacts
                 )
             },
-            attributes + ['org.gradle.status': status]
+            attributes + ['org.gradle.status': status],
+            capabilities
         )
 
         adapter.publishTo(moduleDir)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -445,7 +445,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.artifacts?:defaultArtifacts
                 )
             },
-            attributes + ['org.gradle.status': version.endsWith('-SNAPSHOT') ? 'integration' : 'release']
+            attributes + ['org.gradle.status': version.endsWith('-SNAPSHOT') ? 'integration' : 'release'],
+            capabilities
         )
 
         adapter.publishTo(moduleDir)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -21,6 +21,7 @@ import org.gradle.test.fixtures.GradleModuleMetadata;
 import org.gradle.test.fixtures.Module;
 import org.gradle.test.fixtures.ModuleArtifact;
 import org.gradle.test.fixtures.file.TestFile;
+import org.gradle.test.fixtures.gradle.CapabilitySpec;
 
 import java.util.Map;
 
@@ -269,5 +270,10 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     @Override
     public Map<String, String> getAttributes() {
         return backingModule.getAttributes();
+    }
+
+    @Override
+    public void addCapability(CapabilitySpec spec) {
+        backingModule.addCapability(spec);
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -20,6 +20,7 @@ import org.gradle.internal.Cast;
 import org.gradle.test.fixtures.GradleModuleMetadata;
 import org.gradle.test.fixtures.Module;
 import org.gradle.test.fixtures.file.TestFile;
+import org.gradle.test.fixtures.gradle.CapabilitySpec;
 import org.gradle.test.fixtures.ivy.IvyDescriptor;
 import org.gradle.test.fixtures.ivy.IvyModule;
 
@@ -239,5 +240,10 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
     @Override
     public Map<String, String> getAttributes() {
         return backingModule.getAttributes();
+    }
+
+    @Override
+    public void addCapability(CapabilitySpec spec) {
+        backingModule.addCapability(spec);
     }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.NoOpCapabilitiesHandler;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
@@ -98,7 +99,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
     }
 
     private DefaultLibraryLocalComponentMetadata(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier) {
-        super(id, componentIdentifier, Project.DEFAULT_STATUS, EmptySchema.INSTANCE);
+        super(id, componentIdentifier, Project.DEFAULT_STATUS, EmptySchema.INSTANCE, NoOpCapabilitiesHandler.INSTANCE);
     }
 
     private void addDependencies(Iterable<DependencySpec> dependencies, String projectPath, String usageConfigurationName) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -16,10 +16,13 @@
 
 package org.gradle.jvm.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
+import org.gradle.api.artifacts.dsl.CapabilityHandler;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
@@ -66,6 +69,12 @@ import java.util.List;
 import java.util.Set;
 
 public class DependencyResolvingClasspath extends AbstractFileCollection {
+    private final static CapabilitiesHandler NO_CAPABILITIES = new CapabilitiesHandler() {
+        @Override
+        public void capability(String identifier, Action<? super CapabilityHandler> configureAction) {
+        }
+    };
+
     private final GlobalDependencyResolutionRules globalRules = GlobalDependencyResolutionRules.NO_OP;
     private final List<ResolutionAwareRepository> remoteRepositories;
     private final BinarySpecInternal binary;
@@ -185,7 +194,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             public ArtifactTypeContainer create() {
                 throw new UnsupportedOperationException();
             }
-        });
+        }, NO_CAPABILITIES);
         return result;
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -96,6 +96,11 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
         }
 
         @Override
+        public CapabilityInternal getCapability(String name) {
+            return null;
+        }
+
+        @Override
         public void capability(String identifier, Action<? super CapabilityHandler> configureAction) {
         }
     };

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -16,7 +16,9 @@
 
 package org.gradle.jvm.internal;
 
+import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
@@ -29,6 +31,7 @@ import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilityInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesVisitor;
@@ -64,6 +67,8 @@ import org.gradle.platform.base.internal.BinarySpecInternal;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -72,8 +77,22 @@ import java.util.Set;
 public class DependencyResolvingClasspath extends AbstractFileCollection {
     private final static CapabilitiesHandler NO_CAPABILITIES = new CapabilitiesHandlerInternal() {
         @Override
-        public void convertToReplacementRules() {
+        public void recordCapabilities(ModuleIdentifier module, Multimap<String, ModuleIdentifier> capabilityToModules) {
+        }
 
+        @Override
+        public ModuleIdentifier getPreferred(String capability) {
+            return null;
+        }
+
+        @Override
+        public boolean hasCapabilities() {
+            return false;
+        }
+
+        @Override
+        public Collection<? extends CapabilityInternal> getCapabilities(ModuleIdentifier module) {
+            return Collections.emptyList();
         }
 
         @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -28,6 +28,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
+import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesVisitor;
@@ -69,7 +70,12 @@ import java.util.List;
 import java.util.Set;
 
 public class DependencyResolvingClasspath extends AbstractFileCollection {
-    private final static CapabilitiesHandler NO_CAPABILITIES = new CapabilitiesHandler() {
+    private final static CapabilitiesHandler NO_CAPABILITIES = new CapabilitiesHandlerInternal() {
+        @Override
+        public void convertToReplacementRules() {
+
+        }
+
         @Override
         public void capability(String identifier, Action<? super CapabilityHandler> configureAction) {
         }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -16,22 +16,16 @@
 
 package org.gradle.jvm.internal;
 
-import com.google.common.collect.Multimap;
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
-import org.gradle.api.artifacts.dsl.CapabilityHandler;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.ResolveContext;
-import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilitiesHandlerInternal;
-import org.gradle.api.internal.artifacts.dsl.dependencies.CapabilityInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.NoOpCapabilitiesHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesVisitor;
@@ -67,44 +61,12 @@ import org.gradle.platform.base.internal.BinarySpecInternal;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
 public class DependencyResolvingClasspath extends AbstractFileCollection {
-    private final static CapabilitiesHandler NO_CAPABILITIES = new CapabilitiesHandlerInternal() {
-        @Override
-        public void recordCapabilities(ModuleIdentifier module, Multimap<String, ModuleIdentifier> capabilityToModules) {
-        }
-
-        @Override
-        public ModuleIdentifier getPreferred(String capability) {
-            return null;
-        }
-
-        @Override
-        public boolean hasCapabilities() {
-            return false;
-        }
-
-        @Override
-        public Collection<? extends CapabilityInternal> getCapabilities(ModuleIdentifier module) {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public CapabilityInternal getCapability(String name) {
-            return null;
-        }
-
-        @Override
-        public void capability(String identifier, Action<? super CapabilityHandler> configureAction) {
-        }
-    };
-
     private final GlobalDependencyResolutionRules globalRules = GlobalDependencyResolutionRules.NO_OP;
     private final List<ResolutionAwareRepository> remoteRepositories;
     private final BinarySpecInternal binary;
@@ -224,7 +186,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             public ArtifactTypeContainer create() {
                 throw new UnsupportedOperationException();
             }
-        }, NO_CAPABILITIES);
+        }, NoOpCapabilitiesHandler.INSTANCE);
         return result;
     }
 


### PR DESCRIPTION
## Context

This commit introduces a DSL to declare "capabilities" for modules. Capabilities can be used to declare
that different modules, published at different coordinates, actually provide the same capabilities. This
is typically the case when an API is implemented in different ways (for example, the Slf4j bindings
implement the Slf4j API). It is an error to have multiple modules providing the same capabilities in the
same dependency graph: only one of them should be selected.

This commit adds the ability to declare capabilities, explaining which modules provide the capability, and
provide a way to select the module which will provide that capability. It does NOT make it an error to have
different modules providing the same capability on the graph yet (if a preference is not set).

This solves different use cases:

1. module relocation (`asm:asm` is now found at `org.ow2.asm`)
2. multiple variants of the same module are published at different coordinates (`cglib` vs `cglib-nodep`)
3. multiple implementations of the same API are seen in the graph (`slf4j-simple`, `slf4j-over-log4j`)
4. compatiblity module mimics a different API (log4j2 bridge for log4j1)

See #4383
