### PR TITLE
Let DefaultModuleRegistry find modules when project imported into IntelliJ

### DIFF
--- a/gradle/groovyProject.gradle.kts
+++ b/gradle/groovyProject.gradle.kts
@@ -4,6 +4,7 @@ import org.gradle.build.DefaultJavaInstallation
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 import org.gradle.plugins.compile.AvailableJavaInstallations
+import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.testing.DistributionTest
 
 import java.util.concurrent.Callable
@@ -118,4 +119,13 @@ apply {
 
 val compileAll by tasks.creating {
     dependsOn(compileTasks)
+}
+
+plugins.withType<IdeaPlugin> {
+    configure<IdeaModel> {
+        module {
+            sourceDirs = sourceDirs + generatedResourcesDir
+            testSourceDirs = testSourceDirs + generatedTestResourcesDir
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -179,6 +179,7 @@ public class DefaultModuleRegistry implements ModuleRegistry {
         matcher.matches();
         String projectDirName = matcher.group(1);
         String projectName = toCamelCase(projectDirName);
+        suffixes.add(("/" + projectDirName + "/out/production/classes").replace('/', File.separatorChar));
         suffixes.add(("/out/production/" + projectName).replace('/', File.separatorChar));
         suffixes.add(("/" + projectDirName + "/bin").replace('/', File.separatorChar));
         suffixes.add(("/" + projectDirName + "/src/main/resources").replace('/', File.separatorChar));


### PR DESCRIPTION
This PR is a small step towards #3980 . It allows `DefaultModuleRegistry` to find Gradle modules when running integration tests from the IDE when the build has been imported into IntelliJ (as opposed to using `./gradlew idea`).