### PR TITLE
Handle exceptions in JUnit 5 test engine initialization

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -72,11 +72,6 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         super.stop();
     }
 
-    @Override
-    public void stopNow() {
-        throw new UnsupportedOperationException("stopNow() should not be invoked on remote worker TestClassProcessor");
-    }
-
     private class CollectAllTestClassesExecutor implements Action<String> {
         private final List<Class<?>> testClasses = new ArrayList<>();
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing.junitplatform
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.Issue
 import spock.lang.Unroll
 
 import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
@@ -250,5 +251,35 @@ test {
         result.assertTestClassesExecuted('org.gradle.NestedTest$Inner')
         result.testClass('org.gradle.NestedTest$Inner').assertTestCount(1, 0, 0)
             .assertTestPassed('innerTest')
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/4476')
+    def 'can handle test engine failure'() {
+        given:
+        createSimpleJupiterTest()
+        file('src/test/java/UninstantiatableExtension.java') << '''
+import org.junit.jupiter.api.extension.*;
+public class UninstantiatableExtension implements BeforeEachCallback {
+  private UninstantiatableExtension(){}
+
+  @Override
+  public void beforeEach(final ExtensionContext context) throws Exception {
+  }
+}
+'''
+        file('src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension') << 'UninstantiatableExtension'
+        buildFile << '''
+            test {
+                systemProperty('junit.jupiter.extensions.autodetection.enabled', 'true')
+            }
+        '''
+
+        when:
+        fails('test')
+
+        then:
+        new DefaultTestExecutionResult(testDirectory)
+            .testClass('UnknownClass')
+            .assertTestFailed('initializationError', containsString('Provider UninstantiatableExtension could not be instantiated'))
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AbstractJUnitTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AbstractJUnitTestClassProcessor.java
@@ -70,4 +70,10 @@ public abstract class AbstractJUnitTestClassProcessor<T extends JUnitSpec> imple
     public void stop() {
         resultProcessorActor.stop();
     }
+
+
+    @Override
+    public void stopNow() {
+        throw new UnsupportedOperationException("stopNow() should not be invoked on remote worker TestClassProcessor");
+    }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessor.java
@@ -32,9 +32,4 @@ public class JUnitTestClassProcessor extends AbstractJUnitTestClassProcessor<JUn
         JUnitTestEventAdapter junitEventAdapter = new JUnitTestEventAdapter(threadSafeResultProcessor, clock, idGenerator);
         return new JUnitTestClassExecutor(Thread.currentThread().getContextClassLoader(), spec, junitEventAdapter, threadSafeTestClassListener);
     }
-
-    @Override
-    public void stopNow() {
-        throw new UnsupportedOperationException("stopNow() should not be invoked on remote worker TestClassProcessor");
-    }
 }


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4476

Previously in Gradle, test execution are class-based, which means a "TestClassStart" event will
be emitted before all test cases and a "TestClassEnd" event will be emitted after all test cases
(no matter they're failed or successful). In JUnit 5, if an exception occurs before "TestClassStart"
event (e.g. exceptions in test engine initialization), some event assertions will be violated.

In this situation, this PR will emit corresponding "TestClassStart/TestClassEnd" event to make
Gradle test event infrastructure happy.