### PR TITLE
Construct a composite 'variant name' when multiple configurations are selected

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
@@ -168,7 +168,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                         } else {
                             if (GradleMetadataResolveRunner.useIvy()) {
                                 // Ivy doesn't derive any variant
-                                expectedTargetVariant = 'runtime'
+                                expectedTargetVariant = 'runtime+compile+default+customVariant'
                                 expectedAttributes = [:]
                             } else {
                                 // for Maven, we derive variants for compile/runtime. Variants are then used during selection, and are subject

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -47,6 +47,7 @@ import java.util.Set;
 public class ComponentState implements ComponentResolutionState, ComponentResult, DependencyGraphComponent, ComponentStateWithDependents<ComponentState> {
     private final ModuleVersionIdentifier id;
     private final ComponentMetaDataResolver resolver;
+    private final VariantNameBuilder variantNameBuilder;
     private final List<NodeState> nodes = Lists.newLinkedList();
     private final Long resultId;
     private final ModuleResolveState module;
@@ -59,11 +60,12 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
     private DependencyGraphBuilder.VisitState visitState = DependencyGraphBuilder.VisitState.NotSeen;
     List<SelectorState> allResolvers;
 
-    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentMetaDataResolver resolver) {
+    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentMetaDataResolver resolver, VariantNameBuilder variantNameBuilder) {
         this.resultId = resultId;
         this.module = module;
         this.id = id;
         this.resolver = resolver;
+        this.variantNameBuilder = variantNameBuilder;
     }
 
     @Override
@@ -217,22 +219,10 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
     @Override
     public String getVariantName() {
         String name = null;
-        StringBuilder builder = null;
         for (NodeState node : nodes) {
             if (node.isSelected()) {
-                if (name == null) {
-                    name = node.getMetadata().getName();
-                } else {
-                    if (builder == null) {
-                        builder = new StringBuilder(name);
-                    }
-                    builder.append("+");
-                    builder.append(node.getMetadata().getName());
-                }
+                name = variantNameBuilder.getVariantName(name, node.getMetadata().getName());
             }
-        }
-        if (builder != null) {
-            return builder.toString();
         }
         return name == null ? "unknown" : name;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -216,8 +216,25 @@ public class ComponentState implements ComponentResolutionState, ComponentResult
 
     @Override
     public String getVariantName() {
-        NodeState selected = getSelectedNode();
-        return selected == null ? "unknown" : selected.getMetadata().getName();
+        String name = null;
+        StringBuilder builder = null;
+        for (NodeState node : nodes) {
+            if (node.isSelected()) {
+                if (name == null) {
+                    name = node.getMetadata().getName();
+                } else {
+                    if (builder == null) {
+                        builder = new StringBuilder(name);
+                    }
+                    builder.append("+");
+                    builder.append(node.getMetadata().getName());
+                }
+            }
+        }
+        if (builder != null) {
+            return builder.toString();
+        }
+        return name == null ? "unknown" : name;
     }
 
     private NodeState getSelectedNode() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -41,12 +41,14 @@ class ModuleResolveState implements CandidateModule {
     private final List<EdgeState> unattachedDependencies = new LinkedList<EdgeState>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<ModuleVersionIdentifier, ComponentState>();
     private final List<SelectorState> selectors = Lists.newLinkedList();
+    private final VariantNameBuilder variantNameBuilder;
     private ComponentState selected;
 
-    ModuleResolveState(IdGenerator<Long> idGenerator, ModuleIdentifier id, ComponentMetaDataResolver metaDataResolver) {
+    ModuleResolveState(IdGenerator<Long> idGenerator, ModuleIdentifier id, ComponentMetaDataResolver metaDataResolver, VariantNameBuilder variantNameBuilder) {
         this.idGenerator = idGenerator;
         this.id = id;
         this.metaDataResolver = metaDataResolver;
+        this.variantNameBuilder = variantNameBuilder;
     }
 
     @Override
@@ -163,7 +165,7 @@ class ModuleResolveState implements CandidateModule {
     public ComponentState getVersion(ModuleVersionIdentifier id) {
         ComponentState moduleRevision = versions.get(id);
         if (moduleRevision == null) {
-            moduleRevision = new ComponentState(idGenerator.generateId(), this, id, metaDataResolver);
+            moduleRevision = new ComponentState(idGenerator.generateId(), this, id, metaDataResolver, variantNameBuilder);
             versions.put(id, moduleRevision);
         }
         return moduleRevision;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -64,6 +64,7 @@ class ResolveState {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final ImmutableAttributesFactory attributesFactory;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
+    private final VariantNameBuilder variantNameBuilder = new VariantNameBuilder();
 
     public ResolveState(IdGenerator<Long> idGenerator, ComponentResolveResult rootResult, String rootConfigurationName, DependencyToComponentIdResolver idResolver,
                         ComponentMetaDataResolver metaDataResolver, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema,
@@ -106,7 +107,7 @@ class ResolveState {
     public ModuleResolveState getModule(ModuleIdentifier id) {
         ModuleResolveState module = modules.get(id);
         if (module == null) {
-            module = new ModuleResolveState(idGenerator, id, metaDataResolver);
+            module = new ModuleResolveState(idGenerator, id, metaDataResolver, variantNameBuilder);
             modules.put(id, module);
         }
         return module;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VariantNameBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VariantNameBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import com.google.common.collect.Maps;
+import org.gradle.internal.Pair;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * A memory-efficient builder for variant names.
+ *
+ * When a component has multiple selected nodes (or multiple selected configurations), we build a name for the variant
+ * from the names of the configurations. The set of names for these configurations is relatively limited, so we cache
+ * the generated names to avoid recreating multiple times.
+ */
+public class VariantNameBuilder {
+    private final Map<Pair<String, String>, String> names = Maps.newHashMap();
+
+    public String getVariantName(@Nullable String baseName, String part) {
+        if (baseName == null) {
+            return part;
+        }
+
+        Pair<String, String> key = Pair.of(baseName, part);
+        String name = names.get(key);
+        if (name == null) {
+            name = baseName + "+" + part;
+            names.put(key, name);
+        }
+        return name;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyDependencyDescriptor.java
@@ -155,6 +155,7 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
             }
         }
 
+        // TODO:DAZ Should de-duplicate the configurations based on hierarchy: no need to return 'compile' + 'runtime' + 'default'.
         return targets.build().asList();
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -287,19 +287,19 @@ org:leaf:2.0 -> 1.0
         then:
         output.contains """
 org:leaf:1.0
-   variant "runtime"
+   variant "runtime+compile+default"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:[1.0,2.0] -> 1.0
-   variant "runtime"
+   variant "runtime+compile+default"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:latest.integration -> 1.0
-   variant "runtime"
+   variant "runtime+compile+default"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
@@ -582,20 +582,20 @@ org:foo:1.0 -> 2.0
         then:
         output.contains """
 org:leaf:1.6
-   variant "runtime"
+   variant "runtime+compile+default"
 
 org:leaf:1.+ -> 1.6
-   variant "runtime"
+   variant "runtime+compile+default"
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:[1.5,1.9] -> 1.6
-   variant "runtime"
+   variant "runtime+compile+default"
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:latest.integration -> 1.6
-   variant "runtime"
+   variant "runtime+compile+default"
 \\--- org:top:1.0
      \\--- conf
 """
@@ -722,13 +722,13 @@ org:leaf:2.0 -> 1.5
         then:
         output.contains """
 org:leaf:1.0 (forced)
-   variant "default"
+   variant "default+runtime"
 +--- conf
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
-   variant "default"
+   variant "default+runtime"
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -1093,7 +1093,7 @@ org:leaf2:1.0
         then:
         output.contains """
 project :
-   variant "compile"
+   variant "compile+runtimeElements"
 \\--- project :impl
      \\--- project : (*)
 """

--- a/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
@@ -1,9 +1,9 @@
 commons-codec:commons-codec:1.7 (conflict resolution)
-   variant "default"
+   variant "default+runtime"
 \--- scm
 
 commons-codec:commons-codec:1.6 -> 1.7
-   variant "default"
+   variant "default+runtime"
 \--- org.apache.httpcomponents:httpclient:4.3.6
      \--- org.eclipse.jgit:org.eclipse.jgit:4.9.2.201712150930-r
           \--- scm


### PR DESCRIPTION
While it may appear like legacy configuration selection is another way to choose a particular variant for a component, in many cases the legacy mode may choose _multiple_ configurations from the target component and include them in the graph.

The `dependencyInsight` hides this fact, by just showing the name of the first configuration that is selected. This change makes this more clear, by concatenating the names of all selected configurations to produce a synthetic 'variant name'.

Doing this makes it apparent that in many cases we are choosing redundant configurations where a single one would do. (e.g. ['default', 'compile', 'runtime'] can often be shorted to ['default'].