### PR TITLE
Stop forwarding if a process closed its streams

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
@@ -67,8 +67,19 @@ public class ExecOutputHandleRunner implements Runnable {
             }
             CompositeStoppable.stoppable(inputStream, outputStream).stop();
         } catch (Throwable t) {
+            if (wasInterrupted(t)) {
+                return;
+            }
             LOGGER.error(String.format("Could not %s.", displayName), t);
         }
+    }
+
+    /**
+     * This can happen e.g. on IBM JDK when a remote process was terminated. Instead of
+     * returning -1 on the next read() call, it will interrupt the current read call.
+     */
+    private boolean wasInterrupted(Throwable t) {
+        return t instanceof IOException && "Interrupted system call".equals(t.getMessage());
     }
 
     public void closeInput() throws IOException {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
@@ -24,14 +24,12 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.hamcrest.Matchers
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.AbstractConsoleFunctionalSpec.workInProgressLine
 import static org.gradle.testing.fixture.JvmBlockingTestClassGenerator.*
 
-@Ignore
 abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpec {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitFailFastIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitFailFastIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.testing.junit
 
 import org.gradle.testing.fixture.AbstractJvmFailFastIntegrationSpec
-import spock.lang.Ignore
 
-@Ignore
 class JUnitFailFastIntegrationTest extends AbstractJvmFailFastIntegrationSpec {
     @Override
     String testAnnotationClass() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailFastIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailFastIntegrationTest.groovy
@@ -19,10 +19,8 @@ package org.gradle.testing.testng
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.testing.fixture.AbstractJvmFailFastIntegrationSpec
 import org.hamcrest.Matchers
-import spock.lang.Ignore
 import spock.lang.Unroll
 
-@Ignore
 class TestNGFailFastIntegrationTest extends AbstractJvmFailFastIntegrationSpec {
     @Override
     String testAnnotationClass() {


### PR DESCRIPTION
This fixes an issue where the --fail-fast option would
print error messages about unreadable streams to the
console.

Supersedes https://github.com/gradle/gradle/pull/4393