### PR TITLE
@Nullable should work like @Optional for task inputs

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
+++ b/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
@@ -41,7 +41,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
     @Option(option = "baselines", description = "A comma or semicolon separated list of Gradle versions to be used as baselines for comparing.")
-    public void setBaselines(String baselines) {
+    public void setBaselines(@Nullable String baselines) {
         this.baselines = baselines;
         systemProperty("org.gradle.performance.baselines", baselines);
     }
@@ -52,7 +52,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
     @Option(option = "warmups", description = "Number of warmups before measurements")
-    public void setWarmups(String warmups) {
+    public void setWarmups(@Nullable String warmups) {
         this.warmups = warmups;
         systemProperty("org.gradle.performance.execution.warmups", warmups);
     }
@@ -63,7 +63,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
     @Option(option = "runs", description = "Number of iterations of measurements")
-    public void setRuns(String runs) {
+    public void setRuns(@Nullable String runs) {
         this.runs = runs;
         systemProperty("org.gradle.performance.execution.runs", runs);
     }
@@ -75,7 +75,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
     @Option(option = "checks", description = "Tells which regressions to check. One of [none, speed, all]")
-    public void setChecks(String checks) {
+    public void setChecks(@Nullable String checks) {
         this.checks = checks;
         systemProperty("org.gradle.performance.execution.checks", checks);
     }
@@ -91,7 +91,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
     @Option(option = "channel", description = "Channel to use when running the performance test. By default, 'commits'.")
-    public void setChannel(String channel) {
+    public void setChannel(@Nullable String channel) {
         this.channel = channel;
         systemProperty("org.gradle.performance.execution.channel", channel);
     }

--- a/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
+++ b/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
@@ -19,7 +19,8 @@ package org.gradle.testing;
 import org.gradle.api.internal.tasks.options.Option;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.Optional;
+
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -45,7 +46,7 @@ public class PerformanceTest extends DistributionTest {
         systemProperty("org.gradle.performance.baselines", baselines);
     }
 
-    @Input @Optional
+    @Input @Nullable
     public String getBaselines() {
         return baselines;
     }
@@ -56,7 +57,7 @@ public class PerformanceTest extends DistributionTest {
         systemProperty("org.gradle.performance.execution.warmups", warmups);
     }
 
-    @Input @Optional
+    @Input @Nullable
     public String getWarmups() {
         return warmups;
     }
@@ -68,7 +69,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
 
-    @Input @Optional
+    @Input @Nullable
     public String getRuns() {
         return runs;
     }
@@ -79,12 +80,12 @@ public class PerformanceTest extends DistributionTest {
         systemProperty("org.gradle.performance.execution.checks", checks);
     }
 
-    @Input @Optional
+    @Input @Nullable
     public String getChecks() {
         return checks;
     }
 
-    @Input @Optional
+    @Input @Nullable
     public String getChannel() {
         return channel;
     }

--- a/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
+++ b/buildSrc/src/main/groovy/org/gradle/testing/PerformanceTest.java
@@ -46,7 +46,7 @@ public class PerformanceTest extends DistributionTest {
         systemProperty("org.gradle.performance.baselines", baselines);
     }
 
-    @Input @Nullable
+    @Nullable @Input
     public String getBaselines() {
         return baselines;
     }
@@ -57,7 +57,7 @@ public class PerformanceTest extends DistributionTest {
         systemProperty("org.gradle.performance.execution.warmups", warmups);
     }
 
-    @Input @Nullable
+    @Nullable @Input
     public String getWarmups() {
         return warmups;
     }
@@ -69,7 +69,7 @@ public class PerformanceTest extends DistributionTest {
     }
 
 
-    @Input @Nullable
+    @Nullable @Input
     public String getRuns() {
         return runs;
     }
@@ -80,12 +80,12 @@ public class PerformanceTest extends DistributionTest {
         systemProperty("org.gradle.performance.execution.checks", checks);
     }
 
-    @Input @Nullable
+    @Nullable @Input
     public String getChecks() {
         return checks;
     }
 
-    @Input @Nullable
+    @Nullable @Input
     public String getChannel() {
         return channel;
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -378,8 +378,8 @@ public class Wrapper extends DefaultTask {
      * @since 4.5
      */
     @Incubating
-    @Input
     @Nullable
+    @Input
     public String getDistributionSha256Sum() {
         return distributionSha256Sum;
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.archive.ZipCopyAction;
 import org.gradle.api.internal.plugins.StartScriptGenerator;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
@@ -41,6 +40,7 @@ import org.gradle.wrapper.GradleWrapperMain;
 import org.gradle.wrapper.Install;
 import org.gradle.wrapper.WrapperExecutor;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -379,7 +379,7 @@ public class Wrapper extends DefaultTask {
      */
     @Incubating
     @Input
-    @Optional
+    @Nullable
     public String getDistributionSha256Sum() {
         return distributionSha256Sum;
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -397,7 +397,7 @@ public class Wrapper extends DefaultTask {
      */
     @Incubating
     @Option(option = "gradle-distribution-sha256-sum", description = "The SHA-256 hash sum of the gradle distribution.")
-    public void setDistributionSha256Sum(String distributionSha256Sum) {
+    public void setDistributionSha256Sum(@Nullable String distributionSha256Sum) {
         this.distributionSha256Sum = distributionSha256Sum;
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -68,7 +68,6 @@ public class InitBuild extends DefaultTask {
      * @since 4.5
      */
     @Incubating
-    @Nullable
     @Input
     public String getDsl() {
         return isNullOrEmpty(dsl) ? BuildInitDsl.GROOVY.getId() : dsl;
@@ -152,7 +151,7 @@ public class InitBuild extends DefaultTask {
     }
 
     @Option(option = "test-framework", description = "Set alternative test framework to be used.")
-    public void setTestFramework(String testFramework) {
+    public void setTestFramework(@Nullable String testFramework) {
         this.testFramework = testFramework;
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -24,7 +24,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.options.OptionValues;
@@ -34,6 +33,7 @@ import org.gradle.buildinit.plugins.internal.ProjectLayoutSetupRegistry;
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl;
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -68,7 +68,7 @@ public class InitBuild extends DefaultTask {
      * @since 4.5
      */
     @Incubating
-    @Optional
+    @Nullable
     @Input
     public String getDsl() {
         return isNullOrEmpty(dsl) ? BuildInitDsl.GROOVY.getId() : dsl;
@@ -79,7 +79,7 @@ public class InitBuild extends DefaultTask {
      *
      * This property can be set via command-line option '--test-framework'
      */
-    @Optional
+    @Nullable
     @Input
     public String getTestFramework() {
         return testFramework;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -231,7 +231,7 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
     /**
      * The properties available for use in the configuration file. These are substituted into the configuration file.
      */
-    public void setConfigProperties(Map<String, Object> configProperties) {
+    public void setConfigProperties(@Nullable Map<String, Object> configProperties) {
         this.configProperties = configProperties;
     }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -37,13 +37,13 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.LinkedHashMap;
@@ -223,7 +223,7 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      * The properties available for use in the configuration file. These are substituted into the configuration file.
      */
     @Input
-    @Optional
+    @Nullable
     public Map<String, Object> getConfigProperties() {
         return configProperties;
     }
@@ -246,7 +246,7 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
     @Incubating
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    @Optional
+    @Nullable
     public File getConfigDir() {
         File configDirectory = configDir.getOrNull();
         if (configDirectory!=null && configDirectory.exists()) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -222,8 +222,8 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
     /**
      * The properties available for use in the configuration file. These are substituted into the configuration file.
      */
-    @Input
     @Nullable
+    @Input
     public Map<String, Object> getConfigProperties() {
         return configProperties;
     }
@@ -244,9 +244,9 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      * @since 4.0
      */
     @Incubating
+    @Nullable
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    @Nullable
     public File getConfigDir() {
         File configDirectory = configDir.getOrNull();
         if (configDirectory!=null && configDirectory.exists()) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -44,7 +44,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -54,6 +53,7 @@ import org.gradle.api.tasks.VerificationTask;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -456,7 +456,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * and memory consumption.
      */
     @Input
-    @Optional
+    @Nullable
     public String getEffort() {
         return effort;
     }
@@ -474,7 +474,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * high}, only high priority bugs are reported.
      */
     @Input
-    @Optional
+    @Nullable
     public String getReportLevel() {
         return reportLevel;
     }
@@ -491,7 +491,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The maximum heap size for the forked findbugs process (ex: '1g').
      */
     @Input
-    @Optional
+    @Nullable
     public String getMaxHeapSize() {
         return maxHeapSize;
     }
@@ -508,7 +508,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * run.
      */
     @Input
-    @Optional
+    @Nullable
     public Collection<String> getVisitors() {
         return visitors;
     }
@@ -525,7 +525,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * Similar to {@code visitors} except that it specifies bug detectors which should not be run. By default, no visitors are omitted.
      */
     @Input
-    @Optional
+    @Nullable
     public Collection<String> getOmitVisitors() {
         return omitVisitors;
     }
@@ -544,7 +544,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      */
     @Incubating
     @Nested
-    @Optional
+    @Nullable
     public TextResource getIncludeFilterConfig() {
         return includeFilterConfig;
     }
@@ -566,7 +566,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      */
     @Incubating
     @Nested
-    @Optional
+    @Nullable
     public TextResource getExcludeFilterConfig() {
         return excludeFilterConfig;
     }
@@ -588,7 +588,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      */
     @Incubating
     @Nested
-    @Optional
+    @Nullable
     public TextResource getExcludeBugsFilterConfig() {
         return excludeBugsFilterConfig;
     }
@@ -612,7 +612,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.6
      */
     @Input
-    @Optional
+    @Nullable
     public Collection<String> getExtraArgs() {
         return extraArgs;
     }
@@ -635,7 +635,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 4.2
      */
     @Input
-    @Optional
+    @Nullable
     public boolean getShowProgress() {
         return showProgress;
     }
@@ -657,7 +657,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 4.3
      */
     @Input
-    @Optional
+    @Nullable
     @Incubating
     public Collection<String> getJvmArgs() {
         return jvmArgs;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -465,7 +465,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The analysis effort level. The value specified should be one of {@code min}, {@code default}, or {@code max}. Higher levels increase precision and find more bugs at the expense of running time
      * and memory consumption.
      */
-    public void setEffort(String effort) {
+    public void setEffort(@Nullable String effort) {
         this.effort = effort;
     }
 
@@ -483,7 +483,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The priority threshold for reporting bugs. If set to {@code low}, all bugs are reported. If set to {@code medium} (the default), medium and high priority bugs are reported. If set to {@code
      * high}, only high priority bugs are reported.
      */
-    public void setReportLevel(String reportLevel) {
+    public void setReportLevel(@Nullable String reportLevel) {
         this.reportLevel = reportLevel;
     }
 
@@ -499,7 +499,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     /**
      * The maximum heap size for the forked findbugs process (ex: '1g').
      */
-    public void setMaxHeapSize(String maxHeapSize) {
+    public void setMaxHeapSize(@Nullable String maxHeapSize) {
         this.maxHeapSize = maxHeapSize;
     }
 
@@ -517,7 +517,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The bug detectors which should be run. The bug detectors are specified by their class names, without any package qualification. By default, all detectors which are not disabled by default are
      * run.
      */
-    public void setVisitors(Collection<String> visitors) {
+    public void setVisitors(@Nullable Collection<String> visitors) {
         this.visitors = visitors;
     }
 
@@ -533,7 +533,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     /**
      * Similar to {@code visitors} except that it specifies bug detectors which should not be run. By default, no visitors are omitted.
      */
-    public void setOmitVisitors(Collection<String> omitVisitors) {
+    public void setOmitVisitors(@Nullable Collection<String> omitVisitors) {
         this.omitVisitors = omitVisitors;
     }
 
@@ -555,7 +555,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.2
      */
     @Incubating
-    public void setIncludeFilterConfig(TextResource includeFilterConfig) {
+    public void setIncludeFilterConfig(@Nullable TextResource includeFilterConfig) {
         this.includeFilterConfig = includeFilterConfig;
     }
 
@@ -577,7 +577,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.2
      */
     @Incubating
-    public void setExcludeFilterConfig(TextResource excludeFilterConfig) {
+    public void setExcludeFilterConfig(@Nullable TextResource excludeFilterConfig) {
         this.excludeFilterConfig = excludeFilterConfig;
     }
 
@@ -599,7 +599,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.4
      */
     @Incubating
-    public void setExcludeBugsFilterConfig(TextResource excludeBugsFilterConfig) {
+    public void setExcludeBugsFilterConfig(@Nullable TextResource excludeBugsFilterConfig) {
         this.excludeBugsFilterConfig = excludeBugsFilterConfig;
     }
 
@@ -625,7 +625,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      *
      * @since 2.6
      */
-    public void setExtraArgs(Collection<String> extraArgs) {
+    public void setExtraArgs(@Nullable Collection<String> extraArgs) {
         this.extraArgs = extraArgs;
     }
 
@@ -634,7 +634,6 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      *
      * @since 4.2
      */
-    @Nullable
     @Input
     public boolean getShowProgress() {
         return showProgress;
@@ -671,7 +670,7 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 4.3
      */
     @Incubating
-    public void setJvmArgs(Collection<String> jvmArgs) {
+    public void setJvmArgs(@Nullable Collection<String> jvmArgs) {
         this.jvmArgs = jvmArgs;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -455,8 +455,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The analysis effort level. The value specified should be one of {@code min}, {@code default}, or {@code max}. Higher levels increase precision and find more bugs at the expense of running time
      * and memory consumption.
      */
-    @Input
     @Nullable
+    @Input
     public String getEffort() {
         return effort;
     }
@@ -473,8 +473,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The priority threshold for reporting bugs. If set to {@code low}, all bugs are reported. If set to {@code medium} (the default), medium and high priority bugs are reported. If set to {@code
      * high}, only high priority bugs are reported.
      */
-    @Input
     @Nullable
+    @Input
     public String getReportLevel() {
         return reportLevel;
     }
@@ -490,8 +490,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     /**
      * The maximum heap size for the forked findbugs process (ex: '1g').
      */
-    @Input
     @Nullable
+    @Input
     public String getMaxHeapSize() {
         return maxHeapSize;
     }
@@ -507,8 +507,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * The bug detectors which should be run. The bug detectors are specified by their class names, without any package qualification. By default, all detectors which are not disabled by default are
      * run.
      */
-    @Input
     @Nullable
+    @Input
     public Collection<String> getVisitors() {
         return visitors;
     }
@@ -524,8 +524,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     /**
      * Similar to {@code visitors} except that it specifies bug detectors which should not be run. By default, no visitors are omitted.
      */
-    @Input
     @Nullable
+    @Input
     public Collection<String> getOmitVisitors() {
         return omitVisitors;
     }
@@ -543,8 +543,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.2
      */
     @Incubating
-    @Nested
     @Nullable
+    @Nested
     public TextResource getIncludeFilterConfig() {
         return includeFilterConfig;
     }
@@ -565,8 +565,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.2
      */
     @Incubating
-    @Nested
     @Nullable
+    @Nested
     public TextResource getExcludeFilterConfig() {
         return excludeFilterConfig;
     }
@@ -587,8 +587,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      * @since 2.4
      */
     @Incubating
-    @Nested
     @Nullable
+    @Nested
     public TextResource getExcludeBugsFilterConfig() {
         return excludeBugsFilterConfig;
     }
@@ -611,8 +611,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      *
      * @since 2.6
      */
-    @Input
     @Nullable
+    @Input
     public Collection<String> getExtraArgs() {
         return extraArgs;
     }
@@ -634,8 +634,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      *
      * @since 4.2
      */
-    @Input
     @Nullable
+    @Input
     public boolean getShowProgress() {
         return showProgress;
     }
@@ -656,8 +656,8 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
      *
      * @since 4.3
      */
-    @Input
     @Nullable
+    @Input
     @Incubating
     public Collection<String> getJvmArgs() {
         return jvmArgs;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -210,7 +210,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * @since 2.2
      */
     @Incubating
-    public void setRuleSetConfig(TextResource ruleSetConfig) {
+    public void setRuleSetConfig(@Nullable TextResource ruleSetConfig) {
         this.ruleSetConfig = ruleSetConfig;
     }
 
@@ -332,7 +332,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * @since 2.8
      */
     @Incubating
-    public void setClasspath(FileCollection classpath) {
+    public void setClasspath(@Nullable FileCollection classpath) {
         this.classpath = classpath;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -194,8 +194,8 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * @since 2.2
      */
     @Incubating
-    @Nested
     @Nullable
+    @Nested
     public TextResource getRuleSetConfig() {
         return ruleSetConfig;
     }
@@ -315,8 +315,8 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      *
      * @since 2.8
      */
-    @Classpath
     @Nullable
+    @Classpath
     @Incubating
     public FileCollection getClasspath() {
         return classpath;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -34,7 +34,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
@@ -44,6 +43,7 @@ import org.gradle.internal.nativeintegration.console.ConsoleDetector;
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 
@@ -195,7 +195,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      */
     @Incubating
     @Nested
-    @Optional
+    @Nullable
     public TextResource getRuleSetConfig() {
         return ruleSetConfig;
     }
@@ -316,7 +316,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * @since 2.8
      */
     @Classpath
-    @Optional
+    @Nullable
     @Incubating
     public FileCollection getClasspath() {
         return classpath;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
@@ -20,13 +20,14 @@ import org.gradle.api.plugins.quality.FindBugsReports;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
+
+import javax.annotation.Nullable;
 
 public interface FindBugsReportsInternal extends FindBugsReports {
     @Internal
     SingleFileReport getFirstEnabled();
 
     @Input
-    @Optional
+    @Nullable
     Boolean getWithMessagesFlag();
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
@@ -21,13 +21,10 @@ import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
-import javax.annotation.Nullable;
-
 public interface FindBugsReportsInternal extends FindBugsReports {
     @Internal
     SingleFileReport getFirstEnabled();
 
-    @Nullable
     @Input
     Boolean getWithMessagesFlag();
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
@@ -27,7 +27,7 @@ public interface FindBugsReportsInternal extends FindBugsReports {
     @Internal
     SingleFileReport getFirstEnabled();
 
-    @Input
     @Nullable
+    @Input
     Boolean getWithMessagesFlag();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/resources/TextResource.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/resources/TextResource.java
@@ -21,12 +21,12 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.HasInternalProtocol;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Reader;
 
@@ -77,7 +77,7 @@ public interface TextResource extends Buildable {
      * @return the input properties registered when this resource is used as task input
      */
     @Input
-    @Optional
+    @Nullable
     Object getInputProperties();
 
     /**
@@ -88,7 +88,7 @@ public interface TextResource extends Buildable {
      */
     @PathSensitive(PathSensitivity.NONE)
     @InputFiles
-    @Optional
+    @Nullable
     FileCollection getInputFiles();
 
     @Internal

--- a/subprojects/core-api/src/main/java/org/gradle/api/resources/TextResource.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/resources/TextResource.java
@@ -76,8 +76,8 @@ public interface TextResource extends Buildable {
      *
      * @return the input properties registered when this resource is used as task input
      */
-    @Input
     @Nullable
+    @Input
     Object getInputProperties();
 
     /**
@@ -86,9 +86,9 @@ public interface TextResource extends Buildable {
      *
      * @return the input files registered when this resource is used as task input
      */
+    @Nullable
     @PathSensitive(PathSensitivity.NONE)
     @InputFiles
-    @Nullable
     FileCollection getInputFiles();
 
     @Internal

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -41,7 +41,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      *
      * @return this
      */
-    JavaExecSpec setMain(String main);
+    JavaExecSpec setMain(@Nullable String main);
 
     /**
      * Returns the arguments passed to the main class to be executed.
@@ -75,7 +75,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      * @return this
      * @since 4.0
      */
-    JavaExecSpec setArgs(List<String> args);
+    JavaExecSpec setArgs(@Nullable List<String> args);
 
     /**
      * Sets the args for the main class to be executed.
@@ -84,7 +84,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      *
      * @return this
      */
-    JavaExecSpec setArgs(Iterable<?> args);
+    JavaExecSpec setArgs(@Nullable Iterable<?> args);
 
     /**
      * Argument providers for the application.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -20,8 +20,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -31,7 +31,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
     /**
      * Returns the fully qualified name of the Main class to be executed.
      */
-    @Optional @Input
+    @Nullable @Input
     String getMain();
 
     /**
@@ -46,7 +46,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
     /**
      * Returns the arguments passed to the main class to be executed.
      */
-    @Optional @Input
+    @Nullable @Input
     List<String> getArgs();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -82,7 +82,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @param defaultCharacterEncoding The default character encoding. Use null to use {@link java.nio.charset.Charset#defaultCharset() this JVM's default charset}
      */
-     void setDefaultCharacterEncoding(String defaultCharacterEncoding);
+     void setDefaultCharacterEncoding(@Nullable String defaultCharacterEncoding);
 
     /**
      * Returns the minimum heap size for the process, if any.
@@ -97,7 +97,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @param heapSize The minimum heap size. Use null for the default minimum heap size.
      */
-    void setMinHeapSize(String heapSize);
+    void setMinHeapSize(@Nullable String heapSize);
 
     /**
      * Returns the maximum heap size for the process, if any.
@@ -112,7 +112,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @param heapSize The heap size. Use null for the default maximum heap size.
      */
-    void setMaxHeapSize(String heapSize);
+    void setMaxHeapSize(@Nullable String heapSize);
 
     /**
      * Returns the extra arguments to use to launch the JVM for the process. Does not include system properties and the
@@ -130,7 +130,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * @param arguments The arguments. Must not be null.
      * @since 4.0
      */
-    void setJvmArgs(List<String> arguments);
+    void setJvmArgs(@Nullable List<String> arguments);
 
     /**
      * Sets the extra arguments to use to launch the JVM for the process. System properties
@@ -138,7 +138,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @param arguments The arguments. Must not be null.
      */
-    void setJvmArgs(Iterable<?> arguments);
+    void setJvmArgs(@Nullable Iterable<?> arguments);
 
     /**
      * Adds some arguments to use to launch the JVM for the process.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -22,9 +22,9 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.HasInternalProtocol;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +70,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @return The default character encoding. Returns null if the {@link java.nio.charset.Charset#defaultCharset() default character encoding of this JVM} should be used.
      */
-     @Optional @Input
+    @Nullable @Input
      String getDefaultCharacterEncoding();
 
     /**
@@ -89,7 +89,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @return The minimum heap size. Returns null if the default minimum heap size should be used.
      */
-    @Optional @Input
+    @Nullable @Input
     String getMinHeapSize();
 
     /**
@@ -104,7 +104,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @return The maximum heap size. Returns null if the default maximum heap size should be used.
      */
-    @Optional @Input
+    @Nullable @Input
     String getMaxHeapSize();
 
     /**
@@ -120,7 +120,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @return The arguments. Returns an empty list if there are no arguments.
      */
-    @Optional @Input
+    @Nullable @Input
     List<String> getJvmArgs();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -21,13 +21,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedBuildScanPlugin
 import spock.lang.Unroll
+
+import javax.annotation.Nullable
 
 @Unroll
 class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec {
@@ -262,7 +263,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 }   
 
                 @$Nested.name
-                @$Optional.name
+                @$Nullable.name
                 Object bean
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyMetadataStore.java
@@ -142,6 +142,7 @@ public class DefaultPropertyMetadataStore implements PropertyMetadataStore {
         return ImmutableSet.<Class<? extends Annotation>>builder()
             .addAll(propertyTypeAnnotations)
             .add(Optional.class)
+            .add(Nullable.class)
             .add(SkipWhenEmpty.class)
             .add(PathSensitive.class)
             .build();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyMetadataStore.java
@@ -22,6 +22,7 @@ import com.google.common.base.Predicate;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
@@ -102,6 +103,12 @@ public class DefaultPropertyMetadataStore implements PropertyMetadataStore {
         new NoOpPropertyAnnotationHandler(Internal.class),
         new NoOpPropertyAnnotationHandler(OptionValues.class)
     );
+    private static final Predicate<Annotation> NOT_NULLABLE = new Predicate<Annotation>() {
+        @Override
+        public boolean apply(Annotation input) {
+            return !input.annotationType().equals(Nullable.class);
+        }
+    };
 
     private final Map<Class<? extends Annotation>, PropertyAnnotationHandler> annotationHandlers;
     private final Multimap<Class<? extends Annotation>, Class<? extends Annotation>> annotationOverrides;
@@ -198,7 +205,8 @@ public class DefaultPropertyMetadataStore implements PropertyMetadataStore {
 
     private Iterable<Annotation> mergeDeclaredAnnotations(Method method, @Nullable Field field, DefaultPropertyMetadata propertyContext) {
         Collection<Annotation> methodAnnotations = collectRelevantAnnotations(method.getDeclaredAnnotations());
-        if (Modifier.isPrivate(method.getModifiers()) && !methodAnnotations.isEmpty()) {
+        Collection<Annotation> methodAnnotationsWithoutNullable = Collections2.filter(methodAnnotations, NOT_NULLABLE);
+        if (Modifier.isPrivate(method.getModifiers()) && !methodAnnotationsWithoutNullable.isEmpty()) {
             propertyContext.validationMessage("is private and annotated with an input or output annotation");
         }
         if (field == null) {
@@ -212,7 +220,7 @@ public class DefaultPropertyMetadataStore implements PropertyMetadataStore {
             return fieldAnnotations;
         }
 
-        for (Annotation methodAnnotation : methodAnnotations) {
+        for (Annotation methodAnnotation : methodAnnotationsWithoutNullable) {
             Iterator<Annotation> iFieldAnnotation = fieldAnnotations.iterator();
             while (iFieldAnnotation.hasNext()) {
                 Annotation fieldAnnotation = iFieldAnnotation.next();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyWalker.java
@@ -130,7 +130,7 @@ public class DefaultPropertyWalker implements PropertyWalker {
 
         @Override
         public boolean isOptional() {
-            return isAnnotationPresent(Optional.class);
+            return isAnnotationPresent(Optional.class) || isAnnotationPresent(Nullable.class);
         }
 
         @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -105,7 +105,7 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
      * {@inheritDoc}
      */
     @Override
-    public T setArgs(Iterable<?> arguments) {
+    public T setArgs(@Nullable Iterable<?> arguments) {
         execAction.setArgs(arguments);
         return taskType.cast(this);
     }
@@ -176,7 +176,7 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
      * {@inheritDoc}
      */
     @Override
-    public void setExecutable(String executable) {
+    public void setExecutable(@Nullable String executable) {
         execAction.setExecutable(executable);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -23,6 +23,7 @@ import org.gradle.process.ProcessForkOptions;
 import org.gradle.process.internal.ExecAction;
 import org.gradle.process.internal.ExecActionFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.InputStream;
@@ -112,7 +113,8 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     /**
      * {@inheritDoc}
      */
-    @Optional @Input
+    @Nullable
+    @Input
     @Override
     public List<String> getArgs() {
         return execAction.getArgs();
@@ -163,7 +165,8 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     /**
      * {@inheritDoc}
      */
-    @Optional @Input
+    @Nullable
+    @Input
     @Override
     public String getExecutable() {
         return execAction.getExecutable();

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
@@ -104,7 +104,7 @@ public class GradleBuild extends ConventionTask {
      * @param file The build file. May be null to use the default build file for the build.
      * @since 4.0
      */
-    public void setBuildFile(File file) {
+    public void setBuildFile(@Nullable File file) {
         setBuildFile((Object) file);
     }
 
@@ -113,7 +113,7 @@ public class GradleBuild extends ConventionTask {
      *
      * @param file The build file. May be null to use the default build file for the build.
      */
-    public void setBuildFile(Object file) {
+    public void setBuildFile(@Nullable Object file) {
         getStartParameter().setBuildFile(getProject().file(file));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.invocation.BuildController;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
@@ -92,7 +93,7 @@ public class GradleBuild extends ConventionTask {
      *
      * @return The build file. May be null.
      */
-    @Optional @InputFile
+    @Nullable @InputFile
     public File getBuildFile() {
         return getStartParameter().getBuildFile();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -26,6 +26,7 @@ import org.gradle.process.ProcessForkOptions;
 import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.JavaExecAction;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.InputStream;
@@ -352,7 +353,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     /**
      * {@inheritDoc}
      */
-    @Optional @Input
+    @Nullable @Input
     public String getExecutable() {
         return javaExecHandleBuilder.getExecutable();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -24,6 +24,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.util.PropertiesUtils;
 
+import javax.annotation.Nullable;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -154,7 +155,7 @@ public class WriteProperties extends DefaultTask {
      * Returns the optional comment to add at the beginning of the properties file.
      */
     @Input
-    @Optional
+    @Nullable
     public String getComment() {
         return comment;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -154,8 +154,8 @@ public class WriteProperties extends DefaultTask {
     /**
      * Returns the optional comment to add at the beginning of the properties file.
      */
-    @Input
     @Nullable
+    @Input
     public String getComment() {
         return comment;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -163,7 +163,7 @@ public class WriteProperties extends DefaultTask {
     /**
      * Sets the optional comment to add at the beginning of the properties file.
      */
-    public void setComment(String comment) {
+    public void setComment(@Nullable String comment) {
         this.comment = comment;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
@@ -25,8 +25,8 @@ import org.gradle.api.internal.file.copy.DefaultZipCompressor;
 import org.gradle.api.internal.file.copy.ZipCompressor;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 
+import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 
 /**
@@ -119,7 +119,7 @@ public class Zip extends AbstractArchiveTask {
      * @since 2.14
      */
     @Incubating
-    @Input @Optional
+    @Input @Nullable
     public String getMetadataCharset() {
         return this.metadataCharset;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
@@ -119,7 +119,7 @@ public class Zip extends AbstractArchiveTask {
      * @since 2.14
      */
     @Incubating
-    @Input @Nullable
+    @Nullable @Input
     public String getMetadataCharset() {
         return this.metadataCharset;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleApiSpecProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleApiSpecProvider.java
@@ -33,6 +33,7 @@ public class DefaultGradleApiSpecProvider extends GradleApiSpecProvider.SpecAdap
             "org.slf4j",
             "org.apache.commons.logging",
             "org.apache.log4j",
+            "javax.annotation",
             "javax.inject");
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -209,11 +209,17 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         where:
         type                                      | property
         TaskWithOptionalInputFile                 | 'input-file'
+        TaskWithNullableInputFile                 | 'input-file'
         TaskWithOptionalOutputFile                | 'output-file'
+        TaskWithNullableOutputFile                | 'output-file'
         TaskWithOptionalOutputFiles               | 'output-files'
+        TaskWithNullableOutputFiles               | 'output-files'
         TaskWithOptionalOutputDir                 | 'output-dir'
+        TaskWithNullableOutputDir                 | 'output-dir'
         TaskWithOptionalOutputDirs                | 'output-dirs'
+        TaskWithNullableOutputDirs                | 'output-dirs'
         TaskWithOptionalNestedBean                | 'bean'
+        TaskWithNullableNestedBean                | 'bean'
         TaskWithOptionalNestedBeanWithPrivateType | 'private-bean'
         arguments = type == TaskWithOptionalNestedBean ? [null] : []
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -307,10 +308,25 @@ public class AnnotationProcessingTasks {
         }
     }
 
+    public static class TaskWithNullableOutputFile extends TaskWithAction {
+        @OutputFile
+        @Nullable
+        public File getOutputFile() {
+            return null;
+        }
+    }
+
     public static class TaskWithOptionalOutputFiles extends TaskWithAction {
-        @SuppressWarnings("deprecation")
         @OutputFiles
         @org.gradle.api.tasks.Optional
+        public List<File> getOutputFiles() {
+            return null;
+        }
+    }
+
+    public static class TaskWithNullableOutputFiles extends TaskWithAction {
+        @OutputFiles
+        @Nullable
         public List<File> getOutputFiles() {
             return null;
         }
@@ -351,10 +367,27 @@ public class AnnotationProcessingTasks {
         }
     }
 
+    public static class TaskWithNullableOutputDir extends TaskWithAction {
+        @OutputDirectory
+        @Nullable
+        public File getOutputDir() {
+            return null;
+        }
+    }
+
     public static class TaskWithOptionalOutputDirs extends TaskWithAction {
         @SuppressWarnings("deprecation")
         @OutputDirectories
         @org.gradle.api.tasks.Optional
+        public File getOutputDirs() {
+            return null;
+        }
+
+    }
+
+    public static class TaskWithNullableOutputDirs extends TaskWithAction {
+        @OutputDirectories
+        @Nullable
         public File getOutputDirs() {
             return null;
         }
@@ -393,6 +426,14 @@ public class AnnotationProcessingTasks {
     public static class TaskWithOptionalInputFile extends TaskWithAction {
         @InputFile
         @org.gradle.api.tasks.Optional
+        public File getInputFile() {
+            return null;
+        }
+    }
+
+    public static class TaskWithNullableInputFile extends TaskWithAction {
+        @InputFile
+        @Nullable
         public File getInputFile() {
             return null;
         }
@@ -491,6 +532,20 @@ public class AnnotationProcessingTasks {
 
         @Nested
         @org.gradle.api.tasks.Optional
+        public Bean getBean() {
+            return bean;
+        }
+    }
+
+    public static class TaskWithNullableNestedBean extends TaskWithAction {
+        private final Bean bean;
+
+        public TaskWithNullableNestedBean(Bean bean) {
+            this.bean = bean;
+        }
+
+        @Nested
+        @Nullable
         public Bean getBean() {
             return bean;
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyMetadataStoreTest.groovy
@@ -326,6 +326,7 @@ class DefaultPropertyMetadataStoreTest extends Specification {
             'Input'
         }
 
+        @Nullable
         @OutputFile
         private File getOutputFile() {
             null
@@ -347,6 +348,23 @@ class DefaultPropertyMetadataStoreTest extends Specification {
             "is private and annotated with an input or output annotation",
             "is private and annotated with an input or output annotation",
         ]
+    }
+
+    class TaskWithNullableOnPrivateProperties extends DefaultTask {
+        @Nullable
+        private String getNullable() {
+            'Input'
+        }
+    }
+
+    def "@Nullable on private properties is no validation error"() {
+        def metadataStore = new DefaultPropertyMetadataStore([new ClasspathPropertyAnnotationHandler()])
+
+        when:
+        def metadata = metadataStore.getTypeMetadata(TaskWithNullableOnPrivateProperties).propertiesMetadata
+
+        then:
+        metadata*.validationMessages.flatten().empty
     }
 
     class TaskWithConflictingPropertyTypes extends DefaultTask {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
@@ -110,7 +110,7 @@ public abstract class AbstractReportTask extends ConventionTask {
      *
      * @param outputFile The output file. May be null.
      */
-    public void setOutputFile(File outputFile) {
+    public void setOutputFile(@Nullable File outputFile) {
         this.outputFile = outputFile;
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
@@ -99,8 +99,8 @@ public abstract class AbstractReportTask extends ConventionTask {
      *
      * @return The output file. May be null.
      */
-    @OutputFile
     @Nullable
+    @OutputFile
     public File getOutputFile() {
         return outputFile;
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
@@ -20,7 +20,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.diagnostics.internal.ProjectReportGenerator;
@@ -30,6 +29,7 @@ import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -100,7 +100,7 @@ public abstract class AbstractReportTask extends ConventionTask {
      * @return The output file. May be null.
      */
     @OutputFile
-    @Optional
+    @Nullable
     public File getOutputFile() {
         return outputFile;
     }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -215,7 +215,7 @@ public class Ear extends Jar {
         return libDirName;
     }
 
-    public void setLibDirName(String libDirName) {
+    public void setLibDirName(@Nullable String libDirName) {
         this.libDirName = libDirName;
     }
 

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.EarModule;
@@ -38,6 +37,7 @@ import org.gradle.plugins.ear.descriptor.internal.DefaultEarWebModule;
 import org.gradle.util.ConfigureUtil;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -209,7 +209,7 @@ public class Ear extends Jar {
     /**
      * The name of the library directory in the EAR file. Default is "lib".
      */
-    @Optional
+    @Nullable
     @Input
     public String getLibDirName() {
         return libDirName;

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
@@ -22,7 +22,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.ide.visualstudio.VisualStudioProject;
 import org.gradle.ide.visualstudio.internal.DefaultVisualStudioProject;
 import org.gradle.ide.visualstudio.internal.VisualStudioProjectConfiguration;
@@ -31,6 +30,7 @@ import org.gradle.ide.visualstudio.tasks.internal.VisualStudioProjectFile;
 import org.gradle.plugins.ide.api.XmlGeneratorTask;
 import org.gradle.plugins.ide.internal.IdePlugin;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.concurrent.Callable;
 
@@ -140,7 +140,7 @@ public class GenerateProjectFileTask extends XmlGeneratorTask<VisualStudioProjec
     }
 
     @Input
-    @Optional
+    @Nullable
     public String getGradleArgs() {
         return gradleArgs;
     }

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
@@ -139,8 +139,8 @@ public class GenerateProjectFileTask extends XmlGeneratorTask<VisualStudioProjec
         this.gradleExe = gradleExe;
     }
 
-    @Input
     @Nullable
+    @Input
     public String getGradleArgs() {
         return gradleArgs;
     }

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
@@ -145,7 +145,7 @@ public class GenerateProjectFileTask extends XmlGeneratorTask<VisualStudioProjec
         return gradleArgs;
     }
 
-    public void setGradleArgs(String gradleArgs) {
+    public void setGradleArgs(@Nullable String gradleArgs) {
         this.gradleArgs = gradleArgs;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
@@ -116,7 +116,7 @@ public class GeneratorTask<T> extends ConventionTask {
      *
      * @param inputFile The input file. Use null to use the output file.
      */
-    public void setInputFile(File inputFile) {
+    public void setInputFile(@Nullable File inputFile) {
         this.inputFile = inputFile;
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
@@ -20,13 +20,13 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.ide.internal.generator.generator.Generator;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 
@@ -101,7 +101,7 @@ public class GeneratorTask<T> extends ConventionTask {
     }
 
     // Workaround for when the task is given an input file that doesn't exist
-    @Optional @InputFile
+    @Nullable @InputFile
     protected File getInputFileIfExists() {
         File inputFile = getInputFile();
         if (inputFile != null && inputFile.exists()) {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -26,12 +26,12 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.internal.jacoco.JacocoAgentJar;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaForkOptions;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collections;
 import java.util.concurrent.Callable;
@@ -143,7 +143,7 @@ public class JacocoPluginExtension {
         }
 
         @Nested
-        @Optional
+        @Nullable
         public JacocoTaskExtension getJacoco() {
             return jacoco.isEnabled() ? jacoco : null;
         }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -142,8 +142,8 @@ public class JacocoPluginExtension {
             this.jacoco = jacoco;
         }
 
-        @Nested
         @Nullable
+        @Nested
         public JacocoTaskExtension getJacoco() {
             return jacoco.isEnabled() ? jacoco : null;
         }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -148,7 +148,7 @@ public class JacocoTaskExtension {
         return includes;
     }
 
-    public void setIncludes(List<String> includes) {
+    public void setIncludes(@Nullable List<String> includes) {
         this.includes = includes;
     }
 
@@ -161,7 +161,7 @@ public class JacocoTaskExtension {
         return excludes;
     }
 
-    public void setExcludes(List<String> excludes) {
+    public void setExcludes(@Nullable List<String> excludes) {
         this.excludes = excludes;
     }
 
@@ -174,7 +174,7 @@ public class JacocoTaskExtension {
         return excludeClassLoaders;
     }
 
-    public void setExcludeClassLoaders(List<String> excludeClassLoaders) {
+    public void setExcludeClassLoaders(@Nullable List<String> excludeClassLoaders) {
         this.excludeClassLoaders = excludeClassLoaders;
     }
 
@@ -201,7 +201,7 @@ public class JacocoTaskExtension {
         return sessionId;
     }
 
-    public void setSessionId(String sessionId) {
+    public void setSessionId(@Nullable String sessionId) {
         this.sessionId = sessionId;
     }
 
@@ -238,14 +238,13 @@ public class JacocoTaskExtension {
         return address;
     }
 
-    public void setAddress(String address) {
+    public void setAddress(@Nullable String address) {
         this.address = address;
     }
 
     /**
      * Port to bind to for {@link Output#TCP_SERVER} or {@link Output#TCP_CLIENT}. Defaults to 6300.
      */
-    @Nullable
     @Input
     public int getPort() {
         return port;
@@ -271,7 +270,7 @@ public class JacocoTaskExtension {
      *
      * @since 3.4
      */
-    public void setClassDumpDir(File classDumpDir) {
+    public void setClassDumpDir(@Nullable File classDumpDir) {
         this.classDumpDir = classDumpDir;
     }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -27,12 +27,12 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.LocalState;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.internal.jacoco.JacocoAgentJar;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.RelativePathUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -108,7 +108,7 @@ public class JacocoTaskExtension {
      * The path for the execution data to be written to.
      */
     @OutputFile
-    @Optional
+    @Nullable
     public File getDestinationFile() {
         return destinationFile.getOrNull();
     }
@@ -143,7 +143,7 @@ public class JacocoTaskExtension {
      * List of class names that should be included in analysis. Names can use wildcards (* and ?). If left empty, all classes will be included. Defaults to an empty list.
      */
     @Input
-    @Optional
+    @Nullable
     public List<String> getIncludes() {
         return includes;
     }
@@ -156,7 +156,7 @@ public class JacocoTaskExtension {
      * List of class names that should be excluded from analysis. Names can use wildcard (* and ?). Defaults to an empty list.
      */
     @Input
-    @Optional
+    @Nullable
     public List<String> getExcludes() {
         return excludes;
     }
@@ -169,7 +169,7 @@ public class JacocoTaskExtension {
      * List of classloader names that should be excluded from analysis. Names can use wildcards (* and ?). Defaults to an empty list.
      */
     @Input
-    @Optional
+    @Nullable
     public List<String> getExcludeClassLoaders() {
         return excludeClassLoaders;
     }
@@ -196,7 +196,7 @@ public class JacocoTaskExtension {
      * An identifier for the session written to the execution data. Defaults to an auto-generated identifier.
      */
     @Input
-    @Optional
+    @Nullable
     public String getSessionId() {
         return sessionId;
     }
@@ -233,7 +233,7 @@ public class JacocoTaskExtension {
      * IP address or hostname to use with {@link Output#TCP_SERVER} or {@link Output#TCP_CLIENT}. Defaults to localhost.
      */
     @Input
-    @Optional
+    @Nullable
     public String getAddress() {
         return address;
     }
@@ -246,7 +246,7 @@ public class JacocoTaskExtension {
      * Port to bind to for {@link Output#TCP_SERVER} or {@link Output#TCP_CLIENT}. Defaults to 6300.
      */
     @Input
-    @Optional
+    @Nullable
     public int getPort() {
         return port;
     }
@@ -261,7 +261,7 @@ public class JacocoTaskExtension {
      * @since 3.4
      */
     @LocalState
-    @Optional
+    @Nullable
     public File getClassDumpDir() {
         return classDumpDir;
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -107,8 +107,8 @@ public class JacocoTaskExtension {
     /**
      * The path for the execution data to be written to.
      */
-    @OutputFile
     @Nullable
+    @OutputFile
     public File getDestinationFile() {
         return destinationFile.getOrNull();
     }
@@ -142,8 +142,8 @@ public class JacocoTaskExtension {
     /**
      * List of class names that should be included in analysis. Names can use wildcards (* and ?). If left empty, all classes will be included. Defaults to an empty list.
      */
-    @Input
     @Nullable
+    @Input
     public List<String> getIncludes() {
         return includes;
     }
@@ -155,8 +155,8 @@ public class JacocoTaskExtension {
     /**
      * List of class names that should be excluded from analysis. Names can use wildcard (* and ?). Defaults to an empty list.
      */
-    @Input
     @Nullable
+    @Input
     public List<String> getExcludes() {
         return excludes;
     }
@@ -168,8 +168,8 @@ public class JacocoTaskExtension {
     /**
      * List of classloader names that should be excluded from analysis. Names can use wildcards (* and ?). Defaults to an empty list.
      */
-    @Input
     @Nullable
+    @Input
     public List<String> getExcludeClassLoaders() {
         return excludeClassLoaders;
     }
@@ -195,8 +195,8 @@ public class JacocoTaskExtension {
     /**
      * An identifier for the session written to the execution data. Defaults to an auto-generated identifier.
      */
-    @Input
     @Nullable
+    @Input
     public String getSessionId() {
         return sessionId;
     }
@@ -232,8 +232,8 @@ public class JacocoTaskExtension {
     /**
      * IP address or hostname to use with {@link Output#TCP_SERVER} or {@link Output#TCP_CLIENT}. Defaults to localhost.
      */
-    @Input
     @Nullable
+    @Input
     public String getAddress() {
         return address;
     }
@@ -245,8 +245,8 @@ public class JacocoTaskExtension {
     /**
      * Port to bind to for {@link Output#TCP_SERVER} or {@link Output#TCP_CLIENT}. Defaults to 6300.
      */
-    @Input
     @Nullable
+    @Input
     public int getPort() {
         return port;
     }
@@ -260,8 +260,8 @@ public class JacocoTaskExtension {
      *
      * @since 3.4
      */
-    @LocalState
     @Nullable
+    @LocalState
     public File getClassDumpDir() {
         return classDumpDir;
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -127,7 +127,7 @@ public abstract class JacocoReportBase extends JacocoBase {
         return additionalClassDirs;
     }
 
-    public void setAdditionalClassDirs(FileCollection additionalClassDirs) {
+    public void setAdditionalClassDirs(@Nullable FileCollection additionalClassDirs) {
         this.additionalClassDirs = additionalClassDirs;
     }
 
@@ -141,7 +141,7 @@ public abstract class JacocoReportBase extends JacocoBase {
         return additionalSourceDirs;
     }
 
-    public void setAdditionalSourceDirs(FileCollection additionalSourceDirs) {
+    public void setAdditionalSourceDirs(@Nullable FileCollection additionalSourceDirs) {
         this.additionalSourceDirs = additionalSourceDirs;
     }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSet;
@@ -35,6 +34,7 @@ import org.gradle.api.tasks.TaskCollection;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Arrays;
@@ -120,7 +120,7 @@ public abstract class JacocoReportBase extends JacocoBase {
     /**
      * Additional class dirs that coverage data should be reported for.
      */
-    @Optional
+    @Nullable
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public FileCollection getAdditionalClassDirs() {
@@ -134,7 +134,7 @@ public abstract class JacocoReportBase extends JacocoBase {
     /**
      * Additional source dirs for the classes coverage data is being reported for.
      */
-    @Optional
+    @Nullable
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public FileCollection getAdditionalSourceDirs() {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/rules/JacocoLimit.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/rules/JacocoLimit.java
@@ -73,7 +73,7 @@ public interface JacocoLimit extends Serializable {
      *
      * @param minimum Minimum
      */
-    void setMinimum(BigDecimal minimum);
+    void setMinimum(@Nullable BigDecimal minimum);
 
     /**
      * Gets the maximum expected value for limit. Default to null.
@@ -87,5 +87,5 @@ public interface JacocoLimit extends Serializable {
      *
      * @param maximum Maximum
      */
-    void setMaximum(BigDecimal maximum);
+    void setMaximum(@Nullable BigDecimal maximum);
 }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/rules/JacocoLimit.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/rules/JacocoLimit.java
@@ -18,8 +18,8 @@ package org.gradle.testing.jacoco.tasks.rules;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
@@ -65,7 +65,7 @@ public interface JacocoLimit extends Serializable {
      * Gets the minimum expected value for limit. Default to null.
      */
     @Input
-    @Optional
+    @Nullable
     BigDecimal getMinimum();
 
     /**
@@ -79,7 +79,7 @@ public interface JacocoLimit extends Serializable {
      * Gets the maximum expected value for limit. Default to null.
      */
     @Input
-    @Optional
+    @Nullable
     BigDecimal getMaximum();
 
     /**

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/rules/JacocoLimit.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/rules/JacocoLimit.java
@@ -64,8 +64,8 @@ public interface JacocoLimit extends Serializable {
     /**
      * Gets the minimum expected value for limit. Default to null.
      */
-    @Input
     @Nullable
+    @Input
     BigDecimal getMinimum();
 
     /**
@@ -78,8 +78,8 @@ public interface JacocoLimit extends Serializable {
     /**
      * Gets the maximum expected value for limit. Default to null.
      */
-    @Input
     @Nullable
+    @Input
     BigDecimal getMaximum();
 
     /**

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompileOptions.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompileOptions.java
@@ -17,15 +17,15 @@
 package org.gradle.plugins.javascript.coffeescript;
 
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 
 public class CoffeeScriptCompileOptions implements Serializable {
 
     private String encoding = "UTF-8";
 
-    @Optional @Input
+    @Nullable @Input
     public String getEncoding() {
         return encoding;
     }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompileOptions.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompileOptions.java
@@ -30,7 +30,7 @@ public class CoffeeScriptCompileOptions implements Serializable {
         return encoding;
     }
 
-    public void setEncoding(String encoding) {
+    public void setEncoding(@Nullable String encoding) {
         this.encoding = encoding;
     }
 }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
@@ -106,8 +106,8 @@ public class RhinoShellExec extends JavaExec {
     /**
      * Script file.
      */
-    @InputFile
     @Nullable
+    @InputFile
     public File getScript() {
         return script == null ? null : getProject().file(script);
     }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
@@ -117,14 +117,14 @@ public class RhinoShellExec extends JavaExec {
      *
      * @since 4.0
      */
-    public void setScript(File script) {
+    public void setScript(@Nullable File script) {
         this.script = script;
     }
 
     /**
      * Sets script file.
      */
-    public void setScript(Object script) {
+    public void setScript(@Nullable Object script) {
         this.script = script;
     }
 

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/rhino/RhinoShellExec.java
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.JavaExec;
-import org.gradle.api.tasks.Optional;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.util.CollectionUtils;
 
@@ -108,7 +107,6 @@ public class RhinoShellExec extends JavaExec {
      * Script file.
      */
     @InputFile
-    @Optional
     @Nullable
     public File getScript() {
         return script == null ? null : getProject().file(script);

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -263,7 +263,7 @@ public class GroovyCompileOptions extends AbstractOptions {
      * Sets optimization options for the Groovy compiler. Allowed values for an option are {@code true} and {@code false}.
      * Only takes effect when compiling against Groovy 1.8 or higher.
      */
-    public void setOptimizationOptions(Map<String, Boolean> optimizationOptions) {
+    public void setOptimizationOptions(@Nullable Map<String, Boolean> optimizationOptions) {
         this.optimizationOptions = optimizationOptions;
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -24,7 +24,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 
@@ -180,7 +179,7 @@ public class GroovyCompileOptions extends AbstractOptions {
     @PathSensitive(PathSensitivity.NONE)
     @InputFile
     @Incubating
-    @Optional
+    @Nullable
     public File getConfigurationScript() {
         return configurationScript;
     }
@@ -255,7 +254,7 @@ public class GroovyCompileOptions extends AbstractOptions {
      *     <dd>Enable or disable all optimizations. Note that some optimizations might be mutually exclusive.
      * </dl>
      */
-    @Optional @Input
+    @Nullable @Input
     public Map<String, Boolean> getOptimizationOptions() {
         return optimizationOptions;
     }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -176,10 +176,10 @@ public class GroovyCompileOptions extends AbstractOptions {
      * @see <a href="http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/CompilerConfiguration.html">CompilerConfiguration</a>
      * @see <a href="http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilder.html">CompilerCustomizationBuilder</a>
      */
+    @Nullable
     @PathSensitive(PathSensitivity.NONE)
     @InputFile
     @Incubating
-    @Nullable
     public File getConfigurationScript() {
         return configurationScript;
     }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -247,7 +247,7 @@ public class Groovydoc extends SourceTask {
      *
      * @param windowTitle A text for the windows title
      */
-    public void setWindowTitle(String windowTitle) {
+    public void setWindowTitle(@Nullable String windowTitle) {
         this.windowTitle = windowTitle;
     }
 
@@ -265,7 +265,7 @@ public class Groovydoc extends SourceTask {
      *
      * @param docTitle the docTitle as HTML
      */
-    public void setDocTitle(String docTitle) {
+    public void setDocTitle(@Nullable String docTitle) {
         this.docTitle = docTitle;
     }
 
@@ -283,7 +283,7 @@ public class Groovydoc extends SourceTask {
      *
      * @param header the header as HTML
      */
-    public void setHeader(String header) {
+    public void setHeader(@Nullable String header) {
         this.header = header;
     }
 
@@ -301,7 +301,7 @@ public class Groovydoc extends SourceTask {
      *
      * @param footer the footer as HTML
      */
-    public void setFooter(String footer) {
+    public void setFooter(@Nullable String footer) {
         this.footer = footer;
     }
 
@@ -319,7 +319,7 @@ public class Groovydoc extends SourceTask {
      * <p>
      * <b>Example:</b> {@code overviewText = resources.text.fromFile("/overview.html")}
      */
-    public void setOverviewText(TextResource overviewText) {
+    public void setOverviewText(@Nullable TextResource overviewText) {
         this.overview = overviewText;
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -236,8 +236,8 @@ public class Groovydoc extends SourceTask {
     /**
      * Returns the browser window title for the documentation. Set to {@code null} when there is no window title.
      */
-    @Input
     @Nullable
+    @Input
     public String getWindowTitle() {
         return windowTitle;
     }
@@ -254,8 +254,8 @@ public class Groovydoc extends SourceTask {
     /**
      * Returns the title for the package index(first) page. Set to {@code null} when there is no document title.
      */
-    @Input
     @Nullable
+    @Input
     public String getDocTitle() {
         return docTitle;
     }
@@ -272,8 +272,8 @@ public class Groovydoc extends SourceTask {
     /**
      * Returns the HTML header for each page. Set to {@code null} when there is no header.
      */
-    @Input
     @Nullable
+    @Input
     public String getHeader() {
         return header;
     }
@@ -290,8 +290,8 @@ public class Groovydoc extends SourceTask {
     /**
      * Returns the HTML footer for each page. Set to {@code null} when there is no footer.
      */
-    @Input
     @Nullable
+    @Input
     public String getFooter() {
         return footer;
     }
@@ -308,8 +308,8 @@ public class Groovydoc extends SourceTask {
     /**
      * Returns a HTML text to be used for overview documentation. Set to {@code null} when there is no overview text.
      */
-    @Nested
     @Nullable
+    @Nested
     public TextResource getOverviewText() {
         return overview;
     }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -238,7 +237,7 @@ public class Groovydoc extends SourceTask {
      * Returns the browser window title for the documentation. Set to {@code null} when there is no window title.
      */
     @Input
-    @Optional
+    @Nullable
     public String getWindowTitle() {
         return windowTitle;
     }
@@ -256,7 +255,7 @@ public class Groovydoc extends SourceTask {
      * Returns the title for the package index(first) page. Set to {@code null} when there is no document title.
      */
     @Input
-    @Optional
+    @Nullable
     public String getDocTitle() {
         return docTitle;
     }
@@ -274,7 +273,7 @@ public class Groovydoc extends SourceTask {
      * Returns the HTML header for each page. Set to {@code null} when there is no header.
      */
     @Input
-    @Optional
+    @Nullable
     public String getHeader() {
         return header;
     }
@@ -292,7 +291,7 @@ public class Groovydoc extends SourceTask {
      * Returns the HTML footer for each page. Set to {@code null} when there is no footer.
      */
     @Input
-    @Optional
+    @Nullable
     public String getFooter() {
         return footer;
     }
@@ -310,7 +309,7 @@ public class Groovydoc extends SourceTask {
      * Returns a HTML text to be used for overview documentation. Set to {@code null} when there is no overview text.
      */
     @Nested
-    @Optional
+    @Nullable
     public TextResource getOverviewText() {
         return overview;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -182,7 +182,7 @@ public class CompileOptions extends AbstractOptions {
      * Sets the character encoding to be used when reading source files. Defaults to {@code null}, in which
      * case the platform default encoding will be used.
      */
-    public void setEncoding(String encoding) {
+    public void setEncoding(@Nullable String encoding) {
         this.encoding = encoding;
     }
 
@@ -301,7 +301,7 @@ public class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      */
-    public void setBootstrapClasspath(FileCollection bootstrapClasspath) {
+    public void setBootstrapClasspath(@Nullable FileCollection bootstrapClasspath) {
         this.bootstrapClasspath = bootstrapClasspath;
     }
 
@@ -317,7 +317,7 @@ public class CompileOptions extends AbstractOptions {
     /**
      * Sets the extension dirs to be used for the compiler process. Defaults to {@code null}.
      */
-    public void setExtensionDirs(String extensionDirs) {
+    public void setExtensionDirs(@Nullable String extensionDirs) {
         this.extensionDirs = extensionDirs;
     }
 
@@ -473,7 +473,7 @@ public class CompileOptions extends AbstractOptions {
      * @param sourcepath the source path
      */
     @Incubating
-    public void setSourcepath(FileCollection sourcepath) {
+    public void setSourcepath(@Nullable FileCollection sourcepath) {
         this.sourcepath = sourcepath;
     }
 
@@ -517,7 +517,7 @@ public class CompileOptions extends AbstractOptions {
      * @since 4.3
      */
     @Incubating
-    public void setAnnotationProcessorGeneratedSourcesDirectory(File file) {
+    public void setAnnotationProcessorGeneratedSourcesDirectory(@Nullable File file) {
         this.annotationProcessorGeneratedSourcesDirectory.set(file);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -172,8 +172,8 @@ public class CompileOptions extends AbstractOptions {
      * Returns the character encoding to be used when reading source files. Defaults to {@code null}, in which
      * case the platform default encoding will be used.
      */
-    @Input
     @Nullable
+    @Input
     public String getEncoding() {
         return encoding;
     }
@@ -308,8 +308,8 @@ public class CompileOptions extends AbstractOptions {
     /**
      * Returns the extension dirs to be used for the compiler process. Defaults to {@code null}.
      */
-    @Input
     @Nullable
+    @Input
     public String getExtensionDirs() {
         return extensionDirs;
     }
@@ -459,10 +459,10 @@ public class CompileOptions extends AbstractOptions {
      * @return the source path
      * @see #setSourcepath(FileCollection)
      */
+    @Incubating
+    @Nullable
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
-    @Nullable
-    @Incubating
     public FileCollection getSourcepath() {
         return sourcepath;
     }
@@ -483,8 +483,8 @@ public class CompileOptions extends AbstractOptions {
      * @return The annotation processor path, or {@code null} to use the compile classpath.
      * @since 3.4
      */
-    @Internal // Handled on the compile task
     @Nullable
+    @Internal // Handled on the compile task
     public FileCollection getAnnotationProcessorPath() {
         return annotationProcessorPath;
     }
@@ -504,8 +504,8 @@ public class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      */
-    @Nullable
     @Incubating
+    @Nullable
     @OutputDirectory
     public File getAnnotationProcessorGeneratedSourcesDirectory() {
         return annotationProcessorGeneratedSourcesDirectory.getOrNull();

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -174,7 +173,7 @@ public class CompileOptions extends AbstractOptions {
      * case the platform default encoding will be used.
      */
     @Input
-    @Optional
+    @Nullable
     public String getEncoding() {
         return encoding;
     }
@@ -291,7 +290,7 @@ public class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      */
-    @Optional
+    @Nullable
     @CompileClasspath
     public FileCollection getBootstrapClasspath() {
         return bootstrapClasspath;
@@ -310,7 +309,7 @@ public class CompileOptions extends AbstractOptions {
      * Returns the extension dirs to be used for the compiler process. Defaults to {@code null}.
      */
     @Input
-    @Optional
+    @Nullable
     public String getExtensionDirs() {
         return extensionDirs;
     }
@@ -462,7 +461,7 @@ public class CompileOptions extends AbstractOptions {
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
-    @Optional
+    @Nullable
     @Incubating
     public FileCollection getSourcepath() {
         return sourcepath;
@@ -484,7 +483,6 @@ public class CompileOptions extends AbstractOptions {
      * @return The annotation processor path, or {@code null} to use the compile classpath.
      * @since 3.4
      */
-    @Optional
     @Internal // Handled on the compile task
     @Nullable
     public FileCollection getAnnotationProcessorPath() {
@@ -506,7 +504,6 @@ public class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      */
-    @Optional
     @Nullable
     @Incubating
     @OutputDirectory

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package org.gradle.api.tasks.compile;
 
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * Debug options for Java compilation. Only take effect if {@link CompileOptions#debug}
@@ -44,7 +45,7 @@ public class DebugOptions extends AbstractOptions {
      * By default, only source and line debugging information will be generated.
      */
     @Input
-    @Optional
+    @Nullable
     public String getDebugLevel() {
         return debugLevel;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
@@ -53,7 +53,7 @@ public class DebugOptions extends AbstractOptions {
     /**
      * Sets which debug information is to be generated.
      */
-    public void setDebugLevel(String debugLevel) {
+    public void setDebugLevel(@Nullable String debugLevel) {
         this.debugLevel = debugLevel;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/DebugOptions.java
@@ -44,8 +44,8 @@ public class DebugOptions extends AbstractOptions {
      *
      * By default, only source and line debugging information will be generated.
      */
-    @Input
     @Nullable
+    @Input
     public String getDebugLevel() {
         return debugLevel;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -19,8 +19,8 @@ package org.gradle.api.tasks.compile;
 import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -43,7 +43,7 @@ public class ForkOptions extends BaseForkOptions {
      * <p>Setting the executable disables task output caching.</p>
      */
     @Input
-    @Optional
+    @Nullable
     public String getExecutable() {
         return executable;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -55,7 +55,7 @@ public class ForkOptions extends BaseForkOptions {
      *
      * <p>Setting the executable disables task output caching.</p>
      */
-    public void setExecutable(String executable) {
+    public void setExecutable(@Nullable String executable) {
         this.executable = executable;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -42,8 +42,8 @@ public class ForkOptions extends BaseForkOptions {
      *
      * <p>Setting the executable disables task output caching.</p>
      */
-    @Input
     @Nullable
+    @Input
     public String getExecutable() {
         return executable;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -26,7 +26,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -239,7 +238,7 @@ public class Javadoc extends SourceTask {
      * @return The title, possibly null.
      */
     @Input
-    @Optional
+    @Nullable
     public String getTitle() {
         return title;
     }
@@ -345,7 +344,7 @@ public class Javadoc extends SourceTask {
      *
      * @return The executable. May be null.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getExecutable() {
         return executable;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -246,7 +246,7 @@ public class Javadoc extends SourceTask {
     /**
      * <p>Sets the title for the generated documentation.</p>
      */
-    public void setTitle(String title) {
+    public void setTitle(@Nullable String title) {
         this.title = title;
     }
 
@@ -349,7 +349,7 @@ public class Javadoc extends SourceTask {
         return executable;
     }
 
-    public void setExecutable(String executable) {
+    public void setExecutable(@Nullable String executable) {
         this.executable = executable;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -237,8 +237,8 @@ public class Javadoc extends SourceTask {
      *
      * @return The title, possibly null.
      */
-    @Input
     @Nullable
+    @Input
     public String getTitle() {
         return title;
     }
@@ -344,7 +344,7 @@ public class Javadoc extends SourceTask {
      *
      * @return The executable. May be null.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getExecutable() {
         return executable;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
@@ -21,11 +21,11 @@ import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.process.ExecSpec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -34,14 +34,14 @@ import java.util.List;
  * Provides the core Javadoc options.
  */
 public interface MinimalJavadocOptions {
-    @Input @Optional
+    @Input @Nullable
     String getOverview();
 
     void setOverview(String overview);
 
     MinimalJavadocOptions overview(String overview);
 
-    @Input @Optional
+    @Input @Nullable
     JavadocMemberLevel getMemberLevel();
 
     void setMemberLevel(JavadocMemberLevel memberLevel);
@@ -56,7 +56,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions showAll();
 
-    @Input @Optional
+    @Input @Nullable
     String getDoclet();
 
     void setDoclet(String docletClass);
@@ -70,7 +70,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions docletpath(File ... docletpath);
 
-    @Input @Optional
+    @Input @Nullable
     String getSource();
 
     void setSource(String source);
@@ -93,7 +93,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions bootClasspath(File ... bootClasspath);
 
-    @Optional @PathSensitive(PathSensitivity.RELATIVE) @InputFiles
+    @Nullable @PathSensitive(PathSensitivity.RELATIVE) @InputFiles
     List<File> getExtDirs();
 
     void setExtDirs(List<File> extDirs);
@@ -121,28 +121,28 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions breakIterator();
 
-    @Input @Optional
+    @Input @Nullable
     String getLocale();
 
     void setLocale(String locale);
 
     MinimalJavadocOptions locale(String locale);
 
-    @Input @Optional
+    @Input @Nullable
     String getEncoding();
 
     void setEncoding(String encoding);
 
     MinimalJavadocOptions encoding(String encoding);
 
-    @Optional @Input
+    @Nullable @Input
     List<String> getJFlags();
 
     void setJFlags(List<String> jFlags);
 
     MinimalJavadocOptions jFlags(String ... jFlags);
 
-    @Optional @PathSensitive(PathSensitivity.NONE) @InputFiles
+    @Nullable @PathSensitive(PathSensitivity.NONE) @InputFiles
     List<File> getOptionFiles();
 
     void setOptionFiles(List<File> optionFiles);
@@ -156,14 +156,14 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions destinationDirectory(File directory);
 
-    @Input @Optional
+    @Input @Nullable
     String getWindowTitle();
 
     void setWindowTitle(String windowTitle);
 
     StandardJavadocDocletOptions windowTitle(String windowTitle);
 
-    @Input @Optional
+    @Input @Nullable
     String getHeader();
 
     void setHeader(String header);

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
@@ -34,14 +34,14 @@ import java.util.List;
  * Provides the core Javadoc options.
  */
 public interface MinimalJavadocOptions {
-    @Input @Nullable
+    @Nullable @Input
     String getOverview();
 
     void setOverview(String overview);
 
     MinimalJavadocOptions overview(String overview);
 
-    @Input @Nullable
+    @Nullable @Input
     JavadocMemberLevel getMemberLevel();
 
     void setMemberLevel(JavadocMemberLevel memberLevel);
@@ -56,7 +56,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions showAll();
 
-    @Input @Nullable
+    @Nullable @Input
     String getDoclet();
 
     void setDoclet(String docletClass);
@@ -70,7 +70,7 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions docletpath(File ... docletpath);
 
-    @Input @Nullable
+    @Nullable @Input
     String getSource();
 
     void setSource(String source);
@@ -121,14 +121,14 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions breakIterator();
 
-    @Input @Nullable
+    @Nullable @Input
     String getLocale();
 
     void setLocale(String locale);
 
     MinimalJavadocOptions locale(String locale);
 
-    @Input @Nullable
+    @Nullable @Input
     String getEncoding();
 
     void setEncoding(String encoding);
@@ -156,14 +156,14 @@ public interface MinimalJavadocOptions {
 
     MinimalJavadocOptions destinationDirectory(File directory);
 
-    @Input @Nullable
+    @Nullable @Input
     String getWindowTitle();
 
     void setWindowTitle(String windowTitle);
 
     StandardJavadocDocletOptions windowTitle(String windowTitle);
 
-    @Input @Nullable
+    @Nullable @Input
     String getHeader();
 
     void setHeader(String header);

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
@@ -37,14 +37,14 @@ public interface MinimalJavadocOptions {
     @Nullable @Input
     String getOverview();
 
-    void setOverview(String overview);
+    void setOverview(@Nullable String overview);
 
     MinimalJavadocOptions overview(String overview);
 
     @Nullable @Input
     JavadocMemberLevel getMemberLevel();
 
-    void setMemberLevel(JavadocMemberLevel memberLevel);
+    void setMemberLevel(@Nullable JavadocMemberLevel memberLevel);
 
     MinimalJavadocOptions showFromPublic();
 
@@ -59,7 +59,7 @@ public interface MinimalJavadocOptions {
     @Nullable @Input
     String getDoclet();
 
-    void setDoclet(String docletClass);
+    void setDoclet(@Nullable String docletClass);
 
     MinimalJavadocOptions doclet(String docletClass);
 
@@ -73,7 +73,7 @@ public interface MinimalJavadocOptions {
     @Nullable @Input
     String getSource();
 
-    void setSource(String source);
+    void setSource(@Nullable String source);
 
     MinimalJavadocOptions source(String source);
 
@@ -96,7 +96,7 @@ public interface MinimalJavadocOptions {
     @Nullable @PathSensitive(PathSensitivity.RELATIVE) @InputFiles
     List<File> getExtDirs();
 
-    void setExtDirs(List<File> extDirs);
+    void setExtDirs(@Nullable List<File> extDirs);
 
     MinimalJavadocOptions extDirs(File ... extDirs);
 
@@ -124,49 +124,49 @@ public interface MinimalJavadocOptions {
     @Nullable @Input
     String getLocale();
 
-    void setLocale(String locale);
+    void setLocale(@Nullable String locale);
 
     MinimalJavadocOptions locale(String locale);
 
     @Nullable @Input
     String getEncoding();
 
-    void setEncoding(String encoding);
+    void setEncoding(@Nullable String encoding);
 
     MinimalJavadocOptions encoding(String encoding);
 
     @Nullable @Input
     List<String> getJFlags();
 
-    void setJFlags(List<String> jFlags);
+    void setJFlags(@Nullable List<String> jFlags);
 
     MinimalJavadocOptions jFlags(String ... jFlags);
 
     @Nullable @PathSensitive(PathSensitivity.NONE) @InputFiles
     List<File> getOptionFiles();
 
-    void setOptionFiles(List<File> optionFiles);
+    void setOptionFiles(@Nullable List<File> optionFiles);
 
     MinimalJavadocOptions optionFiles(File ... argumentFiles);
 
     @Internal
     File getDestinationDirectory();
 
-    void setDestinationDirectory(File directory);
+    void setDestinationDirectory(@Nullable File directory);
 
     MinimalJavadocOptions destinationDirectory(File directory);
 
     @Nullable @Input
     String getWindowTitle();
 
-    void setWindowTitle(String windowTitle);
+    void setWindowTitle(@Nullable String windowTitle);
 
     StandardJavadocDocletOptions windowTitle(String windowTitle);
 
     @Nullable @Input
     String getHeader();
 
-    void setHeader(String header);
+    void setHeader(@Nullable String header);
 
     StandardJavadocDocletOptions header(String header);
 
@@ -175,7 +175,7 @@ public interface MinimalJavadocOptions {
     @Internal
     List<String> getSourceNames();
 
-    void setSourceNames(List<String> sourceNames);
+    void setSourceNames(@Nullable List<String> sourceNames);
 
     MinimalJavadocOptions sourceNames(String ... sourceNames);
 

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -393,7 +393,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return docTitle.getValue();
     }
 
-    public void setDocTitle(String docTitle) {
+    public void setDocTitle(@Nullable String docTitle) {
         this.docTitle.setValue(docTitle);
     }
 
@@ -414,7 +414,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return footer.getValue();
     }
 
-    public void setFooter(String footer) {
+    public void setFooter(@Nullable String footer) {
         this.footer.setValue(footer);
     }
 
@@ -436,7 +436,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return bottom.getValue();
     }
 
-    public void setBottom(String bottom) {
+    public void setBottom(@Nullable String bottom) {
         this.bottom.setValue(bottom);
     }
 
@@ -469,7 +469,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return links.getValue();
     }
 
-    public void setLinks(List<String> links) {
+    public void setLinks(@Nullable List<String> links) {
         this.links.setValue(links);
     }
 
@@ -512,7 +512,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return linksOffline.getValue();
     }
 
-    public void setLinksOffline(List<JavadocOfflineLink> linksOffline) {
+    public void setLinksOffline(@Nullable List<JavadocOfflineLink> linksOffline) {
         this.linksOffline.setValue(linksOffline);
     }
 
@@ -604,7 +604,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return groups.getValue();
     }
 
-    public void setGroups(Map<String, List<String>> groups) {
+    public void setGroups(@Nullable Map<String, List<String>> groups) {
         this.groups.setValue(groups);
     }
 
@@ -809,7 +809,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return helpFile.getValue();
     }
 
-    public void setHelpFile(File helpFile) {
+    public void setHelpFile(@Nullable File helpFile) {
         this.helpFile.setValue(helpFile);
     }
 
@@ -830,7 +830,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return stylesheetFile.getValue();
     }
 
-    public void setStylesheetFile(File stylesheetFile) {
+    public void setStylesheetFile(@Nullable File stylesheetFile) {
         this.stylesheetFile.setValue(stylesheetFile);
     }
 
@@ -884,7 +884,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return charSet.getValue();
     }
 
-    public void setCharSet(String charSet) {
+    public void setCharSet(@Nullable String charSet) {
         this.charSet.setValue(charSet);
     }
 
@@ -907,7 +907,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return docEncoding.getValue();
     }
 
-    public void setDocEncoding(String docEncoding) {
+    public void setDocEncoding(@Nullable String docEncoding) {
         this.docEncoding.setValue(docEncoding);
     }
 
@@ -945,7 +945,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return tags.getValue();
     }
 
-    public void setTags(List<String> tags) {
+    public void setTags(@Nullable List<String> tags) {
         this.tags.setValue(tags);
     }
 
@@ -970,7 +970,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return taglets.getValue();
     }
 
-    public void setTaglets(List<String> taglets) {
+    public void setTaglets(@Nullable List<String> taglets) {
         this.taglets.setValue(taglets);
     }
 
@@ -991,7 +991,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return tagletPath.getValue();
     }
 
-    public void setTagletPath(List<File> tagletPath) {
+    public void setTagletPath(@Nullable List<File> tagletPath) {
         this.tagletPath.setValue(tagletPath);
     }
 
@@ -1033,7 +1033,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return excludeDocFilesSubDir.getValue();
     }
 
-    public void setExcludeDocFilesSubDir(List<String> excludeDocFilesSubDir) {
+    public void setExcludeDocFilesSubDir(@Nullable List<String> excludeDocFilesSubDir) {
         this.excludeDocFilesSubDir.setValue(excludeDocFilesSubDir);
     }
 
@@ -1054,7 +1054,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         return noQualifiers.getValue();
     }
 
-    public void setNoQualifiers(List<String> noQualifiers) {
+    public void setNoQualifiers(@Nullable List<String> noQualifiers) {
         this.noQualifiers.setValue(noQualifiers);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -21,12 +21,12 @@ import com.google.common.collect.Maps;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.external.javadoc.internal.GroupsJavadocOptionFileOption;
 import org.gradle.external.javadoc.internal.JavadocOptionFile;
 import org.gradle.external.javadoc.internal.LinksOfflineJavadocOptionFileOption;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
@@ -388,7 +388,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * though if it does, it must be enclosed in quotes. Any internal quotation marks within title may have to be escaped.
      * javadoc -doctitle "Java&lt;sup&gt;&lt;font size=\"-2\"&gt;TM&lt;/font&gt;&lt;/sup&gt;" com.mypackage
      */
-    @Optional @Input
+    @Nullable @Input
     public String getDocTitle() {
         return docTitle.getValue();
     }
@@ -409,7 +409,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * The footer will be placed to the right of the lower navigation bar. footer may contain HTML tags and white space,
      * though if it does, it must be enclosed in quotes. Any internal quotation marks within footer may have to be escaped.
      */
-    @Optional @Input
+    @Nullable @Input
     public String getFooter() {
         return footer.getValue();
     }
@@ -431,7 +431,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * The text may contain HTML tags and white space, though if it does, it must be enclosed in quotes.
      * Any internal quotation marks within text may have to be escaped.
      */
-    @Optional @Input
+    @Nullable @Input
     public String getBottom() {
         return bottom.getValue();
     }
@@ -464,7 +464,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * if you want to link to a file system that has no web server, you can use a file: link -- however,
      * do this only if everyone wanting to access the generated documentation shares the same file system.
      */
-    @Optional @Input
+    @Nullable @Input
     public List<String> getLinks() {
         return links.getValue();
     }
@@ -507,7 +507,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * This can be a URL (http: or file:) or file path, and can be absolute or relative. If relative,
      * make it relative to the current directory from where javadoc was run. Do not include the package-list filename.
      */
-    @Optional @Input
+    @Nullable @Input
     public List<JavadocOfflineLink> getLinksOffline() {
         return linksOffline.getValue();
     }
@@ -599,7 +599,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * Other Packages
      * <br>java.new
      */
-    @Optional @Input
+    @Nullable @Input
     public Map<String, List<String>> getGroups() {
         return groups.getValue();
     }
@@ -804,7 +804,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * <p>
      * javadoc -helpfile C:/user/myhelp.html java.awt
      */
-    @Optional @PathSensitive(NAME_ONLY) @InputFile
+    @Nullable @PathSensitive(NAME_ONLY) @InputFile
     public File getHelpFile() {
         return helpFile.getValue();
     }
@@ -825,7 +825,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * <p>
      * javadoc -stylesheetfile C:/user/mystylesheet.css com.mypackage
      */
-    @Optional @PathSensitive(NAME_ONLY) @InputFile
+    @Nullable @PathSensitive(NAME_ONLY) @InputFile
     public File getStylesheetFile() {
         return stylesheetFile.getValue();
     }
@@ -879,7 +879,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * <p>
      * Also see -encoding and -docencoding.
      */
-    @Optional @Input
+    @Nullable @Input
     public String getCharSet() {
         return charSet.getValue();
     }
@@ -902,7 +902,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
      * <p>
      * Also see -encoding and -charset.
      */
-    @Optional @Input
+    @Nullable @Input
     public String getDocEncoding() {
         return docEncoding.getValue();
     }
@@ -940,7 +940,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
     /**
      * -tag tagname:Xaoptcmf:"taghead".
      */
-    @Optional @Input
+    @Nullable @Input
     public List<String> getTags() {
         return tags.getValue();
     }
@@ -965,7 +965,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
     /**
      * -taglet class.
      */
-    @Optional @Input
+    @Nullable @Input
     public List<String> getTaglets() {
         return taglets.getValue();
     }
@@ -986,7 +986,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
     /**
      * -tagletpath tagletpathlist.
      */
-    @Optional @Classpath
+    @Nullable @Classpath
     public List<File> getTagletPath() {
         return tagletPath.getValue();
     }
@@ -1028,7 +1028,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
     /**
      * -excludedocfilessubdir name1:name2...
      */
-    @Optional @Input
+    @Nullable @Input
     public List<String> getExcludeDocFilesSubDir() {
         return excludeDocFilesSubDir.getValue();
     }
@@ -1049,7 +1049,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
     /**
      * -noqualifier all | packagename1:packagename2:...
      */
-    @Optional @Input
+    @Nullable @Input
     public List<String> getNoQualifiers() {
         return noQualifiers.getValue();
     }

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
@@ -83,7 +83,7 @@ public class BaseForkOptions extends AbstractOptions {
      * Sets any additional JVM arguments for the compiler process.
      * Defaults to the empty list.
      */
-    public void setJvmArgs(List<String> jvmArgs) {
+    public void setJvmArgs(@Nullable List<String> jvmArgs) {
         this.jvmArgs = jvmArgs;
     }
 

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
@@ -73,8 +73,8 @@ public class BaseForkOptions extends AbstractOptions {
      * Returns any additional JVM arguments for the compiler process.
      * Defaults to the empty list.
      */
-    @Input
     @Nullable
+    @Input
     public List<String> getJvmArgs() {
         return jvmArgs;
     }

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
@@ -18,8 +18,8 @@ package org.gradle.api.tasks.compile;
 import com.google.common.collect.Lists;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -74,7 +74,7 @@ public class BaseForkOptions extends AbstractOptions {
      * Defaults to the empty list.
      */
     @Input
-    @Optional
+    @Nullable
     public List<String> getJvmArgs() {
         return jvmArgs;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
@@ -78,7 +78,7 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
         return preCompiledHeader;
     }
 
-    public void setPreCompiledHeader(PreCompiledHeader preCompiledHeader) {
+    public void setPreCompiledHeader(@Nullable PreCompiledHeader preCompiledHeader) {
         this.preCompiledHeader = preCompiledHeader;
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
@@ -20,7 +20,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.language.base.compile.CompilerVersion;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.compile.VersionAwareCompiler;
@@ -74,7 +73,7 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
     /**
      * Returns the pre-compiled header to be used during compilation
      */
-    @Nested @Optional
+    @Nested @Nullable
     public PreCompiledHeader getPreCompiledHeader() {
         return preCompiledHeader;
     }
@@ -89,7 +88,6 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
      * @since 4.4
      */
     @Nested
-    @Optional
     @Nullable
     protected CompilerVersion getCompilerVersion() {
         NativeToolChainInternal toolChain = (NativeToolChainInternal) getToolChain();

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
@@ -73,7 +73,7 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
     /**
      * Returns the pre-compiled header to be used during compilation
      */
-    @Nested @Nullable
+    @Nullable @Nested
     public PreCompiledHeader getPreCompiledHeader() {
         return preCompiledHeader;
     }
@@ -87,8 +87,8 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
      *
      * @since 4.4
      */
-    @Nested
     @Nullable
+    @Nested
     protected CompilerVersion getCompilerVersion() {
         NativeToolChainInternal toolChain = (NativeToolChainInternal) getToolChain();
         NativePlatformInternal targetPlatform = (NativePlatformInternal) getTargetPlatform();

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -57,7 +58,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import org.gradle.nativeplatform.toolchain.internal.compilespec.SwiftCompileSpec;
 import org.gradle.nativeplatform.toolchain.internal.swift.IncrementalSwiftCompiler;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Collection;
@@ -241,7 +241,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * The name of the module to produce.
      */
-    @Nullable
+    @Optional
     @Input
     public Property<String> getModuleName() {
         return moduleName;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -31,7 +31,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -58,6 +57,7 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import org.gradle.nativeplatform.toolchain.internal.compilespec.SwiftCompileSpec;
 import org.gradle.nativeplatform.toolchain.internal.swift.IncrementalSwiftCompiler;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Collection;
@@ -241,7 +241,7 @@ public class SwiftCompile extends DefaultTask {
     /**
      * The name of the module to produce.
      */
-    @Optional
+    @Nullable
     @Input
     public Property<String> getModuleName() {
         return moduleName;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -25,7 +25,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
@@ -33,6 +32,7 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.ExecSpec;
 import org.gradle.util.CollectionUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Set;
 
@@ -74,7 +74,7 @@ public class UnexportMainSymbol extends SourceTask {
      * Object file that may contain a main symbol.
      */
     @InputFile
-    @Optional
+    @Nullable
     public File getMainObject() {
         if (mainObjectFile == null) {
             mainObjectFile = findMainObject();

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -73,8 +73,8 @@ public class UnexportMainSymbol extends SourceTask {
     /**
      * Object file that may contain a main symbol.
      */
-    @InputFile
     @Nullable
+    @InputFile
     public File getMainObject() {
         if (mainObjectFile == null) {
             mainObjectFile = findMainObject();

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -101,8 +101,8 @@ public class BaseScalaCompileOptions extends AbstractOptions {
      * Generate debugging information.
      * Legal values: none, source, line, vars, notailcalls
      */
-    @Input
     @Nullable
+    @Input
     public String getDebugLevel() {
         return debugLevel;
     }
@@ -126,7 +126,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
     /**
      * Encoding of source files.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getEncoding() {
         return encoding;
     }

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -107,7 +107,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
         return debugLevel;
     }
 
-    public void setDebugLevel(String debugLevel) {
+    public void setDebugLevel(@Nullable String debugLevel) {
         this.debugLevel = debugLevel;
     }
 
@@ -131,7 +131,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
         return encoding;
     }
 
-    public void setEncoding(String encoding) {
+    public void setEncoding(@Nullable String encoding) {
         this.encoding = encoding;
     }
 
@@ -159,7 +159,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
         return additionalParameters;
     }
 
-    public void setAdditionalParameters(List<String> additionalParameters) {
+    public void setAdditionalParameters(@Nullable List<String> additionalParameters) {
         this.additionalParameters = additionalParameters;
     }
 

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -20,11 +20,11 @@ import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaForkOptions;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -102,7 +102,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
      * Legal values: none, source, line, vars, notailcalls
      */
     @Input
-    @Optional
+    @Nullable
     public String getDebugLevel() {
         return debugLevel;
     }
@@ -126,7 +126,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
     /**
      * Encoding of source files.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getEncoding() {
         return encoding;
     }
@@ -154,7 +154,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
      * Additional parameters passed to the compiler.
      * Each parameter must start with '-'.
      */
-    @Optional @Input
+    @Nullable @Input
     public List<String> getAdditionalParameters() {
         return additionalParameters;
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
@@ -44,6 +43,7 @@ import org.gradle.nativeplatform.toolchain.Gcc;
 import org.gradle.platform.base.ToolChain;
 import org.gradle.util.GFileUtils;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 
@@ -182,7 +182,7 @@ public class InstallExecutable extends DefaultTask {
      * @since 4.3
      */
     @SkipWhenEmpty
-    @Optional
+    @Nullable
     @InputFile
     protected File getInputFileIfExists() {
         RegularFileProperty sourceFile = getSourceFile();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
@@ -19,7 +19,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.nativeplatform.internal.DefaultLinkerSpec;
 import org.gradle.nativeplatform.internal.LinkerSpec;
@@ -28,6 +27,7 @@ import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.concurrent.Callable;
 
@@ -66,13 +66,13 @@ public class LinkSharedLibrary extends AbstractLinkTask {
      *
      * @since 4.4
      */
-    @Optional @OutputFile
+    @Nullable @OutputFile
     public RegularFileProperty getImportLibrary() {
         return importLibrary;
     }
 
     @Input
-    @Optional
+    @Nullable
     public String getInstallName() {
         return installName;
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
@@ -19,6 +19,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.nativeplatform.internal.DefaultLinkerSpec;
 import org.gradle.nativeplatform.internal.LinkerSpec;
@@ -66,13 +67,13 @@ public class LinkSharedLibrary extends AbstractLinkTask {
      *
      * @since 4.4
      */
-    @Nullable @OutputFile
+    @Optional @OutputFile
     public RegularFileProperty getImportLibrary() {
         return importLibrary;
     }
 
-    @Input
     @Nullable
+    @Input
     public String getInstallName() {
         return installName;
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
@@ -78,7 +78,7 @@ public class LinkSharedLibrary extends AbstractLinkTask {
         return installName;
     }
 
-    public void setInstallName(String installName) {
+    public void setInstallName(@Nullable String installName) {
         this.installName = installName;
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/PreCompiledHeader.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/PreCompiledHeader.java
@@ -23,12 +23,12 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.platform.base.internal.ComponentSpecIdentifier;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public class PreCompiledHeader extends AbstractBuildableComponentSpec {
@@ -55,7 +55,7 @@ public class PreCompiledHeader extends AbstractBuildableComponentSpec {
         return pchObjects;
     }
 
-    @Optional
+    @Nullable
     @InputFile
     @PathSensitive(PathSensitivity.ABSOLUTE)
     public File getPrefixHeaderFile() {
@@ -66,7 +66,7 @@ public class PreCompiledHeader extends AbstractBuildableComponentSpec {
         this.prefixHeaderFile = prefixHeaderFile;
     }
 
-    @Optional @Input
+    @Nullable @Input
     public String getIncludeString() {
         return includeString;
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/PreCompiledHeader.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/PreCompiledHeader.java
@@ -62,7 +62,7 @@ public class PreCompiledHeader extends AbstractBuildableComponentSpec {
         return prefixHeaderFile;
     }
 
-    public void setPrefixHeaderFile(File prefixHeaderFile) {
+    public void setPrefixHeaderFile(@Nullable File prefixHeaderFile) {
         this.prefixHeaderFile = prefixHeaderFile;
     }
 
@@ -71,7 +71,7 @@ public class PreCompiledHeader extends AbstractBuildableComponentSpec {
         return includeString;
     }
 
-    public void setIncludeString(String includeString) {
+    public void setIncludeString(@Nullable String includeString) {
         this.includeString = includeString;
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/TwirlCompile.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/TwirlCompile.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.RelativeFile;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
@@ -44,6 +43,7 @@ import org.gradle.play.internal.twirl.TwirlCompilerFactory;
 import org.gradle.play.platform.PlayPlatform;
 import org.gradle.play.toolchain.PlayToolChain;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Arrays;
@@ -112,7 +112,7 @@ public class TwirlCompile extends SourceTask {
      * Returns the default imports that will be used when compiling templates.
      * @return The imports that will be used.
      */
-    @Optional @Input
+    @Nullable @Input
     public TwirlImports getDefaultImports() {
         return defaultImports;
     }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/TwirlCompile.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/TwirlCompile.java
@@ -121,7 +121,7 @@ public class TwirlCompile extends SourceTask {
      * Sets the default imports to be used when compiling templates.
      * @param defaultImports The imports to be used.
      */
-    public void setDefaultImports(TwirlImports defaultImports) {
+    public void setDefaultImports(@Nullable TwirlImports defaultImports) {
         this.defaultImports = defaultImports;
     }
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.plugin.devel.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
+import javax.annotation.Nullable
+
 class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
@@ -45,6 +47,7 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
                 }
 
                 // Should be ignored because it's not a getter
+                @${Nullable.name}
                 public int getWithParameter(int count) {
                     return count;
                 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.plugin.devel.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-import javax.annotation.Nullable
-
 class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
@@ -47,7 +45,6 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
                 }
 
                 // Should be ignored because it's not a getter
-                @${Nullable.name}
                 public int getWithParameter(int count) {
                     return count;
                 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -39,7 +39,6 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -57,6 +56,7 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -314,7 +314,7 @@ public class ValidateTaskProperties extends ConventionTask implements Verificati
      *
      * @since 4.5
      */
-    @Optional
+    @Nullable
     @OutputFile
     public RegularFileProperty getOutputFile() {
         return outputFile;

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -56,7 +57,6 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -314,7 +314,7 @@ public class ValidateTaskProperties extends ConventionTask implements Verificati
      *
      * @since 4.5
      */
-    @Nullable
+    @Optional
     @OutputFile
     public RegularFileProperty getOutputFile() {
         return outputFile;

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -192,7 +192,7 @@ public class War extends Jar {
      *
      * @param webXml The {@code web.xml} file. Maybe null.
      */
-    public void setWebXml(File webXml) {
+    public void setWebXml(@Nullable File webXml) {
         this.webXml = webXml;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -180,9 +180,9 @@ public class War extends Jar {
      *
      * @return The {@code web.xml} file.
      */
+    @Nullable
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
-    @Nullable
     public File getWebXml() {
         return webXml;
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -25,11 +25,11 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.util.ConfigureUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -140,7 +140,7 @@ public class War extends Jar {
      *
      * @return The classpath. Returns an empty collection when there is no classpath to include in the WAR.
      */
-    @Optional
+    @Nullable
     @Classpath
     public FileCollection getClasspath() {
         return classpath;
@@ -182,7 +182,7 @@ public class War extends Jar {
      */
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
-    @Optional
+    @Nullable
     public File getWebXml() {
         return webXml;
     }

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -214,7 +214,7 @@ public class CreateStartScripts extends ConventionTask {
         return defaultJvmOpts;
     }
 
-    public void setDefaultJvmOpts(Iterable<String> defaultJvmOpts) {
+    public void setDefaultJvmOpts(@Nullable Iterable<String> defaultJvmOpts) {
         this.defaultJvmOpts = defaultJvmOpts;
     }
 
@@ -230,11 +230,11 @@ public class CreateStartScripts extends ConventionTask {
         this.applicationName = applicationName;
     }
 
-    public void setOptsEnvironmentVar(String optsEnvironmentVar) {
+    public void setOptsEnvironmentVar(@Nullable String optsEnvironmentVar) {
         this.optsEnvironmentVar = optsEnvironmentVar;
     }
 
-    public void setExitEnvironmentVar(String exitEnvironmentVar) {
+    public void setExitEnvironmentVar(@Nullable String exitEnvironmentVar) {
         this.exitEnvironmentVar = exitEnvironmentVar;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -115,8 +115,8 @@ public class CreateStartScripts extends ConventionTask {
     /**
      * The environment variable to use to provide additional options to the JVM.
      */
-    @Input
     @Nullable
+    @Input
     public String getOptsEnvironmentVar() {
         if (GUtil.isTrue(optsEnvironmentVar)) {
             return optsEnvironmentVar;
@@ -132,8 +132,8 @@ public class CreateStartScripts extends ConventionTask {
     /**
      * The environment variable to use to control exit value (Windows only).
      */
-    @Input
     @Nullable
+    @Input
     public String getExitEnvironmentVar() {
         if (GUtil.isTrue(exitEnvironmentVar)) {
             return exitEnvironmentVar;
@@ -208,8 +208,8 @@ public class CreateStartScripts extends ConventionTask {
     /**
      * The application's default JVM options. Defaults to an empty list.
      */
-    @Input
     @Nullable
+    @Input
     public Iterable<String> getDefaultJvmOpts() {
         return defaultJvmOpts;
     }

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -27,12 +27,12 @@ import org.gradle.api.internal.plugins.UnixStartScriptGenerator;
 import org.gradle.api.internal.plugins.WindowsStartScriptGenerator;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.application.scripts.ScriptGenerator;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -116,7 +116,7 @@ public class CreateStartScripts extends ConventionTask {
      * The environment variable to use to provide additional options to the JVM.
      */
     @Input
-    @Optional
+    @Nullable
     public String getOptsEnvironmentVar() {
         if (GUtil.isTrue(optsEnvironmentVar)) {
             return optsEnvironmentVar;
@@ -133,7 +133,7 @@ public class CreateStartScripts extends ConventionTask {
      * The environment variable to use to control exit value (Windows only).
      */
     @Input
-    @Optional
+    @Nullable
     public String getExitEnvironmentVar() {
         if (GUtil.isTrue(exitEnvironmentVar)) {
             return exitEnvironmentVar;
@@ -209,7 +209,7 @@ public class CreateStartScripts extends ConventionTask {
      * The application's default JVM options. Defaults to an empty list.
      */
     @Input
-    @Optional
+    @Nullable
     public Iterable<String> getDefaultJvmOpts() {
         return defaultJvmOpts;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -114,7 +114,7 @@ public class ScalaDoc extends SourceTask {
     /**
      * Returns the documentation title.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getTitle() {
         return title;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -119,7 +119,7 @@ public class ScalaDoc extends SourceTask {
         return title;
     }
 
-    public void setTitle(String title) {
+    public void setTitle(@Nullable String title) {
         this.title = title;
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -31,6 +30,7 @@ import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 
@@ -114,7 +114,7 @@ public class ScalaDoc extends SourceTask {
     /**
      * Returns the documentation title.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getTitle() {
         return title;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -17,13 +17,13 @@ package org.gradle.api.tasks.scala;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.DeprecationLogger;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -75,7 +75,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the text to appear in the window title.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getWindowTitle() {
         return windowTitle;
     }
@@ -90,7 +90,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the main frame title.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getDocTitle() {
         return docTitle;
     }
@@ -105,7 +105,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the header for each page.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getHeader() {
         return header;
     }
@@ -120,7 +120,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the footer for each page.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getFooter() {
         return footer;
     }
@@ -135,7 +135,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the top text for each page.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getTop() {
         return top;
     }
@@ -150,7 +150,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the bottom text for each page.
      */
-    @Input @Optional
+    @Input @Nullable
     public String getBottom() {
         return bottom;
     }
@@ -168,7 +168,7 @@ public class ScalaDocOptions extends AbstractOptions {
      * @deprecated Scaladoc does not support to set a stylesheet any more (Scala 2.11).
      */
     @PathSensitive(PathSensitivity.ABSOLUTE)
-    @InputFile @Optional
+    @InputFile @Nullable
     @Deprecated
     public File getStyleSheet() {
         DeprecationLogger.nagUserOfDiscontinuedMethod("ScalaDocOptions.getStyleSheet");
@@ -190,7 +190,7 @@ public class ScalaDocOptions extends AbstractOptions {
      * Returns the additional parameters passed to the compiler.
      * Each parameter starts with '-'.
      */
-    @Input @Optional
+    @Input @Nullable
     public List<String> getAdditionalParameters() {
         return additionalParameters;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -75,7 +75,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the text to appear in the window title.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getWindowTitle() {
         return windowTitle;
     }
@@ -90,7 +90,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the main frame title.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getDocTitle() {
         return docTitle;
     }
@@ -105,7 +105,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the header for each page.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getHeader() {
         return header;
     }
@@ -120,7 +120,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the footer for each page.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getFooter() {
         return footer;
     }
@@ -135,7 +135,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the top text for each page.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getTop() {
         return top;
     }
@@ -150,7 +150,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Returns the HTML text to appear in the bottom text for each page.
      */
-    @Input @Nullable
+    @Nullable @Input
     public String getBottom() {
         return bottom;
     }
@@ -168,7 +168,7 @@ public class ScalaDocOptions extends AbstractOptions {
      * @deprecated Scaladoc does not support to set a stylesheet any more (Scala 2.11).
      */
     @PathSensitive(PathSensitivity.ABSOLUTE)
-    @InputFile @Nullable
+    @Nullable @InputFile
     @Deprecated
     public File getStyleSheet() {
         DeprecationLogger.nagUserOfDiscontinuedMethod("ScalaDocOptions.getStyleSheet");
@@ -190,7 +190,7 @@ public class ScalaDocOptions extends AbstractOptions {
      * Returns the additional parameters passed to the compiler.
      * Each parameter starts with '-'.
      */
-    @Input @Nullable
+    @Nullable @Input
     public List<String> getAdditionalParameters() {
         return additionalParameters;
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -83,7 +83,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Sets the text to appear in the window title.
      */
-    public void setWindowTitle(String windowTitle) {
+    public void setWindowTitle(@Nullable String windowTitle) {
         this.windowTitle = windowTitle;
     }
 
@@ -98,7 +98,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Sets the HTML text to appear in the main frame title.
      */
-    public void setDocTitle(String docTitle) {
+    public void setDocTitle(@Nullable String docTitle) {
         this.docTitle = docTitle;
     }
 
@@ -113,7 +113,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Sets the HTML text to appear in the header for each page.
      */
-    public void setHeader(String header) {
+    public void setHeader(@Nullable String header) {
         this.header = header;
     }
 
@@ -128,7 +128,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Sets the HTML text to appear in the footer for each page.
      */
-    public void setFooter(String footer) {
+    public void setFooter(@Nullable String footer) {
         this.footer = footer;
     }
 
@@ -143,7 +143,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Sets the HTML text to appear in the top text for each page.
      */
-    public void setTop(String top) {
+    public void setTop(@Nullable String top) {
         this.top = top;
     }
 
@@ -158,7 +158,7 @@ public class ScalaDocOptions extends AbstractOptions {
     /**
      * Sets the HTML text to appear in the bottom text for each page.
      */
-    public void setBottom(String bottom) {
+    public void setBottom(@Nullable String bottom) {
         this.bottom = bottom;
     }
 
@@ -181,7 +181,7 @@ public class ScalaDocOptions extends AbstractOptions {
      * @deprecated Scaladoc does not support to set a stylesheet any more (Scala 2.11).
      */
     @Deprecated
-    public void setStyleSheet(File styleSheet) {
+    public void setStyleSheet(@Nullable File styleSheet) {
         DeprecationLogger.nagUserOfDiscontinuedMethod("ScalaDocOptions.setStyleSheet");
         this.styleSheet = styleSheet;
     }
@@ -199,7 +199,7 @@ public class ScalaDocOptions extends AbstractOptions {
      * Sets the additional parameters passed to the compiler.
      * Each parameter must start with '-'.
      */
-    public void setAdditionalParameters(List<String> additionalParameters) {
+    public void setAdditionalParameters(@Nullable List<String> additionalParameters) {
         this.additionalParameters = additionalParameters;
     }
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
@@ -148,8 +148,8 @@ public class InstallXCTestBundle extends DefaultTask {
     }
 
     @SkipWhenEmpty
-    @InputFile
     @Nullable
+    @InputFile
     protected File getBundleBinary() {
         RegularFile bundle = getBundleBinaryFile().get();
         File bundleFile = bundle.getAsFile();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
@@ -29,7 +29,6 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
@@ -38,6 +37,7 @@ import org.gradle.nativeplatform.toolchain.internal.xcode.SwiftStdlibToolLocator
 import org.gradle.process.ExecSpec;
 import org.gradle.util.GFileUtils;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -149,7 +149,7 @@ public class InstallXCTestBundle extends DefaultTask {
 
     @SkipWhenEmpty
     @InputFile
-    @Optional
+    @Nullable
     protected File getBundleBinary() {
         RegularFile bundle = getBundleBinaryFile().get();
         File bundleFile = bundle.getAsFile();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XCTest.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XCTest.java
@@ -25,13 +25,13 @@ import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.testing.AbstractTestTask;
+import org.gradle.nativeplatform.test.xctest.internal.execution.XCTestExecuter;
 import org.gradle.nativeplatform.test.xctest.internal.execution.XCTestSelection;
 import org.gradle.nativeplatform.test.xctest.internal.execution.XCTestTestExecutionSpec;
-import org.gradle.nativeplatform.test.xctest.internal.execution.XCTestExecuter;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -87,7 +87,7 @@ public class XCTest extends AbstractTestTask {
      * Workaround for when the task is given an input file that doesn't exist
      */
     @SkipWhenEmpty
-    @Optional
+    @Nullable
     @InputFile
     protected File getRunScript() {
         RegularFile runScript = getRunScriptFile().get();


### PR DESCRIPTION
For better Kotlin interoperability, we should be able to treat `@Nullable` in Java or Groovy code as `@Optional`, so that task authors don't have to put `@Optional` and `Nullable` on the same method.