### PR TITLE
Make included build build lifecycle state more explicit and avoid data race

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -102,7 +102,7 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Stoppable {
     @Override
     public Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules() {
         // TODO: Synchronization
-        if (availableModules==null) {
+        if (availableModules == null) {
             Gradle gradle = getConfiguredBuild();
             availableModules = Sets.newLinkedHashSet();
             for (Project project : gradle.getRootProject().getAllprojects()) {
@@ -134,10 +134,6 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Stoppable {
 
     @Override
     public void finishBuild() {
-        // If the gradleLauncher is null, then we've already finished building.
-        if (gradleLauncher == null) {
-            return;
-        }
         getGradleLauncher().finishBuild();
     }
 
@@ -158,20 +154,17 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Stoppable {
         launcher.addListener(listener);
         launcher.scheduleTasks(tasks);
         WorkerLeaseService workerLeaseService = launcher.getGradle().getServices().get(WorkerLeaseService.class);
-        try {
-            workerLeaseService.withSharedLease(parentLease, new Runnable() {
-                @Override
-                public void run() {
-                    launcher.executeTasks();
-                }
-            });
-        } finally {
-            markAsNotReusable();
-        }
+        workerLeaseService.withSharedLease(parentLease, new Runnable() {
+            @Override
+            public void run() {
+                launcher.executeTasks();
+            }
+        });
     }
 
-    private void markAsNotReusable() {
-        gradleLauncher.stop();
+    @Override
+    public void reset() {
+        stop();
         gradleLauncher = null;
     }
 
@@ -182,7 +175,7 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Stoppable {
 
     @Override
     public void stop() {
-        if (gradleLauncher!=null) {
+        if (gradleLauncher != null) {
             gradleLauncher.stop();
         }
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
@@ -215,6 +215,7 @@ class DefaultIncludedBuildController implements Runnable, Stoppable, IncludedBui
         } catch (InterruptedException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         } finally {
+            includedBuild.reset();
             lock.unlock();
         }
     }
@@ -235,7 +236,7 @@ class DefaultIncludedBuildController implements Runnable, Stoppable, IncludedBui
         }
     }
 
-    private enum TaskStatus { QUEUED, EXECUTING, FAILED, SUCCESS }
+    private enum TaskStatus {QUEUED, EXECUTING, FAILED, SUCCESS}
 
     private static class TaskState {
         public BuildResult result;

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildInternal.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildInternal.java
@@ -37,4 +37,9 @@ public interface IncludedBuildInternal extends ConfigurableIncludedBuild {
     void finishBuild();
     void addTasks(Iterable<String> tasks);
     void execute(Iterable<String> tasks, Object listener);
+
+    // Allow the build to be executed again.
+    // Required if first using it to contribute a build plugin,
+    // then using again to contribute to build outputs.
+    void reset();
 }


### PR DESCRIPTION
Previously, each included build dropped its lazily created GradleLauncher reference when it completed. However, cross build task references ultimately access the GradleLauncher of the build dependency. If the included build finished all of its tasks (and dropped its launcher) before a cross build task reference involving it was accessed, the build would be implicitly configured _again_ because it had lost all of its state and appeared to be unconfigured.

Instead, there is now an explicit reset() that needs to be invoked on the included build to prepare it to be built again. This is invoked after build a project for the purpose of providing a build plugin.

This bug causes errors in the build scan plugin because it cannot deal with builds being configured multiple times in the manner that they are when this manifests. This is related to #4241, but doesn't require resolution of it.

CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Fcomposite-build-race-condition-fix