### PR TITLE
Make caching of missing group:name permanent

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -91,7 +91,9 @@ public class DefaultCachePolicy implements CachePolicy, ResolutionRules {
     public void cacheDynamicVersionsFor(final int value, final TimeUnit unit) {
         eachDependency(new Action<DependencyResolutionControl>() {
             public void execute(DependencyResolutionControl dependencyResolutionControl) {
-                dependencyResolutionControl.cacheFor(value, unit);
+                if (!dependencyResolutionControl.getCachedResult().isEmpty()) {
+                    dependencyResolutionControl.cacheFor(value, unit);
+                }
             }
         });
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.cache.DependencyResolutionControl
 import org.gradle.api.artifacts.cache.ModuleResolutionControl
 import org.gradle.api.internal.artifacts.DefaultArtifactIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.configurations.MutationValidator
 import org.gradle.internal.Actions
@@ -31,6 +32,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
+import static java.util.Collections.emptySet
 import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
 
 public class DefaultCachePolicySpec extends Specification {
@@ -50,6 +52,23 @@ public class DefaultCachePolicySpec extends Specification {
         hasModuleTimeout(FOREVER)
         hasMissingArtifactTimeout(DAY)
         hasMissingModuleTimeout(FOREVER)
+    }
+
+    def 'never expires missing module for dynamic versions'() {
+        when:
+        def moduleIdentifier = new DefaultModuleIdentifier('org', 'foo')
+        def versions = emptySet()
+
+        then:
+        !cachePolicy.mustRefreshVersionList(moduleIdentifier, versions, WEEK)
+    }
+
+    def 'never expires missing module for non changing module'() {
+        when:
+        def module = moduleComponent('org', 'foo', '1.0')
+
+        then:
+        !cachePolicy.mustRefreshMissingModule(module, WEEK)
     }
 
     def "uses changing module timeout for changing modules"() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -36,6 +36,13 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 ## Potential breaking changes
 
+### Changes in the caching of missing versions
+
+Previously, Gradle would refresh the version list when dynamic version cache expires for repositories that did not contain a version at all.
+From now on, Gradle [will cache forever that a `group:name` was absent](https://github.com/gradle/gradle/issues/4436) from a repository.
+This has a positive performance on dependency resolution when multiple repositories are defined and dynamic versions are used.
+As before, using `--refresh-dependencies` will force a refresh, bypassing all caching.
+
 <!--
 ### Example breaking change
 -->


### PR DESCRIPTION
This aligns the behavior with caching of missing group:name:version.
Added a number of integration tests to further document caching
behavior.
Fixes #4436