### PR TITLE
Remove import of dependencies.gradle from buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -136,7 +136,6 @@ tasks.withType<GroovyCompile> {
 }
 
 if (!isCiServer || System.getProperty("enableCodeQuality")?.toLowerCase() == "true") {
-    apply { from("../gradle/dependencies.gradle") }
     apply { from("../gradle/codeQuality.gradle") }
 }
 

--- a/gradle/codeQuality.gradle
+++ b/gradle/codeQuality.gradle
@@ -36,8 +36,8 @@ dependencies {
             allVariants {
                 withDependencies {
                     it.removeAll { it.group == 'org.codehaus.groovy' }
-                    it.add(libraries.groovy.coordinates) {
-                        version { prefer libraries.groovy.version }
+                    it.add('org.codehaus.groovy:groovy-all') {
+                        version { prefer '2.4.12' }
                         because 'We use groovy-all everywhere'
                     }
                 }


### PR DESCRIPTION
With #4167, only one entry from dependencies.gradle was still used
in codeQuality.gradle (groovy variant/version). I think it is fine
to not share this for now. It's not the final solution for how
we want to solve the groovy-all vs groovy-xxx use case anyway.

This is a preparation for making dependencies.gradle more kotlin-dsl
friendly in a next step.
