### PR TITLE
Add displayName and classDisplayName to TestDescriptor

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
@@ -144,7 +144,17 @@ class TestNgTestClassExecutionResult implements TestClassExecutionResult {
         this
     }
 
+    @Override
+    TestClassExecutionResult assertTestFailed(String name, String displayName, Matcher<? super String>... messageMatchers) {
+        throw new UnsupportedOperationException()
+    }
+
     TestClassExecutionResult assertTestsSkipped(String... testNames) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    TestClassExecutionResult assertTestPassed(String name, String displayName) {
         throw new UnsupportedOperationException()
     }
 
@@ -171,6 +181,11 @@ class TestNgTestClassExecutionResult implements TestClassExecutionResult {
         throw new UnsupportedOperationException("Unsupported.  Implement if you need it.")
     }
 
+    @Override
+    TestClassExecutionResult assertTestSkipped(String name, String displayName) {
+        throw new UnsupportedOperationException()
+    }
+
     TestClassExecutionResult assertStdout(Matcher<? super String> matcher) {
         throw new UnsupportedOperationException();
     }
@@ -190,6 +205,11 @@ class TestNgTestClassExecutionResult implements TestClassExecutionResult {
     @Override
     TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    TestClassExecutionResult assertDisplayName(String classDisplayName) {
+        throw new UnsupportedOperationException()
     }
 
     TestClassExecutionResult assertConfigMethodPassed(String name) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
@@ -109,8 +109,20 @@ class DefaultTestExecutionResult implements TestExecutionResult {
             this
         }
 
+        @Override
+        TestClassExecutionResult assertTestPassed(String name, String displayName) {
+            testClassResults*.assertTestPassed(removeParentheses(name), removeParentheses(displayName))
+            this
+        }
+
         TestClassExecutionResult assertTestPassed(String name) {
             testClassResults*.assertTestPassed(removeParentheses(name))
+            this
+        }
+
+        @Override
+        TestClassExecutionResult assertTestFailed(String name, String displayName, Matcher<? super String>... messageMatchers) {
+            testClassResults*.assertTestFailed(removeParentheses(name), removeParentheses(displayName), messageMatchers)
             this
         }
 
@@ -122,6 +134,12 @@ class DefaultTestExecutionResult implements TestExecutionResult {
         boolean testFailed(String name, Matcher<? super String>... messageMatchers) {
             List<Boolean> results = testClassResults*.testFailed(name, messageMatchers)
             return results.inject { a, b -> a && b }
+        }
+
+        @Override
+        TestClassExecutionResult assertTestSkipped(String name, String displayName) {
+            testClassResults*.assertTestSkipped(removeParentheses(name), removeParentheses(displayName))
+            this
         }
 
         TestClassExecutionResult assertTestSkipped(String name) {
@@ -161,6 +179,12 @@ class DefaultTestExecutionResult implements TestExecutionResult {
 
         TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher) {
             testClassResults*.assertExecutionFailedWithCause(causeMatcher)
+            this
+        }
+
+        @Override
+        TestClassExecutionResult assertDisplayName(String classDisplayName) {
+            testClassResults*.assertDisplayName(classDisplayName)
             this
         }
     }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -110,10 +110,10 @@ class HtmlTestExecutionResult implements TestExecutionResult {
             parseTestClassFile()
         }
 
-        private extractTestCaseTo(String cssSelector, Collection<TestCase> target){
+        private extractTestCaseTo(String cssSelector, Collection<TestCase> target) {
             html.select(cssSelector).each {
-                def testName = it.attr('title')
                 def testDisplayName = it.textNodes().first().wholeText.trim()
+                def testName = it.childNode(1).textNodes().isEmpty() ? testDisplayName : it.childNode(1).textNodes().first().wholeText.trim()
                 def failureMessage = getFailureMessages(testName)
                 def testCase = new TestCase(testName, testDisplayName, failureMessage)
                 testsExecuted << testCase
@@ -182,7 +182,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         }
 
         boolean testFailed(String name, String displayName, Matcher<? super String>... messageMatchers) {
-            def testCase = testsFailures.grep { it.name == name && it.displayName == displayName}
+            def testCase = testsFailures.grep { it.name == name && it.displayName == displayName }
             if (testCase.isEmpty()) {
                 return false
             }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -113,7 +113,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         private extractTestCaseTo(String cssSelector, Collection<TestCase> target) {
             html.select(cssSelector).each {
                 def testDisplayName = it.textNodes().first().wholeText.trim()
-                def testName = it.childNode(1).textNodes().isEmpty() ? testDisplayName : it.childNode(1).textNodes().first().wholeText.trim()
+                def testName = it.nextElementSibling().text()
                 def failureMessage = getFailureMessages(testName)
                 def testCase = new TestCase(testName, testDisplayName, failureMessage)
                 testsExecuted << testCase

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -113,12 +113,16 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         private extractTestCaseTo(String cssSelector, Collection<TestCase> target) {
             html.select(cssSelector).each {
                 def testDisplayName = it.textNodes().first().wholeText.trim()
-                def testName = it.nextElementSibling().text()
+                def testName = hasMethodNameColumn() ? it.nextElementSibling().text() : testDisplayName
                 def failureMessage = getFailureMessages(testName)
                 def testCase = new TestCase(testName, testDisplayName, failureMessage)
                 testsExecuted << testCase
                 target << testCase
             }
+        }
+
+        private boolean hasMethodNameColumn() {
+            return html.select('tr > th').size() == 4
         }
 
         private void parseTestClassFile() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -79,6 +79,11 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
         this
     }
 
+    @Override
+    TestClassExecutionResult assertTestFailed(String name, String displayName, Matcher<? super String>... messageMatchers) {
+        return assertTestFailed(name, messageMatchers)
+    }
+
     TestClassExecutionResult assertTestFailed(String name, Matcher<? super String>... messageMatchers) {
         Map<String, Node> testMethods = findTests()
         Assert.assertThat(testMethods.keySet(), Matchers.hasItem(name))
@@ -112,6 +117,11 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
         return true
     }
 
+    @Override
+    TestClassExecutionResult assertTestSkipped(String name, String displayName) {
+        return assertTestSkipped(name)
+    }
+
     TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher) {
         Map<String, Node> testMethods = findTests()
         String failureMethodName = "execution failure"
@@ -122,6 +132,10 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
         def cause = failures[0].text().readLines().find { it.startsWith causeLinePrefix }?.substring(causeLinePrefix.length())
 
         Assert.assertThat(cause, causeMatcher)
+        this
+    }
+
+    TestClassExecutionResult assertDisplayName(String classDisplayName) {
         this
     }
 
@@ -136,6 +150,11 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
 
         Assert.assertThat(testMethods.keySet(), Matchers.equalTo(testNames as Set))
         this
+    }
+
+    @Override
+    TestClassExecutionResult assertTestPassed(String name, String displayName) {
+        return assertTestPassed(name)
     }
 
     TestClassExecutionResult assertConfigMethodPassed(String name) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
@@ -36,13 +36,16 @@ public interface TestClassExecutionResult {
     /**
      * Asserts that the given test passed.
      */
+    TestClassExecutionResult assertTestPassed(String name, String displayName);
+
     TestClassExecutionResult assertTestPassed(String name);
 
     /**
      * Asserts that the given test failed.
      */
-    TestClassExecutionResult assertTestFailed(String name, Matcher<? super String>... messageMatchers);
+    TestClassExecutionResult assertTestFailed(String name, String displayName, Matcher<? super String>... messageMatchers);
 
+    TestClassExecutionResult assertTestFailed(String name, Matcher<? super String>... messageMatchers);
     /**
      *
      */
@@ -51,6 +54,8 @@ public interface TestClassExecutionResult {
     /**
      * Asserts that the given test was skipped.
      */
+    TestClassExecutionResult assertTestSkipped(String name, String displayName);
+
     TestClassExecutionResult assertTestSkipped(String name);
 
     /**
@@ -72,4 +77,6 @@ public interface TestClassExecutionResult {
     TestClassExecutionResult assertTestCaseStderr(String testCaseName, Matcher<? super String> matcher);
 
     TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher);
+
+    TestClassExecutionResult assertDisplayName(String classDisplayName);
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -96,7 +96,9 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         testDescriptor.parent >> suiteDescriptor
         testDescriptor.composite >> false
         testDescriptor.className >> "class"
+        testDescriptor.classDisplayName >> "class"
         testDescriptor.name >> "method"
+        testDescriptor.displayName >> "method"
 
         def suiteStartEvent = Stub(TestStartEvent) {
             getParentId() >> null

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -52,4 +52,14 @@ public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     public Object getOwnerBuildOperationId() {
         return null;
     }
+
+    @Override
+    public String getDisplayName() {
+        return getName();
+    }
+
+    @Override
+    public String getClassDisplayName() {
+        return getClassName();
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
@@ -53,6 +53,16 @@ public class DecoratingTestDescriptor implements TestDescriptorInternal {
     }
 
     @Override
+    public String getDisplayName() {
+        return descriptor.getDisplayName();
+    }
+
+    @Override
+    public String getClassDisplayName() {
+        return descriptor.getClassDisplayName();
+    }
+
+    @Override
     public String getClassName() {
         return descriptor.getClassName();
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassDescriptor.java
@@ -17,13 +17,30 @@
 package org.gradle.api.internal.tasks.testing;
 
 public class DefaultTestClassDescriptor extends DefaultTestSuiteDescriptor {
+    private final String classDisplayName;
+
     public DefaultTestClassDescriptor(Object id, String className) {
+        this(id, className, className);
+    }
+
+    public DefaultTestClassDescriptor(Object id, String className, String classDisplayName) {
         super(id, className);
+        this.classDisplayName = classDisplayName;
     }
 
     @Override
     public String getClassName() {
         return getName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return classDisplayName;
+    }
+
+    @Override
+    public String getClassDisplayName() {
+        return getDisplayName();
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestDescriptor.java
@@ -17,11 +17,19 @@
 package org.gradle.api.internal.tasks.testing;
 
 public class DefaultTestDescriptor extends AbstractTestDescriptor {
+    private final String displayName;
     private final String className;
+    private final String classDisplayName;
 
     public DefaultTestDescriptor(Object id, String className, String name) {
+        this(id, className, name, className, name);
+    }
+
+    public DefaultTestDescriptor(Object id, String className, String name, String classDisplayName, String displayName) {
         super(id, name);
         this.className = className;
+        this.classDisplayName = classDisplayName;
+        this.displayName = displayName;
     }
 
     @Override
@@ -37,5 +45,15 @@ public class DefaultTestDescriptor extends AbstractTestDescriptor {
     @Override
     public String getClassName() {
         return className;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getClassDisplayName() {
+        return classDisplayName;
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -35,4 +35,17 @@ public interface TestDescriptorInternal extends TestDescriptor {
      */
     @Nullable
     Object getOwnerBuildOperationId();
+
+    /**
+     * The name for display. It may be the same or different with {@link #getName()}
+     *
+     * @return the name for display.
+     */
+    String getDisplayName();
+
+    /**
+     * The class name for display. It may be the same or different with {@link #getClassName()}
+     * @return the class name for display.
+     */
+    String getClassDisplayName();
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -37,14 +37,14 @@ public interface TestDescriptorInternal extends TestDescriptor {
     Object getOwnerBuildOperationId();
 
     /**
-     * The name for display. It may be the same or different with {@link #getName()}
+     * The name for display. It may be the same as or different from {@link #getName()}
      *
      * @return the name for display.
      */
     String getDisplayName();
 
     /**
-     * The class name for display. It may be the same or different with {@link #getClassName()}
+     * The class name for display. It may be the same as or different from {@link #getClassName()}
      * @return the class name for display.
      */
     String getClassDisplayName();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestClassResult.java
@@ -24,18 +24,24 @@ import java.util.List;
 public class TestClassResult {
     private final List<TestMethodResult> methodResults = new ArrayList<TestMethodResult>();
     private final String className;
+    private final String classDisplayName;
     private long startTime;
     private int failuresCount;
     private int skippedCount;
     private long id;
 
     public TestClassResult(long id, String className, long startTime) {
+        this(id, className, className, startTime);
+    }
+
+    public TestClassResult(long id, String className, String classDisplayName, long startTime) {
         if (id < 1) {
             throw new IllegalArgumentException("id must be > 0");
         }
         this.id = id;
         this.className = className;
         this.startTime = startTime;
+        this.classDisplayName = classDisplayName;
     }
 
     public long getId() {
@@ -44,6 +50,10 @@ public class TestClassResult {
 
     public String getClassName() {
         return className;
+    }
+
+    public String getClassDisplayName() {
+        return classDisplayName;
     }
 
     public TestClassResult add(TestMethodResult methodResult) {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestMethodResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestMethodResult.java
@@ -24,22 +24,33 @@ import java.util.List;
 public class TestMethodResult {
     private final long id;
     private final String name;
+    private final String displayName;
     private TestResult.ResultType resultType;
     private long duration;
     private long endTime;
     private List<TestFailure> failures = new ArrayList<TestFailure>();
 
     public TestMethodResult(long id, String name) {
+        this(id, name, name);
+    }
+
+    public TestMethodResult(long id, String name, String displayName) {
         this.id = id;
         this.name = name;
+        this.displayName = displayName;
     }
 
     public TestMethodResult(long id, String name, TestResult.ResultType resultType, long duration, long endTime) {
+        this(id, name, name, resultType, duration, endTime);
+    }
+
+    public TestMethodResult(long id, String name, String displayName, TestResult.ResultType resultType, long duration, long endTime) {
         if (id < 1) {
             throw new IllegalArgumentException("id must be > 0");
         }
         this.id = id;
         this.name = name;
+        this.displayName = displayName;
         this.resultType = resultType;
         this.duration = duration;
         this.endTime = endTime;
@@ -63,6 +74,10 @@ public class TestMethodResult {
 
     public String getName() {
         return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     public List<TestFailure> getFailures() {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
@@ -133,7 +133,7 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
             //it's possible that we receive an output for a suite here
             //in this case we will create the test result for a suite that normally would not be created
             //feels like this scenario should modelled more explicitly
-            classResult = new TestClassResult(internalIdCounter++, className, 0);
+            classResult = new TestClassResult(internalIdCounter++, className, TestDescriptorInternal.class.cast(testDescriptor).getClassDisplayName(), 0);
             results.put(className, classResult);
         }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestResultSerializer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestResultSerializer.java
@@ -66,6 +66,7 @@ public class TestResultSerializer {
     private void write(TestClassResult classResult, Encoder encoder) throws IOException {
         encoder.writeSmallLong(classResult.getId());
         encoder.writeString(classResult.getClassName());
+        encoder.writeString(classResult.getClassDisplayName());
         encoder.writeLong(classResult.getStartTime());
         encoder.writeSmallInt(classResult.getResults().size());
         for (TestMethodResult methodResult : classResult.getResults()) {
@@ -76,6 +77,7 @@ public class TestResultSerializer {
     private void write(TestMethodResult methodResult, Encoder encoder) throws IOException {
         encoder.writeSmallLong(methodResult.getId());
         encoder.writeString(methodResult.getName());
+        encoder.writeString(methodResult.getDisplayName());
         encoder.writeSmallInt(methodResult.getResultType().ordinal());
         encoder.writeSmallLong(methodResult.getDuration());
         encoder.writeLong(methodResult.getEndTime());
@@ -123,8 +125,9 @@ public class TestResultSerializer {
     private TestClassResult readClassResult(Decoder decoder) throws IOException, ClassNotFoundException {
         long id = decoder.readSmallLong();
         String className = decoder.readString();
+        String classDisplayName = decoder.readString();
         long startTime = decoder.readLong();
-        TestClassResult result = new TestClassResult(id, className, startTime);
+        TestClassResult result = new TestClassResult(id, className, classDisplayName, startTime);
         int testMethodCount = decoder.readSmallInt();
         for (int i = 0; i < testMethodCount; i++) {
             TestMethodResult methodResult = readMethodResult(decoder);
@@ -136,10 +139,11 @@ public class TestResultSerializer {
     private TestMethodResult readMethodResult(Decoder decoder) throws ClassNotFoundException, IOException {
         long id = decoder.readSmallLong();
         String name = decoder.readString();
+        String displayName = decoder.readString();
         TestResult.ResultType resultType = TestResult.ResultType.values()[decoder.readSmallInt()];
         long duration = decoder.readSmallLong();
         long endTime = decoder.readLong();
-        TestMethodResult methodResult = new TestMethodResult(id, name, resultType, duration, endTime);
+        TestMethodResult methodResult = new TestMethodResult(id, name, displayName, resultType, duration, endTime);
         int failures = decoder.readSmallInt();
         for (int i = 0; i < failures; i++) {
             String exceptionType = decoder.readString();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/AllTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/AllTestResults.java
@@ -44,12 +44,20 @@ public class AllTestResults extends CompositeTestResults {
     }
 
     public TestResult addTest(long classId, String className, String testName, long duration) {
+        return addTest(classId, className, className, testName, testName, duration);
+    }
+
+    public TestResult addTest(long classId, String className, String classDisplayName, String testName, String testDisplayName, long duration) {
         PackageTestResults packageResults = addPackageForClass(className);
-        return addTest(packageResults.addTest(classId, className, testName, duration));
+        return addTest(packageResults.addTest(classId, className, classDisplayName, testName, testDisplayName, duration));
     }
 
     public ClassTestResults addTestClass(long classId, String className) {
-        return addPackageForClass(className).addClass(classId, className);
+        return addTestClass(classId, className, className);
+    }
+
+    public ClassTestResults addTestClass(long classId, String className, String classDisplayName) {
+        return addPackageForClass(className).addClass(classId, className, classDisplayName);
     }
 
     private PackageTestResults addPackageForClass(String className) {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
@@ -56,7 +56,7 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
 
         for (TestResult test : getResults().getTestResults()) {
             htmlWriter.startElement("tr")
-                .startElement("td").attribute("class", test.getStatusClass()).characters(test.getName()).endElement()
+                .startElement("td").attribute("class", test.getStatusClass()).attribute("title", test.getName()).characters(test.getDisplayName()).endElement()
                 .startElement("td").characters(test.getFormattedDuration()).endElement()
                 .startElement("td").attribute("class", test.getStatusClass()).characters(test.getFormattedResultType()).endElement()
             .endElement();
@@ -69,7 +69,7 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
         for (TestResult test : getResults().getFailures()) {
             htmlWriter.startElement("div").attribute("class", "test")
                 .startElement("a").attribute("name", test.getId().toString()).characters("").endElement() //browsers dont understand <a name="..."/>
-                .startElement("h3").attribute("class", test.getStatusClass()).characters(test.getName()).endElement();
+                .startElement("h3").attribute("class", test.getStatusClass()).characters(test.getDisplayName()).endElement();
             for (TestFailure failure : test.getFailures()) {
                 String message;
                 if (GUtil.isTrue(failure.getMessage()) && !failure.getStackTrace().contains(failure.getMessage())) {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
@@ -40,7 +40,7 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
             .startElement("a").attribute("href", getResults().getUrlTo(getResults().getParent().getParent())).characters("all").endElement()
             .characters(" > ")
             .startElement("a").attribute("href", getResults().getUrlTo(getResults().getPackageResults())).characters(getResults().getPackageResults().getName()).endElement()
-            .characters(" > " + getResults().getSimpleName())
+            .characters(" > " + getResults().getReportName())
         .endElement();
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
@@ -52,16 +52,28 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
                     .startElement("th").characters("Duration").endElement()
                     .startElement("th").characters("Result").endElement()
                 .endElement()
-        .endElement();
+            .endElement();
 
         for (TestResult test : getResults().getTestResults()) {
             htmlWriter.startElement("tr")
-                .startElement("td").attribute("class", test.getStatusClass()).attribute("title", test.getName()).characters(test.getDisplayName()).endElement()
+                .startElement("td").attribute("class", test.getStatusClass())
+                    .characters(test.getDisplayName())
+                        .startElement("span").attribute("class", "method").characters(determineTestName(test))
+                        .endElement()
+                    .endElement()
                 .startElement("td").characters(test.getFormattedDuration()).endElement()
                 .startElement("td").attribute("class", test.getStatusClass()).characters(test.getFormattedResultType()).endElement()
             .endElement();
         }
         htmlWriter.endElement();
+    }
+
+    private String determineTestName(TestResult test) {
+        if (test.getName().equals(test.getDisplayName())) {
+            return ""; // empty span can be invisible via css
+        } else {
+            return test.getName();
+        }
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
@@ -58,7 +58,7 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
             htmlWriter.startElement("tr")
                 .startElement("td").attribute("class", test.getStatusClass())
                     .characters(test.getDisplayName())
-                        .startElement("span").attribute("class", "method").characters(determineTestName(test))
+                        .startElement("span").attribute("class", "method").characters(test.getMethodSpanName())
                         .endElement()
                     .endElement()
                 .startElement("td").characters(test.getFormattedDuration()).endElement()
@@ -66,14 +66,6 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
             .endElement();
         }
         htmlWriter.endElement();
-    }
-
-    private String determineTestName(TestResult test) {
-        if (test.getName().equals(test.getDisplayName())) {
-            return ""; // empty span can be invisible via css
-        } else {
-            return test.getName();
-        }
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
@@ -40,15 +40,17 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
             .startElement("a").attribute("href", getResults().getUrlTo(getResults().getParent().getParent())).characters("all").endElement()
             .characters(" > ")
             .startElement("a").attribute("href", getResults().getUrlTo(getResults().getPackageResults())).characters(getResults().getPackageResults().getName()).endElement()
-            .characters(" > " + getResults().getReportName())
+            .characters(" > " + getResults().getSimpleName())
         .endElement();
     }
 
     private void renderTests(SimpleHtmlWriter htmlWriter) throws IOException {
+        boolean methodNameColumnIsVisible = determineIfMethodNameColumnIsVisible();
         htmlWriter.startElement("table")
             .startElement("thead")
                 .startElement("tr")
                     .startElement("th").characters("Test").endElement()
+                    .startElement("th").attribute("class", methodNameColumnIsVisible ? "" : "invisible").characters("Method name").endElement()
                     .startElement("th").characters("Duration").endElement()
                     .startElement("th").characters("Result").endElement()
                 .endElement()
@@ -56,16 +58,22 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
 
         for (TestResult test : getResults().getTestResults()) {
             htmlWriter.startElement("tr")
-                .startElement("td").attribute("class", test.getStatusClass())
-                    .characters(test.getDisplayName())
-                        .startElement("span").attribute("class", "method").characters(test.getMethodSpanName())
-                        .endElement()
-                    .endElement()
+                .startElement("td").attribute("class", test.getStatusClass()).characters(test.getDisplayName()).endElement()
+                .startElement("td").attribute("class", methodNameColumnIsVisible ? "" : "invisible").characters(test.getName()).endElement()
                 .startElement("td").characters(test.getFormattedDuration()).endElement()
                 .startElement("td").attribute("class", test.getStatusClass()).characters(test.getFormattedResultType()).endElement()
             .endElement();
         }
         htmlWriter.endElement();
+    }
+
+    private boolean determineIfMethodNameColumnIsVisible() {
+        for (TestResult result : getResults().getTestResults()) {
+            if (!result.getName().equals(result.getDisplayName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
@@ -28,14 +28,20 @@ import java.util.TreeSet;
 public class ClassTestResults extends CompositeTestResults {
     private final long id;
     private final String name;
+    private final String displayName;
     private final PackageTestResults packageResults;
     private final Set<TestResult> results = new TreeSet<TestResult>();
     private final String baseUrl;
 
     public ClassTestResults(long id, String name, PackageTestResults packageResults) {
+        this(id, name, name, packageResults);
+    }
+
+    public ClassTestResults(long id, String name, String displayName, PackageTestResults packageResults) {
         super(packageResults);
         this.id = id;
         this.name = name;
+        this.displayName = displayName;
         this.packageResults = packageResults;
         baseUrl = "classes/" + FileUtils.toSafeFileName(name) + ".html";
     }
@@ -58,7 +64,14 @@ public class ClassTestResults extends CompositeTestResults {
         return name;
     }
 
+    public String getDisplayName() {
+        return displayName;
+    }
+
     public String getSimpleName() {
+        if (displayName != null && !displayName.equals(name)) {
+            return displayName;
+        }
         String simpleName = StringUtils.substringAfterLast(name, ".");
         if (simpleName.equals("")) {
             return name;
@@ -74,8 +87,8 @@ public class ClassTestResults extends CompositeTestResults {
         return results;
     }
 
-    public TestResult addTest(String testName, long duration) {
-        TestResult test = new TestResult(testName, duration, this);
+    public TestResult addTest(String testName, String testDisplayName, long duration) {
+        TestResult test = new TestResult(testName, testDisplayName, duration, this);
         results.add(test);
         return addTest(test);
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
@@ -75,7 +75,7 @@ public class ClassTestResults extends CompositeTestResults {
         return getSimpleName();
     }
 
-    public String getSimpleName() {
+    private String getSimpleName() {
         String simpleName = StringUtils.substringAfterLast(name, ".");
         if (simpleName.equals("")) {
             return name;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
@@ -68,10 +68,14 @@ public class ClassTestResults extends CompositeTestResults {
         return displayName;
     }
 
-    public String getSimpleName() {
+    public String getReportName() {
         if (displayName != null && !displayName.equals(name)) {
             return displayName;
         }
+        return getSimpleName();
+    }
+
+    public String getSimpleName() {
         String simpleName = StringUtils.substringAfterLast(name, ".");
         if (simpleName.equals("")) {
             return name;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassTestResults.java
@@ -52,7 +52,7 @@ public class ClassTestResults extends CompositeTestResults {
 
     @Override
     public String getTitle() {
-        return "Class " + name;
+        return name.equals(displayName) ? "Class " + name : displayName;
     }
 
     @Override
@@ -75,7 +75,7 @@ public class ClassTestResults extends CompositeTestResults {
         return getSimpleName();
     }
 
-    private String getSimpleName() {
+    public String getSimpleName() {
         String simpleName = StringUtils.substringAfterLast(name, ".");
         if (simpleName.equals("")) {
             return name;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/DefaultTestReport.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/DefaultTestReport.java
@@ -63,10 +63,10 @@ public class DefaultTestReport implements TestReporter {
         final AllTestResults model = new AllTestResults();
         resultsProvider.visitClasses(new Action<TestClassResult>() {
             public void execute(TestClassResult classResult) {
-                model.addTestClass(classResult.getId(), classResult.getClassName());
+                model.addTestClass(classResult.getId(), classResult.getClassName(), classResult.getClassDisplayName());
                 List<TestMethodResult> collectedResults = classResult.getResults();
                 for (TestMethodResult collectedResult : collectedResults) {
-                    final TestResult testResult = model.addTest(classResult.getId(), classResult.getClassName(), collectedResult.getName(), collectedResult.getDuration());
+                    final TestResult testResult = model.addTest(classResult.getId(), classResult.getClassName(), classResult.getClassDisplayName(), collectedResult.getName(), collectedResult.getDisplayName(), collectedResult.getDuration());
                     if (collectedResult.getResultType() == SKIPPED) {
                         testResult.setIgnored();
                     } else {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackagePageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackagePageRenderer.java
@@ -48,7 +48,10 @@ class PackagePageRenderer extends PageRenderer<PackageTestResults> {
         for (ClassTestResults testClass : getResults().getClasses()) {
             htmlWriter.startElement("tr");
             htmlWriter.startElement("td").attribute("class", testClass.getStatusClass());
-                htmlWriter.startElement("a").attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(testClass))).characters(testClass.getSimpleName()).endElement();
+            htmlWriter.startElement("a")
+                .attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(testClass)))
+                .attribute("title", asHtmlLinkEncoded(testClass.getName()))
+                .characters(testClass.getReportName()).endElement();
             htmlWriter.endElement();
             htmlWriter.startElement("td").characters(Integer.toString(testClass.getTestCount())).endElement();
             htmlWriter.startElement("td").characters(Integer.toString(testClass.getFailureCount())).endElement();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackagePageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackagePageRenderer.java
@@ -50,7 +50,6 @@ class PackagePageRenderer extends PageRenderer<PackageTestResults> {
             htmlWriter.startElement("td").attribute("class", testClass.getStatusClass());
             htmlWriter.startElement("a")
                 .attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(testClass)))
-                .attribute("title", asHtmlLinkEncoded(testClass.getName()))
                 .characters(testClass.getReportName()).endElement();
             htmlWriter.endElement();
             htmlWriter.startElement("td").characters(Integer.toString(testClass.getTestCount())).endElement();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackageTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackageTestResults.java
@@ -51,14 +51,22 @@ public class PackageTestResults extends CompositeTestResults {
     }
 
     public TestResult addTest(long classId, String className, String testName, long duration) {
-        ClassTestResults classResults = addClass(classId, className);
-        return addTest(classResults.addTest(testName, duration));
+        return addTest(classId, className, className, testName, testName, duration);
+    }
+
+    public TestResult addTest(long classId, String className, String classDisplayName, String testName, String testDisplayName, long duration) {
+        ClassTestResults classResults = addClass(classId, className, classDisplayName);
+        return addTest(classResults.addTest(testName, testDisplayName, duration));
     }
 
     public ClassTestResults addClass(long classId, String className) {
+        return addClass(classId, className, className);
+    }
+
+    public ClassTestResults addClass(long classId, String className, String classDisplayName) {
         ClassTestResults classResults = classes.get(className);
         if (classResults == null) {
-            classResults = new ClassTestResults(classId, className, this);
+            classResults = new ClassTestResults(classId, className, classDisplayName, this);
             classes.put(className, classResults);
         }
         return classResults;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PageRenderer.java
@@ -24,6 +24,7 @@ import org.gradle.reporting.TabsRenderer;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Set;
 
 abstract class PageRenderer<T extends CompositeTestResults> extends TabbedPageRenderer<T> {
     private static final URL STYLE_URL = PageRenderer.class.getResource("style.css");
@@ -68,13 +69,24 @@ abstract class PageRenderer<T extends CompositeTestResults> extends TabbedPageRe
     }
 
     protected void renderFailures(SimpleHtmlWriter htmlWriter) throws IOException {
+        renderTestResultList(htmlWriter, results.getFailures());
+    }
+
+    private void renderTestResultList(SimpleHtmlWriter htmlWriter, Set<TestResult> failures) throws IOException {
         htmlWriter.startElement("ul").attribute("class", "linkList");
-        for (TestResult test : results.getFailures()) {
+        for (TestResult test : failures) {
             htmlWriter.startElement("li");
-            htmlWriter.startElement("a").attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults()))).characters(test.getClassResults().getSimpleName()).endElement();
+            htmlWriter.startElement("a")
+                .attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())))
+                .attribute("title", test.getClassResults().getName())
+                .characters(test.getClassResults().getSimpleName())
+                .endElement();
             htmlWriter.characters(".");
             String link = asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())) + "#" + test.getName();
-            htmlWriter.startElement("a").attribute("href", link).characters(test.getName()).endElement();
+            htmlWriter.startElement("a")
+                .attribute("href", link)
+                .attribute("title", test.getName())
+                .characters(test.getDisplayName()).endElement();
             htmlWriter.endElement();
         }
         htmlWriter.endElement();
@@ -91,16 +103,7 @@ abstract class PageRenderer<T extends CompositeTestResults> extends TabbedPageRe
     }
 
     protected void renderIgnoredTests(SimpleHtmlWriter htmlWriter) throws IOException {
-        htmlWriter.startElement("ul").attribute("class", "linkList");
-        for (TestResult test : getResults().getIgnored()) {
-            htmlWriter.startElement("li");
-            htmlWriter.startElement("a").attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults()))).characters(test.getClassResults().getSimpleName()).endElement();
-            htmlWriter.characters(".");
-            String link = asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())) + "#" + test.getName();
-            htmlWriter.startElement("a").attribute("href", link).characters(test.getName()).endElement();
-            htmlWriter.endElement();
-        }
-        htmlWriter.endElement();
+        renderTestResultList(htmlWriter, getResults().getIgnored());
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PageRenderer.java
@@ -79,7 +79,7 @@ abstract class PageRenderer<T extends CompositeTestResults> extends TabbedPageRe
             htmlWriter.startElement("a")
                 .attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())))
                 .attribute("title", test.getClassResults().getName())
-                .characters(test.getClassResults().getSimpleName())
+                .characters(test.getClassResults().getReportName())
                 .endElement();
             htmlWriter.characters(".");
             String link = asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())) + "#" + test.getName();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PageRenderer.java
@@ -78,14 +78,12 @@ abstract class PageRenderer<T extends CompositeTestResults> extends TabbedPageRe
             htmlWriter.startElement("li");
             htmlWriter.startElement("a")
                 .attribute("href", asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())))
-                .attribute("title", test.getClassResults().getName())
                 .characters(test.getClassResults().getReportName())
                 .endElement();
             htmlWriter.characters(".");
             String link = asHtmlLinkEncoded(getResults().getUrlTo(test.getClassResults())) + "#" + test.getName();
             htmlWriter.startElement("a")
                 .attribute("href", link)
-                .attribute("title", test.getName())
                 .characters(test.getDisplayName()).endElement();
             htmlWriter.endElement();
         }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/TestResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/TestResult.java
@@ -27,11 +27,17 @@ public class TestResult extends TestResultModel implements Comparable<TestResult
     final ClassTestResults classResults;
     final List<TestFailure> failures = new ArrayList<TestFailure>();
     final String name;
+    final String displayName;
     boolean ignored;
 
     public TestResult(String name, long duration, ClassTestResults classResults) {
+        this(name, name, duration, classResults);
+    }
+
+    public TestResult(String name, String displayName, long duration, ClassTestResults classResults) {
         this.name = name;
         this.duration = duration;
+        this.displayName = displayName;
         this.classResults = classResults;
     }
 
@@ -41,6 +47,10 @@ public class TestResult extends TestResultModel implements Comparable<TestResult
 
     public String getName() {
         return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/TestResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/TestResult.java
@@ -53,14 +53,6 @@ public class TestResult extends TestResultModel implements Comparable<TestResult
         return displayName;
     }
 
-    public String getMethodSpanName() {
-        if (name.equals(displayName)) {
-            return ""; // empty span can be invisible via css
-        } else {
-            return name;
-        }
-    }
-
     @Override
     public String getTitle() {
         return "Test " + name;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/TestResult.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/TestResult.java
@@ -53,6 +53,14 @@ public class TestResult extends TestResultModel implements Comparable<TestResult
         return displayName;
     }
 
+    public String getMethodSpanName() {
+        if (name.equals(displayName)) {
+            return ""; // empty span can be invisible via css
+        } else {
+            return name;
+        }
+    }
+
     @Override
     public String getTitle() {
         return "Test " + name;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
@@ -51,4 +51,14 @@ public class UnknownTestDescriptor implements TestDescriptorInternal {
     public Object getOwnerBuildOperationId() {
         return null;
     }
+
+    @Override
+    public String getDisplayName() {
+        return getName();
+    }
+
+    @Override
+    public String getClassDisplayName() {
+        return getClassName();
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
@@ -198,15 +198,19 @@ public class TestEventSerializer {
         public DefaultTestDescriptor read(Decoder decoder) throws Exception {
             Object id = idSerializer.read(decoder);
             String className = decoder.readString();
+            String classDisplayName = decoder.readString();
             String name = decoder.readString();
-            return new DefaultTestDescriptor(id, className, name);
+            String displayName = decoder.readString();
+            return new DefaultTestDescriptor(id, className, name, classDisplayName, displayName);
         }
 
         @Override
         public void write(Encoder encoder, DefaultTestDescriptor value) throws Exception {
             idSerializer.write(encoder, (CompositeIdGenerator.CompositeId) value.getId());
             encoder.writeString(value.getClassName());
+            encoder.writeString(value.getClassDisplayName());
             encoder.writeString(value.getName());
+            encoder.writeString(value.getDisplayName());
         }
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
@@ -181,13 +181,15 @@ public class TestEventSerializer {
         public DefaultTestClassDescriptor read(Decoder decoder) throws Exception {
             Object id = idSerializer.read(decoder);
             String name = decoder.readString();
-            return new DefaultTestClassDescriptor(id, name);
+            String displayName = decoder.readString();
+            return new DefaultTestClassDescriptor(id, name, displayName);
         }
 
         @Override
         public void write(Encoder encoder, DefaultTestClassDescriptor value) throws Exception {
             idSerializer.write(encoder, (CompositeIdGenerator.CompositeId) value.getId());
             encoder.writeString(value.getName());
+            encoder.writeString(value.getDisplayName());
         }
     }
 

--- a/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
+++ b/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
@@ -82,11 +82,3 @@ ul.linkList li {
     list-style: none;
     margin-bottom: 5px;
 }
-
-td.invisible {
-    display: none;
-}
-
-th.invisible {
-    display: none;
-}

--- a/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
+++ b/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
@@ -82,3 +82,14 @@ ul.linkList li {
     list-style: none;
     margin-bottom: 5px;
 }
+
+span:empty {
+    display: none;
+}
+
+span.method {
+    padding: 2px 8px;
+    margin: 4px;
+    border-radius: 4px;
+    background-color: #c5f0f5;
+}

--- a/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
+++ b/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
@@ -83,13 +83,10 @@ ul.linkList li {
     margin-bottom: 5px;
 }
 
-span:empty {
+td.invisible {
     display: none;
 }
 
-span.method {
-    padding: 2px 8px;
-    margin: 4px;
-    border-radius: 4px;
-    background-color: #c5f0f5;
+th.invisible {
+    display: none;
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
@@ -19,7 +19,9 @@ import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
 
 class SimpleTestDescriptor implements TestDescriptorInternal {
     String name = "testName"
+    String displayName = "testName"
     String className = "ClassName"
+    String classDisplayName = "ClassName"
     boolean composite = false
     TestDescriptorInternal parent = null
     Object ownerBuildOperationId = null

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/ClassTestResultsTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/ClassTestResultsTest.groovy
@@ -22,5 +22,7 @@ class ClassTestResultsTest extends Specification {
         expect:
         new ClassTestResults(1, 'org.gradle.Test', null).simpleName == 'Test'
         new ClassTestResults(2, 'Test', null).simpleName == 'Test'
+        new ClassTestResults(1, 'org.gradle.Test', 'TestDisplay', null).simpleName == 'TestDisplay'
+        new ClassTestResults(2, 'Test', 'TestDisplay', null).simpleName == 'TestDisplay'
     }
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/ClassTestResultsTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/ClassTestResultsTest.groovy
@@ -20,9 +20,9 @@ import spock.lang.Specification
 class ClassTestResultsTest extends Specification {
     def determinesSimpleName() {
         expect:
-        new ClassTestResults(1, 'org.gradle.Test', null).simpleName == 'Test'
-        new ClassTestResults(2, 'Test', null).simpleName == 'Test'
-        new ClassTestResults(1, 'org.gradle.Test', 'TestDisplay', null).simpleName == 'TestDisplay'
-        new ClassTestResults(2, 'Test', 'TestDisplay', null).simpleName == 'TestDisplay'
+        new ClassTestResults(1, 'org.gradle.Test', null).reportName == 'Test'
+        new ClassTestResults(2, 'Test', null).reportName == 'Test'
+        new ClassTestResults(1, 'org.gradle.Test', 'TestDisplay', null).reportName == 'TestDisplay'
+        new ClassTestResults(2, 'Test', 'TestDisplay', null).reportName == 'TestDisplay'
     }
 }

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -31,8 +31,6 @@ import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
-import java.util.Optional;
-
 import static org.gradle.api.internal.tasks.testing.junitplatform.VintageTestNameAdapter.*;
 import static org.junit.platform.engine.TestExecutionResult.Status.SUCCESSFUL;
 
@@ -167,7 +165,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     }
 
     private TestDescriptorInternal createDescriptor(TestIdentifier test, String name, String displayName) {
-        Optional<TestIdentifier> classIdentifier = findClassSource(test);
+        TestIdentifier classIdentifier = findClassSource(test);
         String className = className(classIdentifier);
         String classDisplayName = classDisplayName(classIdentifier);
         return new DefaultTestDescriptor(idGenerator.generateId(), className, name, classDisplayName, displayName);
@@ -181,37 +179,33 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         return test.getSource().isPresent() && test.getSource().get() instanceof ClassSource;
     }
 
-    private String className(TestIdentifier testIdentifier) {
-        return className(findClassSource(testIdentifier));
-    }
-
-    private Optional<TestIdentifier> findClassSource(TestIdentifier testIdentifier) {
+    private TestIdentifier findClassSource(TestIdentifier testIdentifier) {
         // For tests in default method of interface,
         // we might not be able to get the implementation class directly.
         // In this case, we need to retrieve test plan to get the real implementation class.
         if (isClass(testIdentifier)) {
-            return Optional.of(testIdentifier);
+            return testIdentifier;
         }
         while (testIdentifier.getParentId().isPresent()) {
             testIdentifier = currentTestPlan.getTestIdentifier(testIdentifier.getParentId().get());
             if (isClass(testIdentifier)) {
-                return Optional.of(testIdentifier);
+                return testIdentifier;
             }
         }
-        return Optional.empty();
+        return null;
     }
 
-    private String className(Optional<TestIdentifier> testClassIdentifier) {
-        if (testClassIdentifier.isPresent()) {
-            return ClassSource.class.cast(testClassIdentifier.get().getSource().get()).getClassName();
+    private String className(TestIdentifier testClassIdentifier) {
+        if (testClassIdentifier != null) {
+            return ClassSource.class.cast(testClassIdentifier.getSource().get()).getClassName();
         } else {
             return "UnknownClass";
         }
     }
 
-    private String classDisplayName(Optional<TestIdentifier> testClassIdentifier) {
-        if (testClassIdentifier.isPresent()) {
-            return testClassIdentifier.get().getDisplayName();
+    private String classDisplayName(TestIdentifier testClassIdentifier) {
+        if (testClassIdentifier != null) {
+            return testClassIdentifier.getDisplayName();
         } else {
             return "UnknownClass";
         }

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -136,7 +136,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     }
 
     private void reportTestClassStarted(TestIdentifier testIdentifier) {
-        currentRunningTestClass.start(className(testIdentifier));
+        currentRunningTestClass.start(className(testIdentifier), classDisplayName(testIdentifier));
     }
 
     private void reportTestClassFinished(TestIdentifier testIdentifier, Throwable failure) {
@@ -196,7 +196,7 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     }
 
     private String className(TestIdentifier testClassIdentifier) {
-        if (testClassIdentifier != null) {
+        if (testClassIdentifier != null && testClassIdentifier.getSource().isPresent()) {
             return ClassSource.class.cast(testClassIdentifier.getSource().get()).getClassName();
         } else {
             return "UnknownClass";
@@ -215,10 +215,10 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
         private String name;
         private int count;
 
-        private void start(String className) {
+        private void start(String className, String displayName) {
             if (name == null) {
                 name = className;
-                executionListener.testClassStarted(className);
+                executionListener.testClassStarted(className, displayName);
                 count = 1;
             } else if (className.equals(name)) {
                 count++;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -70,8 +70,9 @@ class JUnitPlatformIntegrationTest extends JUnitPlatformIntegrationSpec {
         fails('test')
 
         then:
-        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
-        result.testClassStartsWith('Gradle Test Executor').assertExecutionFailedWithCause(containsString('consider adding an engine implementation JAR to the classpath'))
+        new DefaultTestExecutionResult(testDirectory)
+            .testClassStartsWith('Gradle Test Executor')
+            .assertExecutionFailedWithCause(containsString('consider adding an engine implementation JAR to the classpath'))
     }
 
     def 'can handle class level ignored tests'() {
@@ -94,9 +95,9 @@ class JUnitPlatformIntegrationTest extends JUnitPlatformIntegrationSpec {
         run('check')
 
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted('org.gradle.IgnoredTest')
-        result.testClass('org.gradle.IgnoredTest').assertTestCount(1, 0, 0).assertTestsSkipped("testIgnored1")
+        new DefaultTestExecutionResult(testDirectory)
+            .assertTestClassesExecuted('org.gradle.IgnoredTest')
+            .testClass('org.gradle.IgnoredTest').assertTestCount(1, 0, 0).assertTestsSkipped("testIgnored1()")
     }
 
     @Unroll
@@ -128,9 +129,9 @@ class JUnitPlatformIntegrationTest extends JUnitPlatformIntegrationSpec {
         fails('test')
 
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted('org.gradle.ClassErrorTest')
-        result.testClass('org.gradle.ClassErrorTest').assertTestCount(successCount + failureCount, failureCount, 0)
+        new DefaultTestExecutionResult(testDirectory)
+            .assertTestClassesExecuted('org.gradle.ClassErrorTest')
+            .testClass('org.gradle.ClassErrorTest').assertTestCount(successCount + failureCount, failureCount, 0)
 
         where:
         location    | beforeStatement                | afterStatement                 | successCount | failureCount
@@ -198,18 +199,19 @@ class JUnitPlatformIntegrationTest extends JUnitPlatformIntegrationSpec {
         fails('test')
 
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted('org.gradle.RepeatTest')
-        result.testClass('org.gradle.RepeatTest').assertTestCount(9, 1, 0)
-            .assertTestPassed('ok 1/3')
-            .assertTestPassed('ok 2/3')
-            .assertTestPassed('ok 3/3')
-            .assertTestPassed('partialFail 1/3')
-            .assertTestFailed('partialFail 2/3', containsString('java.lang.RuntimeException'))
-            .assertTestPassed('partialFail 3/3')
-            .assertTestPassed('partialSkip 1/3')
-            .assertTestsSkipped('partialSkip 2/3')
-            .assertTestPassed('partialSkip 3/3')
+        new DefaultTestExecutionResult(testDirectory)
+            .assertTestClassesExecuted('org.gradle.RepeatTest')
+            .testClass('org.gradle.RepeatTest')
+            .assertTestCount(9, 1, 0)
+            .assertTestPassed('ok()[1]', 'ok 1/3')
+            .assertTestPassed('ok()[2]', 'ok 2/3')
+            .assertTestPassed('ok()[3]', 'ok 3/3')
+            .assertTestPassed('partialFail(RepetitionInfo)[1]', 'partialFail 1/3')
+            .assertTestFailed('partialFail(RepetitionInfo)[2]', 'partialFail 2/3', containsString('java.lang.RuntimeException'))
+            .assertTestPassed('partialFail(RepetitionInfo)[3]', 'partialFail 3/3')
+            .assertTestPassed('partialSkip(RepetitionInfo)[1]', 'partialSkip 1/3')
+            .assertTestSkipped('partialSkip(RepetitionInfo)[2]', 'partialSkip 2/3')
+            .assertTestPassed('partialSkip(RepetitionInfo)[3]', 'partialSkip 3/3')
     }
 
     def 'can filter nested tests'() {
@@ -247,10 +249,10 @@ test {
         succeeds('test')
 
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted('org.gradle.NestedTest$Inner')
-        result.testClass('org.gradle.NestedTest$Inner').assertTestCount(1, 0, 0)
-            .assertTestPassed('innerTest')
+        new DefaultTestExecutionResult(testDirectory)
+            .assertTestClassesExecuted('org.gradle.NestedTest$Inner')
+            .testClass('org.gradle.NestedTest$Inner').assertTestCount(1, 0, 0)
+            .assertTestPassed('innerTest()')
     }
 
     @Issue('https://github.com/gradle/gradle/issues/4476')

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformSampleIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformSampleIntegrationTest.groovy
@@ -39,11 +39,11 @@ class JUnitPlatformSampleIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         new DefaultTestExecutionResult(sample.dir).testClass('org.gradle.junitplatform.JupiterTest').assertTestCount(5, 0, 0)
-            .assertTestPassed('ok()')
-            .assertTestPassed('repetition 1 of 2')
-            .assertTestPassed('repetition 2 of 2')
-            .assertTestPassed('TEST 1')
-            .assertTestsSkipped('disabled()')
+            .assertTestPassed('ok')
+            .assertTestPassed('repeated()[1]', 'repetition 1 of 2')
+            .assertTestPassed('repeated()[2]', 'repetition 2 of 2')
+            .assertTestPassed('test1(TestInfo)', 'TEST 1')
+            .assertTestSkipped('disabled')
     }
 
     @UsesSample('testing/junitplatform/mix')

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformUserGuideIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformUserGuideIntegrationTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
  * These test cases are all from http://junit.org/junit5/docs/current/user-guide
  */
 class JUnitPlatformUserGuideIntegrationTest extends JUnitPlatformIntegrationSpec {
-    def 'can display test case in @DisplayName'() {
+    def 'can display test case and test class in @DisplayName'() {
         given:
         file('src/test/java/org/gradle/DisplayNameDemo.java') << '''
 package org.gradle; 
@@ -45,7 +45,7 @@ class DisplayNameDemo {
 package org.gradle;
 import org.junit.jupiter.api.*;
 
-@DisplayName("A special test case")
+@DisplayName("A special test case2")
 class DisplayNameDemo2 {
 
     @Test
@@ -60,10 +60,14 @@ class DisplayNameDemo2 {
         then:
         def result = new DefaultTestExecutionResult(testDirectory)
             .assertTestClassesExecuted('org.gradle.DisplayNameDemo', 'org.gradle.DisplayNameDemo2')
-        result.testClass('org.gradle.DisplayNameDemo').assertTestCount(1, 0, 0)
-            .assertTestPassed('Custom test name containing spaces')
-        result.testClass('org.gradle.DisplayNameDemo2').assertTestCount(1, 0, 0)
-            .assertTestPassed('╯°□°）╯')
+        result.testClass('org.gradle.DisplayNameDemo')
+            .assertDisplayName('A special test case')
+            .assertTestCount(1, 0, 0)
+            .assertTestPassed('testWithDisplayNameContainingSpaces', 'Custom test name containing spaces')
+        result.testClass('org.gradle.DisplayNameDemo2')
+            .assertDisplayName('A special test case2')
+            .assertTestCount(1, 0, 0)
+            .assertTestPassed('testWithDisplayNameContainingSpecialCharacters', '╯°□°）╯')
     }
 
     def 'can change test instance lifecycle with #method'() {
@@ -188,12 +192,12 @@ class TestingAStackDemo {
         then:
         def result = new DefaultTestExecutionResult(testDirectory)
         result.testClass('org.gradle.TestingAStackDemo').assertTestCount(1, 0, 0)
-            .assertTestPassed('is instantiated with new Stack()')
+            .assertTestPassed('isInstantiatedWithNew', 'is instantiated with new Stack')
         result.testClass('org.gradle.TestingAStackDemo$WhenNew').assertTestCount(2, 0, 0)
-            .assertTestPassed('is empty')
-            .assertTestPassed('throws EmptyStackException when popped')
+            .assertTestPassed('isEmpty', 'is empty')
+            .assertTestPassed('throwsExceptionWhenPopped', 'throws EmptyStackException when popped')
         result.testClass('org.gradle.TestingAStackDemo$WhenNew$AfterPushing').assertTestCount(1, 0, 0)
-            .assertTestPassed('it is no longer empty')
+            .assertTestPassed('isNotEmpty', 'it is no longer empty')
 
         where:
         maxParallelForks << [1, 3]
@@ -240,8 +244,9 @@ class TestInfoDemo {
         then:
         new DefaultTestExecutionResult(testDirectory)
             .testClass('org.gradle.TestInfoDemo').assertTestCount(2, 0, 0)
-            .assertTestPassed('test2')
-            .assertTestPassed('TEST 1')
+            .assertTestPassed('test2', 'test2')
+            .assertTestPassed('test1(TestInfo)', 'TEST 1')
+
     }
 
     def 'can use custom Extension'() {
@@ -312,8 +317,8 @@ public class Test implements TestInterfaceDynamicTestsDemo {
         then:
         new DefaultTestExecutionResult(testDirectory)
             .testClass('org.gradle.Test').assertTestCount(2, 0, 0)
-            .assertTestPassed('1st dynamic test in test interface')
-            .assertTestPassed('2nd dynamic test in test interface')
+            .assertTestPassed('dynamicTestsFromCollection()[1]', '1st dynamic test in test interface')
+            .assertTestPassed('dynamicTestsFromCollection()[2]', '2nd dynamic test in test interface')
             .assertStdout(Matchers.stringContainsInOrder(['Invoked!', 'Invoked!']))
     }
 
@@ -346,9 +351,9 @@ public class Test {
         then:
         new DefaultTestExecutionResult(testDirectory)
             .testClass('org.gradle.Test').assertTestCount(3, 0, 0)
-            .assertTestPassed('[1] a')
-            .assertTestPassed('[2] b')
-            .assertTestPassed('[3] c')
+            .assertTestPassed('ok(String)[1]', '[1] a')
+            .assertTestPassed('ok(String)[2]', '[2] b')
+            .assertTestPassed('ok(String)[3]', '[3] c')
     }
 
     def 'can use test template'() {
@@ -414,39 +419,7 @@ public class TestTemplateTest {
         then:
         new DefaultTestExecutionResult(testDirectory)
             .testClass('org.gradle.TestTemplateTest').assertTestCount(2, 0, 0)
-            .assertTestPassed('foo')
-            .assertTestPassed('bar')
-    }
-
-    def 'can support dynamic tests'() {
-        given:
-        file('src/test/java/org/gradle/DynamicTestsDemo.java') << '''
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
-import static org.junit.jupiter.api.DynamicTest.dynamicTest;
-
-import java.util.*;
-import java.util.function.*;
-import java.util.stream.*;
-
-import org.junit.jupiter.api.*;
-
-class DynamicTestsDemo {
-    // This will result in a JUnitException!
-    @TestFactory
-    List<String> dynamicTestsWithInvalidReturnType() {
-        return Arrays.asList("Hello");
-    }
-
-    @TestFactory
-    Collection<DynamicTest> dynamicTestsFromCollection() {
-        return Arrays.asList(
-            dynamicTest("1st dynamic test", () -> assertTrue(true)),
-            dynamicTest("2nd dynamic test", () -> assertEquals(4, 2 * 2))
-        );
-    }
-}
-'''
-
+            .assertTestPassed('testTemplate(String)[1]', 'foo')
+            .assertTestPassed('testTemplate(String)[2]', 'bar')
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/GenericJUnitTestEventAdapter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/GenericJUnitTestEventAdapter.java
@@ -100,8 +100,6 @@ public class GenericJUnitTestEventAdapter<T> {
         resultProcessor.completed(testInternal.getId(), new TestCompleteEvent(endTime, resultType));
     }
 
-
-
     private TestStartEvent startEvent() {
         return new TestStartEvent(clock.getCurrentTime());
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGenerator.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGenerator.java
@@ -45,7 +45,12 @@ public class TestClassExecutionEventGenerator implements TestResultProcessor, Te
 
     @Override
     public void testClassStarted(String testClassName) {
-        currentTestClass = new DefaultTestClassDescriptor(idGenerator.generateId(), testClassName);
+        testClassStarted(testClassName, testClassName);
+    }
+
+    @Override
+    public void testClassStarted(String testClassName, String testClassDisplayName) {
+        currentTestClass = new DefaultTestClassDescriptor(idGenerator.generateId(), testClassName, testClassDisplayName);
         resultProcessor.started(currentTestClass, new TestStartEvent(clock.getCurrentTime()));
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionListener.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionListener.java
@@ -19,5 +19,7 @@ package org.gradle.api.internal.tasks.testing.junit;
 public interface TestClassExecutionListener {
     void testClassStarted(String testClassName);
 
+    void testClassStarted(String testClassName, String testClassDisplayName);
+
     void testClassFinished(Throwable failure);
 }


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4424
https://github.com/gradle/gradle/issues/4423

JUnit 5 introduces @DisplayName and dynamic tests, which allows users to
customize test case and test class' name. This should be taken into
account. This PR introduces `displayName` and `classDisplayName` which are
used for display. When rendering HTML reports, these two fields will be used.

It's a large PR, but I very much want this to be into `4.6`. To make this change backward-compatible and not cause regression, I did many defensive work, e.g. add overload method signature to guarantee public API unchanged.

![image](https://user-images.githubusercontent.com/12689835/36663625-1d42b0c8-1b1d-11e8-9756-5b25e9802c2c.png)

![image](https://user-images.githubusercontent.com/12689835/36663616-1996c824-1b1d-11e8-9152-aa2f0d507184.png)

Here're 2 screenshots of the HTML reports. "Display name" supersedes "name" and "name" is put into `title` attribute of HTML tag.
