### PR TITLE
Use a different workaround for Kotlin DSL `buildscript.sourceFile`

### DIFF
--- a/gradle/codeQualityConfiguration.gradle.kts
+++ b/gradle/codeQualityConfiguration.gradle.kts
@@ -18,11 +18,12 @@
 
 // As this script is also accessed from the buildSrc project,
 // we can't use rootProject for the path as both builds share the same config directory.
-val codeQualityConfigDir = buildscript.sourceFile!!.let {
-    // Work around https://github.com/gradle/kotlin-dsl/issues/736, remove this once fixed
-    if (rootDir.name == "buildSrc") it.parentFile.parentFile
-    else it.parentFile.parentFile.parentFile
-}.resolve("config")
+// Work around https://github.com/gradle/kotlin-dsl/issues/736, remove this once fixed
+val effectiveRootDir: File =
+    if (rootDir.name == "buildSrc") rootDir.parentFile
+    else rootDir
+
+val codeQualityConfigDir = effectiveRootDir.resolve("config")
 
 configureCheckstyle(codeQualityConfigDir)
 configureCodenarc(codeQualityConfigDir)


### PR DESCRIPTION
One that is compatible with the old and new releases until the Gradle
wrapper is updated.

See gradle/kotlin-dsl#736

Feedback build: https://builds.gradle.org/viewLog.html?buildId=11311188&tab=buildResultsDiv&buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger ✅ 