### PR TITLE
Render references to code samples in Gradle dist from user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/declaringDependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/declaringDependencies.adoc
@@ -39,7 +39,7 @@ Modern software projects rarely build code in isolation. Projects reference modu
 A typical example for such a library in a Java project is the link:https://projects.spring.io/spring-framework/[Spring framework]. The following code snippet declares a compile-time dependency on the Spring web module by its coordinates: `org.springframework:spring-web:5.0.2.RELEASE`. Gradle resolves the module including its transitive dependencies from the link:https://search.maven.org/[Maven Central repository] and uses it to compile Java source code. The version attribute of the dependency coordinates points to a _concrete version_ indicating that the underlying artifacts do not change over time. The use of concrete versions ensure reproducibility for the aspect of dependency resolution.
 
 ++++
-<sample id="dependencies-concrete-version" dir="userguide/dependencyManagement/declaringDependencies/concreteVersion" title="Declaring a dependency with a concrete version">
+<sample id="dependencies-concrete-version" dir="userguide/dependencyManagement/declaringDependencies/concreteVersion" includeLocation="true" title="Declaring a dependency with a concrete version">
     <sourcefile file="build.gradle" snippet="dependencies"/>
 </sample>
 ++++
@@ -51,7 +51,7 @@ A Gradle project can define other types of repositories hosting modules. You can
 A recommended practice for larger projects is to declare dependencies without versions and use <<sec:dependency_constraints,dependency constraints>> for version declaration. The advantage is that dependency constrains allow you to manage versions of all dependencies, including transitive ones, in one place.
 
 ++++
-<sample id="dependencies-without-version" dir="userguide/dependencyManagement/declaringDependencies/withoutVersion" title="Declaring a dependency without version">
+<sample id="dependencies-without-version" dir="userguide/dependencyManagement/declaringDependencies/withoutVersion" includeLocation="true" title="Declaring a dependency without version">
     <sourcefile file="build.gradle" snippet="dependencies-without-version"/>
 </sample>
 ++++
@@ -67,7 +67,7 @@ Using dynamic versions in a build bears the risk of potentially breaking it. As 
 ====
 
 ++++
-<sample id="dependencies-dynamic-version" dir="userguide/dependencyManagement/declaringDependencies/dynamicVersion" title="Declaring a dependency with a dynamic version">
+<sample id="dependencies-dynamic-version" dir="userguide/dependencyManagement/declaringDependencies/dynamicVersion" includeLocation="true" title="Declaring a dependency with a dynamic version">
     <sourcefile file="build.gradle" snippet="dependencies"/>
 </sample>
 ++++
@@ -93,7 +93,7 @@ A team might decide to implement a series of features before releasing a new ver
 In Maven repositories, changing versions are commonly referred to as link:https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version[snapshot versions]. Snapshot versions contain the suffix `-SNAPSHOT`. The following example demonstrates how to declare a snapshot version on the Spring dependency.
 
 ++++
-<sample id="dependencies-changing-version" dir="userguide/dependencyManagement/declaringDependencies/changingVersion" title="Declaring a dependencies with a changing version">
+<sample id="dependencies-changing-version" dir="userguide/dependencyManagement/declaringDependencies/changingVersion" includeLocation="true" title="Declaring a dependencies with a changing version">
     <sourcefile file="build.gradle" snippet="dependencies"/>
 </sample>
 ++++
@@ -119,7 +119,7 @@ Projects sometimes do not rely on a binary repository product e.g. JFrog Artifac
 The following example resolves file dependencies from the directories `ant`, `libs` and `tools`.
 
 ++++
-<sample id="file-dependencies" dir="userguide/dependencyManagement/declaringDependencies/fileDependencies" title="Declaring multiple file dependencies">
+<sample id="file-dependencies" dir="userguide/dependencyManagement/declaringDependencies/fileDependencies" includeLocation="true" title="Declaring multiple file dependencies">
     <sourcefile file="build.gradle" snippet="file-dependencies"/>
 </sample>
 ++++
@@ -145,7 +145,7 @@ Gradle can model dependencies between modules. Those dependencies are called _pr
 The following example declares the dependencies on the `utils` and `api` project from the `web-service` project. The method api:org.gradle.api.Project#project(java.lang.String)[] creates a reference to a specific subproject by path.
 
 ++++
-<sample id="project-dependencies" dir="userguide/dependencyManagement/declaringDependencies/projectDependencies" title="Declaring project dependencies">
+<sample id="project-dependencies" dir="userguide/dependencyManagement/declaringDependencies/projectDependencies" includeLocation="true" title="Declaring project dependencies">
     <sourcefile file="build.gradle" snippet="project-dependencies"/>
 </sample>
 ++++
@@ -164,7 +164,7 @@ Gradle is a polyglot build tool and not limited to just resolving Java libraries
 link:https://developers.google.com/speed/libraries/[Google Hosted Libraries] is a distribution platform for popular, open-source JavaScript libraries. With the help of the artifact-only notation you can download a JavaScript library file e.g. JQuery. The `@` character separates the dependency's coordinates from the artifact's file extension.
 
 ++++
-<sample id="artifact-only-dependency-declaration" dir="userguide/dependencyManagement/declaringDependencies/artifactOnly" title="Resolving a JavaScript artifact for a declared dependency">
+<sample id="artifact-only-dependency-declaration" dir="userguide/dependencyManagement/declaringDependencies/artifactOnly" includeLocation="true" title="Resolving a JavaScript artifact for a declared dependency">
     <sourcefile file="build.gradle" snippet="artifact-only-dependency-declaration"/>
 </sample>
 ++++
@@ -176,7 +176,7 @@ In JavaScript, a library may exist as uncompressed or minified artifact. In Grad
 Let's say we wanted to download the minified artifact of the JQuery library instead of the uncompressed file. You can provide the classifier `min` as part of the dependency declaration.
 
 ++++
-<sample id="artifact-only-dependency-declaration-with-classifier" dir="userguide/dependencyManagement/declaringDependencies/artifactOnlyWithClassifier" title="Resolving a JavaScript artifact with classifier for a declared dependency">
+<sample id="artifact-only-dependency-declaration-with-classifier" dir="userguide/dependencyManagement/declaringDependencies/artifactOnlyWithClassifier" includeLocation="true" title="Resolving a JavaScript artifact with classifier for a declared dependency">
     <sourcefile file="build.gradle" snippet="artifact-only-dependency-declaration"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/declaringRepositories.adoc
+++ b/subprojects/docs/src/docs/userguide/declaringRepositories.adoc
@@ -34,7 +34,7 @@ Organizations building software may want to leverage public binary repositories 
 To declare JCenter as repository, add this code to your build script:
 
 ++++
-<sample id="public-repository" dir="userguide/dependencyManagement/declaringRepositories/publicRepository" title="Declaring JCenter repository as source for resolving dependencies">
+<sample id="public-repository" dir="userguide/dependencyManagement/declaringRepositories/publicRepository" includeLocation="true" title="Declaring JCenter repository as source for resolving dependencies">
     <sourcefile file="build.gradle" snippet="public-repository"/>
 </sample>
 ++++
@@ -49,7 +49,7 @@ Most enterprise projects set up a binary repository available only within an int
 Add the following code to declare an in-house repository for your build reachable through a custom URL.
 
 ++++
-<sample id="custom-repository" dir="userguide/dependencyManagement/declaringRepositories/customRepository" title="Declaring a custom repository by URL">
+<sample id="custom-repository" dir="userguide/dependencyManagement/declaringRepositories/customRepository" includeLocation="true" title="Declaring a custom repository by URL">
     <sourcefile file="build.gradle" snippet="custom-repository"/>
 </sample>
 ++++
@@ -66,12 +66,9 @@ You can define more than one repository for resolving dependencies. Declaring mu
 This example demonstrates how to declare various shortcut and custom URL repositories for a project:
 
 ++++
-<sample id="multiple-repositories" dir="userguide/dependencyManagement/declaringRepositories/multipleRepositories" title="Declaring multiple repositories">
+<sample id="multiple-repositories" dir="userguide/dependencyManagement/declaringRepositories/multipleRepositories" includeLocation="true" title="Declaring multiple repositories">
     <sourcefile file="build.gradle" snippet="multiple-repositories"/>
 </sample>
 ++++
 
-[NOTE]
-====
 The order of declaration determines how Gradle will check for dependencies at runtime. If Gradle finds a module descriptor in a particular repository, it will attempt to download all of the artifacts for that module from _the same repository_. You can learn more about the inner workings of <<sec:dependency_resolution,Gradle's resolution mechanism>>.
-====

--- a/subprojects/docs/src/docs/userguide/inspectingDependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/inspectingDependencies.adoc
@@ -27,7 +27,7 @@ Rendering the dependency tree is particularly useful if you'd like to identify w
 Let's say you'd want to create tasks for your project that use the link:https://www.eclipse.org/jgit/[JGit library] to execute SCM operations e.g. to model a release process. You can declare dependencies for any external tooling with the help of a <<managing_dependency_configurations,custom configuration>> so that it doesn't doesn't pollute other contexts like the compilation classpath for your production source code.
 
 ++++
-<sample id="jgit-dependency" dir="userguide/dependencyManagement/inspectingDependencies/dependenciesReport" title="Declaring the JGit dependency with a custom configuration">
+<sample id="jgit-dependency" dir="userguide/dependencyManagement/inspectingDependencies/dependenciesReport" includeLocation="true" title="Declaring the JGit dependency with a custom configuration">
     <sourcefile file="build.gradle" snippet="dependency-declaration" />
 </sample>
 ++++
@@ -61,7 +61,7 @@ Large software projects inevitably deal with an increased number of dependencies
 Let's have a look at a concrete example. A project may request two different versions of the same dependency either as direct or transitive dependency. Gradle applies version conflict resolution to ensure that only one version of the dependency exists in the dependency graph. In this example the conflicting dependency is represented by `commons-codec:commons-codec`.
 
 ++++
-<sample id="jgit-dependency-with-conflict" dir="userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport" title="Declaring the JGit dependency and a conflicting dependency">
+<sample id="jgit-dependency-with-conflict" dir="userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport" includeLocation="true" title="Declaring the JGit dependency and a conflicting dependency">
     <sourcefile file="build.gradle" snippet="dependency-declaration" />
 </sample>
 ++++
@@ -91,7 +91,7 @@ Every Gradle project provides the task `dependencyInsight` to render the so-call
 When you declare a <<declaring_dependencies,dependency>> or a <<sec:dependency_constraints,dependency constraint>>, you can provide a custom reason for the declaration. This makes the dependency declarations in your build script and the dependency insight report easier to interpret.
 
 ++++
-<sample id="dependencyReason" dir="userguide/dependencyManagement/inspectingDependencies/dependencyReason" title="Giving a reason for choosing a certain module version in a dependency declaration">
+<sample id="dependencyReason" dir="userguide/dependencyManagement/inspectingDependencies/dependencyReason" includeLocation="true" title="Giving a reason for choosing a certain module version in a dependency declaration">
     <sourcefile file="build.gradle" snippet="dependency-reason" />
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/managingDependencyConfigurations.adoc
+++ b/subprojects/docs/src/docs/userguide/managingDependencyConfigurations.adoc
@@ -40,7 +40,7 @@ You can define configurations yourself, so-called _custom configurations_. A cus
 Let's say you wanted to declare a dependency on the link:https://tomcat.apache.org/tomcat-9.0-doc/jasper-howto.html[Jasper Ant task] for the purpose of pre-compiling JSP files that should _not_ end up in the classpath for compiling your source code. It's fairly simple to achieve that goal by introducing a custom configuration and using it in a task.
 
 ++++
-<sample id="custom-configuration" dir="userguide/dependencyManagement/definingUsingConfigurations/custom" title="Declaring and using a custom configuration">
+<sample id="custom-configuration" dir="userguide/dependencyManagement/definingUsingConfigurations/custom" includeLocation="true" title="Declaring and using a custom configuration">
     <sourcefile file="build.gradle" snippet="custom-configuration"/>
 </sample>
 ++++
@@ -68,7 +68,7 @@ Under the covers the `testImplementation` and `implementation` configurations fo
 Let's say you wanted to write a suite of smoke tests. Each smoke test makes a HTTP call to verify a web service endpoint. As the underlying test framework the project already uses JUnit. You can define a new configuration named `smokeTest` that extends from the `testImplementation` configuration to reuse the existing test framework dependency.
 
 ++++
-<sample id="configuration-inheritance" dir="userguide/dependencyManagement/definingUsingConfigurations/inheritance" title="Extending a configuration from another configuration">
+<sample id="configuration-inheritance" dir="userguide/dependencyManagement/definingUsingConfigurations/inheritance" includeLocation="true" title="Extending a configuration from another configuration">
     <sourcefile file="build.gradle" snippet="configuration-definition"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/managingTransitiveDependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/managingTransitiveDependencies.adoc
@@ -23,7 +23,7 @@ Resolution behavior for transitive dependencies can be customized to a high degr
 Dependency constraints allow you to define the version or the version range of both dependencies declared in the build script and transitive dependencies. It is the preferred method to express constraints that should be applied to all dependencies of a configuration. When Gradle attempts to resolve a dependency to a module version, all <<sub:declaring_dependency_with_version,dependency declarations with version>>, all transitive dependencies and all dependency constraints for that module are taken into consideration. The highest version that matches all conditions is selected. If no such version is found, Gradle fails with an error showing the conflicting declarations. If this happens you can adjust your dependencies or dependency constraints declarations, or <<managing_transitive_dependencies,make other adjustments to the transitive dependencies>> if needed. Similar to dependency declarations, dependency constraint declarations are <<managing_dependency_configurations,scoped by configurations>> and can therefore be selectively defined for parts of a build. If a dependency constraint influenced the resolution result, any type of <<sec:dependency_resolve_rules,dependency resolve rules>> may still be applied afterwards.
 
 ++++
-<sample id="declaringDependencyVersionsWithDependencyConstraints" dir="userguide/dependencyManagement/managingTransitiveDependencies/versionsWithConstraints" title="Define dependency constraints">
+<sample id="declaringDependencyVersionsWithDependencyConstraints" dir="userguide/dependencyManagement/managingTransitiveDependencies/versionsWithConstraints" includeLocation="true" title="Define dependency constraints">
     <sourcefile file="build.gradle" snippet="dependency-constraints"/>
 </sample>
 ++++
@@ -50,7 +50,7 @@ Declared dependencies in a build script can pull in a lot of transitive dependen
 Transitive dependencies can be excluded on the level of a declared dependency or a configuration. Let's demonstrate both use cases. In the following two examples the build script declares a dependency on Log4J, a popular logging framework in the Java world. The metadata of the particular version of Log4J also defines transitive dependencies.
 
 ++++
-<sample id="unresolvedTransitiveDependencies" dir="userguide/dependencyManagement/managingTransitiveDependencies/unresolved" title="Unresolved artifacts for transitive dependencies">
+<sample id="unresolvedTransitiveDependencies" dir="userguide/dependencyManagement/managingTransitiveDependencies/unresolved" includeLocation="true" title="Unresolved artifacts for transitive dependencies">
     <sourcefile file="build.gradle" snippet="unresolved-transitive-dependencies"/>
 </sample>
 ++++
@@ -78,7 +78,7 @@ The situation can be fixed by adding a repository containing those dependencies.
 Exclusions need to spelled out as a key/value pair via the attributes `group` and/or `module`. For more information, refer to api:org.gradle.api.artifacts.ModuleDependency#exclude(java.util.Map)[].
 
 ++++
-<sample id="exclude-transitive-for-dependency" dir="userguide/dependencyManagement/managingTransitiveDependencies/excludeForDependency" title="Excluding transitive dependency for a particular dependency declaration">
+<sample id="exclude-transitive-for-dependency" dir="userguide/dependencyManagement/managingTransitiveDependencies/excludeForDependency" includeLocation="true" title="Excluding transitive dependency for a particular dependency declaration">
     <sourcefile file="build.gradle" snippet="exclude-transitive-dependencies"/>
 </sample>
 ++++
@@ -86,15 +86,12 @@ Exclusions need to spelled out as a key/value pair via the attributes `group` an
 You may find that other dependencies will want to pull in the same transitive dependency that misses the artifacts. Alternatively, you can exclude the transitive dependencies for a particular configuration by calling the method api:org.gradle.api.artifacts.Configuration#exclude(java.util.Map)[].
 
 ++++
-<sample id="exclude-transitive-for-configuration" dir="userguide/dependencyManagement/managingTransitiveDependencies/excludeForConfiguration" title="Excluding transitive dependency for a particular configuration">
+<sample id="exclude-transitive-for-configuration" dir="userguide/dependencyManagement/managingTransitiveDependencies/excludeForConfiguration" includeLocation="true" title="Excluding transitive dependency for a particular configuration">
     <sourcefile file="build.gradle" snippet="exclude-transitive-dependencies"/>
 </sample>
 ++++
 
-[NOTE]
-====
 As a build script author you often times know that you want to exclude a dependency for all configurations available in the project. You can use the method api:org.gradle.api.DomainObjectCollection#all(org.gradle.api.Action)[] to define a global rule.
-====
 
 You might encounter other use cases that don't quite fit the bill of an exclude rule. For example you want to automatically select a version for a dependency with a specific requested version or you want to select a different group for a requested dependency to react to a relocation. Those use cases are better solved by the api:org.gradle.api.artifacts.ResolutionStrategy[] API. Some of these use cases are covered in <<customizing_dependency_resolution_behavior>>.
 
@@ -111,7 +108,7 @@ Enforcing a version of a dependency requires a conscious decision. Changing the 
 Let's say a project uses the link:https://hc.apache.org/httpcomponents-client-ga/[HttpClient library] for performing HTTP calls. HttpClient pulls in link:https://commons.apache.org/proper/commons-codec/[Commons Codec] as transitive dependency with version 1.10. However, the production source code of the project requires an API from Commons Codec 1.9 which is not available in 1.10 anymore. A dependency version can be enforced by declaring it in the build script and setting api:org.gradle.api.artifacts.ExternalDependency#setForce(boolean)[] to `true`.
 
 ++++
-<sample id="force-per-dependency" dir="userguide/dependencyManagement/managingTransitiveDependencies/forceForDependency" title="Enforcing a dependency version">
+<sample id="force-per-dependency" dir="userguide/dependencyManagement/managingTransitiveDependencies/forceForDependency" includeLocation="true" title="Enforcing a dependency version">
     <sourcefile file="build.gradle" snippet="force-per-dependency"/>
 </sample>
 ++++
@@ -119,7 +116,7 @@ Let's say a project uses the link:https://hc.apache.org/httpcomponents-client-ga
 If the project requires a specific version of a dependency on a configuration-level then it can be achieved by calling the method api:org.gradle.api.artifacts.ResolutionStrategy#force(java.lang.Object...)[].
 
 ++++
-<sample id="force-per-configuration" dir="userguide/dependencyManagement/managingTransitiveDependencies/forceForConfiguration" title="Enforcing a dependency version on the configuration-level">
+<sample id="force-per-configuration" dir="userguide/dependencyManagement/managingTransitiveDependencies/forceForConfiguration" includeLocation="true" title="Enforcing a dependency version on the configuration-level">
     <sourcefile file="build.gradle" snippet="force-per-configuration"/>
 </sample>
 ++++
@@ -130,20 +127,17 @@ If the project requires a specific version of a dependency on a configuration-le
 By default Gradle resolves all transitive dependencies specified by the dependency metadata. Sometimes this behavior may not be desirable e.g. if the metadata is incorrect or defines a large graph of transitive dependencies. You can tell Gradle to disable transitive dependency management for a dependency by setting api:org.gradle.api.artifacts.ModuleDependency#setTransitive(boolean)[] to `true`. As a result only the main artifact will be resolved for the declared dependency.
 
 ++++
-<sample id="disabling-transitive-dependency-resolution" dir="userguide/dependencyManagement/managingTransitiveDependencies/disableForDependency" title="Disabling transitive dependency resolution for a declared dependency">
+<sample id="disabling-transitive-dependency-resolution" dir="userguide/dependencyManagement/managingTransitiveDependencies/disableForDependency" includeLocation="true" title="Disabling transitive dependency resolution for a declared dependency">
     <sourcefile file="build.gradle" snippet="transitive-per-dependency"/>
 </sample>
 ++++
 
-[NOTE]
-====
 Disabling transitive dependency resolution will likely require you to declare the necessary runtime dependencies in your build script which otherwise would have been resolved automatically. Not doing so might lead to runtime classpath issues.
-====
 
 A project can decide to disable transitive dependency resolution completely. You either don't want to rely on the metadata published to the consumed repositories or you want to gain full control over the dependencies in your graph. For more information, see api:org.gradle.api.artifacts.Configuration#setTransitive(boolean)[].
 
 ++++
-<sample id="disabling-transitive-dependency-resolution-for-configuration" dir="userguide/dependencyManagement/managingTransitiveDependencies/disableForConfiguration" title="Disabling transitive dependency resolution on the configuration-level">
+<sample id="disabling-transitive-dependency-resolution-for-configuration" dir="userguide/dependencyManagement/managingTransitiveDependencies/disableForConfiguration" includeLocation="true" title="Disabling transitive dependency resolution on the configuration-level">
     <sourcefile file="build.gradle" snippet="transitive-per-configuration"/>
 </sample>
 ++++
@@ -154,7 +148,7 @@ A project can decide to disable transitive dependency resolution completely. You
 Gradle provides support for importing https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies[bill of materials (BOM) files], which are effectively `.pom` files that use `<dependencyManagement>` to control the dependency versions of direct and transitive dependencies. The BOM support in Gradle works similar to using `<scope>import</scope>` when depending on a BOM in Maven. In Gradle however, it is done via a regular dependency declaration on the BOM:
 
 ++++
-<sample id="importing-dependency-constraints-from-bom" dir="userguide/dependencyManagement/managingTransitiveDependencies/constraintsFromBOM" title="Depending on a BOM to import its dependency constraints">
+<sample id="importing-dependency-constraints-from-bom" dir="userguide/dependencyManagement/managingTransitiveDependencies/constraintsFromBOM" includeLocation="true" title="Depending on a BOM to import its dependency constraints">
     <sourcefile file="build.gradle" snippet="dependency-on-bom"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/troubleshootingDependencyResolution.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshootingDependencyResolution.adoc
@@ -55,7 +55,7 @@ You can fine-tune certain aspects of caching programmatically using the api:org.
 By default, Gradle caches dynamic versions for 24 hours. To change how long Gradle will cache the resolved version for a dynamic version, use:
 
 ++++
-<sample id="dynamic-version-cache-control" dir="userguide/dependencyManagement/troubleshooting/cache/dynamic" title="Dynamic version cache control">
+<sample id="dynamic-version-cache-control" dir="userguide/dependencyManagement/troubleshooting/cache/dynamic" includeLocation="true" title="Dynamic version cache control">
     <sourcefile file="build.gradle" snippet="dynamic-version-cache-control"/>
 </sample>
 ++++
@@ -63,7 +63,7 @@ By default, Gradle caches dynamic versions for 24 hours. To change how long Grad
 By default, Gradle caches changing modules for 24 hours. To change how long Gradle will cache the meta-data and artifacts for a changing module, use:
 
 ++++
-<sample id="changing-module-cache-control" dir="userguide/dependencyManagement/troubleshooting/cache/changing" title="Changing module cache control">
+<sample id="changing-module-cache-control" dir="userguide/dependencyManagement/troubleshooting/cache/changing" includeLocation="true" title="Changing module cache control">
     <sourcefile file="build.gradle" snippet="changing-module-cache-control"/>
 </sample>
 ++++

--- a/subprojects/docs/src/docs/userguide/workingWithDependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/workingWithDependencies.adoc
@@ -24,7 +24,7 @@ The main entry point for this functionality is the api:org.gradle.api.artifacts.
 Sometimes you'll want to implement logic based on the dependencies declared in the build script of a project e.g. to inspect them in a Gradle plugin. You can iterate over the set of dependencies assigned to a configuration with the help of the method api:org.gradle.api.artifacts.Configuration#getDependencies()[]. Alternatively, you can also use api:org.gradle.api.artifacts.Configuration#getAllDependencies()[] to include the dependencies declared in <<sub:inheriting_dependencies_from_other_configurations,superconfigurations>>. These APIs only return the declared dependencies and do not trigger <<sec:dependency_resolution,dependency resolution>>. Therefore, the dependency sets do not include transitive dependencies. Calling the APIs during the <<sec:build_phases,configuration phase of the build lifecycle>> does not result in a significant performance impact.
 
 ++++
-<sample id="iterating-dependencies" dir="userguide/dependencyManagement/workingWithDependencies/iterateDependencies" title="Iterating over the dependencies assigned to a configuration">
+<sample id="iterating-dependencies" dir="userguide/dependencyManagement/workingWithDependencies/iterateDependencies" includeLocation="true" title="Iterating over the dependencies assigned to a configuration">
     <sourcefile file="build.gradle" snippet="iteration-task" />
 </sample>
 ++++
@@ -36,15 +36,12 @@ None of the <<inspecting_dependencies,dependency reporting>> helps you with insp
 You can iterate over the complete set of artifacts resolved for a module with the help of the method api:org.gradle.api.file.FileCollection#getFiles()[]. Every file instance returned from the method points to its location in the <<dependency_cache,dependency cache>>. Using this method on a `Configuration` instance is possible as the interface extends `FileCollection`.
 
 ++++
-<sample id="iterating-artifacts" dir="userguide/dependencyManagement/workingWithDependencies/iterateArtifacts" title="Iterating over the artifacts resolved for a module">
+<sample id="iterating-artifacts" dir="userguide/dependencyManagement/workingWithDependencies/iterateArtifacts" includeLocation="true" title="Iterating over the artifacts resolved for a module">
     <sourcefile file="build.gradle" snippet="iteration-task" />
 </sample>
 ++++
 
-[NOTE]
-====
 Iterating over the artifacts of a module automatically resolves the configuration. A resolved configuration becomes immutable and cannot add or remove dependencies. If needed you can copy a configuration for further modification via api:org.gradle.api.artifacts.Configuration#copy()[].
-====
 
 === Navigating the dependency graph
 
@@ -53,7 +50,7 @@ As a plugin developer, you may want to navigate the full graph of dependencies a
 The resolution result provides various methods for accessing the resolved and unresolved dependencies. For demonstration purposes the sample code uses api:org.gradle.api.artifacts.result.ResolutionResult#getRoot()[] to access the root node the resolved dependency graph. Each dependency of this component returns an instance of api:org.gradle.api.artifacts.result.ResolvedDependencyResult[] or api:org.gradle.api.artifacts.result.UnresolvedDependencyResult[] providing detailed information about the node.
 
 ++++
-<sample id="walking-dependency-graph" dir="userguide/dependencyManagement/workingWithDependencies/walkGraph" title="Walking the resolved and unresolved dependencies of a configuration">
+<sample id="walking-dependency-graph" dir="userguide/dependencyManagement/workingWithDependencies/walkGraph" includeLocation="true" title="Walking the resolved and unresolved dependencies of a configuration">
     <sourcefile file="build.gradle" snippet="walk-task" />
 </sample>
 ++++
@@ -67,7 +64,7 @@ The artifact query API provides access to the raw files of a module. Currently, 
 Let's say you wanted to post-process the metadata file of a Maven module. The group, name and version of the module component serve as input to the artifact resolution query. After executing the query, you get a handle to all components that match the criteria and their underlying files. Additionally, it's very easy to post-process the metadata file. The example code uses Groovy's link:http://docs.groovy-lang.org/latest/html/api/groovy/util/XmlSlurper.html[XmlSlurper] to ask for POM element values.
 
 ++++
-<sample id="accessingMetadataArtifact" dir="userguide/dependencyManagement/workingWithDependencies/accessMetadataArtifact" title="Accessing a Maven module's metadata artifact">
+<sample id="accessingMetadataArtifact" dir="userguide/dependencyManagement/workingWithDependencies/accessMetadataArtifact" includeLocation="true" title="Accessing a Maven module's metadata artifact">
     <sourcefile file="build.gradle" snippet="accessing-metadata-artifact" />
 </sample>
 ++++


### PR DESCRIPTION
### Context

Reference self-contained sample projects so that users can directly go to the relevant directory and try it out. The output would something like this:

> Note: The code for this example can be found at samples/userguide/dependencyManagement/inspectingDependencies/dependenciesReport in the ‘-all’ distribution of Gradle.

I think this concept only works well if the sample project doesn't cover multiple cases and can run by itself to fulfill a use case. For that very purpose some samples have not been referenced.

Let me know what you think.