### PR TITLE
Fix archiving artifacts for buildSrc test failures

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -93,17 +93,19 @@ if (!isCiServer || System.getProperty("enableCodeQuality")?.toLowerCase() == "tr
 
 if (isCiServer) {
     gradle.buildFinished {
-        tasks.all {
-            if (this is Reporting<*> && state.failure != null) {
-                prepareReportForCIPublishing(this.reports["html"].destination)
+        allprojects.forEach { project ->
+            project.tasks.all {
+                if (this is Reporting<*> && state.failure != null) {
+                    prepareReportForCIPublishing(project.name, this.reports["html"].destination)
+                }
             }
         }
     }
 }
 
-fun Project.prepareReportForCIPublishing(report: File) {
+fun Project.prepareReportForCIPublishing(projectName: String, report: File) {
     if (report.isDirectory) {
-        val destFile = File("${rootProject.buildDir}/report-$name-${report.name}.zip")
+        val destFile = File("${rootProject.buildDir}/report-$projectName-${report.name}.zip")
         ant.withGroovyBuilder {
             "zip"("destFile" to destFile) {
                 "fileset"("dir" to report)
@@ -113,7 +115,7 @@ fun Project.prepareReportForCIPublishing(report: File) {
         copy {
             from(report)
             into(rootProject.buildDir)
-            rename { "report-$name-${report.parentFile.name}-${report.name}" }
+            rename { "report-$projectName-${report.parentFile.name}-${report.name}" }
         }
     }
 }


### PR DESCRIPTION
This was not working anymore since buildSrc is now a multiproject build.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
