### PR TITLE
Only generate VisualStudio metadata for buildable binaries

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelSingleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelSingleProjectIntegrationTest.groovy
@@ -30,6 +30,8 @@ import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
+import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.WINDOWS_GCC
+import static org.junit.Assume.assumeFalse
 
 class VisualStudioSoftwareModelSingleProjectIntegrationTest extends AbstractVisualStudioIntegrationSpec {
     private final Set<String> projectConfigurations = ['win32Debug', 'win32Release', 'x64Debug', 'x64Release'] as Set
@@ -37,6 +39,8 @@ class VisualStudioSoftwareModelSingleProjectIntegrationTest extends AbstractVisu
     def app = new CppHelloWorldApp()
 
     def setup() {
+        assumeFalse(toolChain.meets(WINDOWS_GCC))
+
         settingsFile << """
             rootProject.name = 'app'
         """

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginRules.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginRules.java
@@ -58,7 +58,9 @@ class VisualStudioPluginRules {
         @Mutate
         public static void createVisualStudioModelForBinaries(VisualStudioExtensionInternal visualStudioExtension, BinaryContainer binaries) {
             for (NativeBinarySpec binary : binaries.withType(NativeBinarySpec.class)) {
-                visualStudioExtension.getProjectRegistry().addProjectConfiguration(new NativeSpecVisualStudioTargetBinary(binary));
+                if (binary.isBuildable()) {
+                    visualStudioExtension.getProjectRegistry().addProjectConfiguration(new NativeSpecVisualStudioTargetBinary(binary));
+                }
             }
         }
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -480,6 +480,11 @@ public class AvailableToolChains {
         }
 
         @Override
+        public boolean meets(ToolChainRequirement requirement) {
+            return super.meets(requirement) || requirement == ToolChainRequirement.WINDOWS_GCC;
+        }
+
+        @Override
         public String getId() {
             return getDisplayName().replaceAll("\\W", "");
         }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
@@ -35,6 +35,8 @@ public enum ToolChainRequirement {
     VISUALCPP_2017,
     // Any available Visual Studio >= 2017
     VISUALCPP_2017_OR_NEWER,
+    // Any windows GCC compatible implementation (mingw, cygwin)
+    WINDOWS_GCC,
     // Any available GCC implementation (including mingw, cygwin, but not clang)
     GCC,
     // Any available GCC compatible implementation (including mingw, cygwin, and clang)


### PR DESCRIPTION
This changes VisualStudio metadata generation so that we only generate projects and project configurations for binaries that are buildable.