### PR TITLE
Run previous failed test first

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -28,6 +28,10 @@ For example, the output directory of the FindBugs html report is added as `repor
 When annotating an iterable with [`@Nested`](javadoc/org/gradle/api/tasks/Nested.html), Gradle already treats each element as a separate nested input.
 In addition, if the element implements `Named`, the `name` is now used as property name.
 This allows for declaring nice names when adding `CommandLineArgumentProviders`, as for example done by [`JacocoAgent`](https://github.com/gradle/gradle/blob/1c6fa2d1fa794456d48a5268f6c2dfb85ff30cbf/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java#L139-L163).
+
+### Rerun failed tests first
+
+Now, in the subsequent test, Gradle will execute the previous failed test class first. With [`--fail-fast`](userguide/java_plugin.html#sec:test_execution) option introduced in `4.6`, this can provide a much faster feedback loop for development.
     
 ## Promoted features
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassRunInfo.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassRunInfo.java
@@ -32,4 +32,28 @@ public class DefaultTestClassRunInfo implements TestClassRunInfo {
     public String getTestClassName() {
         return testClassName;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultTestClassRunInfo that = (DefaultTestClassRunInfo) o;
+
+        return testClassName.equals(that.testClassName);
+    }
+
+    @Override
+    public int hashCode() {
+        return testClassName.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultTestClassRunInfo(" + testClassName + ')';
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.processors;
+
+import org.gradle.api.internal.tasks.testing.TestClassProcessor;
+import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
+import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * In order to speed up the development feedback cycle, this class guarantee previous failed test classes
+ * to be passed to its delegate first.
+ */
+public class RunPreviousFailedFirstTestClassProcessor implements TestClassProcessor {
+    private final Set<String> previousFailedTestClasses;
+    private final TestClassProcessor delegate;
+    private final LinkedHashSet<TestClassRunInfo> prioritizedTestClasses = new LinkedHashSet<TestClassRunInfo>();
+    private final LinkedHashSet<TestClassRunInfo> otherTestClasses = new LinkedHashSet<TestClassRunInfo>();
+
+    public RunPreviousFailedFirstTestClassProcessor(Set<String> previousFailedTestClasses, TestClassProcessor delegate) {
+        this.previousFailedTestClasses = previousFailedTestClasses;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void startProcessing(TestResultProcessor resultProcessor) {
+        delegate.startProcessing(resultProcessor);
+    }
+
+    @Override
+    public void processTestClass(TestClassRunInfo testClass) {
+        if (previousFailedTestClasses.contains(testClass.getTestClassName())) {
+            prioritizedTestClasses.add(testClass);
+        } else {
+            otherTestClasses.add(testClass);
+        }
+    }
+
+    @Override
+    public void stop() {
+        for (TestClassRunInfo test : prioritizedTestClasses) {
+            delegate.processTestClass(test);
+        }
+        for (TestClassRunInfo test : otherTestClasses) {
+            delegate.processTestClass(test);
+        }
+        delegate.stop();
+    }
+
+    @Override
+    public void stopNow() {
+        delegate.stopNow();
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -432,6 +432,8 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         addTestListener(eventLogger);
         addTestOutputListener(eventLogger);
 
+        TestExecutionSpec executionSpec = createTestExecutionSpec();
+
         File binaryResultsDir = getBinResultsDir();
         getProject().delete(binaryResultsDir);
         getProject().mkdir(binaryResultsDir);
@@ -465,7 +467,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         TestResultProcessor resultProcessor = new StateTrackingTestResultProcessor(resultProcessorDelegate);
 
         try {
-            testExecuter.execute(createTestExecutionSpec(), resultProcessor);
+            testExecuter.execute(executionSpec, resultProcessor);
         } finally {
             parentProgressLogger.completed();
             testWorkerProgressListener.completeAll();

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessorTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.processors
+
+import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo
+import org.gradle.api.internal.tasks.testing.TestClassProcessor
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import spock.lang.Specification
+
+class RunPreviousFailedFirstTestClassProcessorTest extends Specification {
+    TestClassProcessor delegate = Mock()
+    TestResultProcessor testResultProcessor = Mock()
+    RunPreviousFailedFirstTestClassProcessor processor
+
+    def 'previous failed test classes should be passed to delegate first'() {
+        given:
+        processor = new RunPreviousFailedFirstTestClassProcessor(['Class3'] as Set, delegate)
+
+        when:
+        processor.startProcessing(testResultProcessor)
+        ['Class1', 'Class2', 'Class3'].each { processor.processTestClass(new DefaultTestClassRunInfo(it)) }
+        processor.stop()
+
+        then:
+        1 * delegate.startProcessing(testResultProcessor)
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class3'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class2'))
+        then:
+        1 * delegate.stop()
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/RerunPreviousFailedTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/RerunPreviousFailedTestIntegrationTest.groovy
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junit
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.hamcrest.Matchers
+import spock.lang.Unroll
+
+class RerunPreviousFailedTestIntegrationTest extends AbstractIntegrationSpec {
+    static final String INDEX_OF_TEST_TO_FAIL = "index.of.test.to.fail"
+    static final List<Integer> TESTS = [1, 2, 3]
+    static final List<String> TEST_CLASSES = TESTS.collect { "ConditionalFailingTest_${it}".toString() }
+
+    def setup() {
+        buildFile << """
+            apply plugin: 'java'
+
+            ${mavenCentralRepository()}
+
+
+            dependencies {
+                testCompile 'junit:junit:4.12'
+            }
+        """
+
+        TESTS.each {
+            file("src/test/java/ConditionalFailingTest_${it}.java") << """
+                import org.junit.Test;
+                public class ConditionalFailingTest_${it} {
+                    @Test
+                    public void failedTest() {
+                        if("${it}".equals(System.getProperty("${INDEX_OF_TEST_TO_FAIL}"))) {
+                            throw new RuntimeException();
+                        }
+                    }
+                }
+            """.stripIndent()
+        }
+    }
+
+    def letTestFail(def index) {
+        buildFile << """
+        test {
+            systemProperty('${INDEX_OF_TEST_TO_FAIL}', '${index}')
+        }
+        """
+    }
+
+    @Unroll
+    def 'subsequent execution runs failed test first'() {
+        given:
+        letTestFail(indexOfTestToFail)
+
+        when:
+        fails('test')
+
+        then:
+        testFailed(indexOfTestToFail)
+
+        when:
+        fails('test', '--fail-fast')
+
+        then:
+        testFailedAndOthersIgnoredOrNotExecuted(indexOfTestToFail)
+
+        when:
+        letTestFail(0)
+        succeeds('test')
+
+        then:
+        allTestsSucceed()
+
+        where:
+        indexOfTestToFail << TESTS
+    }
+
+    @Unroll
+    def 'can delete previous failed test'() {
+        given:
+        letTestFail(indexOfTestToFail)
+
+        when:
+        fails('test')
+
+        then:
+        testFailed(indexOfTestToFail)
+
+        when:
+        file("src/test/java/ConditionalFailingTest_${indexOfTestToFail}.java").delete()
+        succeeds('test')
+
+        then:
+        remainTestsSucceed(indexOfTestToFail)
+
+        where:
+        indexOfTestToFail << TESTS
+    }
+
+    @Unroll
+    def 'can modify previous failed test'() {
+        given:
+        letTestFail(indexOfTestToFail)
+
+        when:
+        fails('test')
+
+        then:
+        testFailed(indexOfTestToFail)
+
+        when:
+        file("src/test/java/ConditionalFailingTest_${indexOfTestToFail}.java").text = """
+        public class ConditionalFailingTest_${indexOfTestToFail} {
+            public void failedTest() {
+            }
+        }
+        """
+        succeeds('test')
+
+        then:
+        remainTestsSucceed(indexOfTestToFail)
+
+        where:
+        indexOfTestToFail << TESTS
+    }
+
+    void testFailed(def indexOfTestToFail) {
+        new DefaultTestExecutionResult(testDirectory)
+            .testClass("ConditionalFailingTest_${indexOfTestToFail}").assertTestFailed('failedTest', Matchers.anything())
+    }
+
+    void allTestsSucceed() {
+        new DefaultTestExecutionResult(testDirectory).assertTestClassesExecuted(TEST_CLASSES as String[])
+    }
+
+    void remainTestsSucceed(def indexOfTestToFail) {
+        def failedTest = "ConditionalFailingTest_${indexOfTestToFail}".toString()
+        def testClasses = TEST_CLASSES.clone()
+        testClasses.remove(failedTest)
+        new DefaultTestExecutionResult(testDirectory)
+            .assertTestClassesExecuted(testClasses as String[])
+    }
+
+    void testFailedAndOthersIgnoredOrNotExecuted(def indexOfTestToFail) {
+        def failedTestClass = "ConditionalFailingTest_${indexOfTestToFail}".toString()
+        def testClasses = TEST_CLASSES.clone()
+        testClasses.remove(failedTestClass)
+
+        def result = new DefaultTestExecutionResult(testDirectory)
+        result.testClass(failedTestClass).assertTestFailed('failedTest', Matchers.anything())
+        testClasses.each {
+            if (result.testClassExists(it)) {
+                result.testClass(it).assertTestSkipped('failedTest')
+            }
+        }
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -22,6 +22,7 @@ import org.gradle.process.JavaForkOptions;
 import org.gradle.util.Path;
 
 import java.io.File;
+import java.util.Set;
 
 public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final TestFramework testFramework;
@@ -34,8 +35,9 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final long forkEvery;
     private final JavaForkOptions javaForkOptions;
     private final int maxParallelForks;
+    private final Set<String> previousFailedTestClasses;
 
-    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks) {
+    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
         this.testFramework = testFramework;
         this.classpath = classpath;
         this.candidateClassFiles = candidateClassFiles;
@@ -46,6 +48,7 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         this.forkEvery = forkEvery;
         this.javaForkOptions = javaForkOptions;
         this.maxParallelForks = maxParallelForks;
+        this.previousFailedTestClasses = previousFailedTestClasses;
     }
 
     public TestFramework getTestFramework() {
@@ -86,5 +89,9 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
 
     public int getMaxParallelForks() {
         return maxParallelForks;
+    }
+
+    public Set<String> getPreviousFailedTestClasses() {
+        return previousFailedTestClasses;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.processors.MaxNParallelTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.processors.RestartEveryNTestClassProcessor;
+import org.gradle.api.internal.tasks.testing.processors.RunPreviousFailedFirstTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.processors.TestMainAction;
 import org.gradle.api.internal.tasks.testing.worker.ForkingTestClassProcessor;
 import org.gradle.api.logging.Logger;
@@ -89,7 +90,8 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
                 return new RestartEveryNTestClassProcessor(forkingProcessorFactory, testExecutionSpec.getForkEvery());
             }
         };
-        processor = new MaxNParallelTestClassProcessor(getMaxParallelForks(testExecutionSpec), reforkingProcessorFactory, actorFactory);
+        processor = new RunPreviousFailedFirstTestClassProcessor(testExecutionSpec.getPreviousFailedTestClasses(),
+            new MaxNParallelTestClassProcessor(getMaxParallelForks(testExecutionSpec), reforkingProcessorFactory, actorFactory));
 
         final FileTree testClassFiles = testExecutionSpec.getCandidateClassFiles();
 


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4450

Before the test starts, we collect all failed test classes from the result of last test, and
send them to test worker process first - this is transparent to test infrastructure because
we didn't make any guarantee about test class execution order previously.

This can provide a much faster test feedback for users.

There're potential performance risks: 

- Reading previous result brings extra deserialization overheads.
- Previously, we dispatch all test classes to workers while scanning classes - now all test classes are collected then dispatched after the scan process. This should be kept an eye on.

