### PR TITLE
Update Maven2Gradle.groovy

### DIFF
--- a/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
+++ b/subprojects/build-init/src/main/groovy/org/gradle/buildinit/plugins/internal/maven/Maven2Gradle.groovy
@@ -323,10 +323,10 @@ class Maven2Gradle {
 
     private void compilerSettings(project, builder) {
         def configuration = plugin('maven-compiler-plugin', project).configuration
-        def source = configuration.source.text() ?: '1.5'
+        def source = configuration.source.text() ?: '1.8'
         builder.propertyAssignment(null, "sourceCompatibility", source)
 
-        def target = configuration.target.text() ?: '1.5'
+        def target = configuration.target.text() ?: '1.8'
         if (target != source) {
             builder.propertyAssignment(null, "targetCompatibility", target)
         }


### PR DESCRIPTION
- For the 5.0 Release it need to be set to 1.8.

Signed-off-by: Martin Dünkelmann <nc-duenkekl3@netcologne.de>

### Context
Partially fixed https://github.com/gradle/gradle/issues/4345
I only rised the Java Level from 1.5 to 1.8
The switch from apply plugin to plugins {} is too hard for me, beause my computer is too slow for this project.
Also I get IntelliJ Idea bugs, like "I need to set the project SDK", which is already set to "java"...

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes