### PR TITLE
Make task descriptions consistent

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -145,7 +145,7 @@ public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
 
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, Checkstyle task) {
-        task.setDescription("Run Checkstyle analysis for " + sourceSet.getName() + " classes");
+        task.setDescription("Runs Checkstyle analysis for " + sourceSet.getName() + " classes");
         task.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
         task.setSource(sourceSet.getAllJava());
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.java
@@ -143,7 +143,7 @@ public class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc> {
 
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, CodeNarc task) {
-        task.setDescription("Run CodeNarc analysis for " + sourceSet.getName() + " classes");
+        task.setDescription("Runs CodeNarc analysis for " + sourceSet.getName() + " classes");
         DynamicObject dynamicObject = new DslObject(sourceSet).getAsDynamicObject();
         task.setSource(dynamicObject.getProperty("allGroovy"));
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
@@ -192,7 +192,7 @@ public class FindBugsPlugin extends AbstractCodeQualityPlugin<FindBugs> {
 
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, FindBugs task) {
-        task.setDescription("Run FindBugs analysis for " + sourceSet.getName() + " classes");
+        task.setDescription("Runs FindBugs analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
         ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("classes", new Callable<FileCollection>() {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/JDependPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/JDependPlugin.java
@@ -109,7 +109,7 @@ public class JDependPlugin extends AbstractCodeQualityPlugin<JDepend> {
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, JDepend task) {
         task.dependsOn(sourceSet.getOutput());
-        task.setDescription("Run JDepend analysis for " + sourceSet.getName() + " classes");
+        task.setDescription("Runs JDepend analysis for " + sourceSet.getName() + " classes");
         task.setClassesDirs(sourceSet.getOutput().getClassesDirs());
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -179,7 +179,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
 
     @Override
     protected void configureForSourceSet(final SourceSet sourceSet, final Pmd task) {
-        task.setDescription("Run PMD analysis for " + sourceSet.getName() + " classes");
+        task.setDescription("Runs PMD analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
         ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("classpath", new Callable<FileCollection>() {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/TaskExecutionLogger.java
@@ -48,7 +48,7 @@ public class TaskExecutionLogger implements TaskExecutionListener {
 
         ProgressLogger currentTask = progressLoggerFactory.newOperation(TaskExecutionLogger.class, parentLoggerProvider.getLogger());
         String displayName = getDisplayName((TaskInternal) task);
-        currentTask.setDescription("Execute ".concat(displayName));
+        currentTask.setDescription("Executes ".concat(displayName));
         currentTask.setShortDescription(displayName);
         currentTask.setLoggingHeader(displayName);
         currentTask.started();

--- a/subprojects/docs/src/docs/userguide/moreAboutTasks.adoc
+++ b/subprojects/docs/src/docs/userguide/moreAboutTasks.adoc
@@ -285,6 +285,8 @@ You can add a description to your task. This description is displayed when execu
         </sample>
 ++++
 
+It is recommended to start a description of a task with a verb in third person.
+
 
 [[sec:replacing_tasks]]
 === Replacing tasks

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -232,7 +232,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
     private void addDefaultReportTask(final JacocoPluginExtension extension, final Test task) {
         final JacocoReport reportTask = project.getTasks().create("jacoco" + StringUtils.capitalize(task.getName()) + "Report", JacocoReport.class);
         reportTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-        reportTask.setDescription(String.format("Generates code coverage report for the %s task.", task.getName()));
+        reportTask.setDescription(String.format("Generates code coverage report for %s task.", task.getName()));
         reportTask.executionData(task);
         reportTask.sourceSets(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("main"));
         reportTask.getReports().all(new Action<ConfigurableReport>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/SourceCompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/SourceCompileTaskConfig.java
@@ -39,7 +39,7 @@ public class SourceCompileTaskConfig extends CompileTaskConfig {
     protected void configureCompileTask(AbstractNativeCompileTask abstractTask, final NativeBinarySpecInternal binary, final LanguageSourceSetInternal sourceSet) {
         AbstractNativeSourceCompileTask task = (AbstractNativeSourceCompileTask) abstractTask;
 
-        task.setDescription("Compiles the " + sourceSet + " of " + binary);
+        task.setDescription("Compiles " + sourceSet + " of " + binary);
 
         task.source(sourceSet.getSource());
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/NativeComponents.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/NativeComponents.java
@@ -103,14 +103,14 @@ public class NativeComponents {
                 @Override
                 public void execute(DefaultTask assembleDependents) {
                     assembleDependents.setGroup("Build Dependents");
-                    assembleDependents.setDescription("Assemble dependents of " + component.getDisplayName() + ".");
+                    assembleDependents.setDescription("Assembles dependents of " + component.getDisplayName() + ".");
                 }
             });
             tasks.create(getBuildDependentComponentsTaskName(component), DefaultTask.class, new Action<DefaultTask>() {
                 @Override
                 public void execute(DefaultTask buildDependents) {
                     buildDependents.setGroup("Build Dependents");
-                    buildDependents.setDescription("Build dependents of " + component.getDisplayName() + ".");
+                    buildDependents.setDescription("Builds dependents of " + component.getDisplayName() + ".");
                 }
             });
         }
@@ -121,7 +121,7 @@ public class NativeComponents {
             @Override
             public void execute(DefaultTask buildDependentsTask) {
                 buildDependentsTask.setGroup("Build Dependents");
-                buildDependentsTask.setDescription("Assemble dependents of " + binary.getDisplayName() + ".");
+                buildDependentsTask.setDescription("Assembles dependents of " + binary.getDisplayName() + ".");
                 buildDependentsTask.dependsOn(binary);
             }
         });
@@ -129,7 +129,7 @@ public class NativeComponents {
             @Override
             public void execute(DefaultTask buildDependentsTask) {
                 buildDependentsTask.setGroup("Build Dependents");
-                buildDependentsTask.setDescription("Build dependents of " + binary.getDisplayName() + ".");
+                buildDependentsTask.setDescription("Builds dependents of " + binary.getDisplayName() + ".");
                 buildDependentsTask.dependsOn(binary);
             }
         });

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayRoutesPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayRoutesPlugin.java
@@ -112,7 +112,7 @@ public class PlayRoutesPlugin extends RuleSource {
                     File generatedSourceDir = binary.getNamingScheme().getOutputDirectory(task.getProject().getBuildDir(), "src");
                     File routesCompileOutputDirectory = new File(generatedSourceDir, routesScalaSources.getName());
 
-                    routesCompile.setDescription("Generates routes for the '" + routesSourceSet.getName() + "' source set.");
+                    routesCompile.setDescription("Generates routes for '" + routesSourceSet.getName() + "' source set.");
                     routesCompile.setPlatform(binary.getTargetPlatform());
                     routesCompile.setAdditionalImports(new ArrayList<String>());
                     routesCompile.setSource(routesSourceSet.getSource());

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
@@ -58,7 +58,7 @@ public class PlayTestPlugin extends RuleSource {
             final File testClassesDir = new File(buildDir, binary.getProjectScopedName() + "/testClasses");
             tasks.create(testCompileTaskName, PlatformScalaCompile.class, new Action<PlatformScalaCompile>() {
                 public void execute(PlatformScalaCompile scalaCompile) {
-                    scalaCompile.setDescription("Compiles the scala and java test sources for the " + binary.getDisplayName() + ".");
+                    scalaCompile.setDescription("Compiles the scala and java test sources for " + binary.getDisplayName() + ".");
 
                     scalaCompile.setClasspath(testCompileClasspath);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -104,7 +104,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
                 GroovyCompile compile = project.getTasks().create(compileTaskName, GroovyCompile.class);
                 SourceSetUtil.configureForSourceSet(sourceSet, groovySourceSet.getGroovy(), compile, compile.getOptions(), project);
                 compile.dependsOn(sourceSet.getCompileJavaTaskName());
-                compile.setDescription("Compiles the " + sourceSet.getName() + " Groovy source.");
+                compile.setDescription("Compiles " + sourceSet.getName() + " Groovy source.");
                 compile.setSource(groovySourceSet.getGroovy());
 
                 project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(compileTaskName);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -310,7 +310,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     public void configureForSourceSet(final SourceSet sourceSet, final AbstractCompile compile) {
         SingleMessageLogger.nagUserOfDiscontinuedMethod("configureForSourceSet(SourceSet, AbstractCompile)");
         ConventionMapping conventionMapping;
-        compile.setDescription("Compiles the " + sourceSet.getJava() + ".");
+        compile.setDescription("Compiles " + sourceSet.getJava() + ".");
         conventionMapping = compile.getConventionMapping();
         compile.setSource(sourceSet.getJava());
         conventionMapping.map("classpath", new Callable<Object>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -88,7 +88,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     public static final String TEST_CLASSES_TASK_NAME = "testClasses";
 
     /**
-     * The name of the task which compiles the test Java sources.
+     * The name of the task which compiles test Java sources.
      */
     public static final String COMPILE_TEST_JAVA_TASK_NAME = "compileTestJava";
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/SourceSetUtil.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/SourceSetUtil.java
@@ -35,7 +35,7 @@ public class SourceSetUtil {
     private SourceSetUtil() {}
 
     public static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, final Project target) {
-        compile.setDescription("Compiles the " + sourceDirectorySet.getDisplayName() + ".");
+        compile.setDescription("Compiles " + sourceDirectorySet.getDisplayName() + ".");
         compile.setSource(sourceSet.getJava());
         compile.getConventionMapping().map("classpath", new Callable<Object>() {
             public Object call() throws Exception {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyBasePluginTest.groovy
@@ -58,7 +58,7 @@ class GroovyBasePluginTest {
 
         def task = project.tasks['compileCustomGroovy']
         assertThat(task, instanceOf(GroovyCompile.class))
-        assertThat(task.description, equalTo('Compiles the custom Groovy source.'))
+        assertThat(task.description, equalTo('Compiles custom Groovy source.'))
         assertThat(task, dependsOn('compileCustomJava'))
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -84,7 +84,7 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task instanceof GroovyCompile
-        task.description == 'Compiles the main Groovy source.'
+        task.description == 'Compiles main Groovy source.'
         dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME).matches(task)
 
         when:
@@ -92,7 +92,7 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task instanceof GroovyCompile
-        task.description == 'Compiles the test Groovy source.'
+        task.description == 'Compiles test Groovy source.'
         dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME).matches(task)
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -118,7 +118,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
         Convention scalaConvention = (Convention) InvokerHelper.getProperty(sourceSet, "convention");
         ScalaSourceSet scalaSourceSet = scalaConvention.findPlugin(ScalaSourceSet.class);
         SourceSetUtil.configureForSourceSet(sourceSet, scalaSourceSet.getScala(), scalaCompile, scalaCompile.getOptions(), project);
-        scalaCompile.setDescription("Compiles the " + scalaSourceSet.getScala() + ".");
+        scalaCompile.setDescription("Compiles " + scalaSourceSet.getScala() + ".");
         scalaCompile.setSource(scalaSourceSet.getScala());
         project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(taskName);
 

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
@@ -81,7 +81,7 @@ class ScalaBasePluginTest {
         SourceSet customSourceSet = project.sourceSets.custom
         def task = project.tasks['compileCustomScala']
         assertThat(task, instanceOf(ScalaCompile.class))
-        assertThat(task.description, equalTo('Compiles the custom Scala source.'))
+        assertThat(task.description, equalTo('Compiles custom Scala source.'))
         assertThat(task.classpath.files as List, equalTo([
             customSourceSet.java.outputDir
         ]))

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
@@ -63,7 +63,7 @@ class ScalaPluginTest {
         def task = project.tasks['compileScala']
         SourceSet mainSourceSet = project.sourceSets.main
         assertThat(task, instanceOf(ScalaCompile.class))
-        assertThat(task.description, equalTo('Compiles the main Scala source.'))
+        assertThat(task.description, equalTo('Compiles main Scala source.'))
         assertThat(task.classpath.files as List, equalTo([
             mainSourceSet.java.outputDir
         ]))
@@ -73,7 +73,7 @@ class ScalaPluginTest {
         task = project.tasks['compileTestScala']
         def testSourceSet = project.sourceSets.test
         assertThat(task, instanceOf(ScalaCompile.class))
-        assertThat(task.description, equalTo('Compiles the test Scala source.'))
+        assertThat(task.description, equalTo('Compiles test Scala source.'))
         assertThat(task.classpath.files as List, equalTo([
             mainSourceSet.java.outputDir,
             mainSourceSet.scala.outputDir,

--- a/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
@@ -84,7 +84,7 @@ public class TestingModelBasePlugin implements Plugin<Project> {
             }
             TaskInternal binaryLifecycleTask = taskFactory.create(binary.getNamingScheme().getTaskName("check"), DefaultTask.class);
             binaryLifecycleTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-            binaryLifecycleTask.setDescription("Check " + binary);
+            binaryLifecycleTask.setDescription("Checks " + binary);
             binary.setCheckTask(binaryLifecycleTask);
         }
 


### PR DESCRIPTION
Most of task descriptions are already in third person. I propose to make this a rule.
Task descriptions are noticeable by users. Looking at `gradle tasks` output I'm annoyed that some tasks are out of line.

Signed-off-by: Basil Peace <grv87@yandex.ru>