### PR TITLE
Make tests relocatable when gradle-java-plugin is applied

### DIFF
--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
@@ -89,6 +89,6 @@ class JavaGradlePluginRelocationTest extends AbstractProjectRelocationIntegratio
 
     @Override
     protected extractResultsFrom(TestFile projectDir) {
-        return null
+        return projectDir.file("build/${JavaGradlePluginPlugin.GENERATE_PLUGIN_DESCRIPTORS_TASK_NAME}/org.example.plugin.properties").text
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.devel.plugins
+
+import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.test.fixtures.file.TestFile
+
+class JavaGradlePluginRelocationTest extends AbstractProjectRelocationIntegrationTest {
+    final String taskName = ":test"
+
+    @Override
+    protected void setupProjectIn(TestFile projectDir) {
+        projectDir.with {
+            file("src/main/groovy/CustomTask.groovy") << """
+                import org.gradle.api.*
+                import org.gradle.api.tasks.*
+    
+                @CacheableTask
+                class CustomTask extends DefaultTask {
+                    @InputFile @PathSensitive(PathSensitivity.NONE) File inputFile
+                    @OutputFile File outputFile
+                    @TaskAction void doSomething() {
+                        outputFile.text = inputFile.text
+                    }
+                }
+            """
+
+            file("src/main/groovy/CustomPlugin.groovy") << """
+                import org.gradle.api.*
+    
+                class CustomPlugin implements Plugin<Project> {
+                    @Override
+                    void apply(Project project) {
+                        project.tasks.create("customTask", CustomTask) {
+                            inputFile = project.file("input.txt")
+                            outputFile = project.file("build/output.txt")
+                        }
+                    }
+                }
+            """
+            file("src/test/groovy/PluginSpec.groovy") << """
+                import spock.lang.Specification
+                
+                class PluginSpec extends Specification {
+                    def "dummy test"() {
+                        expect:
+                        true
+                    }
+                }
+            """
+            file("build.gradle") << """
+                apply plugin: "java-gradle-plugin" 
+                apply plugin: "groovy"
+                
+                gradlePlugin {
+                    plugins {
+                        examplePlugin {
+                            id = "org.example.plugin"
+                            implementationClass = "CustomPlugin"
+                        }
+                    }
+                }
+                
+                ${jcenterRepository()}
+                
+                dependencies {
+                    testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
+                        exclude module: 'groovy-all'
+                    }
+                }                
+            """
+        }
+
+    }
+
+    @Override
+    protected extractResultsFrom(TestFile projectDir) {
+        return null
+    }
+}

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -38,9 +38,11 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.ClasspathNormalizer;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.model.Model;
 import org.gradle.model.RuleSource;
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
@@ -366,6 +368,14 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
             DependencyHandler dependencies = project.getDependencies();
             Set<SourceSet> testSourceSets = extension.getTestSourceSets();
             project.getNormalization().getRuntimeClasspath().ignore(PluginUnderTestMetadata.METADATA_FILE_NAME);
+            project.getTasks().withType(Test.class, new Action<Test>() {
+                @Override
+                public void execute(Test test) {
+                    test.getInputs().files(pluginClasspathTask.getPluginClasspath())
+                        .withPropertyName("pluginClasspath")
+                        .withNormalizer(ClasspathNormalizer.class);
+                }
+            });
 
             for (SourceSet testSourceSet : testSourceSets) {
                 String compileConfigurationName = testSourceSet.getCompileConfigurationName();

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -365,6 +365,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
         public void execute(Project project) {
             DependencyHandler dependencies = project.getDependencies();
             Set<SourceSet> testSourceSets = extension.getTestSourceSets();
+            project.getNormalization().getRuntimeClasspath().ignore(PluginUnderTestMetadata.METADATA_FILE_NAME);
 
             for (SourceSet testSourceSet : testSourceSets) {
                 String compileConfigurationName = testSourceSet.getCompileConfigurationName();

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -51,6 +52,7 @@ import org.gradle.plugin.devel.tasks.GeneratePluginDescriptors;
 import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata;
 import org.gradle.plugin.devel.tasks.ValidateTaskProperties;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -70,6 +72,7 @@ import java.util.concurrent.Callable;
  * Integrates with the 'maven-publish' and 'ivy-publish' plugins to automatically publish the plugins so they can be resolved using the `pluginRepositories` and `plugins` DSL.
  */
 @Incubating
+@NonNullApi
 public class JavaGradlePluginPlugin implements Plugin<Project> {
     private static final Logger LOGGER = Logging.getLogger(JavaGradlePluginPlugin.class);
     static final String COMPILE_CONFIGURATION = "compile";
@@ -135,7 +138,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
     }
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {
-        Jar jarTask = (Jar) project.getTasks().findByName(JAR_TASK);
+        Jar jarTask = (Jar) project.getTasks().getByName(JAR_TASK);
         List<PluginDescriptor> descriptors = new ArrayList<PluginDescriptor>();
         Set<String> classList = new HashSet<String>();
         PluginDescriptorCollectorAction pluginDescriptorCollector = new PluginDescriptorCollectorAction(descriptors);
@@ -167,13 +170,13 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
         ConventionMapping conventionMapping = new DslObject(pluginUnderTestMetadataTask).getConventionMapping();
         conventionMapping.map("pluginClasspath", new Callable<Object>() {
-            public Object call() throws Exception {
+            public Object call() {
                 FileCollection gradleApi = gradlePluginConfiguration.getIncoming().getFiles();
                 return extension.getPluginSourceSet().getRuntimeClasspath().minus(gradleApi);
             }
         });
         conventionMapping.map("outputDirectory", new Callable<Object>() {
-            public Object call() throws Exception {
+            public Object call() {
                 return new File(project.getBuildDir(), pluginUnderTestMetadataTask.getName());
             }
         });
@@ -206,13 +209,13 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
         generatePluginDescriptors.setDescription(GENERATE_PLUGIN_DESCRIPTORS_TASK_DESCRIPTION);
         generatePluginDescriptors.conventionMapping("declarations", new Callable<List<PluginDeclaration>>() {
             @Override
-            public List<PluginDeclaration> call() throws Exception {
+            public List<PluginDeclaration> call() {
                 return Lists.newArrayList(extension.getPlugins());
             }
         });
         generatePluginDescriptors.conventionMapping("outputDirectory", new Callable<File>() {
             @Override
-            public File call() throws Exception {
+            public File call() {
                 return new File(project.getBuildDir(), generatePluginDescriptors.getName());
             }
         });
@@ -221,7 +224,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
         copyPluginDescriptors.into("META-INF/gradle-plugins");
         copyPluginDescriptors.from(new Callable<File>() {
             @Override
-            public File call() throws Exception {
+            public File call() {
                 return generatePluginDescriptors.getOutputDirectory();
             }
         });
@@ -267,7 +270,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
         private final Collection<PluginDescriptor> descriptors;
         private final Set<String> classes;
 
-        PluginValidationAction(Collection<PluginDeclaration> plugins, Collection<PluginDescriptor> descriptors, Set<String> classes) {
+        PluginValidationAction(Collection<PluginDeclaration> plugins, @Nullable Collection<PluginDescriptor> descriptors, Set<String> classes) {
             this.plugins = plugins;
             this.descriptors = descriptors;
             this.classes = classes;

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
@@ -19,7 +19,6 @@ package org.gradle.plugin.devel.tasks;
 import com.google.common.base.Joiner;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
-import org.gradle.api.NonNullApi;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
@@ -43,7 +42,6 @@ import static org.gradle.util.CollectionUtils.collect;
  * @since 2.13
  */
 @Incubating
-@NonNullApi
 public class PluginUnderTestMetadata extends DefaultTask {
 
     public static final String IMPLEMENTATION_CLASSPATH_PROP_KEY = "implementation-classpath";

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
+import static java.util.Collections.emptyList;
 import static org.gradle.util.CollectionUtils.collect;
 
 /**
@@ -78,7 +79,7 @@ public class PluginUnderTestMetadata extends DefaultTask {
     public void generate() {
         Properties properties = new Properties();
 
-        if (!getPluginClasspath().isEmpty()) {
+        if (getPluginClasspath() != null && !getPluginClasspath().isEmpty()) {
             properties.setProperty(IMPLEMENTATION_CLASSPATH_PROP_KEY, implementationClasspath());
         }
 
@@ -111,7 +112,10 @@ public class PluginUnderTestMetadata extends DefaultTask {
     }
 
     private Iterable<File> classpathFiles() {
-        return getPluginClasspath();
+        if (getPluginClasspath() != null) {
+            return getPluginClasspath();
+        }
+        return emptyList();
     }
 
 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.plugin.devel.tasks;
 import com.google.common.base.Joiner;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
@@ -33,7 +34,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
-import static java.util.Collections.emptyList;
 import static org.gradle.util.CollectionUtils.collect;
 
 /**
@@ -42,6 +42,7 @@ import static org.gradle.util.CollectionUtils.collect;
  * @since 2.13
  */
 @Incubating
+@NonNullApi
 public class PluginUnderTestMetadata extends DefaultTask {
 
     public static final String IMPLEMENTATION_CLASSPATH_PROP_KEY = "implementation-classpath";
@@ -77,7 +78,7 @@ public class PluginUnderTestMetadata extends DefaultTask {
     public void generate() {
         Properties properties = new Properties();
 
-        if (getPluginClasspath() != null && !getPluginClasspath().isEmpty()) {
+        if (!getPluginClasspath().isEmpty()) {
             properties.setProperty(IMPLEMENTATION_CLASSPATH_PROP_KEY, implementationClasspath());
         }
 
@@ -110,10 +111,7 @@ public class PluginUnderTestMetadata extends DefaultTask {
     }
 
     private Iterable<File> classpathFiles() {
-        if (getPluginClasspath() != null) {
-            return getPluginClasspath();
-        }
-        return emptyList();
+        return getPluginClasspath();
     }
 
 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
@@ -26,8 +26,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.internal.classloader.ClasspathHasher;
-import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.util.PropertiesUtils;
 
 import java.io.File;
@@ -47,7 +45,6 @@ import static org.gradle.util.CollectionUtils.collect;
 public class PluginUnderTestMetadata extends DefaultTask {
 
     public static final String IMPLEMENTATION_CLASSPATH_PROP_KEY = "implementation-classpath";
-    public static final String IMPLEMENTATION_CLASSPATH_HASH_PROP_KEY = "implementation-classpath-hash";
     public static final String METADATA_FILE_NAME = "plugin-under-test-metadata.properties";
     private FileCollection pluginClasspath;
     private File outputDirectory;
@@ -82,7 +79,6 @@ public class PluginUnderTestMetadata extends DefaultTask {
 
         if (getPluginClasspath() != null && !getPluginClasspath().isEmpty()) {
             properties.setProperty(IMPLEMENTATION_CLASSPATH_PROP_KEY, implementationClasspath());
-            properties.setProperty(IMPLEMENTATION_CLASSPATH_HASH_PROP_KEY, implementationClasspathHash());
         }
 
         File outputFile = new File(getOutputDirectory(), METADATA_FILE_NAME);
@@ -93,13 +89,6 @@ public class PluginUnderTestMetadata extends DefaultTask {
         StringBuilder implementationClasspath = new StringBuilder();
         Joiner.on(File.pathSeparator).appendTo(implementationClasspath, getPaths());
         return implementationClasspath.toString();
-    }
-
-    private String implementationClasspathHash() {
-        // As these files are inputs into this task, they have just been snapshotted by the task up-to-date checking.
-        // We should be reusing those persistent snapshots to avoid reading into memory again.
-        ClasspathHasher classpathHasher = getServices().get(ClasspathHasher.class);
-        return classpathHasher.hash(new DefaultClassPath(getPluginClasspath())).toString();
     }
 
     private void saveProperties(Properties properties, File outputFile) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -27,7 +27,6 @@ import com.google.common.io.Files;
 import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.NonNullApi;
 import org.gradle.api.Task;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.EmptyFileVisitor;
@@ -108,7 +107,6 @@ import java.util.Map;
  */
 @Incubating
 @CacheableTask
-@NonNullApi
 @SuppressWarnings("WeakerAccess")
 public class ValidateTaskProperties extends ConventionTask implements VerificationTask {
     private FileCollection classes;

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/package-info.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Tasks for assisting with plugin development.
  */
+@NonNullApi
 package org.gradle.plugin.devel.tasks;
+
+import org.gradle.api.NonNullApi;


### PR DESCRIPTION
`plugin-under-test-metadata.properties` contains absolute paths, making test tasks non-relocatable.