### PR TITLE
Fix release note transform after jsoup upgrade

### DIFF
--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -32,10 +32,10 @@ transformDocument {
             append("<title>Gradle @version@ Release Notes</title>").
             append("<link rel='stylesheet' type='text/css' href='https://assets.gradle.com/lato/css/lato-font.css'/>")
 
-    head().append("<style>p{}</style>").children().last().childNode(0).attr("data", baseStyleFile.text + releaseNotesStyleFile.text)
+    head().append("<style>${baseStyleFile.text}${releaseNotesStyleFile.text}</style>")
 
     [project.configurations.jquery.singleFile, project.configurations.jqueryTipTip.singleFile, scriptFile].each {
-        head().append("<script type='text/javascript'>1;</script>").children().last().childNode(0).attr("data", it.text)
+        head().append("<script type='text/javascript'>${it.text}</script>")
     }
 }
 


### PR DESCRIPTION
The jsoup upgrade (in efa8f1e214ab0a49910aa53765de4c40b23dc02f following up on #4429) caused the release notes to be rendered without css nor javascript:

![image](https://user-images.githubusercontent.com/132773/36804232-40cb46d8-1cba-11e8-93e6-41fba7029ced.png)

This PR fix the jsoup api usage in the release notes transform:

![image](https://user-images.githubusercontent.com/132773/36804286-681b40c6-1cba-11e8-9545-5c1c516554d2.png)
