### PR TITLE
Annotate public build cache types with `@NonNullApi`

### DIFF
--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCacheCredentials.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCacheCredentials.java
@@ -18,6 +18,8 @@ package org.gradle.caching.http;
 
 import org.gradle.api.credentials.PasswordCredentials;
 
+import javax.annotation.Nullable;
+
 /**
  * Password credentials for a HTTP build cache backend.
  *
@@ -32,6 +34,7 @@ public class HttpBuildCacheCredentials implements PasswordCredentials {
      *
      * @return The user name. May be null.
      */
+    @Nullable
     public String getUsername() {
         return username;
     }
@@ -41,7 +44,7 @@ public class HttpBuildCacheCredentials implements PasswordCredentials {
      *
      * @param username The user name. May be null.
      */
-    public void setUsername(String username) {
+    public void setUsername(@Nullable String username) {
         this.username = username;
     }
 
@@ -50,6 +53,7 @@ public class HttpBuildCacheCredentials implements PasswordCredentials {
      *
      * @return The password. May be null.
      */
+    @Nullable
     public String getPassword() {
         return password;
     }
@@ -59,7 +63,7 @@ public class HttpBuildCacheCredentials implements PasswordCredentials {
      *
      * @param password The password. May be null.
      */
-    public void setPassword(String password) {
+    public void setPassword(@Nullable String password) {
         this.password = password;
     }
 }

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/package-info.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.5
  */
+@NonNullApi
 package org.gradle.caching.http;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCacheConfiguration.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCacheConfiguration.java
@@ -20,6 +20,8 @@ import org.gradle.api.Action;
 import org.gradle.caching.BuildCacheServiceFactory;
 import org.gradle.internal.HasInternalProtocol;
 
+import javax.annotation.Nullable;
+
 /**
  * Configuration for the <a href="https://docs.gradle.org/current/userguide/build_cache.html">build cache</a> for an entire Gradle build.
  *
@@ -73,6 +75,7 @@ public interface BuildCacheConfiguration {
     /**
      * Returns the remote cache configuration.
      */
+    @Nullable
     BuildCache getRemote();
 
     /**

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/package-info.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.5
  */
+@NonNullApi
 package org.gradle.caching.configuration;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/package-info.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.5
  */
+@NonNullApi
 package org.gradle.caching.local;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/package-info.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.3
  */
+@NonNullApi
 package org.gradle.caching;
+
+import org.gradle.api.NonNullApi;


### PR DESCRIPTION
For better interop with Kotlin.