### PR TITLE
Fix potential deadlock when service registry closes a child

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -1284,6 +1284,19 @@ class DefaultServiceRegistryTest extends Specification {
         thrown IllegalStateException
     }
 
+    def "cannot lookup services while closing" () {
+        given:
+        registry.add(Closeable, { registry.get(String) } as Closeable)
+
+        when:
+        registry.close()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains("closed")
+
+    }
+
     private Factory<Number> numberFactory
     private Factory<String> stringFactory
     private Factory<? super BigDecimal> superBigDecimalFactory

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionScopeServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.provider;
 
+import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
@@ -26,6 +27,8 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.launcher.daemon.client.DaemonClientFactory;
 import org.gradle.launcher.daemon.client.DaemonClientGlobalServices;
+import org.gradle.launcher.daemon.client.DaemonStopClient;
+import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.launcher.exec.BuildExecuter;
 import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter;
 import org.gradle.tooling.internal.provider.serialization.ClassLoaderCache;
@@ -54,7 +57,9 @@ public class ConnectionScopeServices {
     }
 
     ShutdownCoordinator createShutdownCoordinator(ListenerManager listenerManager, DaemonClientFactory daemonClientFactory, OutputEventListener outputEventListener) {
-        ShutdownCoordinator shutdownCoordinator = new ShutdownCoordinator(daemonClientFactory, outputEventListener);
+        ServiceRegistry clientServices = daemonClientFactory.createStopDaemonServices(outputEventListener, new DaemonParameters(new BuildLayoutParameters()));
+        DaemonStopClient client = clientServices.get(DaemonStopClient.class);
+        ShutdownCoordinator shutdownCoordinator = new ShutdownCoordinator(client);
         listenerManager.addListener(shutdownCoordinator);
         return shutdownCoordinator;
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ShutdownCoordinator.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ShutdownCoordinator.java
@@ -16,14 +16,9 @@
 
 package org.gradle.tooling.internal.provider;
 
-import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.logging.events.OutputEventListener;
-import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.launcher.daemon.client.DaemonClientFactory;
 import org.gradle.launcher.daemon.client.DaemonStartListener;
 import org.gradle.launcher.daemon.client.DaemonStopClient;
-import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.launcher.daemon.context.DaemonConnectDetails;
 
 import java.util.Set;
@@ -31,12 +26,10 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 public class ShutdownCoordinator implements DaemonStartListener, Stoppable {
     private final Set<DaemonConnectDetails> daemons = new CopyOnWriteArraySet<DaemonConnectDetails>();
-    private final DaemonClientFactory clientFactory;
-    private final OutputEventListener outputEventListener;
+    private final DaemonStopClient client;
 
-    public ShutdownCoordinator(DaemonClientFactory clientFactory, OutputEventListener outputEventListener) {
-        this.clientFactory = clientFactory;
-        this.outputEventListener = outputEventListener;
+    public ShutdownCoordinator(DaemonStopClient client) {
+        this.client = client;
     }
 
     public void daemonStarted(DaemonConnectDetails daemon) {
@@ -44,8 +37,6 @@ public class ShutdownCoordinator implements DaemonStartListener, Stoppable {
     }
 
     public void stop() {
-        ServiceRegistry clientServices = clientFactory.createStopDaemonServices(outputEventListener, new DaemonParameters(new BuildLayoutParameters()));
-        DaemonStopClient client = clientServices.get(DaemonStopClient.class);
         client.gracefulStop(daemons);
     }
 }


### PR DESCRIPTION
When a service registry closes a child and at the same time
the child requests a service from that parent, this could
result in a deadlock. This was caused by the parent holding
its state lock while closing its services, which was unnecessary.

The fix is to only hold the state lock while waiting for requests
to the parent that were already in progress and then releasing
the lock again before closing the services (which might include
child registries).