### PR TITLE
Upgrade Kotlin DSL {0.15.6 => 0.16.0}

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ buildTypes {
 }
 
 ext {
-    gradle_kotlin_dsl_version = '0.15.6'
+    gradle_kotlin_dsl_version = '0.16.0'
     jvm = org.gradle.internal.jvm.Jvm.current()
     javaVersion = JavaVersion.current()
     isCiServer = System.getenv().containsKey("CI")


### PR DESCRIPTION
With improvements to the IDE UX:
 - Handle scripts with name ending with`.settings.gradle.kts` as `Settings` scripts (gradle/kotlin-dsl#735)
 - Make `buildSrc` classpath available to script plugins in the IDE (gradle/kotlin-dsl#728)

CI build: https://builds.gradle.org/viewLog.html?buildId=11245649&tab=buildResultsDiv&buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger ✅ 