### PR TITLE
Fix issue with TERM being set to null on bare metal agents

### DIFF
--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetectorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetectorTest.groovy
@@ -23,10 +23,25 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Specification
 
+@Requires(TestPrecondition.SET_ENV_VARIABLE)
 class NativePlatformConsoleDetectorTest extends Specification {
     private Terminals terminals = Mock()
     private NativePlatformConsoleDetector detector = new NativePlatformConsoleDetector(terminals)
     final ProcessEnvironment env = NativeServicesTestFixture.getInstance().get(ProcessEnvironment)
+    String originalTerm
+
+    def setup() {
+        originalTerm = System.getenv("TERM")
+        env.setEnvironmentVariable("TERM", "mock")
+    }
+
+    def cleanup() {
+        if (originalTerm != null) {
+            env.setEnvironmentVariable("TERM", originalTerm)
+        } else {
+            env.removeEnvironmentVariable("TERM")
+        }
+    }
 
     def "returns null when neither stdout or stderr is attached to console"() {
         given:
@@ -73,16 +88,20 @@ class NativePlatformConsoleDetectorTest extends Specification {
         detector.console.stdErr
     }
 
-    @Requires([TestPrecondition.SET_ENV_VARIABLE, TestPrecondition.UNIX])
+    @Requires(TestPrecondition.UNIX)
     def "returns null when TERM is not set"() {
         given:
-        def oldTerm = System.getenv('TERM')
         env.removeEnvironmentVariable('TERM')
 
         expect:
         detector.console == null
+    }
 
-        cleanup:
-        env.setEnvironmentVariable('TERM', oldTerm)
+    def "returns null when TERM is set to dumb"() {
+        given:
+        env.setEnvironmentVariable("TERM", "dumb")
+
+        expect:
+        detector.console == null
     }
 }


### PR DESCRIPTION
The new bare metal CI agents don't have a TERM environment variable set, which was causing this test to fail.  These changes ensure that a TERM environment variable is set to something predictable when these tests run and then set it back (or unset it as the case may be) after the test.