### PR TITLE
Ignore non-static nested classes

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -38,11 +38,13 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.isNestedClassInsideEnclosedRunner;
 import static org.gradle.api.internal.tasks.testing.junitplatform.VintageTestNameAdapter.*;
 import static org.junit.platform.launcher.EngineFilter.excludeEngines;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
@@ -78,9 +80,10 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         @Override
         public void execute(String testClassName) {
             Class<?> klass = loadClass(testClassName);
-            if (isTopClass(klass)) {
-                testClasses.add(klass);
+            if (isInnerClass(klass) || isNestedClassInsideEnclosedRunner(klass)) {
+                return;
             }
+            testClasses.add(klass);
         }
 
         private void processAllTestClasses() {
@@ -88,11 +91,10 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
             launcher.registerTestExecutionListeners(new JUnitPlatformTestExecutionListener(resultProcessor, clock, idGenerator, executionListener));
             launcher.execute(createLauncherDiscoveryRequest(testClasses));
         }
-
     }
 
-    private boolean isTopClass(Class<?> klass) {
-        return klass.getEnclosingClass() == null;
+    private boolean isInnerClass(Class<?> klass) {
+        return klass.getEnclosingClass() != null && !Modifier.isStatic(klass.getModifiers());
     }
 
     private Class<?> loadClass(String className) {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecutor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecutor.java
@@ -65,7 +65,7 @@ public class JUnitTestClassExecutor implements Action<String> {
 
     private void runTestClass(String testClassName) throws ClassNotFoundException {
         final Class<?> testClass = Class.forName(testClassName, false, applicationClassLoader);
-        if (isInnerClassInsideEnclosedRunner(testClass)) {
+        if (isNestedClassInsideEnclosedRunner(testClass)) {
             return;
         }
         List<Filter> filters = new ArrayList<Filter>();
@@ -107,7 +107,7 @@ public class JUnitTestClassExecutor implements Action<String> {
     }
 
     // https://github.com/gradle/gradle/issues/2319
-    private boolean isInnerClassInsideEnclosedRunner(Class<?> testClass) {
+    public static boolean isNestedClassInsideEnclosedRunner(Class<?> testClass) {
         if (testClass.getEnclosingClass() == null) {
             return false;
         }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -56,10 +56,7 @@ public class JUnitPlatformTestFramework implements TestFramework {
     public Action<WorkerProcessBuilder> getWorkerConfigurationAction() {
         return new Action<WorkerProcessBuilder>() {
             public void execute(WorkerProcessBuilder workerProcessBuilder) {
-                workerProcessBuilder.sharedPackages("org.junit.platform.engine");
-                workerProcessBuilder.sharedPackages("org.junit.platform.commons");
-                workerProcessBuilder.sharedPackages("org.junit.platform.launcher.core");
-                workerProcessBuilder.sharedPackages("org.junit.platform.launcher");
+                workerProcessBuilder.sharedPackages("org.junit");
             }
         };
     }


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4427

Previously we only pass top-level classes to JUnit 5, which might cause issues (#4427 test cases in nested class can't be picked up). This PR fixes this behaviour: only ignore classes which are annotated with `@Nested` or inside a `Enclosed` runner (See #4363 )
