### PR TITLE
Fixes for Windows SDK discovery with Visual Studio 2017

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesIntegrationTest.groovy
@@ -194,7 +194,7 @@ model {
 
     static List<WindowsSdk> getNonDefaultSdks() {
         WindowsSdkLocator locator = new DefaultWindowsSdkLocator(OperatingSystem.current(), NativeServicesTestFixture.getInstance().get(WindowsRegistry.class))
-        WindowsSdk defaultSdk = locator.locateWindowsSdks(null).sdk
-        return locator.locateAllWindowsSdks() - defaultSdk
+        WindowsSdk defaultSdk = locator.locateComponent(null).component
+        return locator.locateAllComponents() - defaultSdk
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/AbstractWindowsKitComponentLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/AbstractWindowsKitComponentLocator.java
@@ -39,7 +39,7 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitComponent> implements WindowsKitComponentLocator<T> {
+public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitComponent> implements WindowsComponentLocator<T> {
     private static final String USER_PROVIDED = "User-provided";
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractWindowsKitComponentLocator.class);
     private final Map<File, Set<T>> foundComponents = new HashMap<File, Set<T>>();
@@ -68,7 +68,7 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
     }
 
     @Override
-    public WindowsKitComponentLocator.SearchResult<T> locateComponents(File candidate) {
+    public SearchResult<T> locateComponent(File candidate) {
         initializeComponents();
 
         if (candidate != null) {
@@ -96,7 +96,7 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
         }
     }
 
-    private WindowsKitComponentLocator.SearchResult<T> locateDefaultComponent() {
+    private SearchResult<T> locateDefaultComponent() {
         T selected = getBestComponent();
         return selected == null
             ? new ComponentNotFound("Could not locate a " + getDisplayName() + " installation using the Windows registry.")
@@ -144,7 +144,7 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
         }
     }
 
-    private WindowsKitComponentLocator.SearchResult<T> locateUserSpecifiedComponent(File candidate) {
+    private SearchResult<T> locateUserSpecifiedComponent(File candidate) {
         File windowsKitDir = FileUtils.canonicalize(candidate);
         String[] versionDirs = getComponentVersionDirs(windowsKitDir);
         if (isValidComponentBaseDir(windowsKitDir) && versionDirs.length > 0) {
@@ -228,7 +228,7 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
 
     abstract T newComponent(File baseDir, VersionNumber version, DiscoveryType discoveryType);
 
-    private class ComponentFound implements WindowsKitComponentLocator.SearchResult<T> {
+    private class ComponentFound implements SearchResult<T> {
         private final T component;
 
         public ComponentFound(T component) {
@@ -247,7 +247,7 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
         }
     }
 
-    private class ComponentNotFound implements WindowsKitComponentLocator.SearchResult<T> {
+    private class ComponentNotFound implements SearchResult<T> {
         private final String message;
 
         private ComponentNotFound(String message) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/AbstractWindowsKitComponentLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/AbstractWindowsKitComponentLocator.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import net.rubygrapefruit.platform.MissingRegistryEntryException;
 import net.rubygrapefruit.platform.WindowsRegistry;
 import org.gradle.internal.FileUtils;
-import org.gradle.util.TreeVisitor;
 import org.gradle.util.VersionNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,8 +98,8 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
     private SearchResult<T> locateDefaultComponent() {
         T selected = getBestComponent();
         return selected == null
-            ? new ComponentNotFound("Could not locate a " + getDisplayName() + " installation using the Windows registry.")
-            : new ComponentFound(selected);
+            ? new ComponentNotFound<T>("Could not locate a " + getDisplayName() + " installation using the Windows registry.")
+            : new ComponentFound<T>(selected);
     }
 
     private T getBestComponent(File baseDir) {
@@ -155,9 +154,9 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
                     putComponent(newComponent(windowsKitDir, version, DiscoveryType.USER));
                 }
             }
-            return new ComponentFound(getBestComponent(candidate));
+            return new ComponentFound<T>(getBestComponent(candidate));
         } else {
-            return new ComponentNotFound(String.format("The specified installation directory '%s' does not appear to contain a %s installation.", candidate, getDisplayName()));
+            return new ComponentNotFound<T>(String.format("The specified installation directory '%s' does not appear to contain a %s installation.", candidate, getDisplayName()));
         }
     }
 
@@ -227,45 +226,6 @@ public abstract class AbstractWindowsKitComponentLocator<T extends WindowsKitCom
     abstract boolean isValidComponentLibDir(File libDir);
 
     abstract T newComponent(File baseDir, VersionNumber version, DiscoveryType discoveryType);
-
-    private class ComponentFound implements SearchResult<T> {
-        private final T component;
-
-        public ComponentFound(T component) {
-            this.component = component;
-        }
-
-        public T getComponent() {
-            return component;
-        }
-
-        public boolean isAvailable() {
-            return true;
-        }
-
-        public void explain(TreeVisitor<? super String> visitor) {
-        }
-    }
-
-    private class ComponentNotFound implements SearchResult<T> {
-        private final String message;
-
-        private ComponentNotFound(String message) {
-            this.message = message;
-        }
-
-        public T getComponent() {
-            return null;
-        }
-
-        public boolean isAvailable() {
-            return false;
-        }
-
-        public void explain(TreeVisitor<? super String> visitor) {
-            visitor.node(message);
-        }
-    }
 
     private class DescendingComponentVersionComparator implements Comparator<T> {
         @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ComponentFound.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ComponentFound.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.toolchain.internal.msvcpp;
+
+import org.gradle.util.TreeVisitor;
+
+class ComponentFound<T> implements SearchResult<T> {
+    private final T component;
+
+    public ComponentFound(T component) {
+        this.component = component;
+    }
+
+    public T getComponent() {
+        return component;
+    }
+
+    public boolean isAvailable() {
+        return true;
+    }
+
+    public void explain(TreeVisitor<? super String> visitor) {
+    }
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ComponentNotFound.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ComponentNotFound.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.toolchain.internal.msvcpp;
+
+import org.gradle.util.TreeVisitor;
+
+class ComponentNotFound<T> implements SearchResult<T> {
+    private final String message;
+
+    ComponentNotFound(String message) {
+        this.message = message;
+    }
+
+    public T getComponent() {
+        return null;
+    }
+
+    public boolean isAvailable() {
+        return false;
+    }
+
+    public void explain(TreeVisitor<? super String> visitor) {
+        visitor.node(message);
+    }
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ComponentNotFound.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/ComponentNotFound.java
@@ -18,11 +18,21 @@ package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
 import org.gradle.util.TreeVisitor;
 
+import java.util.Collection;
+import java.util.Collections;
+
 class ComponentNotFound<T> implements SearchResult<T> {
     private final String message;
+    private final Collection<String> locations;
 
     ComponentNotFound(String message) {
         this.message = message;
+        this.locations = Collections.emptyList();
+    }
+
+    ComponentNotFound(String message, Collection<String> locations) {
+        this.message = message;
+        this.locations = locations;
     }
 
     public T getComponent() {
@@ -35,5 +45,12 @@ class ComponentNotFound<T> implements SearchResult<T> {
 
     public void explain(TreeVisitor<? super String> visitor) {
         visitor.node(message);
+        if (!locations.isEmpty()) {
+            visitor.startChildren();
+            for (String location : locations) {
+                visitor.node(location);
+            }
+            visitor.endChildren();
+        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocator.java
@@ -15,11 +15,10 @@
  */
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import java.io.File;
-
+import net.rubygrapefruit.platform.WindowsRegistry;
 import org.gradle.util.VersionNumber;
 
-import net.rubygrapefruit.platform.WindowsRegistry;
+import java.io.File;
 
 public class DefaultUcrtLocator extends AbstractWindowsKitComponentLocator<Ucrt> implements UcrtLocator {
     private static final String DISPLAY_NAME = "Universal C Runtime";
@@ -39,7 +38,7 @@ public class DefaultUcrtLocator extends AbstractWindowsKitComponentLocator<Ucrt>
     }
 
     @Override
-    boolean isValidComponentBaseDir(File baseDir) {
+    boolean isValidComponentBinDir(File binDir) {
         // Nothing special to check for UCRT
         return true;
     }
@@ -59,7 +58,8 @@ public class DefaultUcrtLocator extends AbstractWindowsKitComponentLocator<Ucrt>
         return true;
     }
 
-    public Ucrt newComponent(File baseDir, VersionNumber version, DiscoveryType discoveryType) {
+    @Override
+    Ucrt newComponent(File baseDir, File binDir, VersionNumber version, DiscoveryType discoveryType) {
         return new Ucrt(baseDir, version, getVersionedDisplayName(version, discoveryType));
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocator.java
@@ -80,6 +80,8 @@ public class DefaultVisualStudioLocator implements VisualStudioLocator {
 
     @Override
     public SearchResult<VisualStudioInstall> locateComponent(@Nullable File candidate) {
+        initializeVisualStudioInstalls();
+
         if (candidate != null) {
             return locateUserSpecifiedInstall(candidate);
         }
@@ -213,8 +215,6 @@ public class DefaultVisualStudioLocator implements VisualStudioLocator {
     }
 
     private SearchResult<VisualStudioInstall> determineDefaultInstall() {
-        initializeVisualStudioInstalls();
-
         VisualStudioInstall candidate = null;
 
         for (VisualStudioInstall visualStudio : foundInstalls.values()) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.rubygrapefruit.platform.SystemInfo;
@@ -26,7 +25,6 @@ import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioM
 import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioMetadata.Compatibility;
 import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioVersionLocator;
 import org.gradle.util.CollectionUtils;
-import org.gradle.util.TreeVisitor;
 import org.gradle.util.VersionNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,10 +132,10 @@ public class DefaultVisualStudioLocator implements VisualStudioLocator {
         VisualStudioMetadata install = versionDeterminer.getVisualStudioMetadataFromInstallDir(candidate);
 
         if (install != null && addInstallIfValid(install, "user provided path")) {
-            return new InstallFound(foundInstalls.get(install.getInstallDir()));
+            return new ComponentFound<VisualStudioInstall>(foundInstalls.get(install.getInstallDir()));
         } else {
             LOGGER.debug("Ignoring candidate Visual C++ install for {} as it does not look like a Visual C++ installation.", candidate);
-            return new InstallNotFound(String.format("The specified installation directory '%s' does not appear to contain a Visual Studio installation.", candidate));
+            return new ComponentNotFound<VisualStudioInstall>(String.format("The specified installation directory '%s' does not appear to contain a Visual Studio installation.", candidate));
         }
     }
 
@@ -220,7 +218,7 @@ public class DefaultVisualStudioLocator implements VisualStudioLocator {
             }
         }
 
-        return candidate == null ? new InstallNotFound("Could not locate a Visual Studio installation, using the command line tool, Windows registry or system path.") : new InstallFound(candidate);
+        return candidate == null ? new ComponentNotFound<VisualStudioInstall>("Could not locate a Visual Studio installation, using the command line tool, Windows registry or system path.") : new ComponentFound<VisualStudioInstall>(candidate);
     }
 
     private static boolean isValidInstall(VisualStudioMetadata install) {
@@ -242,50 +240,5 @@ public class DefaultVisualStudioLocator implements VisualStudioLocator {
 
     private static boolean isVS2017VisualCpp(File candidate) {
         return new File(candidate, PATH_BIN + VS2017_COMPILER_FILENAME).isFile();
-    }
-
-    private static class InstallFound implements SearchResult<VisualStudioInstall> {
-        private final VisualStudioInstall install;
-
-        public InstallFound(VisualStudioInstall install) {
-            this.install = Preconditions.checkNotNull(install);
-        }
-
-        @Override
-        public VisualStudioInstall getComponent() {
-            return install;
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return true;
-        }
-
-        @Override
-        public void explain(TreeVisitor<? super String> visitor) {
-        }
-    }
-
-    private static class InstallNotFound implements SearchResult<VisualStudioInstall> {
-        private final String message;
-
-        private InstallNotFound(String message) {
-            this.message = message;
-        }
-
-        @Override
-        public VisualStudioInstall getComponent() {
-            return null;
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return false;
-        }
-
-        @Override
-        public void explain(TreeVisitor<? super String> visitor) {
-            visitor.node(message);
-        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocator.java
@@ -22,15 +22,16 @@ import net.rubygrapefruit.platform.WindowsRegistry;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.util.TreeVisitor;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
 public class DefaultWindowsSdkLocator implements WindowsSdkLocator {
     private final WindowsSdkLocator legacyWindowsSdkLocator;
-    private final WindowsKitComponentLocator<WindowsKitWindowsSdk> windowsKitWindowsSdkLocator;
+    private final WindowsComponentLocator<WindowsKitWindowsSdk> windowsKitWindowsSdkLocator;
 
     @VisibleForTesting
-    DefaultWindowsSdkLocator(WindowsSdkLocator legacyWindowsSdkLocator, WindowsKitComponentLocator<WindowsKitWindowsSdk> windowsKitWindowsSdkLocator) {
+    DefaultWindowsSdkLocator(WindowsSdkLocator legacyWindowsSdkLocator, WindowsComponentLocator<WindowsKitWindowsSdk> windowsKitWindowsSdkLocator) {
         this.legacyWindowsSdkLocator = legacyWindowsSdkLocator;
         this.windowsKitWindowsSdkLocator = windowsKitWindowsSdkLocator;
     }
@@ -40,33 +41,33 @@ public class DefaultWindowsSdkLocator implements WindowsSdkLocator {
     }
 
     @Override
-    public SearchResult locateWindowsSdks(File candidate) {
-        return new SdkSearchResult(legacyWindowsSdkLocator.locateWindowsSdks(candidate), windowsKitWindowsSdkLocator.locateComponents(candidate));
+    public SearchResult<WindowsSdk> locateComponent(@Nullable File candidate) {
+        return new SdkSearchResult(legacyWindowsSdkLocator.locateComponent(candidate), windowsKitWindowsSdkLocator.locateComponent(candidate));
     }
 
     @Override
-    public List<WindowsSdk> locateAllWindowsSdks() {
+    public List<WindowsSdk> locateAllComponents() {
         List<WindowsSdk> allSdks = Lists.newArrayList();
-        allSdks.addAll(legacyWindowsSdkLocator.locateAllWindowsSdks());
+        allSdks.addAll(legacyWindowsSdkLocator.locateAllComponents());
         allSdks.addAll(windowsKitWindowsSdkLocator.locateAllComponents());
         return allSdks;
     }
 
-    private static class SdkSearchResult implements SearchResult {
-        final SearchResult legacySearchResult;
-        final WindowsKitComponentLocator.SearchResult<WindowsKitWindowsSdk> windowsKitSearchResult;
+    private static class SdkSearchResult implements SearchResult<WindowsSdk> {
+        final SearchResult<WindowsSdk> legacySearchResult;
+        final SearchResult<WindowsKitWindowsSdk> windowsKitSearchResult;
 
-        SdkSearchResult(SearchResult legacySearchResult, WindowsKitComponentLocator.SearchResult<WindowsKitWindowsSdk> windowsKitSearchResult) {
+        SdkSearchResult(SearchResult<WindowsSdk> legacySearchResult, SearchResult<WindowsKitWindowsSdk> windowsKitSearchResult) {
             this.legacySearchResult = legacySearchResult;
             this.windowsKitSearchResult = windowsKitSearchResult;
         }
 
         @Override
-        public WindowsSdk getSdk() {
+        public WindowsSdk getComponent() {
             if (windowsKitSearchResult.isAvailable()) {
                 return windowsKitSearchResult.getComponent();
             } else if (legacySearchResult.isAvailable()) {
-                return legacySearchResult.getSdk();
+                return legacySearchResult.getComponent();
             } else {
                 return null;
             }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocator.java
@@ -80,7 +80,7 @@ public class DefaultWindowsSdkLocator implements WindowsSdkLocator {
 
         @Override
         public void explain(TreeVisitor<? super String> visitor) {
-            legacySearchResult.explain(visitor);
+            windowsKitSearchResult.explain(visitor);
         }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocator.java
@@ -21,7 +21,6 @@ import net.rubygrapefruit.platform.WindowsRegistry;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.util.TreeVisitor;
 import org.gradle.util.VersionNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,18 +189,18 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
     private SearchResult<WindowsSdk> locateUserSpecifiedSdk(File candidate) {
         File sdkDir = FileUtils.canonicalize(candidate);
         if (!isWindowsSdk(sdkDir)) {
-            return new SdkNotFound(String.format("The specified installation directory '%s' does not appear to contain a Windows SDK installation.", candidate));
+            return new ComponentNotFound<WindowsSdk>(String.format("The specified installation directory '%s' does not appear to contain a Windows SDK installation.", candidate));
         }
 
         if (!foundSdks.containsKey(sdkDir)) {
             addSdk(sdkDir, VERSION_USER, NAME_USER);
         }
-        return new SdkFound(foundSdks.get(sdkDir));
+        return new ComponentFound<WindowsSdk>(foundSdks.get(sdkDir));
     }
 
     private SearchResult<WindowsSdk> locateDefaultSdk() {
         if (pathSdk != null) {
-            return new SdkFound(pathSdk);
+            return new ComponentFound<WindowsSdk>(pathSdk);
         }
 
         WindowsSdk candidate = null;
@@ -210,7 +209,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
                 candidate = windowsSdk;
             }
         }
-        return candidate == null ? new SdkNotFound("Could not locate a Windows SDK installation, using the Windows registry and system path.") : new SdkFound(candidate);
+        return candidate == null ? new ComponentNotFound<WindowsSdk>("Could not locate a Windows SDK installation, using the Windows registry and system path.") : new ComponentFound<WindowsSdk>(candidate);
     }
 
     private void addSdk(File path, String version, String name) {
@@ -246,50 +245,5 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         }
 
         return version;
-    }
-
-    private static class SdkFound implements SearchResult<WindowsSdk> {
-        private final WindowsSdk sdk;
-
-        public SdkFound(WindowsSdk sdk) {
-            this.sdk = sdk;
-        }
-
-        @Override
-        public WindowsSdk getComponent() {
-            return sdk;
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return true;
-        }
-
-        @Override
-        public void explain(TreeVisitor<? super String> visitor) {
-        }
-    }
-
-    private static class SdkNotFound implements SearchResult<WindowsSdk> {
-        private final String message;
-
-        private SdkNotFound(String message) {
-            this.message = message;
-        }
-
-        @Override
-        public WindowsSdk getComponent() {
-            return null;
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return false;
-        }
-
-        @Override
-        public void explain(TreeVisitor<? super String> visitor) {
-            visitor.node(message);
-        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocator.java
@@ -26,6 +26,7 @@ import org.gradle.util.VersionNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
@@ -78,7 +79,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
     }
 
     @Override
-    public SearchResult locateWindowsSdks(File candidate) {
+    public SearchResult<WindowsSdk> locateComponent(@Nullable File candidate) {
         initializeWindowsSdks();
 
         if (candidate != null) {
@@ -89,9 +90,8 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
     }
 
     @Override
-    public List<WindowsSdk> locateAllWindowsSdks() {
+    public List<? extends WindowsSdk> locateAllComponents() {
         initializeWindowsSdks();
-
         return Lists.newArrayList(foundSdks.values());
     }
 
@@ -187,7 +187,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         pathSdk = foundSdks.get(sdkDir);
     }
 
-    private SearchResult locateUserSpecifiedSdk(File candidate) {
+    private SearchResult<WindowsSdk> locateUserSpecifiedSdk(File candidate) {
         File sdkDir = FileUtils.canonicalize(candidate);
         if (!isWindowsSdk(sdkDir)) {
             return new SdkNotFound(String.format("The specified installation directory '%s' does not appear to contain a Windows SDK installation.", candidate));
@@ -199,7 +199,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         return new SdkFound(foundSdks.get(sdkDir));
     }
 
-    private SearchResult locateDefaultSdk() {
+    private SearchResult<WindowsSdk> locateDefaultSdk() {
         if (pathSdk != null) {
             return new SdkFound(pathSdk);
         }
@@ -248,7 +248,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         return version;
     }
 
-    private static class SdkFound implements SearchResult {
+    private static class SdkFound implements SearchResult<WindowsSdk> {
         private final WindowsSdk sdk;
 
         public SdkFound(WindowsSdk sdk) {
@@ -256,7 +256,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         }
 
         @Override
-        public WindowsSdk getSdk() {
+        public WindowsSdk getComponent() {
             return sdk;
         }
 
@@ -270,7 +270,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         }
     }
 
-    private static class SdkNotFound implements SearchResult {
+    private static class SdkNotFound implements SearchResult<WindowsSdk> {
         private final String message;
 
         private SdkNotFound(String message) {
@@ -278,7 +278,7 @@ public class LegacyWindowsSdkLocator implements WindowsSdkLocator {
         }
 
         @Override
-        public WindowsSdk getSdk() {
+        public WindowsSdk getComponent() {
             return null;
         }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/SearchResult.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/SearchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import java.io.File;
-import java.util.List;
+package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
 import org.gradle.platform.base.internal.toolchain.ToolSearchResult;
 
-public interface WindowsKitComponentLocator<T extends WindowsKitComponent> {
-    String[] PLATFORMS = new String[] {"x86", "x64"};
-
-    SearchResult<T> locateComponents(File candidate);
-
-    List<T> locateAllComponents();
-
-    interface SearchResult<T> extends ToolSearchResult {
-        T getComponent();
-    }
+public interface SearchResult<T> extends ToolSearchResult {
+    T getComponent();
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/UcrtLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/UcrtLocator.java
@@ -16,5 +16,5 @@
 
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-public interface UcrtLocator extends WindowsKitComponentLocator<Ucrt> {
+public interface UcrtLocator extends WindowsComponentLocator<Ucrt> {
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChain.java
@@ -162,21 +162,21 @@ public class VisualCppToolChain extends ExtendableToolChain<VisualCppPlatformToo
             return;
         }
 
-        VisualStudioLocator.SearchResult visualStudioSearchResult = visualStudioLocator.locateDefaultVisualStudioInstall(installDir);
+        SearchResult<VisualStudioInstall> visualStudioSearchResult = visualStudioLocator.locateComponent(installDir);
         availability.mustBeAvailable(visualStudioSearchResult);
         if (visualStudioSearchResult.isAvailable()) {
-            visualCpp = visualStudioSearchResult.getVisualStudio().getVisualCpp();
+            visualCpp = visualStudioSearchResult.getComponent().getVisualCpp();
         }
 
-        WindowsSdkLocator.SearchResult windowsSdkSearchResult = windowsSdkLocator.locateWindowsSdks(windowsSdkDir);
+        SearchResult<WindowsSdk> windowsSdkSearchResult = windowsSdkLocator.locateComponent(windowsSdkDir);
         availability.mustBeAvailable(windowsSdkSearchResult);
         if (windowsSdkSearchResult.isAvailable()) {
-            windowsSdk = windowsSdkSearchResult.getSdk();
+            windowsSdk = windowsSdkSearchResult.getComponent();
         }
 
         // Universal CRT is required only for VS2015
         if (isVisualCpp2015()) {
-            WindowsKitComponentLocator.SearchResult<Ucrt> ucrtSearchResult = ucrtLocator.locateComponents(ucrtDir);
+            SearchResult<Ucrt> ucrtSearchResult = ucrtLocator.locateComponent(ucrtDir);
             availability.mustBeAvailable(ucrtSearchResult);
             if (ucrtSearchResult.isAvailable()) {
                 ucrt = ucrtSearchResult.getComponent();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualStudioLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualStudioLocator.java
@@ -15,20 +15,5 @@
  */
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import org.gradle.platform.base.internal.toolchain.ToolSearchResult;
-
-import java.io.File;
-import java.util.List;
-
-public interface VisualStudioLocator {
-
-    List<SearchResult> locateAllVisualStudioVersions();
-
-    SearchResult locateDefaultVisualStudioInstall();
-
-    SearchResult locateDefaultVisualStudioInstall(File candidate);
-
-    interface SearchResult extends ToolSearchResult {
-        VisualStudioInstall getVisualStudio();
-    }
+public interface VisualStudioLocator extends WindowsComponentLocator<VisualStudioInstall> {
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsComponentLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsComponentLocator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.nativeplatform.toolchain.internal.msvcpp;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.List;
+
+public interface WindowsComponentLocator<T> {
+    String[] PLATFORMS = new String[] {"x86", "x64"};
+
+    /**
+     * Locates a component to use.
+     *
+     * @param candidate The install dir to use. Can be null.
+     * @return A result containing the best component, or an unavailable result that explains why the lookup failed
+     */
+    SearchResult<T> locateComponent(@Nullable File candidate);
+
+    /**
+     * Locates all available components. Does not explain why things were not found. This method is only used for testing.
+     */
+    List<? extends T> locateAllComponents();
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsComponentLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsComponentLocator.java
@@ -20,8 +20,6 @@ import java.io.File;
 import java.util.List;
 
 public interface WindowsComponentLocator<T> {
-    String[] PLATFORMS = new String[] {"x86", "x64"};
-
     /**
      * Locates a component to use.
      *

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitComponent.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitComponent.java
@@ -45,6 +45,11 @@ public abstract class WindowsKitComponent implements Named {
     }
 
     @Override
+    public String toString() {
+        return name + " " + version;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdk.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdk.java
@@ -22,9 +22,11 @@ import org.gradle.util.VersionNumber;
 import java.io.File;
 
 public class WindowsKitWindowsSdk extends WindowsKitComponent implements WindowsSdk {
+    private final File binDir;
 
-    public WindowsKitWindowsSdk(File baseDir, VersionNumber version, String name) {
+    public WindowsKitWindowsSdk(File baseDir, VersionNumber version, File binDir, String name) {
         super(baseDir, version, name);
+        this.binDir = binDir;
     }
 
     @Override
@@ -35,12 +37,12 @@ public class WindowsKitWindowsSdk extends WindowsKitComponent implements Windows
     @Override
     public File getBinDir(NativePlatformInternal platform) {
         if (platform.getArchitecture().isAmd64()) {
-            return new File(getBaseDir(), "bin/x64");
+            return new File(binDir, "x64");
         }
         if (platform.getArchitecture().isArm()) {
-            return new File(getBaseDir(), "bin/arm");
+            return new File(binDir, "arm");
         }
-        return new File(getBaseDir(), "bin/x86");
+        return new File(binDir, "x86");
     }
 
     public File[] getIncludeDirs() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocator.java
@@ -41,9 +41,9 @@ public class WindowsKitWindowsSdkLocator extends AbstractWindowsKitComponentLoca
     }
 
     @Override
-    boolean isValidComponentBaseDir(File baseDir) {
+    boolean isValidComponentBinDir(File binDir) {
         for (String platform : PLATFORMS) {
-            if (!new File(baseDir, "bin/" + platform + "/" + RC_EXE).exists()) {
+            if (!new File(binDir, platform + "/" + RC_EXE).exists()) {
                 return false;
             }
         }
@@ -66,7 +66,7 @@ public class WindowsKitWindowsSdkLocator extends AbstractWindowsKitComponentLoca
     }
 
     @Override
-    WindowsKitWindowsSdk newComponent(File baseDir, VersionNumber version, DiscoveryType discoveryType) {
-        return new WindowsKitWindowsSdk(baseDir, version, getVersionedDisplayName(version, discoveryType));
+    WindowsKitWindowsSdk newComponent(File baseDir, File binDir, VersionNumber version, DiscoveryType discoveryType) {
+        return new WindowsKitWindowsSdk(baseDir, version, binDir, getVersionedDisplayName(version, discoveryType));
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsSdkLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsSdkLocator.java
@@ -15,18 +15,5 @@
  */
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import org.gradle.platform.base.internal.toolchain.ToolSearchResult;
-
-import java.io.File;
-import java.util.List;
-
-public interface WindowsSdkLocator {
-
-    SearchResult locateWindowsSdks(File candidate);
-
-    List<WindowsSdk> locateAllWindowsSdks();
-
-    interface SearchResult extends ToolSearchResult {
-        WindowsSdk getSdk();
-    }
+public interface WindowsSdkLocator extends WindowsComponentLocator<WindowsSdk> {
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
@@ -24,12 +24,12 @@ import org.gradle.util.VersionNumber
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.nativeplatform.toolchain.internal.msvcpp.WindowsKitComponentLocator.PLATFORMS
+import static WindowsComponentLocator.PLATFORMS
 
 class DefaultUcrtLocatorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     final WindowsRegistry windowsRegistry = Stub(WindowsRegistry)
-    final WindowsKitComponentLocator ucrtLocator = new DefaultUcrtLocator(windowsRegistry)
+    final WindowsComponentLocator ucrtLocator = new DefaultUcrtLocator(windowsRegistry)
 
     def "uses ucrt found in registry"() {
         def dir1 = ucrtDir("ucrt", "10.0.10150.0")
@@ -38,7 +38,7 @@ class DefaultUcrtLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
 
         when:
-        def result = ucrtLocator.locateComponents(null)
+        def result = ucrtLocator.locateComponent(null)
 
         then:
         result.available
@@ -55,7 +55,7 @@ class DefaultUcrtLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
 
         when:
-        def result = ucrtLocator.locateComponents(null)
+        def result = ucrtLocator.locateComponent(null)
 
         then:
         result.available
@@ -71,7 +71,7 @@ class DefaultUcrtLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> { throw new MissingRegistryEntryException("missing") }
 
         when:
-        def result = ucrtLocator.locateComponents(null)
+        def result = ucrtLocator.locateComponent(null)
 
         then:
         !result.available
@@ -91,10 +91,10 @@ class DefaultUcrtLocatorTest extends Specification {
 
         given:
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> ignoredDir.absolutePath
-        assert ucrtLocator.locateComponents(null).available
+        assert ucrtLocator.locateComponent(null).available
 
         when:
-        def result = ucrtLocator.locateComponents(ucrtDir1)
+        def result = ucrtLocator.locateComponent(ucrtDir1)
 
         then:
         result.available
@@ -103,7 +103,7 @@ class DefaultUcrtLocatorTest extends Specification {
         result.component.version == VersionNumber.withPatchNumber().parse("10.0.10150.1")
 
         when:
-        result = ucrtLocator.locateComponents(ucrtDir2)
+        result = ucrtLocator.locateComponent(ucrtDir2)
 
         then:
         result.available
@@ -117,10 +117,10 @@ class DefaultUcrtLocatorTest extends Specification {
 
         given:
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> ucrtDir1.absolutePath
-        assert ucrtLocator.locateComponents(null).available
+        assert ucrtLocator.locateComponent(null).available
 
         when:
-        def result = ucrtLocator.locateComponents(ucrtDir1)
+        def result = ucrtLocator.locateComponent(ucrtDir1)
 
         then:
         result.available
@@ -136,10 +136,10 @@ class DefaultUcrtLocatorTest extends Specification {
 
         given:
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> ignoredDir.absolutePath
-        assert ucrtLocator.locateComponents(null).available
+        assert ucrtLocator.locateComponent(null).available
 
         when:
-        def result = ucrtLocator.locateComponents(ucrtDir1)
+        def result = ucrtLocator.locateComponent(ucrtDir1)
 
         then:
         !result.available
@@ -159,7 +159,7 @@ class DefaultUcrtLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> ucrtDir.absolutePath
 
         when:
-        def result = ucrtLocator.locateComponents(ucrtDir)
+        def result = ucrtLocator.locateComponent(ucrtDir)
 
         then:
         result.available

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal.msvcpp
 
 import net.rubygrapefruit.platform.MissingRegistryEntryException
 import net.rubygrapefruit.platform.WindowsRegistry
+import org.gradle.internal.text.TreeFormatter
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TreeVisitor
 import org.gradle.util.VersionNumber
@@ -65,10 +66,10 @@ class DefaultUcrtLocatorTest extends Specification {
     }
 
     def "handles missing ucrt"() {
-        def visitor = Mock(TreeVisitor)
+        def visitor = new TreeFormatter()
 
         given:
-        windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> { throw new MissingRegistryEntryException("missing") }
+        windowsRegistry.getStringValue(_, _, _) >> { throw new MissingRegistryEntryException("missing") }
 
         when:
         def result = ucrtLocator.locateComponent(null)
@@ -81,7 +82,7 @@ class DefaultUcrtLocatorTest extends Specification {
         result.explain(visitor)
 
         then:
-        1 * visitor.node("Could not locate a Universal C Runtime installation using the Windows registry.")
+        visitor.toString() == "Could not locate a Universal C Runtime installation using the Windows registry."
     }
 
     def "uses ucrt using specified install dir"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.util.VersionNumber
 import org.junit.Rule
 import spock.lang.Specification
 
-import static WindowsComponentLocator.PLATFORMS
+import static org.gradle.nativeplatform.toolchain.internal.msvcpp.AbstractWindowsKitComponentLocator.PLATFORMS
 
 class DefaultUcrtLocatorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocatorTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.toolchain.internal.msvcpp
 
 import net.rubygrapefruit.platform.SystemInfo
-
 import org.gradle.nativeplatform.platform.internal.Architectures
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal
 import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioMetaDataProvider
@@ -28,7 +27,6 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TreeVisitor
 import org.gradle.util.VersionNumber
 import org.junit.Rule
-
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -53,15 +51,15 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall()
+        def result = visualStudioLocator.locateComponent(null)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 12.0.0"
-        result.visualStudio.version == VersionNumber.parse("12.0")
-        result.visualStudio.baseDir == dir2
-        result.visualStudio.visualCpp.name == "Visual C++ 12.0.0"
-        result.visualStudio.visualCpp.version == VersionNumber.parse("12.0")
+        result.component.name == "Visual Studio 12.0.0"
+        result.component.version == VersionNumber.parse("12.0")
+        result.component.baseDir == dir2
+        result.component.visualCpp.name == "Visual C++ 12.0.0"
+        result.component.visualCpp.version == VersionNumber.parse("12.0")
     }
 
     def "use highest visual studio version found from the command line"() {
@@ -75,15 +73,15 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall()
+        def result = visualStudioLocator.locateComponent(null)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 15.0.0"
-        result.visualStudio.version == VersionNumber.parse("15.0")
-        result.visualStudio.baseDir == dir3
-        result.visualStudio.visualCpp.name == "Visual C++ 1.2.3-4"
-        result.visualStudio.visualCpp.version == VersionNumber.parse("1.2.3.4")
+        result.component.name == "Visual Studio 15.0.0"
+        result.component.version == VersionNumber.parse("15.0")
+        result.component.baseDir == dir3
+        result.component.visualCpp.name == "Visual C++ 1.2.3-4"
+        result.component.visualCpp.version == VersionNumber.parse("1.2.3.4")
     }
 
     def "can locate all versions of visual studio using registry"() {
@@ -97,12 +95,11 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
 
         when:
-        def allResults = visualStudioLocator.locateAllVisualStudioVersions()
+        def allResults = visualStudioLocator.locateAllComponents()
 
         then:
         allResults.size() == 3
-        allResults.collect { it.visualStudio.visualCpp.name } == [ "Visual C++ 13.0.0", "Visual C++ 12.0.0", "Visual C++ 11.0.0" ]
-        allResults.every { it.available }
+        allResults.collect { it.visualCpp.name } == [ "Visual C++ 13.0.0", "Visual C++ 12.0.0", "Visual C++ 11.0.0" ]
     }
 
     def "can locate all versions of visual studio using command line"() {
@@ -117,12 +114,11 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
 
         when:
-        def allResults = visualStudioLocator.locateAllVisualStudioVersions()
+        def allResults = visualStudioLocator.locateAllComponents()
 
         then:
         allResults.size() == 4
-        allResults.collect { it.visualStudio.visualCpp.name } == [ "Visual C++ 1.2.3-4", "Visual C++ 13.0.0", "Visual C++ 12.0.0", "Visual C++ 11.0.0" ]
-        allResults.every { it.available }
+        allResults.collect { it.visualCpp.name } == [ "Visual C++ 1.2.3-4", "Visual C++ 13.0.0", "Visual C++ 12.0.0", "Visual C++ 11.0.0" ]
     }
 
     def "visual studio not available when nothing in registry or command line and executable not found in path"() {
@@ -134,11 +130,11 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * systemPathLocator.getVisualStudioInstalls() >> []
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall()
+        def result = visualStudioLocator.locateComponent(null)
 
         then:
         !result.available
-        result.visualStudio == null
+        result.component == null
 
         when:
         result.explain(visitor)
@@ -148,26 +144,16 @@ class DefaultVisualStudioLocatorTest extends Specification {
     }
 
     def "visual studio not available when locating all versions and nothing in registry or command line and executable not found in path"() {
-        def visitor = Mock(TreeVisitor)
-
         given:
         1 * commandLineLocator.getVisualStudioInstalls() >> []
         1 * windowsRegistryLocator.getVisualStudioInstalls() >> []
         1 * systemPathLocator.getVisualStudioInstalls() >> []
 
         when:
-        def allResults = visualStudioLocator.locateAllVisualStudioVersions()
+        def allResults = visualStudioLocator.locateAllComponents()
 
         then:
-        allResults.size() == 1
-        !allResults.get(0).available
-        allResults.get(0).visualStudio == null
-
-        when:
-        allResults.get(0).explain(visitor)
-
-        then:
-        1 * visitor.node("Could not locate a Visual Studio installation, using the Windows registry and system path.")
+        allResults.empty
     }
 
     def "locates visual studio 2017 installation based on executables in path"() {
@@ -180,15 +166,15 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * systemPathLocator.getSource() >> "system path"
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall()
+        def result = visualStudioLocator.locateComponent(null)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio from system path"
-        result.visualStudio.version == VersionNumber.UNKNOWN
-        result.visualStudio.baseDir == vsDir
-        result.visualStudio.visualCpp.name == "Visual C++ 1.2.3-4"
-        result.visualStudio.visualCpp.version == VersionNumber.parse("1.2.3.4")
+        result.component.name == "Visual Studio from system path"
+        result.component.version == VersionNumber.UNKNOWN
+        result.component.baseDir == vsDir
+        result.component.visualCpp.name == "Visual C++ 1.2.3-4"
+        result.component.visualCpp.version == VersionNumber.parse("1.2.3.4")
     }
 
     def "uses legacy visual studio using specified install dir"() {
@@ -202,25 +188,25 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(vsDir1) >> legacyVsInstall(vsDir1, "11.0")
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(vsDir2) >> legacyVsInstall(vsDir2, "14.0")
-        assert visualStudioLocator.locateDefaultVisualStudioInstall().available
+        assert visualStudioLocator.locateComponent(null).available
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir1)
+        def result = visualStudioLocator.locateComponent(vsDir1)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 11.0.0"
-        result.visualStudio.version == VersionNumber.parse("11.0")
-        result.visualStudio.baseDir == vsDir1
+        result.component.name == "Visual Studio 11.0.0"
+        result.component.version == VersionNumber.parse("11.0")
+        result.component.baseDir == vsDir1
 
         when:
-        result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir2)
+        result = visualStudioLocator.locateComponent(vsDir2)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 14.0.0"
-        result.visualStudio.version == VersionNumber.parse("14.0")
-        result.visualStudio.baseDir == vsDir2
+        result.component.name == "Visual Studio 14.0.0"
+        result.component.version == VersionNumber.parse("14.0")
+        result.component.baseDir == vsDir2
     }
 
     def "uses visual studio 2017 using specified install dir"() {
@@ -234,27 +220,27 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(vsDir1) >> vs2017Install(vsDir1, "15.1")
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(vsDir2) >> vs2017Install(vsDir2, "15.2")
-        assert visualStudioLocator.locateDefaultVisualStudioInstall().available
+        assert visualStudioLocator.locateComponent(null).available
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir1)
+        def result = visualStudioLocator.locateComponent(vsDir1)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 15.1.0"
-        result.visualStudio.version == VersionNumber.parse("15.1")
-        result.visualStudio.baseDir == vsDir1
-        result.visualStudio.visualCpp.version == VersionNumber.parse("1.2.3.4")
+        result.component.name == "Visual Studio 15.1.0"
+        result.component.version == VersionNumber.parse("15.1")
+        result.component.baseDir == vsDir1
+        result.component.visualCpp.version == VersionNumber.parse("1.2.3.4")
 
         when:
-        result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir2)
+        result = visualStudioLocator.locateComponent(vsDir2)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 15.2.0"
-        result.visualStudio.version == VersionNumber.parse("15.2")
-        result.visualStudio.baseDir == vsDir2
-        result.visualStudio.visualCpp.version == VersionNumber.parse("1.2.3.4")
+        result.component.name == "Visual Studio 15.2.0"
+        result.component.version == VersionNumber.parse("15.2")
+        result.component.baseDir == vsDir2
+        result.component.visualCpp.version == VersionNumber.parse("1.2.3.4")
     }
 
     def "uses version of visual studio 2017 using specified install dir when visual cpp version can be determined"() {
@@ -268,27 +254,27 @@ class DefaultVisualStudioLocatorTest extends Specification {
         0 * systemPathLocator.getVisualStudioInstalls()
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(vsDir1) >> vs2017Install(vsDir1, null)
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(vsDir2) >> vs2017Install(vsDir2, null)
-        assert visualStudioLocator.locateDefaultVisualStudioInstall().available
+        assert visualStudioLocator.locateComponent(null).available
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir1)
+        def result = visualStudioLocator.locateComponent(vsDir1)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio from user provided path"
-        result.visualStudio.version == VersionNumber.UNKNOWN
-        result.visualStudio.baseDir == vsDir1
-        result.visualStudio.visualCpp.version == VersionNumber.parse("1.2.3.4")
+        result.component.name == "Visual Studio from user provided path"
+        result.component.version == VersionNumber.UNKNOWN
+        result.component.baseDir == vsDir1
+        result.component.visualCpp.version == VersionNumber.parse("1.2.3.4")
 
         when:
-        result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir2)
+        result = visualStudioLocator.locateComponent(vsDir2)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio from user provided path"
-        result.visualStudio.version == VersionNumber.UNKNOWN
-        result.visualStudio.baseDir == vsDir2
-        result.visualStudio.visualCpp.version == VersionNumber.parse("1.2.3.4")
+        result.component.name == "Visual Studio from user provided path"
+        result.component.version == VersionNumber.UNKNOWN
+        result.component.baseDir == vsDir2
+        result.component.visualCpp.version == VersionNumber.parse("1.2.3.4")
     }
 
     def "visual studio not found when specified directory does not look like an install"() {
@@ -300,14 +286,14 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * commandLineLocator.getVisualStudioInstalls() >> []
         1 * windowsRegistryLocator.getVisualStudioInstalls() >> { [legacyVsInstall(ignored, "12.0")] }
         0 * systemPathLocator.getVisualStudioInstalls()
-        assert visualStudioLocator.locateDefaultVisualStudioInstall().available
+        assert visualStudioLocator.locateComponent(null).available
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(providedDir)
+        def result = visualStudioLocator.locateComponent(providedDir)
 
         then:
         !result.available
-        result.visualStudio == null
+        result.component == null
 
         when:
         result.explain(visitor)
@@ -326,11 +312,11 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * systemPathLocator.getVisualStudioInstalls() >> { [legacyVsInstall(ignored, null)] }
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall()
+        def result = visualStudioLocator.locateComponent(null)
 
         then:
         !result.available
-        result.visualStudio == null
+        result.component == null
 
         when:
         result.explain(visitor)
@@ -349,14 +335,14 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * windowsRegistryLocator.getVisualStudioInstalls() >> { [legacyVsInstall(ignored, "12.0")] }
         0 * systemPathLocator.getVisualStudioInstalls()
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> legacyVsInstall(providedDir, null)
-        assert visualStudioLocator.locateDefaultVisualStudioInstall().available
+        assert visualStudioLocator.locateComponent(null).available
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(providedDir)
+        def result = visualStudioLocator.locateComponent(providedDir)
 
         then:
         !result.available
-        result.visualStudio == null
+        result.component == null
 
         when:
         result.explain(visitor)
@@ -371,15 +357,15 @@ class DefaultVisualStudioLocatorTest extends Specification {
         given:
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> legacyVsInstall(vsDir, "12.0")
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir)
+        def result = visualStudioLocator.locateComponent(vsDir)
 
         then:
         result.available
-        result.visualStudio.name == "Visual Studio 12.0.0"
-        result.visualStudio.version == VersionNumber.parse("12.0")
-        result.visualStudio.baseDir == vsDir
-        result.visualStudio.visualCpp.name == "Visual C++ 12.0.0"
-        result.visualStudio.visualCpp.version == VersionNumber.parse("12.0")
+        result.component.name == "Visual Studio 12.0.0"
+        result.component.version == VersionNumber.parse("12.0")
+        result.component.baseDir == vsDir
+        result.component.visualCpp.name == "Visual C++ 12.0.0"
+        result.component.visualCpp.version == VersionNumber.parse("12.0")
     }
 
     @Unroll
@@ -392,12 +378,12 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> legacyVsInstall(vsDir, "12.0")
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir)
+        def result = visualStudioLocator.locateComponent(vsDir)
 
         then:
-        result.visualStudio.visualCpp.getCompiler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), "cl.exe")
-        result.visualStudio.visualCpp.getLibraryPath(platform(targetPlatform)) == expectedBuilder.getLibPath(vcDir)
-        result.visualStudio.visualCpp.getAssembler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), expectedBuilder.asmFilename)
+        result.component.visualCpp.getCompiler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), "cl.exe")
+        result.component.visualCpp.getLibraryPath(platform(targetPlatform)) == expectedBuilder.getLibPath(vcDir)
+        result.component.visualCpp.getAssembler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), expectedBuilder.asmFilename)
 
         where:
         os       | systemArchitecture            | targetPlatform | is64BitInstall | expectedBuilder
@@ -428,12 +414,12 @@ class DefaultVisualStudioLocatorTest extends Specification {
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> vs2017Install(vsDir, "15.0")
 
         when:
-        def result = visualStudioLocator.locateDefaultVisualStudioInstall(vsDir)
+        def result = visualStudioLocator.locateComponent(vsDir)
 
         then:
-        result.visualStudio.visualCpp.getCompiler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), "cl.exe")
-        result.visualStudio.visualCpp.getLibraryPath(platform(targetPlatform)) == expectedBuilder.getLibPath(vcDir)
-        result.visualStudio.visualCpp.getAssembler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), expectedBuilder.asmFilename)
+        result.component.visualCpp.getCompiler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), "cl.exe")
+        result.component.visualCpp.getLibraryPath(platform(targetPlatform)) == expectedBuilder.getLibPath(vcDir)
+        result.component.visualCpp.getAssembler(platform(targetPlatform)) == new File(expectedBuilder.getBinPath(vcDir), expectedBuilder.asmFilename)
 
         where:
         os       | systemArchitecture            | targetPlatform | is64BitInstall | expectedBuilder

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocatorTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioM
 import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioMetadataBuilder
 import org.gradle.nativeplatform.toolchain.internal.msvcpp.version.VisualStudioVersionLocator
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TextUtil
 import org.gradle.util.TreeVisitor
 import org.gradle.util.VersionNumber
 import org.junit.Rule
@@ -202,9 +203,9 @@ class DefaultVisualStudioLocatorTest extends Specification {
         result.explain(visitor)
 
         then:
-        visitor.toString() == """Could not locate a Visual Studio installation. None of the following locations contain a valid installation:
+        visitor.toString() == TextUtil.toPlatformLineSeparators("""Could not locate a Visual Studio installation. None of the following locations contain a valid installation:
   - ${dir1}
-  - ${dir2}"""
+  - ${dir2}""")
     }
 
     def "locates visual studio 2017 installation based on executables in path"() {
@@ -406,7 +407,11 @@ class DefaultVisualStudioLocatorTest extends Specification {
         def vsDir = vsDir("vs")
 
         given:
+        1 * commandLineLocator.getVisualStudioInstalls() >> []
+        1 * windowsRegistryLocator.getVisualStudioInstalls() >> []
+        1 * systemPathLocator.getVisualStudioInstalls() >> []
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> legacyVsInstall(vsDir, "12.0")
+
         when:
         def result = visualStudioLocator.locateComponent(vsDir)
 
@@ -426,6 +431,9 @@ class DefaultVisualStudioLocatorTest extends Specification {
 
         given:
         systemInfo.getArchitecture() >> systemArchitecture
+        1 * commandLineLocator.getVisualStudioInstalls() >> []
+        1 * windowsRegistryLocator.getVisualStudioInstalls() >> []
+        1 * systemPathLocator.getVisualStudioInstalls() >> []
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> legacyVsInstall(vsDir, "12.0")
 
         when:
@@ -462,6 +470,9 @@ class DefaultVisualStudioLocatorTest extends Specification {
 
         given:
         systemInfo.getArchitecture() >> systemArchitecture
+        1 * commandLineLocator.getVisualStudioInstalls() >> []
+        1 * windowsRegistryLocator.getVisualStudioInstalls() >> []
+        1 * systemPathLocator.getVisualStudioInstalls() >> []
         1 * versionDeterminer.getVisualStudioMetadataFromInstallDir(_) >> vs2017Install(vsDir, "15.0")
 
         when:

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocatorTest.groovy
@@ -71,9 +71,9 @@ class DefaultWindowsSdkLocatorTest extends Specification {
         given:
         legacySdkLookup.available >> false
         legacySdkLookup.sdk >> null
-        legacySdkLookup.explain(_) >> { args -> args[0].node("fail") }
         windowsKitLookup.available >> false
         windowsKitLookup.component >> null
+        windowsKitLookup.explain(_) >> { args -> args[0].node("fail") }
 
         when:
         def result = locator.locateComponent(null)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultWindowsSdkLocatorTest.groovy
@@ -21,30 +21,31 @@ import spock.lang.Specification
 
 
 class DefaultWindowsSdkLocatorTest extends Specification {
-    final WindowsSdkLocator.SearchResult legacySdkLookup = Stub(WindowsSdkLocator.SearchResult)
+    final SearchResult<WindowsSdk> legacySdkLookup = Stub(SearchResult)
     final WindowsSdkLocator legacyWindowsSdkLocator = Stub(WindowsSdkLocator) {
-        locateWindowsSdks(_) >> legacySdkLookup
+        locateComponent(_) >> legacySdkLookup
     }
-    final WindowsKitComponentLocator.SearchResult windowsKitLookup = Stub(WindowsKitComponentLocator.SearchResult)
-    WindowsKitComponentLocator windowsKitSdkLocator = Stub(WindowsKitComponentLocator) {
-        locateComponents(_) >> windowsKitLookup
+    final SearchResult windowsKitLookup = Stub(SearchResult)
+    WindowsComponentLocator windowsKitSdkLocator = Stub(WindowsComponentLocator) {
+        locateComponent(_) >> windowsKitLookup
     }
 
     WindowsSdkLocator locator = new DefaultWindowsSdkLocator(legacyWindowsSdkLocator, windowsKitSdkLocator)
 
     def "prefers a windows kit sdk over a legacy sdk"() {
         def sdk = Mock(WindowsKitWindowsSdk)
+
         given:
         legacySdkLookup.available >> true
         windowsKitLookup.available >> true
         windowsKitLookup.component >> sdk
 
         when:
-        def result = locator.locateWindowsSdks(null)
+        def result = locator.locateComponent(null)
 
         then:
         result.available
-        result.sdk == sdk
+        result.component == sdk
     }
 
     def "finds a legacy sdk when a windows kit sdk cannot be found"() {
@@ -52,16 +53,16 @@ class DefaultWindowsSdkLocatorTest extends Specification {
 
         given:
         legacySdkLookup.available >> true
-        legacySdkLookup.sdk >> sdk
+        legacySdkLookup.component >> sdk
         windowsKitLookup.available >> false
         windowsKitLookup.component >> null
 
         when:
-        def result = locator.locateWindowsSdks(null)
+        def result = locator.locateComponent(null)
 
         then:
         result.available
-        result.sdk == sdk
+        result.component == sdk
     }
 
     def "does not find an sdk if neither locator is successful"() {
@@ -75,11 +76,11 @@ class DefaultWindowsSdkLocatorTest extends Specification {
         windowsKitLookup.component >> null
 
         when:
-        def result = locator.locateWindowsSdks(null)
+        def result = locator.locateComponent(null)
 
         then:
         !result.available
-        result.sdk == null
+        result.component == null
 
         when:
         result.explain(visitor)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocatorTest.groovy
@@ -53,9 +53,9 @@ class LegacyWindowsSdkLocatorTest extends Specification {
 
         then:
         result.available
-        result.sdk.name == "sdk 2"
-        result.sdk.version == VersionNumber.parse("7.1")
-        result.sdk.baseDir == dir2
+        result.component.name == "sdk 2"
+        result.component.version == VersionNumber.parse("7.1")
+        result.component.baseDir == dir2
     }
 
     def "uses windows kit if version is higher than windows SDK"() {
@@ -77,9 +77,9 @@ class LegacyWindowsSdkLocatorTest extends Specification {
 
         then:
         result.available
-        result.sdk.name == "Windows Kit 8.1"
-        result.sdk.version == VersionNumber.parse("8.1")
-        result.sdk.baseDir == dir3
+        result.component.name == "Windows Kit 8.1"
+        result.component.version == VersionNumber.parse("8.1")
+        result.component.baseDir == dir3
     }
 
     def "handles missing SDKs and Kits"() {
@@ -96,9 +96,9 @@ class LegacyWindowsSdkLocatorTest extends Specification {
 
         then:
         result.available
-        result.sdk.name == "Windows Kit 8.1"
-        result.sdk.version == VersionNumber.parse("8.1")
-        result.sdk.baseDir == dir
+        result.component.name == "Windows Kit 8.1"
+        result.component.version == VersionNumber.parse("8.1")
+        result.component.baseDir == dir
     }
 
     def "locates windows SDK based on executables in path"() {
@@ -112,9 +112,9 @@ class LegacyWindowsSdkLocatorTest extends Specification {
 
         then:
         result.available
-        result.sdk.name == "Path-resolved Windows SDK"
-        result.sdk.version == VersionNumber.UNKNOWN
-        result.sdk.baseDir == sdkDir
+        result.component.name == "Path-resolved Windows SDK"
+        result.component.version == VersionNumber.UNKNOWN
+        result.component.baseDir == sdkDir
     }
 
     def "SDK not available when not found in registry or system path"() {
@@ -213,9 +213,9 @@ class LegacyWindowsSdkLocatorTest extends Specification {
 
         then:
         result.available
-        result.sdk.name == "installed sdk"
-        result.sdk.version == VersionNumber.parse("7.0")
-        result.sdk.baseDir == sdkDir
+        result.component.name == "installed sdk"
+        result.component.version == VersionNumber.parse("7.0")
+        result.component.baseDir == sdkDir
     }
 
     def "fills in meta-data from registry for SDK specified by user"() {
@@ -235,9 +235,9 @@ class LegacyWindowsSdkLocatorTest extends Specification {
 
         then:
         result.available
-        result.sdk.name == "installed sdk"
-        result.sdk.version == VersionNumber.parse("7.0")
-        result.sdk.baseDir == sdkDir
+        result.component.name == "installed sdk"
+        result.component.version == VersionNumber.parse("7.0")
+        result.component.baseDir == sdkDir
     }
 
     def sdkDir(String name) {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocatorTest.groovy
@@ -49,7 +49,7 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v2/, "ProductName") >> "sdk 2"
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -73,7 +73,7 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot81") >> dir3.absolutePath
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -92,7 +92,7 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot81") >> dir.absolutePath
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -108,7 +108,7 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         operatingSystem.findInPath("rc.exe") >> sdkDir.file("bin/rc.exe")
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -124,11 +124,11 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         operatingSystem.findInPath(_) >> null
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         !result.available
-        result.sdk == null
+        result.component == null
 
         when:
         result.explain(visitor)
@@ -148,25 +148,25 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "InstallationFolder") >> ignoredDir.absolutePath
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "ProductVersion") >> "7.0"
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "ProductName") >> "installed sdk"
-        assert windowsSdkLocator.locateWindowsSdks(null).available
+        assert windowsSdkLocator.locateComponent(null).available
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(sdkDir1)
+        def result = windowsSdkLocator.locateComponent(sdkDir1)
 
         then:
         result.available
-        result.sdk.name == "User-provided Windows SDK"
-        result.sdk.version == VersionNumber.UNKNOWN
-        result.sdk.baseDir == sdkDir1
+        result.component.name == "User-provided Windows SDK"
+        result.component.version == VersionNumber.UNKNOWN
+        result.component.baseDir == sdkDir1
 
         when:
-        result = windowsSdkLocator.locateWindowsSdks(sdkDir2)
+        result = windowsSdkLocator.locateComponent(sdkDir2)
 
         then:
         result.available
-        result.sdk.name == "User-provided Windows SDK"
-        result.sdk.version == VersionNumber.UNKNOWN
-        result.sdk.baseDir == sdkDir2
+        result.component.name == "User-provided Windows SDK"
+        result.component.version == VersionNumber.UNKNOWN
+        result.component.baseDir == sdkDir2
     }
 
     def "SDK not available when specified install dir does not look like an SDK"() {
@@ -180,14 +180,14 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "InstallationFolder") >> ignoredDir.absolutePath
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "ProductVersion") >> "7.0"
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "ProductName") >> "installed sdk"
-        assert windowsSdkLocator.locateWindowsSdks(null).available
+        assert windowsSdkLocator.locateComponent(null).available
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(sdkDir1)
+        def result = windowsSdkLocator.locateComponent(sdkDir1)
 
         then:
         !result.available
-        result.sdk == null
+        result.component == null
 
         when:
         result.explain(visitor)
@@ -209,7 +209,7 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "ProductName") >> "installed sdk"
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -231,7 +231,7 @@ class LegacyWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Microsoft SDKs\Windows\v1/, "ProductName") >> "installed sdk"
 
         when:
-        def result = windowsSdkLocator.locateWindowsSdks(sdkDir)
+        def result = windowsSdkLocator.locateComponent(sdkDir)
 
         then:
         result.available

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChainTest.groovy
@@ -41,21 +41,21 @@ class VisualCppToolChainTest extends Specification {
     final ExecActionFactory execActionFactory = Mock(ExecActionFactory)
     final CompilerOutputFileNamingSchemeFactory compilerOutputFileNamingSchemeFactory = Mock(CompilerOutputFileNamingSchemeFactory)
     final BuildOperationExecutor buildOperationExecutor = Stub(BuildOperationExecutor)
-    final VisualStudioLocator.SearchResult visualStudioLookup = Stub(VisualStudioLocator.SearchResult)
-    final WindowsSdkLocator.SearchResult windowsSdkLookup = Stub(WindowsSdkLocator.SearchResult)
-	final WindowsKitComponentLocator.SearchResult<Ucrt> ucrtLookup = Stub(WindowsKitComponentLocator.SearchResult)
+    final SearchResult<VisualStudioInstall> visualStudioLookup = Stub(SearchResult)
+    final SearchResult<WindowsSdk> windowsSdkLookup = Stub(SearchResult)
+	final SearchResult<Ucrt> ucrtLookup = Stub(SearchResult)
     final WorkerLeaseService workerLeaseService = Stub(WorkerLeaseService)
     final Instantiator instantiator = DirectInstantiator.INSTANCE
     VisualCppToolChain toolChain
 
     final VisualStudioLocator visualStudioLocator = Stub(VisualStudioLocator) {
-        locateDefaultVisualStudioInstall(_) >> visualStudioLookup
+        locateComponent(_) >> visualStudioLookup
     }
     final WindowsSdkLocator windowsSdkLocator = Stub(WindowsSdkLocator) {
-        locateWindowsSdks(_) >> windowsSdkLookup
+        locateComponent(_) >> windowsSdkLookup
     }
     final UcrtLocator ucrtLocator = Stub(UcrtLocator) {
-        locateComponents(_) >> ucrtLookup
+        locateComponent(_) >> ucrtLookup
     }
 	final OperatingSystem operatingSystem = Stub(OperatingSystem) {
         isWindows() >> true
@@ -99,10 +99,10 @@ class VisualCppToolChainTest extends Specification {
     def "is not available when windows SDK cannot be located"() {
         when:
         visualStudioLookup.available >> true
+        visualStudioLookup.component >> Stub(VisualStudioInstall)
 
         windowsSdkLookup.available >> false
         windowsSdkLookup.explain(_) >> { TreeVisitor<String> visitor -> visitor.node("sdk not found anywhere") }
-		ucrtLookup.available >> false
 
         and:
         def result = toolChain.select(Stub(NativePlatformInternal))
@@ -118,11 +118,14 @@ class VisualCppToolChainTest extends Specification {
         def visualCpp = Stub(VisualCppInstall)
         def platform = Stub(NativePlatformInternal)
         platform.displayName >> '<platform>'
+
         visualStudioLookup.available >> true
+        visualStudioLookup.component >> visualStudio
+
         windowsSdkLookup.available >> true
-		ucrtLookup.available >> false
-        visualStudioLookup.visualStudio >> visualStudio
-        visualStudioLookup.visualStudio >> Stub(VisualStudioInstall)
+        windowsSdkLookup.component >> Stub(WindowsSdk)
+
+        ucrtLookup.available >> false
         visualStudio.visualCpp >> visualCpp
         visualCpp.isSupportedPlatform(platform) >> false
 
@@ -140,10 +143,11 @@ class VisualCppToolChainTest extends Specification {
         def visualCpp = Stub(VisualCppInstall)
         def platform = Stub(NativePlatformInternal)
         visualStudioLookup.available >> true
+        visualStudioLookup.component >> visualStudio
+
         windowsSdkLookup.available >> true
-		ucrtLookup.available >> false
-        visualStudioLookup.visualStudio >> visualStudio
-        visualStudioLookup.visualStudio >> Stub(VisualStudioInstall)
+        windowsSdkLookup.component >> Stub(WindowsSdk)
+
         visualStudio.visualCpp >> visualCpp
         visualCpp.isSupportedPlatform(platform) >> true
 
@@ -163,11 +167,13 @@ class VisualCppToolChainTest extends Specification {
         fileResolver.resolve("install-dir") >> file("vs")
         visualStudioLocator.locateDefaultVisualStudioInstall(file("vs")) >> visualStudioLookup
         visualStudioLookup.available >> true
+        visualStudioLookup.component >> Stub(VisualStudioInstall)
 
         and:
         fileResolver.resolve("windows-sdk-dir") >> file("win-sdk")
         windowsSdkLocator.locateWindowsSdks(file("win-sdk")) >> windowsSdkLookup
         windowsSdkLookup.available >> true
+        windowsSdkLookup.component >> Stub(WindowsSdk)
 		ucrtLookup.available >> false
 
         and:
@@ -207,10 +213,11 @@ class VisualCppToolChainTest extends Specification {
         def visualStudio = Stub(VisualStudioInstall)
         def visualCpp = Stub(VisualCppInstall)
         visualStudioLookup.available >> true
+        visualStudioLookup.component >> visualStudio
+
         windowsSdkLookup.available >> true
-		ucrtLookup.available >> false
-        visualStudioLookup.visualStudio >> visualStudio
-        visualStudioLookup.visualStudio >> Stub(VisualStudioInstall)
+        windowsSdkLookup.component >> Stub(WindowsSdk)
+
         visualStudio.visualCpp >> visualCpp
         visualCpp.isSupportedPlatform(platform) >> true
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocatorTest.groovy
@@ -24,12 +24,12 @@ import org.gradle.util.VersionNumber
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.nativeplatform.toolchain.internal.msvcpp.WindowsKitComponentLocator.PLATFORMS
+import static WindowsComponentLocator.PLATFORMS
 
 class WindowsKitWindowsSdkLocatorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     final WindowsRegistry windowsRegistry = Stub(WindowsRegistry)
-    final WindowsKitComponentLocator<WindowsKitWindowsSdk> windowsSdkLocator = new WindowsKitWindowsSdkLocator(windowsRegistry)
+    final WindowsComponentLocator<WindowsKitWindowsSdk> windowsSdkLocator = new WindowsKitWindowsSdkLocator(windowsRegistry)
 
     def "uses highest Windows Kit version found"() {
         def dir1 = kitDir("sdk1", versions as String[])
@@ -38,7 +38,7 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
 
         when:
-        def result = windowsSdkLocator.locateComponents(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -61,7 +61,7 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> { throw new MissingRegistryEntryException("missing") }
 
         when:
-        def result = windowsSdkLocator.locateComponents(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         !result.available
@@ -82,7 +82,7 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
 
         when:
-        def result = windowsSdkLocator.locateComponents(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         !result.available
@@ -103,7 +103,7 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
 
         when:
-        def result = windowsSdkLocator.locateComponents(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         !result.available
@@ -124,7 +124,7 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
 
         when:
-        def result = windowsSdkLocator.locateComponents(null)
+        def result = windowsSdkLocator.locateComponent(null)
 
         then:
         result.available
@@ -141,10 +141,10 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
 
         given:
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
-        assert windowsSdkLocator.locateComponents(null).available
+        assert windowsSdkLocator.locateComponent(null).available
 
         when:
-        def result = windowsSdkLocator.locateComponents(dir2)
+        def result = windowsSdkLocator.locateComponent(dir2)
 
         then:
         result.available
@@ -154,7 +154,7 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         result.component.includeDirs as Set == [ dir2.file("Include/10.0.10150.0/um"), dir2.file("Include/10.0.10150.0/shared") ] as Set
 
         when:
-        result = windowsSdkLocator.locateComponents(dir3)
+        result = windowsSdkLocator.locateComponent(dir3)
 
         then:
         result.available
@@ -171,10 +171,10 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
 
         given:
         windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
-        assert windowsSdkLocator.locateComponents(null).available
+        assert windowsSdkLocator.locateComponent(null).available
 
         when:
-        def result = windowsSdkLocator.locateComponents(dir2)
+        def result = windowsSdkLocator.locateComponent(dir2)
 
         then:
         !result.available

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocatorTest.groovy
@@ -19,12 +19,14 @@ package org.gradle.nativeplatform.toolchain.internal.msvcpp
 import net.rubygrapefruit.platform.MissingRegistryEntryException
 import net.rubygrapefruit.platform.WindowsRegistry
 import org.gradle.internal.text.TreeFormatter
+import org.gradle.nativeplatform.platform.internal.ArchitectureInternal
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.VersionNumber
 import org.junit.Rule
 import spock.lang.Specification
 
-import static WindowsComponentLocator.PLATFORMS
+import static org.gradle.nativeplatform.toolchain.internal.msvcpp.AbstractWindowsKitComponentLocator.PLATFORMS
 
 class WindowsKitWindowsSdkLocatorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -46,12 +48,33 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         result.component.version == VersionNumber.withPatchNumber().parse(expected)
         result.component.baseDir == dir1
         result.component.includeDirs as Set == [ dir1.file("Include/${expected}/um"), dir1.file("Include/${expected}/shared") ] as Set
+        result.component.getBinDir(x64()) == dir1.file("bin/x64")
+        result.component.getLibDir(x64()) == dir1.file("Lib/${expected}/um/x64")
 
         where:
         versions                                           | expected
         [ "10.0.10150.0" ]                                 | "10.0.10150.0"
         [ "10.0.10150.0", "10.0.10240.0", "10.0.10500.0" ] | "10.0.10500.0"
         [ "10.0.10240.0", "10.0.10500.0", "10.1.10080.0" ] | "10.1.10080.0"
+    }
+
+    def "locates Windows Kit with versioned bin dir"() {
+        def dir1 = kitDirWithVersionedBinDir("sdk1", ["10.0.10150.0", "10.0.10500.0"] as String[])
+
+        given:
+        windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
+
+        when:
+        def result = windowsSdkLocator.locateComponent(null)
+
+        then:
+        result.available
+        result.component.name == "Windows SDK 10"
+        result.component.version == VersionNumber.withPatchNumber().parse("10.0.10500.0")
+        result.component.baseDir == dir1
+        result.component.includeDirs as Set == [ dir1.file("Include/10.0.10500.0/um"), dir1.file("Include/10.0.10500.0/shared") ] as Set
+        result.component.getBinDir(x64()) == dir1.file("bin/10.0.10500.0/x64")
+        result.component.getLibDir(x64()) == dir1.file("Lib/10.0.10500.0/um/x64")
     }
 
     def "SDK not available when not found in registry"() {
@@ -154,6 +177,8 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         result.component.baseDir == dir2
         result.component.version == VersionNumber.withPatchNumber().parse("10.0.10150.0")
         result.component.includeDirs as Set == [ dir2.file("Include/10.0.10150.0/um"), dir2.file("Include/10.0.10150.0/shared") ] as Set
+        result.component.getBinDir(x64()) == dir2.file("bin/x64")
+        result.component.getLibDir(x64()) == dir2.file("Lib/10.0.10150.0/um/x64")
 
         when:
         result = windowsSdkLocator.locateComponent(dir3)
@@ -164,6 +189,29 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         result.component.baseDir == dir3
         result.component.version == VersionNumber.withPatchNumber().parse("10.0.10500.0")
         result.component.includeDirs as Set == [ dir3.file("Include/10.0.10500.0/um"), dir3.file("Include/10.0.10500.0/shared") ] as Set
+        result.component.getBinDir(x64()) == dir3.file("bin/x64")
+        result.component.getLibDir(x64()) == dir3.file("Lib/10.0.10500.0/um/x64")
+    }
+
+    def "uses windows SDK with versioned bin dir using specified install dir"() {
+        def dir1 = kitDirWithVersionedBinDir("sdk1", "10.0.10240.0")
+        def dir2 = kitDirWithVersionedBinDir("sdk2", "10.0.10150.0")
+
+        given:
+        windowsRegistry.getStringValue(WindowsRegistry.Key.HKEY_LOCAL_MACHINE, /SOFTWARE\Microsoft\Windows Kits\Installed Roots/, "KitsRoot10") >> dir1.absolutePath
+        assert windowsSdkLocator.locateComponent(null).available
+
+        when:
+        def result = windowsSdkLocator.locateComponent(dir2)
+
+        then:
+        result.available
+        result.component.name == "User-provided Windows SDK 10"
+        result.component.baseDir == dir2
+        result.component.version == VersionNumber.withPatchNumber().parse("10.0.10150.0")
+        result.component.includeDirs as Set == [ dir2.file("Include/10.0.10150.0/um"), dir2.file("Include/10.0.10150.0/shared") ] as Set
+        result.component.getBinDir(x64()) == dir2.file("bin/10.0.10150.0/x64")
+        result.component.getLibDir(x64()) == dir2.file("Lib/10.0.10150.0/um/x64")
     }
 
     def "SDK not available when specified install dir does not look like an SDK"() {
@@ -189,10 +237,28 @@ class WindowsKitWindowsSdkLocatorTest extends Specification {
         visitor.toString() == "The specified installation directory '$dir2' does not appear to contain a Windows SDK installation."
     }
 
+    def x64() {
+        def platform = Stub(NativePlatformInternal)
+        def architecture = Stub(ArchitectureInternal)
+        platform.architecture >> architecture
+        architecture.isAmd64() >> true
+        platform
+    }
+
     def kitDir(String name, String... versions) {
         def dir = tmpDir.createDir(name)
         PLATFORMS.each { dir.createFile("bin/${it}/rc.exe") }
         versions.each { version ->
+            dir.createFile("Include/${version}/um/windows.h")
+            PLATFORMS.each { dir.createFile("Lib/${version}/um/${it}/kernel32.lib") }
+        }
+        return dir
+    }
+
+    def kitDirWithVersionedBinDir(String name, String... versions) {
+        def dir = tmpDir.createDir(name)
+        versions.each { version ->
+            PLATFORMS.each { dir.createFile("bin/${version}/${it}/rc.exe") }
             dir.createFile("Include/${version}/um/windows.h")
             PLATFORMS.each { dir.createFile("Lib/${version}/um/${it}/kernel32.lib") }
         }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -33,7 +33,6 @@ import org.gradle.nativeplatform.toolchain.VisualCpp;
 import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.GccMetadata;
 import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.GccMetadataProvider;
 import org.gradle.nativeplatform.toolchain.internal.msvcpp.VisualStudioInstall;
-import org.gradle.nativeplatform.toolchain.internal.msvcpp.VisualStudioLocator;
 import org.gradle.nativeplatform.toolchain.internal.swift.metadata.SwiftcMetadata;
 import org.gradle.nativeplatform.toolchain.internal.swift.metadata.SwiftcMetadataProvider;
 import org.gradle.nativeplatform.toolchain.plugins.ClangCompilerPlugin;
@@ -61,6 +60,7 @@ public class AvailableToolChains {
 
     /**
      * Locates the tool chain that would be used as the default for the current machine, if any.
+     *
      * @return null if there is no such tool chain.
      */
     @Nullable
@@ -136,16 +136,13 @@ public class AvailableToolChains {
 
     static private List<ToolChainCandidate> findVisualCpps() {
         // Search in the standard installation locations
-        final List<VisualStudioLocator.SearchResult> searchResults = VisualStudioLocatorTestFixture.getVisualStudioLocator().locateAllVisualStudioVersions();
+        final List<? extends VisualStudioInstall> searchResults = VisualStudioLocatorTestFixture.getVisualStudioLocator().locateAllComponents();
 
         List<ToolChainCandidate> toolChains = Lists.newArrayList();
 
-        for (VisualStudioLocator.SearchResult searchResult : searchResults) {
-            if (searchResult.isAvailable()) {
-                VisualStudioInstall install = searchResult.getVisualStudio();
-                if (isTestableVisualStudioVersion(install.getVersion())) {
-                    toolChains.add(new InstalledVisualCpp(getVisualStudioVersion(install.getVersion())).withInstall(install));
-                }
+        for (VisualStudioInstall install : searchResults) {
+            if (isTestableVisualStudioVersion(install.getVersion())) {
+                toolChains.add(new InstalledVisualCpp(getVisualStudioVersion(install.getVersion())).withInstall(install));
             }
         }
 
@@ -259,7 +256,7 @@ public class AvailableToolChains {
 
         public abstract void resetEnvironment();
 
-   }
+    }
 
     public abstract static class InstalledToolChain extends ToolChainCandidate {
         private static final ProcessEnvironment PROCESS_ENVIRONMENT = NativeServicesTestFixture.getInstance().get(ProcessEnvironment.class);

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/DumpbinBinaryInfo.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/DumpbinBinaryInfo.groovy
@@ -42,7 +42,7 @@ class DumpbinBinaryInfo implements BinaryInfo {
     }
 
     static @Nullable VisualStudioInstall findVisualStudio() {
-        return VisualStudioLocatorTestFixture.visualStudioLocator.locateDefaultVisualStudioInstall().visualStudio
+        return VisualStudioLocatorTestFixture.visualStudioLocator.locateComponent(null).component
     }
 
     private findExe(String exe) {


### PR DESCRIPTION
### Context

This change improves Windows SDK discovery to work with recent Visual Studio 2017 releases.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
