### PR TITLE
Fix one-off issue with ListValueSnapshot

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ListValueSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ListValueSnapshot.java
@@ -68,6 +68,7 @@ public class ListValueSnapshot implements ValueSnapshot, Isolatable<List> {
             if (element != newElement) {
                 break;
             }
+            newElement = null;
         }
         if (pos == elements.length && pos == list.size()) {
             // Same size and no differences
@@ -78,10 +79,12 @@ public class ListValueSnapshot implements ValueSnapshot, Isolatable<List> {
         ValueSnapshot[] newElements = new ValueSnapshot[list.size()];
         System.arraycopy(elements, 0, newElements, 0, pos);
         if (pos < list.size()) {
+            // If we broke out of the comparison because there was a difference, we can reuse the snapshot of the new element
             if (newElement != null) {
                 newElements[pos] = newElement;
                 pos++;
             }
+            // Anything left over only exists in the new list
             for (int i = pos; i < list.size(); i++) {
                 newElements[i] = snapshotter.snapshot(list.get(i));
             }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ValueSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ValueSnapshotterTest.groovy
@@ -610,8 +610,11 @@ class ValueSnapshotterTest extends Specification {
 
         def snapshot4 = snapshotter.snapshot([new Bean(prop: "value1"), new Bean(prop: "value2")])
         snapshotter.snapshot([new Bean(prop: "value1"), new Bean(prop: "value2")], snapshot4).is(snapshot4)
-
         snapshotter.snapshot([new Bean(prop: "value1"), new Bean(prop: "value3")], snapshot4) != snapshot4
+
+        def snapshot5 = snapshotter.snapshot(["abc", "123"])
+        def snapshot6 = snapshotter.snapshot(["abc", "123", "xyz"], snapshot5)
+        snapshotter.snapshot(["abc", "123", "xyz"], snapshot6).is(snapshot6)
     }
 
     def "creates snapshot for set from candidates"() {


### PR DESCRIPTION
This fixes an issue where when comparing a snapshot to a list that matches,
but has additional elements at the end of the list (i.e. [a,b,c] vs [a,b,c,d]),
we actually end up generating an incorrect snapshot (i.e. the snapshot ends up being of [a,b,c,c]).

@lptr It looks like you were the last one to touch this code - do you mind doing a quick review?