### PR TITLE
Support single origin incremental annotation processors

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class DefaultFileHierarchySet {
@@ -44,7 +43,7 @@ public class DefaultFileHierarchySet {
     /**
      * Creates a set containing the given directories and all their descendants.
      */
-    public static FileHierarchySet of(Collection<File> rootDirs) {
+    public static FileHierarchySet of(Iterable<File> rootDirs) {
         FileHierarchySet set = EMPTY;
         for (File rootDir : rootDirs) {
             set = set.plus(rootDir);

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/MultipleOriginIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/MultipleOriginIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -64,7 +64,7 @@ class MultipleOriginIncrementalAnnotationProcessingIntegrationTest extends Abstr
         fails "compileJava"
 
         and:
-        errorOutput.contains("Generated file 'AThing' must have at least one originating element.")
+        errorOutput.contains("Generated type 'AThing' must have at least one originating element.")
     }
 
     def "processors can't access resources"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/SingleOriginIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/SingleOriginIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -66,7 +66,7 @@ class SingleOriginIncrementalAnnotationProcessingIntegrationTest extends Abstrac
         fails "compileJava"
 
         and:
-        errorOutput.contains("Generated file 'AThing' must have exactly one originating element, but had 0.")
+        errorOutput.contains("Generated type 'AThing' must have exactly one originating element, but had 0.")
     }
 
     def "processors can't access resources"() {
@@ -92,6 +92,6 @@ class SingleOriginIncrementalAnnotationProcessingIntegrationTest extends Abstrac
         fails "compileJava"
 
         and:
-        errorOutput.contains("Generated file 'ServiceRegistry' must have exactly one originating element, but had 2.")
+        errorOutput.contains("Generated type 'ServiceRegistry' must have exactly one originating element, but had 2.")
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/SingleOriginIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/SingleOriginIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -148,6 +148,36 @@ class SingleOriginIncrementalAnnotationProcessingIntegrationTest extends Abstrac
         outputContains("the chosen compiler did not support incremental annotation processing")
     }
 
+    def "all files are recompiled if a generated source file is deleted"() {
+        given:
+        java "@Helper class A {}"
+        java "class Unrelated {}"
+
+        outputs.snapshot { run "compileJava" }
+
+        when:
+        file("build/classes/java/main/AHelper.java").delete()
+        run "compileJava"
+
+        then:
+        outputs.recompiledClasses('A', "AHelper", "Unrelated")
+    }
+
+    def "all files are recompiled if a generated class is deleted"() {
+        given:
+        java "@Helper class A {}"
+        java "class Unrelated {}"
+
+        outputs.snapshot { run "compileJava" }
+
+        when:
+        file("build/classes/java/main/AHelper.class").delete()
+        run "compileJava"
+
+        then:
+        outputs.recompiledClasses('A', "AHelper", "Unrelated")
+    }
+
     def "processors must provide an originating element for each source element"() {
         given:
         withProcessor(new NonIncrementalProcessorFixture().withDeclaredType(IncrementalAnnotationProcessorType.SINGLE_ORIGIN))

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/UnknownIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/UnknownIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -51,4 +51,25 @@ class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncr
         output.contains("The following annotation processors don't support incremental compilation:")
         output.contains("Processor (type: UNKNOWN)")
     }
+
+    def "generated files are deleted when processor is removed"() {
+        given:
+        def a = java "@Thing class A {}"
+
+        when:
+        outputs.snapshot { run "compileJava" }
+
+        then:
+        file("build/classes/java/main/AThing.java").exists()
+
+        when:
+        buildFile << "compileJava.options.annotationProcessorPath = files()"
+        run "compileJava", "--info"
+
+        then:
+        !file("build/classes/java/main/AThing.java").exists()
+
+        and:
+        output.contains("Annotation processor path changed")
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/IncrementalAnnotationProcessingCompileTask.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/IncrementalAnnotationProcessingCompileTask.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.internal.tasks.compile.processing.IncrementalAnnotationProcessorType;
 import org.gradle.api.internal.tasks.compile.processing.MultipleOriginProcessor;
@@ -42,14 +43,16 @@ class IncrementalAnnotationProcessingCompileTask implements JavaCompiler.Compila
     private final JavaCompiler.CompilationTask delegate;
     private final Set<AnnotationProcessorDeclaration> processorDeclarations;
     private final List<File> annotationProcessorPath;
+    private final AnnotationProcessingResult result;
 
     private URLClassLoader processorClassloader;
     private boolean called;
 
-    IncrementalAnnotationProcessingCompileTask(JavaCompiler.CompilationTask delegate, Set<AnnotationProcessorDeclaration> processorDeclarations, List<File> annotationProcessorPath) {
+    IncrementalAnnotationProcessingCompileTask(JavaCompiler.CompilationTask delegate, Set<AnnotationProcessorDeclaration> processorDeclarations, List<File> annotationProcessorPath, AnnotationProcessingResult result) {
         this.delegate = delegate;
         this.processorDeclarations = processorDeclarations;
         this.annotationProcessorPath = annotationProcessorPath;
+        this.result = result;
     }
 
     @Override
@@ -95,9 +98,9 @@ class IncrementalAnnotationProcessingCompileTask implements JavaCompiler.Compila
     private Processor decorateIfIncremental(Processor processor, IncrementalAnnotationProcessorType type) {
         switch (type) {
             case SINGLE_ORIGIN:
-                return new SingleOriginProcessor(processor);
+                return new SingleOriginProcessor(processor, result);
             case MULTIPLE_ORIGIN:
-                return new MultipleOriginProcessor(processor);
+                return new MultipleOriginProcessor(processor, result);
             default:
                 return processor;
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompilerResult.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompilerResult.java
@@ -14,27 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.compile.processing;
+package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
+import org.gradle.workers.internal.DefaultWorkResult;
 
-import javax.annotation.processing.Filer;
-import javax.annotation.processing.Messager;
-import javax.annotation.processing.Processor;
+public class JdkJavaCompilerResult extends DefaultWorkResult {
 
+    private AnnotationProcessingResult annotationProcessingResult = new AnnotationProcessingResult();
 
-/**
- * A single origin processor must provide at least one originating element
- * for each file it generates.
- */
-public class MultipleOriginProcessor extends IncrementalProcessor {
-
-    public MultipleOriginProcessor(Processor delegate, AnnotationProcessingResult result) {
-        super(delegate, result);
+    JdkJavaCompilerResult() {
+        super(true, null);
     }
 
-    @Override
-    IncrementalFiler wrapFiler(Filer filer, AnnotationProcessingResult result, Messager messager) {
-        return new MultipleOriginFiler(filer, result, messager);
+    public AnnotationProcessingResult getAnnotationProcessingResult() {
+        return annotationProcessingResult;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/AnnotationProcessorChangeProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/AnnotationProcessorChangeProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental;
+
+import com.google.common.collect.Iterables;
+import org.gradle.api.internal.tasks.compile.incremental.jar.PreviousCompilation;
+import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
+import org.gradle.api.tasks.incremental.InputFileDetails;
+import org.gradle.internal.file.DefaultFileHierarchySet;
+import org.gradle.internal.file.FileHierarchySet;
+
+class AnnotationProcessorChangeProcessor {
+    private final FileHierarchySet jointProcessorPath;
+
+    AnnotationProcessorChangeProcessor(CurrentCompilation current, PreviousCompilation previous) {
+        this.jointProcessorPath = DefaultFileHierarchySet.of(Iterables.concat(current.getAnnotationProcessorPath(), previous.getAnnotationProcessorPath()));
+    }
+
+    public void processChange(InputFileDetails input, RecompilationSpec spec) {
+        if (jointProcessorPath.contains(input.getFile())) {
+            spec.setFullRebuildCause("Annotation processor path changed", input.getFile());
+        }
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/ClassSetAnalysisUpdater.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/ClassSetAnalysisUpdater.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassFilesAnal
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.WorkResult;
 import org.gradle.cache.internal.Stash;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.time.Time;
@@ -56,7 +57,10 @@ public class ClassSetAnalysisUpdater {
         this.fileHasher = fileHasher;
     }
 
-    public void updateAnalysis(JavaCompileSpec spec) {
+    public void updateAnalysis(JavaCompileSpec spec, WorkResult result) {
+        if (result instanceof RecompilationNotNecessary) {
+            return;
+        }
         Timer clock = Time.startTimer();
         Set<File> baseDirs = Sets.newLinkedHashSet();
         baseDirs.add(spec.getDestinationDir());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/CurrentCompilation.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/CurrentCompilation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
+import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshot;
+import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotProvider;
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
+import org.gradle.api.tasks.incremental.InputFileDetails;
+
+import java.io.File;
+import java.util.Collection;
+
+public class CurrentCompilation {
+    private final IncrementalTaskInputs inputs;
+    private final JavaCompileSpec spec;
+    private final JarClasspathSnapshotProvider jarClasspathSnapshotProvider;
+
+    CurrentCompilation(IncrementalTaskInputs inputs, JavaCompileSpec spec, JarClasspathSnapshotProvider jarClasspathSnapshotProvider) {
+
+        this.inputs = inputs;
+        this.spec = spec;
+        this.jarClasspathSnapshotProvider = jarClasspathSnapshotProvider;
+    }
+
+    public JarClasspathSnapshot getClasspathSnapshot() {
+        return jarClasspathSnapshotProvider.getJarClasspathSnapshot(spec.getCompileClasspath());
+    }
+
+    public Collection<File> getAnnotationProcessorPath() {
+        return spec.getAnnotationProcessorPath();
+    }
+
+    public void visitChanges(Action<InputFileDetails> action) {
+        inputs.outOfDate(action);
+        inputs.removed(action);
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
@@ -71,7 +71,7 @@ public class IncrementalCompilerDecorator {
 
     public Compiler<JavaCompileSpec> prepareCompiler(IncrementalTaskInputs inputs) {
         Compiler<JavaCompileSpec> compiler = getCompiler(inputs, sourceDirs);
-        IncrementalResultStoringDecorator compilationFinalizer = new IncrementalResultStoringDecorator(compiler, jarClasspathSnapshotMaker, classSetAnalysisUpdater);
+        IncrementalResultStoringDecorator compilationFinalizer = new IncrementalResultStoringDecorator(compiler, jarClasspathSnapshotMaker, classSetAnalysisUpdater, compileCaches.getAnnotationProcessorPathStore());
         return new IncrementalAnnotationProcessingCompiler(compilationFinalizer, annotationProcessorDetector);
     }
 
@@ -94,7 +94,7 @@ public class IncrementalCompilerDecorator {
             LOG.info("{} - is not incremental. No class analysis data available from the previous build.", displayName);
             return cleaningCompiler;
         }
-        PreviousCompilation previousCompilation = new PreviousCompilation(new ClassSetAnalysis(data), compileCaches.getLocalJarClasspathSnapshotStore(), compileCaches.getJarSnapshotCache());
+        PreviousCompilation previousCompilation = new PreviousCompilation(new ClassSetAnalysis(data), compileCaches.getLocalJarClasspathSnapshotStore(), compileCaches.getJarSnapshotCache(), compileCaches.getAnnotationProcessorPathStore());
         return new SelectiveCompiler(inputs, previousCompilation, cleaningCompiler, staleClassDetecter, compilationInitializer, jarClasspathSnapshotMaker);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapsho
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotter;
 import org.gradle.api.internal.tasks.compile.incremental.jar.LocalJarClasspathSnapshotStore;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.StreamHasher;
@@ -75,6 +76,7 @@ public class IncrementalCompilerFactory {
     private CompileCaches createCompileCaches(String path) {
         final LocalClassSetAnalysisStore localClassSetAnalysisStore = generalCompileCaches.createLocalClassSetAnalysisStore(path);
         final LocalJarClasspathSnapshotStore localJarClasspathSnapshotStore = generalCompileCaches.createLocalJarClasspathSnapshotStore(path);
+        final AnnotationProcessorPathStore annotationProcessorPathStore = generalCompileCaches.createAnnotationProcessorPathStore(path);
         return new CompileCaches() {
             public ClassAnalysisCache getClassAnalysisCache() {
                 return generalCompileCaches.getClassAnalysisCache();
@@ -90,6 +92,11 @@ public class IncrementalCompilerFactory {
 
             public LocalClassSetAnalysisStore getLocalClassSetAnalysisStore() {
                 return localClassSetAnalysisStore;
+            }
+
+            @Override
+            public AnnotationProcessorPathStore getAnnotationProcessorPathStore() {
+                return annotationProcessorPathStore;
             }
         };
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecorator.java
@@ -39,13 +39,8 @@ class IncrementalResultStoringDecorator implements Compiler<JavaCompileSpec> {
     @Override
     public WorkResult execute(JavaCompileSpec spec) {
         WorkResult out = delegate.execute(spec);
-
-        if (!(out instanceof RecompilationNotNecessary)) {
-            updater.updateAnalysis(spec);
-        }
-
+        updater.updateAnalysis(spec, out);
         writer.storeJarSnapshots(spec.getCompileClasspath());
-
         return out;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecorator.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile.incremental;
 
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotWriter;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.language.base.internal.compile.Compiler;
 
@@ -29,11 +30,13 @@ class IncrementalResultStoringDecorator implements Compiler<JavaCompileSpec> {
     private final Compiler<JavaCompileSpec> delegate;
     private final JarClasspathSnapshotWriter writer;
     private final ClassSetAnalysisUpdater updater;
+    private final AnnotationProcessorPathStore annotationProcessorPathStore;
 
-    public IncrementalResultStoringDecorator(Compiler<JavaCompileSpec> delegate, JarClasspathSnapshotWriter writer, ClassSetAnalysisUpdater updater) {
+    public IncrementalResultStoringDecorator(Compiler<JavaCompileSpec> delegate, JarClasspathSnapshotWriter writer, ClassSetAnalysisUpdater updater, AnnotationProcessorPathStore annotationProcessorPathStore) {
         this.delegate = delegate;
         this.writer = writer;
         this.updater = updater;
+        this.annotationProcessorPathStore = annotationProcessorPathStore;
     }
 
     @Override
@@ -41,6 +44,7 @@ class IncrementalResultStoringDecorator implements Compiler<JavaCompileSpec> {
         WorkResult out = delegate.execute(spec);
         updater.updateAnalysis(spec, out);
         writer.storeJarSnapshots(spec.getCompileClasspath());
+        annotationProcessorPathStore.put(spec.getAnnotationProcessorPath());
         return out;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/InputChangeAction.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/InputChangeAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
+import org.gradle.api.tasks.incremental.InputFileDetails;
+
+import static org.gradle.internal.FileUtils.hasExtension;
+
+class InputChangeAction implements Action<InputFileDetails> {
+    private final RecompilationSpec spec;
+    private final JavaChangeProcessor javaChangeProcessor;
+    private final ClassChangeProcessor classChangeProcessor;
+    private final AnnotationProcessorChangeProcessor annotationProcessorChangeProcessor;
+
+    InputChangeAction(RecompilationSpec spec, JavaChangeProcessor javaChangeProcessor, ClassChangeProcessor classChangeProcessor, AnnotationProcessorChangeProcessor annotationProcessorChangeProcessor) {
+        this.spec = spec;
+        this.javaChangeProcessor = javaChangeProcessor;
+        this.classChangeProcessor = classChangeProcessor;
+        this.annotationProcessorChangeProcessor = annotationProcessorChangeProcessor;
+    }
+
+    @Override
+    public void execute(InputFileDetails input) {
+        if (spec.getFullRebuildCause() != null) {
+            return;
+        }
+
+        annotationProcessorChangeProcessor.processChange(input, spec);
+
+        if (hasExtension(input.getFile(), ".java")) {
+            javaChangeProcessor.processChange(input, spec);
+        } else if (hasExtension(input.getFile(), ".class")) {
+            classChangeProcessor.processChange(input, spec);
+        }
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile.incremental;
 
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
-import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshot;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotProvider;
 import org.gradle.api.internal.tasks.compile.incremental.jar.PreviousCompilation;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
@@ -53,8 +52,9 @@ class SelectiveCompiler implements org.gradle.language.base.internal.compile.Com
     @Override
     public WorkResult execute(JavaCompileSpec spec) {
         Timer clock = Time.startTimer();
-        JarClasspathSnapshot jarClasspathSnapshot = jarClasspathSnapshotProvider.getJarClasspathSnapshot(spec.getCompileClasspath());
-        RecompilationSpec recompilationSpec = recompilationSpecProvider.provideRecompilationSpec(inputs, previousCompilation, jarClasspathSnapshot);
+        CurrentCompilation currentCompilation = new CurrentCompilation(inputs, spec, jarClasspathSnapshotProvider);
+
+        RecompilationSpec recompilationSpec = recompilationSpecProvider.provideRecompilationSpec(currentCompilation, previousCompilation);
 
         if (recompilationSpec.isFullRebuildNeeded()) {
             LOG.info("Full recompilation is required because {}. Analysis took {}.", recompilationSpec.getFullRebuildCause(), clock.getElapsed());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/CompilationResultAnalyzer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/CompilationResultAnalyzer.java
@@ -21,26 +21,28 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassDependentsAccumulator;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 
-public class ClassFilesAnalyzer implements FileVisitor {
+public class CompilationResultAnalyzer implements FileVisitor {
     private final ClassDependenciesAnalyzer analyzer;
     private final ClassDependentsAccumulator accumulator;
     private final FileHasher hasher;
 
-    public ClassFilesAnalyzer(ClassDependenciesAnalyzer analyzer, FileHasher fileHasher) {
+    public CompilationResultAnalyzer(ClassDependenciesAnalyzer analyzer, FileHasher fileHasher) {
         this(analyzer, fileHasher, new ClassDependentsAccumulator());
     }
 
-   ClassFilesAnalyzer(ClassDependenciesAnalyzer analyzer, FileHasher fileHasher, ClassDependentsAccumulator accumulator) {
-       this.analyzer = analyzer;
-       this.hasher = fileHasher;
-       this.accumulator = accumulator;
-   }
+    CompilationResultAnalyzer(ClassDependenciesAnalyzer analyzer, FileHasher fileHasher, ClassDependentsAccumulator accumulator) {
+        this.analyzer = analyzer;
+        this.hasher = fileHasher;
+        this.accumulator = accumulator;
+    }
 
     @Override
-    public void visitDir(FileVisitDetails dirDetails) {}
+    public void visitDir(FileVisitDetails dirDetails) {
+    }
 
     @Override
     public void visitFile(FileVisitDetails fileDetails) {
@@ -56,5 +58,13 @@ public class ClassFilesAnalyzer implements FileVisitor {
 
     public ClassSetAnalysisData getAnalysis() {
         return accumulator.getAnalysis();
+    }
+
+    public void visitAnnotationProcessingResult(AnnotationProcessingResult annotationProcessingResult) {
+        if (annotationProcessingResult == null) {
+            accumulator.fullRebuildNeeded("the chosen compiler did not support incremental annotation processing");
+        } else {
+            accumulator.addGeneratedTypeMappings(annotationProcessingResult);
+        }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/CompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/CompileCaches.java
@@ -20,10 +20,12 @@ import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassAnalysisC
 import org.gradle.api.internal.tasks.compile.incremental.deps.LocalClassSetAnalysisStore;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 import org.gradle.api.internal.tasks.compile.incremental.jar.LocalJarClasspathSnapshotStore;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 
 public interface CompileCaches {
     ClassAnalysisCache getClassAnalysisCache();
     JarSnapshotCache getJarSnapshotCache();
     LocalJarClasspathSnapshotStore getLocalJarClasspathSnapshotStore();
     LocalClassSetAnalysisStore getLocalClassSetAnalysisStore();
+    AnnotationProcessorPathStore getAnnotationProcessorPathStore();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/GeneralCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/GeneralCompileCaches.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassAnalysisC
 import org.gradle.api.internal.tasks.compile.incremental.deps.LocalClassSetAnalysisStore;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 import org.gradle.api.internal.tasks.compile.incremental.jar.LocalJarClasspathSnapshotStore;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 
 public interface GeneralCompileCaches {
     ClassAnalysisCache getClassAnalysisCache();
@@ -29,4 +30,6 @@ public interface GeneralCompileCaches {
     LocalJarClasspathSnapshotStore createLocalJarClasspathSnapshotStore(String taskPath);
 
     LocalClassSetAnalysisStore createLocalClassSetAnalysisStore(String taskPath);
+
+    AnnotationProcessorPathStore createAnnotationProcessorPathStore(String taskPath);
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -101,6 +101,15 @@ public class ClassDependentsAccumulator {
     }
 
     public ClassSetAnalysisData getAnalysis() {
-        return new ClassSetAnalysisData(filePathToClassName, getDependentsMap(), getClassesToConstants(), parentToChildren);
+        return new ClassSetAnalysisData(filePathToClassName, getDependentsMap(), getClassesToConstants(), asMap(parentToChildren));
     }
+
+    private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {
+        ImmutableMap.Builder<K, Set<V>> builder = ImmutableMap.builder();
+        for (K key : multimap.keySet()) {
+            builder.put(key, ImmutableSet.copyOf(multimap.get(key)));
+        }
+        return builder.build();
+    }
+
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
 
 import java.io.File;
 import java.util.Collections;
@@ -37,6 +38,7 @@ public class ClassDependentsAccumulator {
     private final Map<String, IntSet> classesToConstants = new HashMap<String, IntSet>();
     private final Set<String> seenClasses = Sets.newHashSet();
     private final Multimap<String, String> parentToChildren = HashMultimap.create();
+    private String fullRebuildCause;
 
     public ClassDependentsAccumulator() {
     }
@@ -100,8 +102,19 @@ public class ClassDependentsAccumulator {
         return classesToConstants;
     }
 
+    public void addGeneratedTypeMappings(AnnotationProcessingResult annotationProcessingResult) {
+        for (Map.Entry<String, Set<String>> entry : annotationProcessingResult.getGeneratedTypesByOrigin().entrySet()) {
+            Set<String> dependents = rememberClass(entry.getKey());
+            dependents.addAll(entry.getValue());
+        }
+    }
+
+    public void fullRebuildNeeded(String fullRebuildCause) {
+        this.fullRebuildCause = fullRebuildCause;
+    }
+
     public ClassSetAnalysisData getAnalysis() {
-        return new ClassSetAnalysisData(filePathToClassName, getDependentsMap(), getClassesToConstants(), asMap(parentToChildren));
+        return new ClassSetAnalysisData(filePathToClassName, getDependentsMap(), getClassesToConstants(), asMap(parentToChildren), fullRebuildCause);
     }
 
     private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {
@@ -111,5 +124,4 @@ public class ClassDependentsAccumulator {
         }
         return builder.build();
     }
-
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
@@ -51,27 +51,23 @@ public class ClassSetAnalysis {
 
     public DependentsSet getRelevantDependents(String className, IntSet constants) {
         DependentsSet deps = data.getDependents(className);
-        if (deps != null && deps.isDependencyToAll()) {
+        if (deps.isDependencyToAll()) {
             return deps;
-        }
-        if (deps == null && constants.isEmpty()) {
-            return DefaultDependentsSet.EMPTY;
         }
         if (!constants.isEmpty()) {
             return DependencyToAll.INSTANCE;
         }
-        Set<String> result = new HashSet<String>();
-        if (deps != null && !deps.isDependencyToAll()) {
-            recurseDependents(new HashSet<String>(), result, deps.getDependentClasses());
+        if (deps.getDependentClasses().isEmpty()) {
+            return DefaultDependentsSet.EMPTY;
         }
+        Set<String> result = new HashSet<String>();
+        recurseDependents(new HashSet<String>(), result, deps.getDependentClasses());
         result.remove(className);
         return new DefaultDependentsSet(result);
-
     }
 
     public boolean isDependencyToAll(String className) {
-        DependentsSet deps = data.getDependents(className);
-        return deps != null && deps.isDependencyToAll();
+        return data.getDependents(className).isDependencyToAll();
     }
 
     private void recurseDependents(Set<String> visited, Set<String> result, Set<String> dependentClasses) {
@@ -79,14 +75,18 @@ public class ClassSetAnalysis {
             if (!visited.add(d)) {
                 continue;
             }
-            if (!d.contains("$")) { //filter out the inner classes
+            if (!isInnerClass(d)) {
                 result.add(d);
             }
             DependentsSet currentDependents = data.getDependents(d);
-            if (currentDependents != null && !currentDependents.isDependencyToAll()) {
+            if (!currentDependents.isDependencyToAll()) {
                 recurseDependents(visited, result, currentDependents.getDependentClasses());
             }
         }
+    }
+
+    private boolean isInnerClass(String d) {
+        return d.contains("$");
     }
 
     public ClassSetAnalysisData getData() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
@@ -75,7 +75,7 @@ public class ClassSetAnalysis {
             if (!visited.add(d)) {
                 continue;
             }
-            if (!isInnerClass(d)) {
+            if (!isNestedClass(d)) {
                 result.add(d);
             }
             DependentsSet currentDependents = data.getDependents(d);
@@ -85,7 +85,7 @@ public class ClassSetAnalysis {
         }
     }
 
-    private boolean isInnerClass(String d) {
+    private boolean isNestedClass(String d) {
         return d.contains("$");
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile.incremental.deps;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import org.gradle.internal.serialize.AbstractSerializer;
@@ -38,10 +37,6 @@ public class ClassSetAnalysisData {
     final Map<String, IntSet> classesToConstants;
     final Map<String, Set<String>> classesToChildren;
 
-    public ClassSetAnalysisData(Map<String, String> filePathToClassName, Map<String, DependentsSet> dependents, Map<String, IntSet> classesToConstants, Multimap<String, String> classesToChildren) {
-        this(filePathToClassName, dependents, classesToConstants, asMap(classesToChildren));
-    }
-
     public ClassSetAnalysisData(Map<String, String> filePathToClassName, Map<String, DependentsSet> dependents, Map<String, IntSet> classesToConstants, Map<String, Set<String>> classesToChildren) {
         this.filePathToClassName = filePathToClassName;
         this.dependents = dependents;
@@ -49,20 +44,13 @@ public class ClassSetAnalysisData {
         this.classesToChildren = classesToChildren;
     }
 
-    private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {
-        ImmutableMap.Builder<K, Set<V>> builder = ImmutableMap.builder();
-        for (K key : multimap.keySet()) {
-            builder.put(key, ImmutableSet.copyOf(multimap.get(key)));
-        }
-        return builder.build();
-    }
-
     public String getClassNameForFile(String filePath) {
         return filePathToClassName.get(filePath);
     }
 
     public DependentsSet getDependents(String className) {
-        return dependents.get(className);
+        DependentsSet dependentsSet = dependents.get(className);
+        return dependentsSet == null ? DefaultDependentsSet.EMPTY : dependentsSet;
     }
 
     public IntSet getConstants(String className) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -36,12 +36,14 @@ public class ClassSetAnalysisData {
     final Map<String, DependentsSet> dependents;
     final Map<String, IntSet> classesToConstants;
     final Map<String, Set<String>> classesToChildren;
+    final String fullRebuildCause;
 
-    public ClassSetAnalysisData(Map<String, String> filePathToClassName, Map<String, DependentsSet> dependents, Map<String, IntSet> classesToConstants, Map<String, Set<String>> classesToChildren) {
+    public ClassSetAnalysisData(Map<String, String> filePathToClassName, Map<String, DependentsSet> dependents, Map<String, IntSet> classesToConstants, Map<String, Set<String>> classesToChildren, String fullRebuildCause) {
         this.filePathToClassName = filePathToClassName;
         this.dependents = dependents;
         this.classesToConstants = classesToConstants;
         this.classesToChildren = classesToChildren;
+        this.fullRebuildCause = fullRebuildCause;
     }
 
     public String getClassNameForFile(String filePath) {
@@ -49,6 +51,9 @@ public class ClassSetAnalysisData {
     }
 
     public DependentsSet getDependents(String className) {
+        if (fullRebuildCause != null) {
+            return new DependencyToAll(fullRebuildCause);
+        }
         DependentsSet dependentsSet = dependents.get(className);
         return dependentsSet == null ? DefaultDependentsSet.EMPTY : dependentsSet;
     }
@@ -109,7 +114,9 @@ public class ClassSetAnalysisData {
                 classNameToChildren.put(parent, namesBuilder.build());
             }
 
-            return new ClassSetAnalysisData(filePathToClassNameBuilder.build(), dependentsBuilder.build(), classesToConstantsBuilder.build(), classNameToChildren.build());
+            String fullRebuildCause = decoder.readNullableString();
+
+            return new ClassSetAnalysisData(filePathToClassNameBuilder.build(), dependentsBuilder.build(), classesToConstantsBuilder.build(), classNameToChildren.build(), fullRebuildCause);
         }
 
         @Override
@@ -144,6 +151,8 @@ public class ClassSetAnalysisData {
                     writeClassName(className, classNameMap, encoder);
                 }
             }
+
+            encoder.writeNullableString(value.fullRebuildCause);
         }
 
         private DependentsSet readDependentsSet(Decoder decoder, Map<Integer, String> classNameMap) throws IOException {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/PreviousCompilation.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/PreviousCompilation.java
@@ -16,13 +16,15 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.jar;
 
-import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
-import org.gradle.api.internal.tasks.compile.incremental.deps.DependentsSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
+import org.gradle.api.internal.tasks.compile.incremental.deps.DependentsSet;
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,12 +33,14 @@ public class PreviousCompilation {
     private ClassSetAnalysis analysis;
     private LocalJarClasspathSnapshotStore classpathSnapshotStore;
     private final JarSnapshotCache jarSnapshotCache;
+    private final AnnotationProcessorPathStore annotationProcessorPathStore;
     private Map<File, JarSnapshot> jarSnapshots;
 
-    public PreviousCompilation(ClassSetAnalysis analysis, LocalJarClasspathSnapshotStore classpathSnapshotStore, JarSnapshotCache jarSnapshotCache) {
+    public PreviousCompilation(ClassSetAnalysis analysis, LocalJarClasspathSnapshotStore classpathSnapshotStore, JarSnapshotCache jarSnapshotCache, AnnotationProcessorPathStore annotationProcessorPathStore) {
         this.analysis = analysis;
         this.classpathSnapshotStore = classpathSnapshotStore;
         this.jarSnapshotCache = jarSnapshotCache;
+        this.annotationProcessorPathStore = annotationProcessorPathStore;
     }
 
     public DependentsSet getDependents(Set<String> allClasses, IntSet constants) {
@@ -67,5 +71,9 @@ public class PreviousCompilation {
             jarSnapshots = jarSnapshotCache.getJarSnapshots(data.getJarHashes());
         }
         return Collections.unmodifiableMap(jarSnapshots);
+    }
+
+    public List<File> getAnnotationProcessorPath() {
+        return annotationProcessorPathStore.get();
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessingResult.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessingResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.processing;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AnnotationProcessingResult implements Serializable {
+
+    private HashMap<String, Set<String>> generatedTypesByOrigin = new LinkedHashMap<String, Set<String>>();
+
+    public void addGeneratedType(String name, Set<String> originatingElements) {
+        for (String originatingElement : originatingElements) {
+            Set<String> derived = generatedTypesByOrigin.get(originatingElement);
+            if (derived == null) {
+                derived = new LinkedHashSet<String>();
+                generatedTypesByOrigin.put(originatingElement, derived);
+            }
+            derived.add(name);
+        }
+    }
+
+    public Map<String, Set<String>> getGeneratedTypesByOrigin() {
+        return generatedTypesByOrigin;
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessorPathStore.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/processing/AnnotationProcessorPathStore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.processing;
+
+import org.gradle.cache.PersistentIndexedCache;
+
+import java.io.File;
+import java.util.List;
+
+public class AnnotationProcessorPathStore {
+    private final String taskPath;
+    private final PersistentIndexedCache<String, List<File>> cache;
+
+    public AnnotationProcessorPathStore(String taskPath, PersistentIndexedCache<String, List<File>> cache) {
+        this.taskPath = taskPath;
+        this.cache = cache;
+    }
+
+    public void put(List<File> processorPath) {
+        cache.put(taskPath, processorPath);
+    }
+
+    public List<File> get() {
+        return cache.get(taskPath);
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalAnnotationProcessorType.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalAnnotationProcessorType.java
@@ -33,11 +33,6 @@ package org.gradle.api.internal.tasks.compile.processing;
  * </p>
  *
  * <p>
- * All processor types are currently treated as non-incremental. This will improve over time as we add more
- * capabilities to the compiler.
- * </p>
- *
- * <p>
  * Processors can register themselves as incremental by providing a <code>META-INF/gradle/incremental.annotation.processors</code> file,
  * which has one line per processor, each line containing the fully qualified class name and one of the processor types listed
  * here, separated by a comma. E.g.:
@@ -53,7 +48,7 @@ public enum IncrementalAnnotationProcessorType {
     /**
      * A processor whose generated files have exactly one originating element.
      */
-    SINGLE_ORIGIN(false),
+    SINGLE_ORIGIN(true),
     /**
      * A processor whose generated files can have more than one originating element.
      */

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalFiler.java
@@ -66,7 +66,7 @@ abstract class IncrementalFiler implements Filer {
         result.addGeneratedType(generatedType, originatingTypes);
     }
 
-    protected abstract void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager);
+    protected abstract void checkGeneratedType(String generatedType, Set<String> originatingTypes, Messager messager);
 
     private Set<String> getTopLevelTypeNames(Element[] originatingElements) {
         if (originatingElements == null || originatingElements.length == 0) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalFiler.java
@@ -16,14 +16,20 @@
 
 package org.gradle.api.internal.tasks.compile.processing;
 
+import com.google.common.collect.Sets;
+
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * A decorator for the {@link Filer} which ensures that incremental
@@ -40,17 +46,55 @@ abstract class IncrementalFiler implements Filer {
 
     @Override
     public final JavaFileObject createSourceFile(CharSequence name, Element... originatingElements) throws IOException {
-        checkOriginatingElements(name, originatingElements, messager);
+        checkGeneratedType(name, originatingElements, messager);
         return delegate.createSourceFile(name, originatingElements);
     }
 
     @Override
     public final JavaFileObject createClassFile(CharSequence name, Element... originatingElements) throws IOException {
-        checkOriginatingElements(name, originatingElements, messager);
+        checkGeneratedType(name, originatingElements, messager);
         return delegate.createClassFile(name, originatingElements);
     }
+    
+    private void checkGeneratedType(CharSequence name, Element[] originatingElements, Messager messager) {
+        String generatedType = name.toString();
+        Set<String> originatingTypes = getTopLevelTypeNames(originatingElements);
+        checkGeneratedType(generatedType, originatingTypes, messager);
+    }
 
-    protected abstract void checkOriginatingElements(CharSequence name, Element[] originatingElements, Messager messager);
+    protected abstract void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager);
+
+    private Set<String> getTopLevelTypeNames(Element[] originatingElements) {
+        if (originatingElements == null || originatingElements.length == 0) {
+            return Collections.emptySet();
+        }
+        if (originatingElements.length == 1) {
+            String topLevelTypeName = getTopLevelTypeName(originatingElements[0]);
+            return topLevelTypeName != null ? Collections.singleton(topLevelTypeName) : Collections.<String>emptySet();
+        }
+        Set<String> typeNames = Sets.newLinkedHashSet();
+        for (Element element : originatingElements) {
+            String topLevelTypeName = getTopLevelTypeName(element);
+            if (topLevelTypeName != null) {
+                typeNames.add(topLevelTypeName);
+            }
+        }
+        return typeNames;
+    }
+
+    private String getTopLevelTypeName(Element originatingElement) {
+        Element current = originatingElement;
+        Element parent = originatingElement;
+        while (parent != null && !(parent instanceof PackageElement)) {
+            current = parent;
+            parent = current.getEnclosingElement();
+        }
+        if (!(current instanceof TypeElement)) {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Incremental annotation processors must use types (or elements contained in types) as originating elements.");
+            return null;
+        }
+        return ((TypeElement) current).getQualifiedName().toString();
+    }
 
     @Override
     public final FileObject createResource(JavaFileManager.Location location, CharSequence pkg, CharSequence relativeName, Element... originatingElements) throws IOException {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/IncrementalProcessor.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.compile.processing;
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
+
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -36,9 +38,11 @@ import java.util.Set;
  */
 abstract class IncrementalProcessor implements Processor {
     private Processor delegate;
+    private final AnnotationProcessingResult result;
 
-    IncrementalProcessor(Processor delegate) {
+    IncrementalProcessor(Processor delegate, AnnotationProcessingResult result) {
         this.delegate = delegate;
+        this.result = result;
     }
 
     @Override
@@ -60,12 +64,12 @@ abstract class IncrementalProcessor implements Processor {
     public final void init(ProcessingEnvironment processingEnv) {
         Filer filer = processingEnv.getFiler();
         Messager messager = processingEnv.getMessager();
-        IncrementalFiler incrementalFiler = wrapFiler(filer, messager);
+        IncrementalFiler incrementalFiler = wrapFiler(filer, result, messager);
         IncrementalProcessingEnvironment incrementalProcessingEnvironment = new IncrementalProcessingEnvironment(processingEnv, incrementalFiler);
         delegate.init(incrementalProcessingEnvironment);
     }
 
-    abstract IncrementalFiler wrapFiler(Filer filer, Messager messager);
+    abstract IncrementalFiler wrapFiler(Filer filer, AnnotationProcessingResult result, Messager messager);
 
     @Override
     public final boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFiler.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.tasks.compile.processing;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
-import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;
+import java.util.Set;
 
 /**
  * Decorates the filer to validate the correct behavior for {@link MultipleOriginProcessor}s.
@@ -30,9 +30,9 @@ class MultipleOriginFiler extends IncrementalFiler {
         super(delegate, messager);
     }
 
-    protected void checkOriginatingElements(CharSequence name, Element[] originatingElements, Messager messager) {
-        if (originatingElements.length == 0) {
-            messager.printMessage(Diagnostic.Kind.ERROR, "Generated file '" + name + "' must have at least one originating element.");
+    protected void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager) {
+        if (orignatingTypes.isEmpty()) {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Generated type '" + generatedType + "' must have at least one originating element.");
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFiler.java
@@ -32,8 +32,8 @@ class MultipleOriginFiler extends IncrementalFiler {
         super(delegate, result, messager);
     }
 
-    protected void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager) {
-        if (orignatingTypes.isEmpty()) {
+    protected void checkGeneratedType(String generatedType, Set<String> originatingTypes, Messager messager) {
+        if (originatingTypes.isEmpty()) {
             messager.printMessage(Diagnostic.Kind.ERROR, "Generated type '" + generatedType + "' must have at least one originating element.");
         }
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFiler.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.compile.processing;
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
+
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
@@ -26,8 +28,8 @@ import java.util.Set;
  */
 class MultipleOriginFiler extends IncrementalFiler {
 
-    MultipleOriginFiler(Filer delegate, Messager messager) {
-        super(delegate, messager);
+    MultipleOriginFiler(Filer delegate, AnnotationProcessingResult result, Messager messager) {
+        super(delegate, result, messager);
     }
 
     protected void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginFiler.java
@@ -32,8 +32,8 @@ class SingleOriginFiler extends IncrementalFiler {
         super(delegate, result, messager);
     }
 
-    protected void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager) {
-        int size = orignatingTypes.size();
+    protected void checkGeneratedType(String generatedType, Set<String> originatingTypes, Messager messager) {
+        int size = originatingTypes.size();
         if (size != 1) {
             messager.printMessage(Diagnostic.Kind.ERROR, "Generated type '" + generatedType + "' must have exactly one originating element, but had " + size + ".");
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginFiler.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.tasks.compile.processing;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
-import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;
+import java.util.Set;
 
 /**
  * Decorates the filer to validate the correct behavior for {@link SingleOriginProcessor}s.
@@ -30,9 +30,10 @@ class SingleOriginFiler extends IncrementalFiler {
         super(delegate, messager);
     }
 
-    protected void checkOriginatingElements(CharSequence name, Element[] originatingElements, Messager messager) {
-        if (originatingElements.length != 1) {
-            messager.printMessage(Diagnostic.Kind.ERROR, "Generated file '" + name + "' must have exactly one originating element, but had " + originatingElements.length + ".");
+    protected void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager) {
+        int size = orignatingTypes.size();
+        if (size != 1) {
+            messager.printMessage(Diagnostic.Kind.ERROR, "Generated type '" + generatedType + "' must have exactly one originating element, but had " + size + ".");
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginFiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginFiler.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.compile.processing;
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
+
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
@@ -26,8 +28,8 @@ import java.util.Set;
  */
 class SingleOriginFiler extends IncrementalFiler {
 
-    SingleOriginFiler(Filer delegate, Messager messager) {
-        super(delegate, messager);
+    SingleOriginFiler(Filer delegate, AnnotationProcessingResult result, Messager messager) {
+        super(delegate, result, messager);
     }
 
     protected void checkGeneratedType(String generatedType, Set<String> orignatingTypes, Messager messager) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SingleOriginProcessor.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.compile.processing;
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
+
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.Processor;
@@ -26,12 +28,12 @@ import javax.annotation.processing.Processor;
  */
 public class SingleOriginProcessor extends IncrementalProcessor {
 
-    public SingleOriginProcessor(Processor delegate) {
-        super(delegate);
+    public SingleOriginProcessor(Processor delegate, AnnotationProcessingResult result) {
+        super(delegate, result);
     }
 
     @Override
-    SingleOriginFiler wrapFiler(Filer filer, Messager messager) {
-        return new SingleOriginFiler(filer, messager);
+    IncrementalFiler wrapFiler(Filer filer, AnnotationProcessingResult result, Messager messager) {
+        return new SingleOriginFiler(filer, result, messager);
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
@@ -30,17 +30,21 @@ class IncrementalCompilationInitializerTest extends Specification {
     @Subject initializer = new IncrementalCompilationInitializer(fileOperations)
 
     def "prepares patterns"() {
-        PatternSet classesToDelete = Mock(PatternSet)
+        PatternSet filesToDelete = Mock(PatternSet)
         PatternSet sourceToCompile = Mock(PatternSet)
 
         when:
-        initializer.preparePatterns(["com.Foo", "Bar"], classesToDelete, sourceToCompile)
+        initializer.preparePatterns(["com.Foo", "Bar"], filesToDelete, sourceToCompile)
 
         then:
-        1 * classesToDelete.include('com/Foo.class')
-        1 * classesToDelete.include('com/Foo$*.class')
-        1 * classesToDelete.include('Bar.class')
-        1 * classesToDelete.include('Bar$*.class')
+        1 * filesToDelete.include('com/Foo.class')
+        1 * filesToDelete.include('com/Foo.java')
+        1 * filesToDelete.include('com/Foo$*.class')
+        1 * filesToDelete.include('com/Foo$*.java')
+        1 * filesToDelete.include('Bar.class')
+        1 * filesToDelete.include('Bar.java')
+        1 * filesToDelete.include('Bar$*.class')
+        1 * filesToDelete.include('Bar$*.java')
 
         1 * sourceToCompile.include('Bar.java')
         1 * sourceToCompile.include('com/Foo.java')
@@ -48,11 +52,6 @@ class IncrementalCompilationInitializerTest extends Specification {
         1 * sourceToCompile.include('com/Foo$*.java')
 
         0 * _
-    }
-
-    def "does not prepare patterns when stale classes empty"() {
-        when: initializer.preparePatterns([], Mock(PatternSet), Mock(PatternSet))
-        then: thrown(AssertionError)
     }
 
     def "configures empty source when stale classes empty"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecoratorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecoratorTest.groovy
@@ -33,22 +33,15 @@ class IncrementalResultStoringDecoratorTest extends Specification {
     @Subject finalizer = new IncrementalResultStoringDecorator(compiler, writer, infoUpdater)
 
     def "performs finalization"() {
+        given:
+        def result = Stub(WorkResult)
+
         when:
         finalizer.execute(compileSpec)
 
         then:
-        1 * compiler.execute(compileSpec) >> Mock(WorkResult)
-        1 * infoUpdater.updateAnalysis(compileSpec)
-        1 * writer.storeJarSnapshots(_)
-        0 * _
-    }
-
-    def "does not update if rebuild was not required"() {
-        when:
-        finalizer.execute(compileSpec)
-
-        then:
-        1 * compiler.execute(compileSpec) >> Mock(RecompilationNotNecessary)
+        1 * compiler.execute(compileSpec) >> result
+        1 * infoUpdater.updateAnalysis(compileSpec, result)
         1 * writer.storeJarSnapshots(_)
         0 * _
     }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecoratorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringDecoratorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile.incremental
 
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotWriter
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore
 import org.gradle.api.tasks.WorkResult
 import org.gradle.language.base.internal.compile.Compiler
 import spock.lang.Specification
@@ -29,8 +30,9 @@ class IncrementalResultStoringDecoratorTest extends Specification {
     def writer = Mock(JarClasspathSnapshotWriter)
     def infoUpdater = Mock(ClassSetAnalysisUpdater)
     def compileSpec = Stub(JavaCompileSpec)
+    def processorPathStore = Mock(AnnotationProcessorPathStore)
 
-    @Subject finalizer = new IncrementalResultStoringDecorator(compiler, writer, infoUpdater)
+    @Subject finalizer = new IncrementalResultStoringDecorator(compiler, writer, infoUpdater, processorPathStore)
 
     def "performs finalization"() {
         given:
@@ -43,6 +45,7 @@ class IncrementalResultStoringDecoratorTest extends Specification {
         1 * compiler.execute(compileSpec) >> result
         1 * infoUpdater.updateAnalysis(compileSpec, result)
         1 * writer.storeJarSnapshots(_)
+        1 * processorPathStore.put(_)
         0 * _
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
@@ -36,7 +36,7 @@ class ClassSetAnalysisDataSerializerTest extends Specification {
             ["A": dependents("B", "C"), "B": new DefaultDependentsSet(["C"] as Set), "C": dependents(), "D": new DependencyToAll(),],
             [C: new IntOpenHashSet([1, 2]) as IntSet, D: IntSets.EMPTY_SET]
             ,
-            ['A': ['SA'] as Set, B: ['SB1', 'SB2'] as Set]
+            ['A': ['SA'] as Set, B: ['SB1', 'SB2'] as Set], "Because"
         )
         def os = new ByteArrayOutputStream()
         def e = new OutputStreamBackedEncoder(os)
@@ -57,5 +57,6 @@ class ClassSetAnalysisDataSerializerTest extends Specification {
         read.filePathToClassName == ["A.class": "A", "B.class": "B"]
         read.classesToConstants == [C: [1,2] as Set, D: [] as Set]
         read.classesToChildren == ['A': ['SA'] as Set, B: ['SB1', 'SB2'] as Set]
+        read.fullRebuildCause == "Because"
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
@@ -26,8 +26,8 @@ class ClassSetAnalysisTest extends Specification {
 
     ClassSetAnalysis analysis(Map<String, DependentsSet> dependents,
                               Map<String, IntSet> classToConstants = [:],
-                              Map<String, Set<String>> classesToChildren = [:]) {
-        new ClassSetAnalysis(new ClassSetAnalysisData([:], dependents, classToConstants, classesToChildren))
+                              Map<String, Set<String>> classesToChildren = [:], String fullRebuildCause = null) {
+        new ClassSetAnalysis(new ClassSetAnalysisData([:], dependents, classToConstants, classesToChildren, fullRebuildCause))
     }
 
     def "returns empty analysis"() {
@@ -179,6 +179,15 @@ class ClassSetAnalysisTest extends Specification {
         !a.isDependencyToAll("A")
         a.isDependencyToAll("C")
         !a.isDependencyToAll("Unknown")
+    }
+
+    def "all classes are dependencies to all if a full rebuild cause is given"() {
+        def a = analysis(
+            [:], [:], [:], "Some cause"
+        )
+
+        expect:
+        a.isDependencyToAll("DoesNotMatter")
     }
 
     private static DependentsSet dependentSet(boolean dependencyToAll, Collection<String> dependentClasses) {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/CompilationResultAnalyzerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/CompilationResultAnalyzerTest.groovy
@@ -20,19 +20,19 @@ package org.gradle.api.internal.tasks.compile.incremental.deps
 
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassDependenciesAnalyzer
-import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassFilesAnalyzer
+import org.gradle.api.internal.tasks.compile.incremental.analyzer.CompilationResultAnalyzer
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.HashCode
 import spock.lang.Specification
 import spock.lang.Subject
 
-class ClassFilesAnalyzerTest extends Specification {
+class CompilationResultAnalyzerTest extends Specification {
 
     def classAnalyzer = Mock(ClassDependenciesAnalyzer)
     def accumulator = Mock(ClassDependentsAccumulator)
     def fileHasher = Mock(FileHasher)
-    @Subject analyzer = new ClassFilesAnalyzer(classAnalyzer, fileHasher, accumulator)
+    @Subject analyzer = new CompilationResultAnalyzer(classAnalyzer, fileHasher, accumulator)
 
     def "does not visit dirs"() {
         when: analyzer.visitDir(null)

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/IncrementalFilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/IncrementalFilerTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.processing;
+
+import spock.lang.Specification
+
+import javax.annotation.processing.Filer
+import javax.annotation.processing.Messager
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.Name
+import javax.lang.model.element.PackageElement
+import javax.lang.model.element.TypeElement
+import javax.tools.Diagnostic
+import javax.tools.StandardLocation;
+
+abstract class IncrementalFilerTest extends Specification {
+    def delegate = Stub(Filer)
+    def messager = Mock(Messager)
+    def filer
+
+    def setup() {
+        filer = createFiler(delegate, messager)
+    }
+
+    abstract Filer createFiler(Filer filer, Messager messager)
+
+    def "fails when a package element is given as an originating element"() {
+        when:
+        filer.createSourceFile("Foo", pkg("fizz"))
+
+        then:
+        1 * messager.printMessage(Diagnostic.Kind.ERROR, "Incremental annotation processors must use types (or elements contained in types) as originating elements.")
+    }
+
+    def "fails when trying to read resources"() {
+        when:
+        filer.getResource(StandardLocation.SOURCE_OUTPUT, "", "foo.txt")
+
+        then:
+        1 * messager.printMessage(Diagnostic.Kind.ERROR, "Incremental annotation processors are not allowed to read resources.")
+    }
+
+    def "fails when trying to write resources"() {
+        when:
+        filer.createResource(StandardLocation.SOURCE_OUTPUT, "", "foo.txt")
+
+        then:
+        1 * messager.printMessage(Diagnostic.Kind.ERROR, "Incremental annotation processors are not allowed to create resources.")
+    }
+
+    PackageElement pkg(String packageName) {
+        Stub(PackageElement) {
+            getEnclosingElement() >> null
+        }
+    }
+
+    TypeElement type(String typeName) {
+        Stub(TypeElement) {
+            getEnclosingElement() >> pkg("")
+            getQualifiedName() >> Stub(Name) {
+                toString() >> typeName
+            }
+        }
+    }
+
+    ExecutableElement methodInside(String typeName) {
+        Stub(ExecutableElement) {
+            getEnclosingElement() >> type(typeName)
+        }
+    }
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFilerTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.processing
+
+import javax.annotation.processing.Filer
+import javax.annotation.processing.Messager
+import javax.tools.Diagnostic
+
+class MultipleOriginFilerTest extends IncrementalFilerTest {
+
+    @Override
+    Filer createFiler(Filer filer, Messager messager) {
+        new MultipleOriginFiler(delegate, messager)
+    }
+
+    def "fails when no originating elements are given"() {
+        when:
+        filer.createSourceFile("Foo")
+
+        then:
+        1 * messager.printMessage(Diagnostic.Kind.ERROR, "Generated type 'Foo' must have at least one originating element.")
+    }
+    def "does not fail when many originating elements are given"() {
+        when:
+        filer.createSourceFile("Foo", type("Bar"), type("Baz"))
+
+        then:
+        0 * messager._
+    }
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/MultipleOriginFilerTest.groovy
@@ -16,15 +16,18 @@
 
 package org.gradle.api.internal.tasks.compile.processing
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult
+
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
 import javax.tools.Diagnostic
 
 class MultipleOriginFilerTest extends IncrementalFilerTest {
 
+
     @Override
-    Filer createFiler(Filer filer, Messager messager) {
-        new MultipleOriginFiler(delegate, messager)
+    Filer createFiler(Filer filer, AnnotationProcessingResult result, Messager messager) {
+        new MultipleOriginFiler(delegate, result, messager)
     }
 
     def "fails when no originating elements are given"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/SingleOriginFilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/SingleOriginFilerTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.compile.processing
 
+import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult
+
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
 import javax.tools.Diagnostic
@@ -23,8 +25,8 @@ import javax.tools.Diagnostic
 class SingleOriginFilerTest extends IncrementalFilerTest {
 
     @Override
-    Filer createFiler(Filer filer, Messager messager) {
-        new SingleOriginFiler(delegate, messager)
+    Filer createFiler(Filer filer, AnnotationProcessingResult result, Messager messager) {
+        new SingleOriginFiler(delegate, result, messager)
     }
 
     def "fails when no originating elements are given"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/SingleOriginFilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/SingleOriginFilerTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.processing
+
+import javax.annotation.processing.Filer
+import javax.annotation.processing.Messager
+import javax.tools.Diagnostic
+
+class SingleOriginFilerTest extends IncrementalFilerTest {
+
+    @Override
+    Filer createFiler(Filer filer, Messager messager) {
+        new SingleOriginFiler(delegate, messager)
+    }
+
+    def "fails when no originating elements are given"() {
+        when:
+        filer.createSourceFile("Foo")
+
+        then:
+        1 * messager.printMessage(Diagnostic.Kind.ERROR, "Generated type 'Foo' must have exactly one originating element, but had 0.")
+    }
+
+    def "fails when too many originating elements are given"() {
+        when:
+        filer.createSourceFile("Foo", type("Bar"), type("Baz"))
+
+        then:
+        1 * messager.printMessage(Diagnostic.Kind.ERROR, "Generated type 'Foo' must have exactly one originating element, but had 2.")
+    }
+
+    def "does not fail when all originating elements come from the same tpye"() {
+        when:
+        filer.createSourceFile("Foo", methodInside("Bar"), methodInside("Bar"))
+
+        then:
+        0 * messager._
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
@@ -17,7 +17,7 @@
 package org.gradle.workers.internal;
 
 public interface ActionExecutionSpec extends WorkSpec {
-    Class<? extends Runnable> getImplementationClass();
+    Class<?> getImplementationClass();
 
     @Override
     String getDisplayName();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
@@ -16,9 +16,11 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.reflect.Instantiator;
 
 import javax.inject.Inject;
+import java.util.concurrent.Callable;
 
 public class DefaultWorkerServer implements WorkerProtocol<ActionExecutionSpec> {
     private final Instantiator instantiator;
@@ -31,10 +33,23 @@ public class DefaultWorkerServer implements WorkerProtocol<ActionExecutionSpec> 
     @Override
     public DefaultWorkResult execute(ActionExecutionSpec spec) {
         try {
-            Class<? extends Runnable> implementationClass = spec.getImplementationClass();
-            Runnable runnable = instantiator.newInstance(implementationClass, spec.getParams(implementationClass.getClassLoader()));
-            runnable.run();
-            return new DefaultWorkResult(true, null);
+            Class<?> implementationClass = spec.getImplementationClass();
+            Object action = instantiator.newInstance(implementationClass, spec.getParams(implementationClass.getClassLoader()));
+            if (action instanceof Runnable) {
+                ((Runnable) action).run();
+                return new DefaultWorkResult(true, null);
+            } else if (action instanceof Callable) {
+                Object result = ((Callable) action).call();
+                if (result instanceof DefaultWorkResult) {
+                    return (DefaultWorkResult) result;
+                } else if (result instanceof WorkResult) {
+                    return new DefaultWorkResult(((WorkResult) result).getDidWork(), null);
+                } else {
+                    throw new IllegalArgumentException("Worker actions must return a WorkResult.");
+                }
+            } else {
+                throw new IllegalArgumentException("Worker actions must either implement Runnable or Callable<WorkResult>.");
+            }
         } catch (Throwable t) {
             return new DefaultWorkResult(true, t);
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
@@ -19,12 +19,12 @@ package org.gradle.workers.internal;
 import java.io.File;
 
 public class SimpleActionExecutionSpec implements ActionExecutionSpec {
-    private final Class<? extends Runnable> implementationClass;
+    private final Class<?> implementationClass;
     private final String displayName;
     private final File executionWorkingDir;
     private final Object[] params;
 
-    public SimpleActionExecutionSpec(Class<? extends Runnable> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
+    public SimpleActionExecutionSpec(Class<?> implementationClass, String displayName, File executionWorkingDir, Object[] params) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.executionWorkingDir = executionWorkingDir;
@@ -32,7 +32,7 @@ public class SimpleActionExecutionSpec implements ActionExecutionSpec {
     }
 
     @Override
-    public Class<? extends Runnable> getImplementationClass() {
+    public Class<?> getImplementationClass() {
         return implementationClass;
     }
 


### PR DESCRIPTION
Fixes #4132 and #4135 

This change contains the following high level changes:

1. We can now return results from the worker back to the main build, so we can extract data from the compiler without hitting the file system.
2. We extract the origin->generated type mapping from annotation processors
3. We insert a new dependency edge into our class dependency graph, so the generated file is recompiled when the origin file changes
4. We now don't just delete generated .class files, but also generated .java files
5. We now track changes to the annotation processor path, so that we still do full recompiles when it changes. This fixes a long-standing bug where we wouldn't clean up generated files when the last annotation processor was removed.
6. Some smaller refactorings