### PR TITLE
Enable attribute matching with improved-pom-support

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -41,10 +41,8 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
             // classic maven and ivy metadata interpretation does not honor api/runtime separation
             return true
         }
-        if (testVariant == 'api+experimental' && repoType == 'ivy' && prevRepoType != 'maven') {
-            // maven now honors api/runtime separation
-            // it also works for ivy if it is chained behind a maven repo, because we then do an explicit selection of the 'compile' configuration
-            // and if the ivy modules provides a 'compile', which we do here as ivy-publishing would, the configuration is selected
+        if (testVariant == 'api+experimental' && repoType == 'ivy') {
+            // With improved POM support, Maven does not leak runtime when 'api' variant is requested
             return true
         }
         return false

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -44,6 +44,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private final ModuleComponentIdentifier componentId;
     private final ExternalDependencyDescriptor dependencyDescriptor;
     private final String reason;
+    private boolean alwaysUseAttributeMatching;
 
     private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, String reason) {
         this.configuration = configuration;
@@ -56,6 +57,11 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         this(configuration, componentId, dependencyDescriptor, null);
     }
 
+    public ConfigurationBoundExternalDependencyMetadata alwaysUseAttributeMatching() {
+        this.alwaysUseAttributeMatching = true;
+        return this;
+    }
+
     /**
      * Choose a set of target configurations based on: a) the consumer attributes (with associated schema) and b) the target component.
      *
@@ -66,7 +72,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         // This is a slight different condition than that used for a dependency declared in a Gradle project,
         // which is (targetHasVariants || consumerHasAttributes), relying on the fallback to 'default' for consumer attributes without any variants.
-        if (hasVariants(targetComponent)) {
+        if (alwaysUseAttributeMatching || hasVariants(targetComponent)) {
             return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, targetComponent, consumerSchema));
         }
         return dependencyDescriptor.selectLegacyConfigurations(componentId, configuration, targetComponent);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -132,7 +132,11 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     }
 
     private ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, MavenDependencyDescriptor incoming) {
-        return new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming);
+        ConfigurationBoundExternalDependencyMetadata dependency = new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming);
+        if (improvedPomSupportEnabled) {
+            dependency.alwaysUseAttributeMatching();
+        }
+        return dependency;
     }
 
     private boolean includeInOptionalConfiguration(MavenDependencyDescriptor dependency) {


### PR DESCRIPTION
With 'improved-pom-support' enabled, every Maven module provides
variants, which then triggers attribute matching of variants
when the module is selected.

However, dependencies from an 'improved' POM component to a non-POM
component were still reverting to 'legacy' configuration selection
when the target component did not declare any variants. This PR
updates this behaviour: attribute matching is used to choose a target
variant for any dependency _from_ a Maven module with improved POM
support, regardless of the type (or variant-awareness) of the target.

In practise, this will impact 2 cases (when 'improved-pom-support'
is enabled):
- When a Maven module transitively depends on an Ivy module, the
  'default' configuration of the Ivy module will be chosen instead of
  a combination or 'compile','runtime', 'master' and 'default'.
- When a Maven module transitively depends on a Gradle project via
  dependency substitution, and that Gradle project does not have any
  configuration attributes defined, the 'default' configuration will
  be chosen instead of a combination of 'compile', 'runtime', 'master'
  and 'default'.
