### PR TITLE
Improve cache cleanup log message

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -121,7 +121,7 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
                 } else {
                     long duration = System.currentTimeMillis() - gcFile.lastModified();
                     long timeInDays = TimeUnit.MILLISECONDS.toDays(duration);
-                    LOGGER.info("{} has not been cleaned up in {} days", DefaultPersistentDirectoryCache.this, timeInDays);
+                    LOGGER.debug("{} has last been cleaned up {} days ago", DefaultPersistentDirectoryCache.this, timeInDays);
                     return timeInDays >= CLEANUP_INTERVAL;
                 }
             }


### PR DESCRIPTION
Change phrasing of log message about last cleanup to sound less like it's a call to action, and demote it to debug level.
