### PR TITLE
Remove eager start for included build controllers

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
@@ -30,7 +30,6 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
     private final Map<BuildIdentifier, IncludedBuildController> buildControllers = Maps.newHashMap();
     private final ManagedExecutor executorService;
     private final IncludedBuildRegistry includedBuildRegistry;
-    private boolean taskExecutionStarted;
 
     DefaultIncludedBuildControllers(ExecutorFactory executorFactory, IncludedBuildRegistry includedBuildRegistry) {
         this.includedBuildRegistry = includedBuildRegistry;
@@ -47,18 +46,11 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
         DefaultIncludedBuildController newBuildController = new DefaultIncludedBuildController(build);
         buildControllers.put(buildId, newBuildController);
         executorService.submit(newBuildController);
-
-        // Required for build controllers created after initial start
-        if (taskExecutionStarted) {
-            newBuildController.startTaskExecution();
-        }
-
         return newBuildController;
     }
 
     @Override
     public void startTaskExecution() {
-        this.taskExecutionStarted = true;
         populateTaskGraphs();
         for (IncludedBuildController buildController : buildControllers.values()) {
             buildController.startTaskExecution();


### PR DESCRIPTION
This change removes some legacy 'eager-start' functionality
for included build controllers, that is no longer required for
composite builds.

In early iterations of the feature, tasks for included builds were
executed as they were discovered, and in some cases tasks were
discovered late in the execution cycle. This required a
eager-start approach for included build controllers.

Subsequently, composite builds were improved so that the set of tasks
to execute are known prior to commencing execution, and the included
build lifecycle is more carefully managed. Unfortunately, the old
eager-start code was not removed, leading to included builds being
configured and executed multiple times in a single build invocation.

The only case where an included build should be configured multiple
times is when it provides artifacts for the buildscript classpath,
AND it is involved in the composite build execution. This case is
also handled without the eager-start functionality that is
removed in this commit.