### PR TITLE
find 'latest' available changing module (snapshot) across repositories

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
@@ -22,7 +22,7 @@ class MavenFileRepoResolveIntegrationTest extends AbstractDependencyResolutionTe
         given:
         def moduleA = mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT')
         def moduleB = mavenRepo().module('group', 'projectB', '9.1')
-        moduleA.publish()
+        moduleA.withNonUniqueSnapshots().publish()
         moduleB.publish()
 
         and:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -297,8 +297,8 @@ Required by:
     def "mavenLocal skipped if contains pom but no artifact for snapshot"() {
         given:
         def anotherRepo = maven("another-local-repo")
-        m2.mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT').publishPom()
-        def moduleARemote = anotherRepo.module('group', 'projectA', '1.2-SNAPSHOT').publish()
+        m2.mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT').withNonUniqueSnapshots().publishPom()
+        def moduleARemote = anotherRepo.module('group', 'projectA', '1.2-SNAPSHOT').withNonUniqueSnapshots().publish()
 
         and:
         buildFile.text = """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepository.java
@@ -70,4 +70,9 @@ public class BaseModuleComponentRepository implements ModuleComponentRepository 
         return delegate.getComponentMetadataSupplier();
     }
 
+    @Override
+    public boolean isRemote() {
+        return delegate.isRemote();
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -123,6 +123,11 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
     }
 
     @Override
+    public boolean isRemote() {
+        return delegate.isRemote();
+    }
+
+    @Override
     public Map<ComponentArtifactIdentifier, ResolvableArtifact> getArtifactCache() {
         throw new UnsupportedOperationException();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -92,6 +92,11 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
     }
 
     @Override
+    public boolean isRemote() {
+        return delegate.isRemote();
+    }
+
+    @Override
     public Map<ComponentArtifactIdentifier, ResolvableArtifact> getArtifactCache() {
         return delegate.getArtifactCache();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepository.java
@@ -50,6 +50,8 @@ public interface ModuleComponentRepository {
      */
     ModuleComponentRepositoryAccess getRemoteAccess();
 
+    boolean isRemote();
+
     // TODO - put this somewhere else
     Map<ComponentArtifactIdentifier, ResolvableArtifact> getArtifactCache();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/maven/MavenMetadataLoader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/maven/MavenMetadataLoader.java
@@ -78,12 +78,17 @@ public class MavenMetadataLoader {
                             throws SAXException {
                         if ("metadata/versioning/snapshot/timestamp".equals(getContext())) {
                             mavenMetadata.timestamp = getText();
-                        }
-                        if ("metadata/versioning/snapshot/buildNumber".equals(getContext())) {
+                        } else if ("metadata/versioning/snapshot/buildNumber".equals(getContext())) {
                             mavenMetadata.buildNumber = getText();
-                        }
-                        if ("metadata/versioning/versions/version".equals(getContext())) {
+                        } else if ("metadata/versioning/versions/version".equals(getContext())) {
                             mavenMetadata.versions.add(getText().trim());
+                        } else if ("metadata/versioning/lastUpdated".equals(getContext())) {
+                            // timestamp will be null for local repositories
+                            if (mavenMetadata.timestamp == null) {
+                                String lastUpdated = getText();
+                                mavenMetadata.timestamp = lastUpdated.substring(0, 8) + "." + lastUpdated.substring(8, lastUpdated.length());
+                                mavenMetadata.buildNumber = "0";
+                            }
                         }
                         super.endElement(uri, localName, qName);
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/maven/MavenVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/maven/MavenVersionLister.java
@@ -40,7 +40,14 @@ public class MavenVersionLister {
         List<String> versions = Lists.newArrayList();
         boolean hasResult = false;
         for (ResourcePattern pattern : patterns) {
-            ExternalResourceName metadataLocation = pattern.toModulePath(module).resolve("maven-metadata.xml");
+
+            String metadataFileName = "maven-metadata.xml";
+
+            // Maven metadata filename for local repository is in form: maven-metadata-<repo-id>.xml
+            if (pattern.getPattern().startsWith("file:")) {
+                metadataFileName = "maven-metadata-local.xml";
+            }
+            ExternalResourceName metadataLocation = pattern.toModulePath(module).resolve(metadataFileName);
 
             if (searched.add(metadataLocation)) {
                 result.attempted(metadataLocation);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -122,6 +122,11 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
         return remoteRepositoryAccess;
     }
 
+    @Override
+    public boolean isRemote() {
+        return !isLocal();
+    }
+
     private class IvyLocalRepositoryAccess extends LocalRepositoryAccess {
         @Override
         protected void resolveModuleArtifacts(IvyModuleResolveMetadata module, BuildableComponentArtifactsResolveResult result) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePattern.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePattern.java
@@ -47,13 +47,17 @@ public class M2ResourcePattern extends AbstractResourcePattern {
     }
 
     private String maybeSubstituteTimestamp(ModuleComponentArtifactMetadata artifact, String pattern) {
-        if (artifact.getComponentId() instanceof MavenUniqueSnapshotComponentIdentifier) {
+        if (artifact.getComponentId() instanceof MavenUniqueSnapshotComponentIdentifier && !isLocal()) {
             MavenUniqueSnapshotComponentIdentifier snapshotId = (MavenUniqueSnapshotComponentIdentifier) artifact.getComponentId();
             pattern = pattern
                     .replaceFirst("\\-\\[revision\\]", "-" + snapshotId.getTimestampedVersion())
                     .replace("[revision]", snapshotId.getSnapshotVersion());
         }
         return pattern;
+    }
+
+    private boolean isLocal() {
+        return this.getPattern().startsWith("file:");
     }
 
     public ExternalResourceName toVersionListPattern(ModuleIdentifier module, IvyArtifactName artifact) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryTest.groovy
@@ -23,15 +23,17 @@ class BaseModuleComponentRepositoryTest extends Specification {
     final localAccess = Mock(ModuleComponentRepositoryAccess)
     final remoteAccess = Mock(ModuleComponentRepositoryAccess)
 
-    def "delegates id and name methods"() {
+    def "delegates id, name and remote methods"() {
         when:
         final repository = new BaseModuleComponentRepository(delegate, localAccess, remoteAccess)
         1 * delegate.id >> "id"
         1 * delegate.name >> "name"
+        1 * delegate.remote >> true
 
         then:
         repository.id == "id"
         repository.name == "name"
+        repository.remote
     }
 
     def "delegates access methods"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
@@ -103,5 +103,9 @@ class DependencyResolverIdentifierTest extends Specification {
             throw new UnsupportedOperationException()
         }
 
+        @Override
+        boolean isRemote() {
+            return true
+        }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePatternTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePatternTest.groovy
@@ -62,6 +62,16 @@ class M2ResourcePatternTest extends Specification {
         pattern.getLocation(artifact1).path == 'prefix/group/projectA/1.2-SNAPSHOT/projectA-1.2-2014-timestamp-3333.pom'
     }
 
+    def "doesn't substitutes snapshot artifact attributes into pattern for local repository"() {
+        def pattern = new M2ResourcePattern("file:/.m2/" + MavenPattern.M2_PATTERN)
+        def snapshotId = new MavenUniqueSnapshotComponentIdentifier("group", "projectA", "1.2-SNAPSHOT", "2014-timestamp-3333")
+
+        def artifact1 = new DefaultModuleComponentArtifactMetadata(new DefaultModuleComponentArtifactIdentifier(snapshotId, "projectA", "pom", "pom"))
+
+        expect:
+        pattern.getLocation(artifact1).path == 'file:/.m2/group/projectA/1.2-SNAPSHOT/projectA-1.2-SNAPSHOT.pom'
+    }
+
     def "determines artifact location by substituting artifact attributes into pattern and resolving relative to base URI"() {
         def pattern = new M2ResourcePattern(new URI("http://server/lookup"), "[organisation]/[module]/[revision]/[type]s/[revision]/[artifact].[ext]")
         def artifact = artifact(group, module, version)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
@@ -85,5 +85,10 @@ public class TestResolver extends ExternalResourceResolver<ModuleComponentResolv
         };
     }
 
+    @Override
+    public boolean isRemote() {
+        return true;
+    }
+
     interface MutableTestResolveMetadata extends MutableModuleComponentResolveMetadata {}
 }

--- a/subprojects/docs/src/docs/userguide/introduction_dependency_management.adoc
+++ b/subprojects/docs/src/docs/userguide/introduction_dependency_management.adoc
@@ -64,6 +64,8 @@ Gradle takes your dependency declarations and repository definitions and attempt
 
 ** For a dynamic version, a 'higher' concrete version is preferred over a 'lower' version.
 
+** For a changing modules, a 'latest' available module is preferred. The search for 'latest' available module ends when module is found in remote repository, potentially multiple local repositories are searched. The 'latest' module is determined by timestamp found in `maven-metadata.xml` or `maven-metadata-local.xml` files.
+
 ** Modules declared by a module metadata file (`.module`, `.pom` or `ivy.xml` file) are preferred over modules that have an artifact file only.
 
 ** Modules from earlier repositories are preferred over modules in later repositories.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -34,6 +34,8 @@ import java.text.SimpleDateFormat
 
 abstract class AbstractMavenModule extends AbstractModule implements MavenModule {
     protected static final String MAVEN_METADATA_FILE = "maven-metadata.xml"
+    protected static final String MAVEN_METADATA_LOCAL_FILE = "maven-metadata-local.xml"
+
     private final TestFile rootDir
     final TestFile moduleDir
     final String groupId
@@ -49,6 +51,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     private final List artifacts = []
     final updateFormat = new SimpleDateFormat("yyyyMMddHHmmss")
     final timestampFormat = new SimpleDateFormat("yyyyMMdd.HHmmss")
+    private String timestamp = "20100101120000"
+    private boolean remote = false
 
     AbstractMavenModule(TestFile rootDir, TestFile moduleDir, String groupId, String artifactId, String version) {
         this.rootDir = rootDir
@@ -319,12 +323,12 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
     @Override
     DefaultRootMavenMetaData getRootMetaData() {
-        new DefaultRootMavenMetaData("$moduleRootPath/${MAVEN_METADATA_FILE}", rootMetaDataFile)
+        new DefaultRootMavenMetaData("$moduleRootPath/${getMetaDataFileName()}", rootMetaDataFile)
     }
 
     @Override
     DefaultSnapshotMavenMetaData getSnapshotMetaData() {
-        new DefaultSnapshotMavenMetaData("$path/${MAVEN_METADATA_FILE}", snapshotMetaDataFile)
+        new DefaultSnapshotMavenMetaData("$path/${getMetaDataFileName()}", snapshotMetaDataFile)
     }
 
     @Override
@@ -351,17 +355,37 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         return moduleDir.file("$artifactId-${publishArtifactVersion}.pom")
     }
 
+    String getMetaDataFileName() {
+        return remote ? MAVEN_METADATA_FILE : MAVEN_METADATA_LOCAL_FILE
+    }
+
+    @Override
+    boolean isRemote() {
+        return remote
+    }
+
+    @Override
+    void setRemote(boolean remote) {
+        this.remote = remote
+    }
+
+    @Override
+    MavenModule withTimestamp(String timestamp) {
+        this.timestamp = timestamp
+        return this
+    }
+
     @Override
     TestFile getMetaDataFile() {
-        moduleDir.file(MAVEN_METADATA_FILE)
+        moduleDir.file(getMetaDataFileName())
     }
 
     TestFile getRootMetaDataFile() {
-        moduleDir.parentFile.file(MAVEN_METADATA_FILE)
+        moduleDir.parentFile.file(getMetaDataFileName())
     }
 
     TestFile getSnapshotMetaDataFile() {
-        moduleDir.file(MAVEN_METADATA_FILE)
+        moduleDir.file(getMetaDataFileName())
     }
 
     TestFile artifactFile(Map<String, ?> options) {
@@ -424,7 +448,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     }
 
     Date getPublishTimestamp() {
-        return new Date(updateFormat.parse("20100101120000").time + publishCount * 1000)
+        return new Date(updateFormat.parse(timestamp).time + publishCount * 1000)
     }
 
     private void publishModuleMetadata() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -252,6 +252,22 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public boolean isRemote() {
+        return backingModule.isRemote();
+    }
+
+    @Override
+    public void setRemote(boolean remote) {
+        backingModule.setRemote(remote);
+    }
+
+    @Override
+    public T withTimestamp(String timestamp) {
+        backingModule.withTimestamp(timestamp);
+        return t();
+    }
+
+    @Override
     public boolean getUniqueSnapshots() {
         return backingModule.getUniqueSnapshots();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
@@ -81,7 +81,7 @@ class MavenFileModule extends AbstractMavenModule {
 
     @Override
     protected boolean publishesMetaDataFile() {
-        uniqueSnapshots && version.endsWith("-SNAPSHOT")
+        uniqueSnapshots && version.endsWith("-SNAPSHOT") || !isRemote()
     }
 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -119,6 +119,12 @@ interface MavenModule extends Module {
 
     TestFile getMetaDataFile()
 
+    boolean isRemote()
+
+    void setRemote(boolean remote)
+
+    MavenModule withTimestamp(String timestamp)
+
     MavenPom getParsedPom()
 
     ModuleArtifact getRootMetaData()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MavenHttpModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MavenHttpModule.groovy
@@ -34,6 +34,7 @@ class MavenHttpModule extends DelegatingMavenModule<MavenHttpModule> implements 
         this.repoRoot = repoRoot
         this.moduleRootUriPath = "${repoRoot}/${backingModule.moduleRootPath}"
         this.uriPath = "${repoRoot}/${backingModule.path}"
+        backingModule.setRemote(true)
     }
 
     HttpArtifact getArtifact(Map options = [:]) {


### PR DESCRIPTION
Signed-off-by: Martin Vehovsky <vehovsky@gmail.com>

### Context
I believe it fixes following issues:
#1397 SNAPSHOT version are not searched across repositories
#1737 Treat Maven snapshot dependencies as dynamic versions

This will greatly improve workflow when you have coexisting Gradle and Maven projects. Especially when your Gradle project depends on SNAPSHOT version of Maven project that can't be for whatever reason converted to Gradle. You will now be able to resolve 'latest' version of the snapshot (changing module) from local maven repository or remote repo.
 

### Comments
The main change, that forced me to do certain alignments in integration tests is that for local maven repositories metadata file name is _maven-metadata-local.xml_ instead of _maven-metadata.xml_ [see Maven doc](http://maven.apache.org/ref/3.3.9/maven-repository-metadata/).

I also needed to know when to stop looking for the 'latest' snapshot (changing module), that is when the snapshot is resolved from remote repository.

Apart of units there are two new integration tests verifying the behaviour:
 - resolve and cache latest snapshot from remote
 - resolve latest snapshot from local

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
