### PR TITLE
Upgrade JUnit Platform to 5.1.0 in samples

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -74,8 +74,8 @@ You can find more information on [test grouping and filtering in the Java Plugin
 To enable `JUnit Jupiter` support, add the following dependencies:
 
     dependencies {
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.3'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.3'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
     }      
 
 Put your first `Jupiter` test into `src/test/java/foo/bar`:
@@ -104,7 +104,7 @@ If you want to run JUnit 3/4 tests on `JUnit Platform`, you should add extra `JU
     
     dependencies {
         testCompileOnly 'junit:junit:4.12' 
-        testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:4.12.3' 
+        testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.1.0' 
     }
     
 You can mix JUnit 3/4 tests with `Jupiter` tests without the need to rewrite old tests.

--- a/subprojects/docs/src/samples/testing/junitplatform/engine/build.gradle
+++ b/subprojects/docs/src/samples/testing/junitplatform/engine/build.gradle
@@ -6,10 +6,10 @@ repositories {
 
 // START SNIPPET vintage-dependencies
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.3'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
     testCompileOnly 'junit:junit:4.12'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:4.12.3'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.1.0'
 }
 // END SNIPPET vintage-dependencies
 

--- a/subprojects/docs/src/samples/testing/junitplatform/jupiter/build.gradle
+++ b/subprojects/docs/src/samples/testing/junitplatform/jupiter/build.gradle
@@ -6,8 +6,8 @@ repositories {
 
 // START SNIPPET jupiter-dependencies
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.3'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
 }
 // END SNIPPET jupiter-dependencies
 

--- a/subprojects/docs/src/samples/testing/junitplatform/tagging/build.gradle
+++ b/subprojects/docs/src/samples/testing/junitplatform/tagging/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.junit.jupiter:junit-jupiter-api:5.0.3'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.3'
+    implementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
 }
 
 // START SNIPPET test-tags

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -19,8 +19,8 @@ package org.gradle.test.fixtures.junitplatform
 import groovy.io.FileType
 
 class JUnitPlatformTestRewriter {
-    static final String LATEST_JUPITER_VERSION = '5.1.0-RC1'
-    static final String LATEST_VINTAGE_VERSION = '5.1.0-RC1'
+    static final String LATEST_JUPITER_VERSION = '5.1.0'
+    static final String LATEST_VINTAGE_VERSION = '5.1.0'
     static Map replacements = ['org.junit.Test': 'org.junit.jupiter.api.Test',
                                'org.junit.Before;': 'org.junit.jupiter.api.BeforeEach;',
                                'org.junit.After;': 'org.junit.jupiter.api.AfterEach;',

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.testing.fixture.JUnitCoverage.*
 import static org.hamcrest.Matchers.*
 
 // https://github.com/junit-team/junit5/issues/1285
-@TargetCoverage({ JUNIT_4_LATEST + emptyIfJava7(JUPITER, 'Vintage:5.1.0-M2') })
+@TargetCoverage({ JUNIT_4_LATEST + emptyIfJava7(JUPITER, VINTAGE) })
 class TestReportIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     @Rule Sample sample = new Sample(temporaryFolder)
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
@@ -20,13 +20,13 @@ import org.gradle.api.JavaVersion
 
 /**
  * NEWEST is JUnit 4 series, i.e. junit:junit:4.12
- * JUPITER is JUnit Jupiter engine, i.e. org.junit.jupiter:junit-jupiter-api:5.0.x
- * VINTAGE is JUnit Vintage engine which supports JUnit 4 tests on top of JUnit Platform, i.e. org.junit.vintage:junit-vintage-engine:4.12.3
+ * JUPITER is JUnit Jupiter engine, i.e. org.junit.jupiter:junit-jupiter-api:5.1.0
+ * VINTAGE is JUnit Vintage engine which supports JUnit 4 tests on top of JUnit Platform, i.e. org.junit.vintage:junit-vintage-engine:5.1.0
  */
 class JUnitCoverage {
     final static String NEWEST = '4.12'
-    final static String LATEST_JUPITER_VERSION = '5.1.0-RC1'
-    final static String LATEST_VINTAGE_VERSION = '5.1.0-RC1'
+    final static String LATEST_JUPITER_VERSION = '5.1.0'
+    final static String LATEST_VINTAGE_VERSION = '5.1.0'
     final static String JUPITER = 'Jupiter:' + LATEST_JUPITER_VERSION
     final static String VINTAGE = 'Vintage:' + LATEST_VINTAGE_VERSION
     final static String[] LARGE_COVERAGE = ['4.0', '4.4', '4.8.2', NEWEST]

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.is
 
 // https://github.com/junit-team/junit5/issues/1285
-@TargetCoverage({ JUNIT_4_LATEST + emptyIfJava7(JUPITER, 'Vintage:5.1.0-M2') })
+@TargetCoverage({ JUNIT_4_LATEST + emptyIfJava7(JUPITER, VINTAGE) })
 class JUnitLoggingOutputCaptureIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     def setup() {
         buildFile << """


### PR DESCRIPTION
Upgrade JUnit Platform to 5.1.0, both in samples and tests.

This PR does not change any production code and closes #4509 