### PR TITLE
Use attribute matching whenever target component has variants

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
@@ -187,7 +187,7 @@ project(':child2') {
         }
     }
 
-    def "a dependency on compile scope of maven module includes the compile dependencies of target project that is using the Java plugin"() {
+    def "a dependency on compile scope of maven module includes the runtime dependencies of target project that is using the Java plugin"() {
         mavenRepo.module("org.test", "m1", "1.0").publish()
         mavenRepo.module("org.test", "m2", "1.0").publish()
         mavenRepo.module("org.test", "maven", "1.0")
@@ -207,11 +207,12 @@ project(':child2') {
     apply plugin: 'java'
     dependencies {
         compile 'org.test:m1:1.0'
-        compileOnly 'org.test.ignore-me:1.0'
-        runtime 'org.test.ignore-me:1.0'
-        testCompile 'org.test.ignore-me:1.0'
-        testRuntime 'org.test.ignore-me:1.0'
-        "default" 'org.test.ignore-me:1.0'
+        runtime 'org.test:m2:1.0'
+        
+        compileOnly 'org.test:ignore-me:1.0'
+        testCompile 'org.test:ignore-me:1.0'
+        testRuntime 'org.test:ignore-me:1.0'
+        "default" 'org.test:ignore-me:1.0'
     }
 }
 """
@@ -223,9 +224,8 @@ project(':child2') {
                     configuration = 'compile'
                     edge('org.test:replaced:1.0', 'project :child2', 'testproject:child2:') {
                         selectedByRule()
-                        // TODO - should include artifacts
-                        noArtifacts()
                         module('org.test:m1:1.0')
+                        module('org.test:m2:1.0')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -57,19 +57,16 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     }
 
     /**
-     * Choose a set of target configurations based on: a) the consumer attributes, b) the fromConfiguration and c) the target component.
+     * Choose a set of target configurations based on: a) the consumer attributes (with associated schema) and b) the target component.
      *
-     * Use attribute matching to choose a single variant when:
-     *   - The target component has variants AND
-     *   - Either: we have consumer attributes OR the target component is from an external repository (not a Gradle project).
-     *
-     * Otherwise, revert to legacy selection of target configurations.
+     * Use attribute matching to choose a single variant when the target component has variants,
+     * otherwise revert to legacy selection of target configurations.
      */
     @Override
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         // This is a slight different condition than that used for a dependency declared in a Gradle project,
         // which is (targetHasVariants || consumerHasAttributes), relying on the fallback to 'default' for consumer attributes without any variants.
-        if (hasVariants(targetComponent) && (hasAttributes(consumerAttributes) || isExternal(targetComponent))) {
+        if (hasVariants(targetComponent)) {
             return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, targetComponent, consumerSchema));
         }
         return dependencyDescriptor.selectLegacyConfigurations(componentId, configuration, targetComponent);
@@ -78,15 +75,6 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private boolean hasVariants(ComponentResolveMetadata targetComponent) {
         return !targetComponent.getVariantsForGraphTraversal().isEmpty();
     }
-
-    private boolean hasAttributes(ImmutableAttributes attributes) {
-        return !attributes.isEmpty();
-    }
-
-    private boolean isExternal(ComponentResolveMetadata targetComponent) {
-        return targetComponent instanceof ModuleComponentResolveMetadata;
-    }
-
     @Override
     public List<IvyArtifactName> getArtifacts() {
         return dependencyDescriptor.getConfigurationArtifacts(configuration);


### PR DESCRIPTION
Previously, for a dependency _declared in_ a POM or Ivy descriptor file, we
would _not_ use attribute matching to choose a variant from a local Gradle
project. Since there's no way a POM or Ivy file could reference a Gradle
project directly, this could only occur if the dependency was substituted with
a project dependency.

This is a slight breaking change to the (still) incubating dependency substitution
behaviour, but it makes the behaviour more consistent with regular project
dependencies.
- If the target project configurations do not declare attributes, then the behaviour
  is unchanged.
- If the target project configurations have attributes (ie apply the 'java' plugin')
  then attribute matching will be used to choose the appropriate target configuration.
  This means that the 'api' variant will be selected when resolving a 'compileClasspath'
  and the 'implementation' variant will be selected when resolving a 'runtimeClasspath'.
