### PR TITLE
Improve local cache

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -47,9 +47,17 @@ public class GFileUtils {
 
     public static void touch(File file) {
         try {
-            FileUtils.touch(file);
+            if (!file.createNewFile()) {
+                touchExisting(file);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    public static void touchExisting(File file) {
+        if (!file.setLastModified(System.currentTimeMillis())) {
+            throw new UncheckedIOException("Could not update time stamp for " + file);
         }
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -69,6 +69,13 @@ public class GFileUtils {
         }
     }
 
+    public static void moveExistingFile(File source, File destination) {
+        boolean rename = source.renameTo(destination);
+        if (!rename) {
+            moveFile(source, destination);
+        }
+    }
+
     public static void copyFile(File source, File destination) {
         try {
             FileUtils.copyFile(source, destination);
@@ -90,6 +97,13 @@ public class GFileUtils {
             FileUtils.moveDirectory(source, destination);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    public static void moveExistingDirectory(File source, File destination) {
+        boolean rename = source.renameTo(destination);
+        if (!rename) {
+            moveDirectory(source, destination);
         }
     }
 
@@ -170,6 +184,14 @@ public class GFileUtils {
 
     public static boolean deleteQuietly(@Nullable File file) {
         return FileUtils.deleteQuietly(file);
+    }
+
+    public static boolean deleteFileQuietly(@Nullable File file) {
+        if (file != null) {
+            return file.delete();
+        } else {
+            return false;
+        }
     }
 
     public static class TailReadingException extends RuntimeException {

--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -45,6 +45,10 @@ public class GFileUtils {
         }
     }
 
+    /**
+     * Ensures that the given file (or directory) is marked as modified. If the file
+     * (or directory) does not exist, a new file is created.
+     */
     public static void touch(File file) {
         try {
             if (!file.createNewFile()) {
@@ -55,6 +59,10 @@ public class GFileUtils {
         }
     }
 
+    /**
+     * Ensures that the given file (or directory) is marked as modified. The file
+     * (or directory) must exist.
+     */
     public static void touchExisting(File file) {
         if (!file.setLastModified(System.currentTimeMillis())) {
             throw new UncheckedIOException("Could not update time stamp for " + file);

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GFileUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GFileUtilsTest.groovy
@@ -108,4 +108,40 @@ three
         readFileQuietly(new File("missing")) == "Unable to read file 'missing' due to: org.gradle.api.UncheckedIOException: java.io.FileNotFoundException: File 'missing' does not exist"
         readFileQuietly(temp.createDir("dir")).startsWith "Unable to read file"
     }
+
+    def "touch creates new empty file"() {
+        def foo = temp.file("foo.txt")
+
+        when:
+        touch(foo)
+        then:
+        foo.exists()
+        foo.length() == 0
+        foo.file
+    }
+
+    def "touch touches existing file"() {
+        def foo = temp.file("foo.txt") << "data"
+        def original = foo.makeOlder().lastModified()
+
+        when:
+        touch(foo)
+        then:
+        foo.file
+        foo.text == "data"
+        foo.lastModified() > original
+    }
+
+    def "touch touches existing directory"() {
+        def foo = temp.file("foo").createDir()
+        def child = foo.file("data.txt") << "data"
+        def original = foo.makeOlder().lastModified()
+
+        when:
+        touch(foo)
+        then:
+        foo.directory
+        foo.lastModified() > original
+        child.text == "data"
+    }
 }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
@@ -67,7 +67,7 @@ public class DirectoryBuildCacheService implements LocalBuildCacheService, Build
         public void execute(@Nonnull File file) {
             try {
                 // Mark as recently used
-                GFileUtils.touch(file);
+                GFileUtils.touchExisting(file);
 
                 Closer closer = Closer.create();
                 FileInputStream stream = closer.register(new FileInputStream(file));

--- a/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
+++ b/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
@@ -27,6 +27,7 @@ import org.gradle.api.plugins.buildcomparison.compare.internal.BuildComparisonRe
 import org.gradle.api.plugins.buildcomparison.gradle.internal.ComparableGradleBuildExecuter;
 import org.gradle.api.plugins.buildcomparison.gradle.internal.DefaultGradleBuildInvocationSpec;
 import org.gradle.api.plugins.buildcomparison.gradle.internal.GradleBuildComparison;
+import org.gradle.api.plugins.buildcomparison.gradle.internal.MovableFileStore;
 import org.gradle.api.plugins.buildcomparison.outcome.internal.archive.GeneratedArchiveBuildOutcome;
 import org.gradle.api.plugins.buildcomparison.outcome.internal.archive.GeneratedArchiveBuildOutcomeComparator;
 import org.gradle.api.plugins.buildcomparison.outcome.internal.archive.GeneratedArchiveBuildOutcomeComparisonResultHtmlRenderer;
@@ -45,7 +46,10 @@ import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.resource.local.FileStore;
+import org.gradle.internal.resource.local.FileStoreException;
+import org.gradle.internal.resource.local.LocallyAvailableResource;
 import org.gradle.internal.resource.local.PathNormalisingKeyFileStore;
+import org.gradle.util.GFileUtils;
 import org.gradle.util.GradleVersion;
 
 import javax.inject.Inject;
@@ -266,7 +270,7 @@ public class CompareGradleBuilds extends DefaultTask implements VerificationTask
         );
 
         File fileStoreTmpBase = getFileResolver().resolve(String.format(TMP_FILESTORAGE_PREFIX + "-%s-%s", getName(), System.currentTimeMillis()));
-        FileStore<String> fileStore = new PathNormalisingKeyFileStore(fileStoreTmpBase);
+        MovableFileStore<String> fileStore = new Files(fileStoreTmpBase);
 
         Map<String, String> hostAttributes = new LinkedHashMap<String, String>(4);
         hostAttributes.put("Project", getProject().getRootDir().getAbsolutePath());
@@ -293,4 +297,28 @@ public class CompareGradleBuilds extends DefaultTask implements VerificationTask
         }
     }
 
+    private static class Files implements MovableFileStore<String> {
+        private final File baseDir;
+        private final FileStore<String> delegate;
+
+        public Files(File baseDir) {
+            this.baseDir = baseDir;
+            this.delegate = new PathNormalisingKeyFileStore(baseDir);
+        }
+
+        @Override
+        public void moveFileStore(File destination) {
+            GFileUtils.moveDirectory(baseDir, destination);
+        }
+
+        @Override
+        public LocallyAvailableResource move(String key, File source) throws FileStoreException {
+            return delegate.move(key, source);
+        }
+
+        @Override
+        public LocallyAvailableResource add(String key, Action<File> addAction) throws FileStoreException {
+            return delegate.add(key, addAction);
+        }
+    }
 }

--- a/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
+++ b/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/CompareGradleBuilds.java
@@ -308,7 +308,9 @@ public class CompareGradleBuilds extends DefaultTask implements VerificationTask
 
         @Override
         public void moveFileStore(File destination) {
-            GFileUtils.moveDirectory(baseDir, destination);
+            if (baseDir.isDirectory()) {
+                GFileUtils.moveDirectory(baseDir, destination);
+            }
         }
 
         @Override

--- a/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/GradleBuildComparison.java
+++ b/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/GradleBuildComparison.java
@@ -108,7 +108,7 @@ public class GradleBuildComparison {
         return String.format("executing %s build %s", name, executer.getSpec());
     }
 
-    public BuildComparisonResult compare(FileStore<String> fileStore, File reportDir, Map<String, String> hostAttributes) {
+    public BuildComparisonResult compare(MovableFileStore<String> fileStore, File reportDir, Map<String, String> hostAttributes) {
         String executingSourceBuildMessage = executingMessage("source", sourceBuildExecuter);
         String executingTargetBuildMessage = executingMessage("target", targetBuildExecuter);
 
@@ -190,12 +190,12 @@ public class GradleBuildComparison {
         return connector.connect();
     }
 
-    private void writeReport(final BuildComparisonResult result, final File reportDir, FileStore<String> fileStore, final Map<String, String> hostAttributes) {
+    private void writeReport(final BuildComparisonResult result, final File reportDir, MovableFileStore<String> fileStore, final Map<String, String> hostAttributes) {
         if (reportDir.exists() && reportDir.list().length > 0) {
             GFileUtils.cleanDirectory(reportDir);
         }
 
-        fileStore.moveFilestore(new File(reportDir, FILES_DIR_NAME));
+        fileStore.moveFileStore(new File(reportDir, FILES_DIR_NAME));
 
         final Charset encoding = Charset.defaultCharset();
         IoActions.writeTextFile(new File(reportDir, HTML_REPORT_FILE_NAME), encoding.name(), new Action<BufferedWriter>() {

--- a/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/MovableFileStore.java
+++ b/subprojects/build-comparison/src/main/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/MovableFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.resource.local;
+package org.gradle.api.plugins.buildcomparison.gradle.internal;
 
-import javax.annotation.Nullable;
+import org.gradle.internal.resource.local.FileStore;
 
-/**
- * File store that accepts the target path as the key for the entry.
- */
-public interface PathKeyFileStore extends FileStore<String>, FileStoreSearcher<String> {
-    @Nullable
-    LocallyAvailableResource get(String key);
+import java.io.File;
+
+public interface MovableFileStore<K> extends FileStore<K> {
+    void moveFileStore(File destination);
 }

--- a/subprojects/build-comparison/src/test/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/GradleBuildOutcomeSetTransformerTest.groovy
+++ b/subprojects/build-comparison/src/test/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/GradleBuildOutcomeSetTransformerTest.groovy
@@ -40,10 +40,6 @@ class GradleBuildOutcomeSetTransformerTest extends Specification {
             new DefaultLocallyAvailableResource(source)
         }
 
-        void moveFilestore(File destination) {
-            throw new UnsupportedOperationException()
-        }
-
         LocallyAvailableResource add(String key, Action<File> addAction) {
             throw new UnsupportedOperationException()
         }

--- a/subprojects/build-comparison/src/test/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/GradleBuildOutcomeSetTransformerTest.groovy
+++ b/subprojects/build-comparison/src/test/groovy/org/gradle/api/plugins/buildcomparison/gradle/internal/GradleBuildOutcomeSetTransformerTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.api.plugins.buildcomparison.gradle.internal
 
 import org.gradle.api.Action
-import org.gradle.internal.resource.local.FileStore
 import org.gradle.api.plugins.buildcomparison.fixtures.ProjectOutcomesBuilder
 import org.gradle.api.plugins.buildcomparison.outcome.internal.archive.GeneratedArchiveBuildOutcome
 import org.gradle.api.plugins.buildcomparison.outcome.internal.unknown.UnknownBuildOutcome
 import org.gradle.internal.resource.local.DefaultLocallyAvailableResource
+import org.gradle.internal.resource.local.FileStore
 import org.gradle.internal.resource.local.LocallyAvailableResource
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -37,10 +37,6 @@ class GradleBuildOutcomeSetTransformerTest extends Specification {
 
     def store = new FileStore<String>() {
         LocallyAvailableResource move(String key, File source) {
-            new DefaultLocallyAvailableResource(source)
-        }
-
-        LocallyAvailableResource copy(String key, File source) {
             new DefaultLocallyAvailableResource(source)
         }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.internal.service.scopes.GlobalScopeServices
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
-import org.gradle.util.GFileUtils
 import org.gradle.util.GradleVersion
 import org.gradle.util.RedirectStdOutAndErr
 import org.junit.Rule
@@ -32,6 +31,8 @@ import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
+
+import static org.apache.commons.io.FileUtils.touch
 
 class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     private final static String CACHE_IDENTIFIER = 'test'
@@ -74,7 +75,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
                 void execute(File file) {
                     startSecondInvocation.countDown()
                     Thread.sleep(JAR_GENERATION_TIME_MS)
-                    GFileUtils.touch(file)
+                    touch(file)
                 }
             })
         }
@@ -112,7 +113,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
                     void execute(File file) {
                         triggeredJarFileGeneration.incrementAndGet()
                         Thread.sleep(JAR_GENERATION_TIME_MS)
-                        GFileUtils.touch(file)
+                        touch(file)
                     }
                 })
 

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultPathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultPathKeyFileStore.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.local;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Action;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
@@ -46,6 +47,7 @@ import static org.gradle.internal.FileUtils.hasExtension;
  * <p>
  * This file store also provides searching via relative ant path patterns.
  */
+@NonNullApi
 public class DefaultPathKeyFileStore implements PathKeyFileStore {
 
     /*

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultPathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultPathKeyFileStore.java
@@ -16,13 +16,12 @@
 
 package org.gradle.internal.resource.local;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.api.Action;
 import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileVisitDetails;
-import org.gradle.api.internal.file.IdentityFileResolver;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.file.collections.SingleIncludePatternFileTree;
-import org.gradle.api.internal.file.delete.Deleter;
 import org.gradle.internal.UncheckedException;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.RelativePathUtil;
@@ -57,12 +56,9 @@ public class DefaultPathKeyFileStore implements PathKeyFileStore {
     public static final String IN_PROGRESS_MARKER_FILE_SUFFIX = ".fslck";
 
     private File baseDir;
-    private final Deleter deleter;
 
     public DefaultPathKeyFileStore(File baseDir) {
         this.baseDir = baseDir;
-        IdentityFileResolver fileResolver = new IdentityFileResolver();
-        deleter = new Deleter(fileResolver, fileResolver.getFileSystem());
     }
 
     protected File getBaseDir() {
@@ -87,8 +83,8 @@ public class DefaultPathKeyFileStore implements PathKeyFileStore {
         File file = getFile(path);
         File markerFile = getInProgressMarkerFile(file);
         if (markerFile.exists()) {
-            deleter.delete(file);
-            deleter.delete(markerFile);
+            FileUtils.deleteQuietly(file);
+            FileUtils.deleteQuietly(markerFile);
         }
         return file;
     }
@@ -156,13 +152,13 @@ public class DefaultPathKeyFileStore implements PathKeyFileStore {
         File inProgressMarkerFile = getInProgressMarkerFile(destination);
         GFileUtils.touch(inProgressMarkerFile);
         try {
-            deleter.delete(destination);
+            FileUtils.deleteQuietly(destination);
             action.execute(destination);
         } catch (Throwable t) {
-            deleter.delete(destination);
+            FileUtils.deleteQuietly(destination);
             throw UncheckedException.throwAsUncheckedException(t);
         } finally {
-            deleter.delete(inProgressMarkerFile);
+            FileUtils.deleteQuietly(inProgressMarkerFile);
         }
         return entryAt(destination);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStore.java
@@ -44,10 +44,6 @@ public class GroupedAndNamedUniqueFileStore<K> implements FileStore<K>, FileStor
         return delegate.move(toPath(key, getChecksum(source)), source);
     }
 
-    public LocallyAvailableResource copy(K key, File source) {
-        return delegate.copy(toPath(key, getChecksum(source)), source);
-    }
-
     public Set<? extends LocallyAvailableResource> search(K key) {
         return delegate.search(toPath(key, "*"));
     }
@@ -65,10 +61,6 @@ public class GroupedAndNamedUniqueFileStore<K> implements FileStore<K>, FileStor
 
     public File getTempFile() {
         return temporaryFileProvider.createTemporaryFile("filestore", "bin");
-    }
-
-    public void moveFilestore(File destination) {
-        delegate.moveFilestore(destination);
     }
 
     public LocallyAvailableResource add(K key, Action<File> addAction) {

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/PathNormalisingKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/PathNormalisingKeyFileStore.java
@@ -23,22 +23,14 @@ import java.util.Set;
 
 public class PathNormalisingKeyFileStore implements FileStore<String>, FileStoreSearcher<String> {
 
-    private final PathKeyFileStore delegate;
+    private final DefaultPathKeyFileStore delegate;
 
     public PathNormalisingKeyFileStore(File baseDir) {
-        this(new DefaultPathKeyFileStore(baseDir));
-    }
-
-    public PathNormalisingKeyFileStore(PathKeyFileStore delegate) {
-        this.delegate = delegate;
+        this.delegate = new DefaultPathKeyFileStore(baseDir);
     }
 
     public LocallyAvailableResource move(String key, File source) {
         return delegate.move(normalizePath(key), source);
-    }
-
-    public LocallyAvailableResource copy(String key, File source) {
-        return delegate.copy(key, source);
     }
 
     protected String normalizePath(String path) {
@@ -47,10 +39,6 @@ public class PathNormalisingKeyFileStore implements FileStore<String>, FileStore
 
     protected String normalizeSearchPath(String path) {
         return path.replaceAll("[^\\d\\w\\.\\*/]", "_");
-    }
-
-    public void moveFilestore(File destination) {
-        delegate.moveFilestore(destination);
     }
 
     public LocallyAvailableResource add(String key, Action<File> addAction) {

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/UniquePathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/UniquePathKeyFileStore.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.local;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Action;
+import org.gradle.api.NonNullApi;
 
 import java.io.File;
 
@@ -26,6 +27,7 @@ import java.io.File;
  *
  * Can be used as an optimisation if path contains a checksum of the file, as there is no point to perform the replace in that circumstance.
  */
+@NonNullApi
 public class UniquePathKeyFileStore extends DefaultPathKeyFileStore {
 
     public UniquePathKeyFileStore(File baseDir) {

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/UniquePathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/UniquePathKeyFileStore.java
@@ -42,10 +42,9 @@ public class UniquePathKeyFileStore extends DefaultPathKeyFileStore {
     }
 
     @Override
-    protected LocallyAvailableResource doAdd(File destination, Action<File> action) {
-        if (destination.exists()) {
-            return entryAt(destination);
+    protected void doAdd(File destination, Action<File> action) {
+        if (!destination.exists()) {
+            super.doAdd(destination, action);
         }
-        return super.doAdd(destination, action);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/file/MicroBenchmarkPerformanceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/file/MicroBenchmarkPerformanceTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.api.file
 
+import org.apache.commons.io.FileUtils
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
-import org.gradle.util.GFileUtils
 import spock.lang.Unroll
 
 /**
@@ -36,6 +36,6 @@ class MicroBenchmarkPerformanceTest extends AbstractProjectBuilderSpec {
     }
 
     def touch(String filePath) {
-        GFileUtils.touch(project.file(filePath))
+        FileUtils.touch(project.file(filePath))
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
@@ -26,11 +26,11 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.GFileUtils
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+import static org.apache.commons.io.FileUtils.touch
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes
 import static org.hamcrest.Matchers.equalTo
 
@@ -154,10 +154,10 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void containsFilesFromEachSourceDirectory() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file2.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file2.txt'))
         File srcDir2 = new File(testDir, 'dir2')
-        GFileUtils.touch(new File(srcDir2, 'subdir2/file1.txt'))
+        touch(new File(srcDir2, 'subdir2/file1.txt'))
 
         when:
         set.srcDir 'dir1'
@@ -216,13 +216,13 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void canUsePatternsToFilterCertainFiles() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file2.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/ignored.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file2.txt'))
+        touch(new File(srcDir1, 'subdir/ignored.txt'))
         File srcDir2 = new File(testDir, 'dir2')
-        GFileUtils.touch(new File(srcDir2, 'subdir2/file1.txt'))
-        GFileUtils.touch(new File(srcDir2, 'subdir2/file2.txt'))
-        GFileUtils.touch(new File(srcDir2, 'subdir2/ignored.txt'))
+        touch(new File(srcDir2, 'subdir2/file1.txt'))
+        touch(new File(srcDir2, 'subdir2/file2.txt'))
+        touch(new File(srcDir2, 'subdir2/ignored.txt'))
 
         when:
         set.srcDir 'dir1'
@@ -236,13 +236,13 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void canUseFilterPatternsToFilterCertainFiles() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file2.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/ignored.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file2.txt'))
+        touch(new File(srcDir1, 'subdir/ignored.txt'))
         File srcDir2 = new File(testDir, 'dir2')
-        GFileUtils.touch(new File(srcDir2, 'subdir2/file1.txt'))
-        GFileUtils.touch(new File(srcDir2, 'subdir2/file2.txt'))
-        GFileUtils.touch(new File(srcDir2, 'subdir2/ignored.txt'))
+        touch(new File(srcDir2, 'subdir2/file1.txt'))
+        touch(new File(srcDir2, 'subdir2/file2.txt'))
+        touch(new File(srcDir2, 'subdir2/ignored.txt'))
 
         when:
         set.srcDir 'dir1'
@@ -256,7 +256,7 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void ignoresSourceDirectoriesWhichDoNotExist() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
 
         when:
         set.srcDir 'dir1'
@@ -268,7 +268,7 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void failsWhenSourceDirectoryIsNotADirectory() {
         File srcDir = new File(testDir, 'dir1')
-        GFileUtils.touch(srcDir)
+        touch(srcDir)
 
         when:
         set.srcDir 'dir1'
@@ -350,7 +350,7 @@ public class DefaultSourceDirectorySetTest extends Specification {
     public void doesNotThrowStopExceptionWhenSomeSourceDirectoriesAreNotEmpty() {
         when:
         set.srcDir 'dir1'
-        GFileUtils.touch(new File(testDir, 'dir1/file1.txt'))
+        touch(new File(testDir, 'dir1/file1.txt'))
         set.srcDir 'dir2'
         set.stopExecutionIfEmpty()
 
@@ -360,9 +360,9 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void canUseMatchingMethodToFilterCertainFiles() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file2.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir2/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file2.txt'))
+        touch(new File(srcDir1, 'subdir2/file1.txt'))
 
         when:
         set.srcDir 'dir1'
@@ -377,11 +377,11 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void canUsePatternsAndFilterPatternsAndMatchingMethodToFilterSourceFiles() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.other'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file2.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/ignored.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir2/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file1.other'))
+        touch(new File(srcDir1, 'subdir/file2.txt'))
+        touch(new File(srcDir1, 'subdir/ignored.txt'))
+        touch(new File(srcDir1, 'subdir2/file1.txt'))
 
         when:
         set.srcDir 'dir1'
@@ -398,10 +398,10 @@ public class DefaultSourceDirectorySetTest extends Specification {
 
     public void filteredSetIsLive() {
         File srcDir1 = new File(testDir, 'dir1')
-        GFileUtils.touch(new File(srcDir1, 'subdir/file1.txt'))
-        GFileUtils.touch(new File(srcDir1, 'subdir/file2.txt'))
+        touch(new File(srcDir1, 'subdir/file1.txt'))
+        touch(new File(srcDir1, 'subdir/file2.txt'))
         File srcDir2 = new File(testDir, 'dir2')
-        GFileUtils.touch(new File(srcDir2, 'subdir2/file1.txt'))
+        touch(new File(srcDir2, 'subdir2/file1.txt'))
 
         when:
         set.srcDir 'dir1'

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -30,11 +30,11 @@ import org.gradle.api.tasks.TaskValidationException
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.GFileUtils
 import spock.lang.Unroll
 
 import java.util.concurrent.Callable
 
+import static org.apache.commons.io.FileUtils.touch
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.*
 
 class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
@@ -315,7 +315,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     def validationActionFailsWhenSpecifiedOutputFileParentIsAFile() {
         given:
         def task = expectTaskCreated(TaskWithOutputFile, new File(testDir, "subdir/output.txt"))
-        GFileUtils.touch(task.outputFile.getParentFile())
+        touch(task.outputFile.getParentFile())
 
         when:
         execute(task)
@@ -328,7 +328,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     def validationActionFailsWhenSpecifiedOutputFilesParentIsAFile() {
         given:
         def task = expectTaskCreated(TaskWithOutputFiles, [new File(testDir, "subdir/output.txt")] as List)
-        GFileUtils.touch(task.outputFiles.get(0).getParentFile())
+        touch(task.outputFiles.get(0).getParentFile())
 
         when:
         execute(task)
@@ -365,7 +365,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     def validationActionFailsWhenParentOfOutputDirectoryIsAFile() {
         given:
         def task = expectTaskCreated(TaskWithOutputDir, new File(testDir, "subdir/output"))
-        GFileUtils.touch(task.outputDir.getParentFile())
+        touch(task.outputDir.getParentFile())
 
         when:
         execute(task)
@@ -378,7 +378,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     def validationActionFailsWhenParentOfOutputDirectoriesIsAFile() {
         given:
         def task = expectTaskCreated(TaskWithOutputDirs, [new File(testDir, "subdir/output")])
-        GFileUtils.touch(task.outputDirs.get(0).getParentFile())
+        touch(task.outputDirs.get(0).getParentFile())
 
         when:
         execute(task)
@@ -403,7 +403,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     def validationActionFailsWhenInputDirectoryIsAFile() {
         given:
         def task = expectTaskCreated(TaskWithInputDir, existingFile)
-        GFileUtils.touch(task.inputDir)
+        touch(task.inputDir)
 
         when:
         execute(task)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.cache.internal
 
+import org.apache.commons.io.FileUtils
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.GFileUtils
 import org.gradle.util.GradleVersion
 import org.junit.Rule
 import spock.lang.Specification
@@ -98,7 +98,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         jarFile == resolvedFile
 
         when:
-        GFileUtils.touch(jarFile)
+        FileUtils.touch(jarFile)
         resolvedFile = provider.get("api") { Assert.fail("Should not be called if file already exists") }
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/DefaultPathKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/DefaultPathKeyFileStoreTest.groovy
@@ -36,43 +36,6 @@ class DefaultPathKeyFileStoreTest extends Specification {
         store = new DefaultPathKeyFileStore(fsBase)
     }
 
-    def "can copy file to filestore"() {
-        def a = createFile("abc")
-        def b = createFile("def")
-
-        when:
-        store.copy("a", a)
-        store.copy("b", b)
-
-        then:
-        def storedA = store.get("a")
-        storedA.file.text == "abc"
-        storedA.file == fsBase.file("a")
-        a.text == "abc"
-
-        def storedB = store.get("b")
-        storedB.file.text == "def"
-        storedB.file == fsBase.file("b")
-        b.text == "def"
-    }
-
-    def "can copy directory to filestore"() {
-        def a = dir.createDir("a")
-        a.file("child-1").createFile()
-        a.file("dir/child-2").createFile()
-
-        when:
-        store.copy("a", a)
-
-        then:
-        def stored = store.get("a")
-        stored.file.directory
-        stored.file == fsBase.file("a")
-        fsBase.file("a").assertHasDescendants("child-1", "dir/child-2")
-        a.directory
-        a.assertHasDescendants("child-1", "dir/child-2")
-    }
-
     def "can move file to filestore"() {
         def a = createFile("abc")
         def b = createFile("def")
@@ -252,39 +215,6 @@ class DefaultPathKeyFileStoreTest extends Specification {
         then:
         search.size() == 2
         search.collect {entry -> entry.file.name}.sort() == ["a", "c"]
-    }
-
-    def "move filestore"() {
-        given:
-        def a = store.move("a", createFile("abc"))
-        def b = store.move("b", createFile("def"))
-
-        expect:
-        a.file == dir.file("fs/a")
-        b.file == dir.file("fs/b")
-
-        when:
-        store.moveFilestore(dir.file("new-store"))
-
-        then:
-        store.baseDir == dir.file("new-store")
-
-        and:
-        a.file == dir.file("new-store/a")
-        b.file == dir.file("new-store/b")
-
-        !dir.file("fs").exists()
-    }
-
-    def "can move filestore that doesn't exist yet"() {
-        expect:
-        !store.baseDir.exists()
-
-        when:
-        store.moveFilestore(dir.file("new-filestore"))
-
-        then:
-        notThrown Exception
     }
 
     def createFile(String content, String path = "f${pathCounter++}") {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/PathNormalisingKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/PathNormalisingKeyFileStoreTest.groovy
@@ -34,7 +34,7 @@ class PathNormalisingKeyFileStoreTest extends Specification {
 
     def setup() {
         fsBase = dir.createDir("fs")
-        store = new PathNormalisingKeyFileStore(new DefaultPathKeyFileStore(fsBase))
+        store = new PathNormalisingKeyFileStore(fsBase)
     }
 
     def "can move to filestore"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/UniquePathKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/UniquePathKeyFileStoreTest.groovy
@@ -57,33 +57,6 @@ class UniquePathKeyFileStoreTest extends Specification {
         0 * action.execute(_)
     }
 
-    def "copy returns existing file it it already exists"() {
-        setup:
-        def source = temporaryFolder.createFile("some-file")
-        def file = temporaryFolder.createFile("fsbase/a/a");
-        file.text = 'existing content'
-
-        when:
-        def fileInStore = uniquePathKeyFileStore.copy("a/a", source)
-
-        then:
-        fileInStore.file == file
-        file.text == 'existing content'
-    }
-
-    def "copy adds file it it does not exist"() {
-        setup:
-        def source = temporaryFolder.createFile("some-file")
-        def file = temporaryFolder.file("fsbase/a/a");
-
-        when:
-        def fileInStore = uniquePathKeyFileStore.copy("a/a", source)
-
-        then:
-        fileInStore.file == file
-        file.assertIsCopyOf(source)
-    }
-
     def "move returns existing file it it already exists"() {
         setup:
         def source = temporaryFolder.createFile("some-file")

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/javadoc/JavadocTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.api.tasks.javadoc
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.internal.file.collections.SimpleFileCollection
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.platform.base.internal.toolchain.ToolProvider
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
-import org.gradle.util.GFileUtils
 import org.gradle.util.TestUtil
 import org.gradle.util.WrapUtil
 
@@ -42,7 +42,7 @@ class JavadocTest extends AbstractProjectBuilderSpec {
         task.setClasspath(configurationMock)
         task.setExecutable(executable)
         task.setToolChain(toolChain)
-        GFileUtils.touch(new File(srcDir, "file.java"))
+        FileUtils.touch(new File(srcDir, "file.java"))
     }
 
     def defaultExecution() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/AbstractNativeComponentPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/AbstractNativeComponentPluginTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language
 
+import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Task
@@ -27,7 +28,6 @@ import org.gradle.nativeplatform.NativeExecutableBinarySpec
 import org.gradle.nativeplatform.NativeExecutableSpec
 import org.gradle.nativeplatform.NativeLibrarySpec
 import org.gradle.platform.base.PlatformBaseSpecification
-import org.gradle.util.GFileUtils
 
 abstract class AbstractNativeComponentPluginTest extends PlatformBaseSpecification {
     abstract Class<? extends Plugin> getPluginClass()
@@ -166,6 +166,6 @@ abstract class AbstractNativeComponentPluginTest extends PlatformBaseSpecificati
 
 
     def touch(String filePath) {
-        GFileUtils.touch(project.file(filePath))
+        FileUtils.touch(project.file(filePath))
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/assembler/plugins/AssemblerPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/assembler/plugins/AssemblerPluginTest.groovy
@@ -16,13 +16,18 @@
 
 package org.gradle.language.assembler.plugins
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.tasks.TaskDependencyMatchers
 import org.gradle.language.assembler.AssemblerSourceSet
 import org.gradle.language.assembler.tasks.Assemble
 import org.gradle.model.ModelMap
-import org.gradle.nativeplatform.*
+import org.gradle.nativeplatform.NativeBinary
+import org.gradle.nativeplatform.NativeExecutableBinarySpec
+import org.gradle.nativeplatform.NativeExecutableSpec
+import org.gradle.nativeplatform.NativeLibrarySpec
+import org.gradle.nativeplatform.SharedLibraryBinarySpec
+import org.gradle.nativeplatform.StaticLibraryBinarySpec
 import org.gradle.platform.base.PlatformBaseSpecification
-import org.gradle.util.GFileUtils
 
 class AssemblerPluginTest extends PlatformBaseSpecification {
 
@@ -160,6 +165,6 @@ class AssemblerPluginTest extends PlatformBaseSpecification {
     }
 
     def touch(String filePath) {
-        GFileUtils.touch(project.file(filePath))
+        FileUtils.touch(project.file(filePath))
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -115,7 +115,7 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
         @Override
         public boolean requiresCleanup() {
             // Dead simple check that it's been more than 7 days since we last checked for cleanup
-            if (cleanupAction!=null) {
+            if (cleanupAction != null) {
                 if (!gcFile.exists()) {
                     GFileUtils.touch(gcFile);
                 } else {
@@ -130,12 +130,12 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
 
         @Override
         public void cleanup() {
-            if (cleanupAction!=null) {
+            if (cleanupAction != null) {
                 Timer timer = Time.startTimer();
                 cleanupAction.clean(DefaultPersistentDirectoryCache.this);
                 LOGGER.info("{} cleaned up in {}.", DefaultPersistentDirectoryCache.this, timer.getElapsed());
             }
-            gcFile.setLastModified(System.currentTimeMillis());
+            GFileUtils.touch(gcFile);
         }
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileTest.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.api.tasks.compile
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec
 import org.gradle.api.tasks.WorkResult
 import org.gradle.language.base.internal.compile.Compiler
-import org.gradle.util.GFileUtils
 import spock.lang.Unroll
 
 public class GroovyCompileTest extends AbstractCompileTest {
@@ -46,7 +46,7 @@ public class GroovyCompileTest extends AbstractCompileTest {
         testObj = createTask(GroovyCompile.class)
         testObj.setCompiler(groovyCompilerMock)
 
-        GFileUtils.touch(new File(srcDir, "incl/file.groovy"))
+        FileUtils.touch(new File(srcDir, "incl/file.groovy"))
     }
 
     @Unroll

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.testing
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
@@ -40,7 +41,6 @@ import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.internal.DefaultJavaForkOptions
 import org.gradle.process.internal.worker.WorkerProcessBuilder
-import org.gradle.util.GFileUtils
 
 import java.lang.ref.WeakReference
 
@@ -67,7 +67,7 @@ class TestTest extends AbstractConventionTaskTest {
     def setup() {
         classesDir = temporaryFolder.createDir("classes")
         File classfile = new File(classesDir, "FileTest.class")
-        GFileUtils.touch(classfile)
+        FileUtils.touch(classfile)
         resultsDir = temporaryFolder.createDir("testResults")
         binResultsDir = temporaryFolder.createDir("binResults")
         reportDir = temporaryFolder.createDir("report")

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileStore.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/FileStore.java
@@ -31,16 +31,6 @@ public interface FileStore<K> {
     LocallyAvailableResource move(K key, File source) throws FileStoreException;
 
     /**
-     * Copies the given file into the store.
-     */
-    LocallyAvailableResource copy(K key, File source) throws FileStoreException;
-
-    /**
-     * Moves the contents of this store to the given destination.
-     */
-    void moveFilestore(File destination) throws FileStoreException;
-
-    /**
      * Adds an entry to the store, using the given action to produce the file.
      *
      * @throws FileStoreAddActionException When the action fails

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.tasks.scala
 
+import org.apache.commons.io.FileUtils
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ConventionTask
@@ -26,7 +27,6 @@ import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.AbstractCompileTest
 import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.language.scala.tasks.BaseScalaCompileOptions
-import org.gradle.util.GFileUtils
 
 class ScalaCompileTest extends AbstractCompileTest {
     private ScalaCompile scalaCompile
@@ -50,8 +50,8 @@ class ScalaCompileTest extends AbstractCompileTest {
         scalaCompile = createTask(ScalaCompile)
         scalaCompile.setCompiler(scalaCompiler)
 
-        GFileUtils.touch(new File(srcDir, "incl/file.scala"))
-        GFileUtils.touch(new File(srcDir, "incl/file.java"))
+        FileUtils.touch(new File(srcDir, "incl/file.scala"))
+        FileUtils.touch(new File(srcDir, "incl/file.java"))
     }
 
     def "execute doing work"() {


### PR DESCRIPTION
Some performance optimizations to improve local cache performance (among other things).

- Remove `FileStore.copy()` as it was never used.
- Do not allow generic `FileStore`s to be moved. Moving the contents of a file store only happens in build comparison, and only when we've stop otherwise using the file store.
- Touch, move and delete files in more specific ways to avoid having to call `File.exists()` and `IsDirectory()`. The existing approach was to do these things via `Deleter` and methods in `GFileUtils` that were not designed for performance but to succeed without prior any knowledge.
