### PR TITLE
Fix `./gradlew :idea` to generate a functional IDEA project

### DIFF
--- a/subprojects/composite-builds/composite-builds.gradle
+++ b/subprojects/composite-builds/composite-builds.gradle
@@ -4,13 +4,13 @@ dependencies {
     compile project(':launcher')
 
     integTestRuntime project(":toolingApiBuilders")
+    integTestRuntime project(":ide")
     integTestRuntime project(":pluginDevelopment")
     integTestRuntime project(":testKit")
 }
 
 testFixtures {
     from(':dependencyManagement')
-    from(':ide')
     from(':launcher')
 }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -30,7 +30,6 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
     List<File> includedBuilds = []
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
-
     def setup() {
         buildTestFixture.withBuildInSubDir()
         buildA = singleProjectBuild("buildA") {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.initialization.ConfigureBuildBuildOperationType
+import org.gradle.initialization.LoadBuildBuildOperationType
+import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
+import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
+import org.gradle.util.CollectionUtils
+
+import java.util.regex.Pattern
+
+class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    BuildTestFile buildB
+
+    def setup() {
+        buildB = multiProjectBuild("buildB", ['b1', 'b2']) {
+            file("buildSrc/src/main/java/Thing.java") << "class Thing { }"
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+                }
+"""
+        }
+        includedBuilds << buildB
+    }
+
+    def "generates configure, task graph and run tasks operations for buildSrc of included builds"() {
+        given:
+        dependency 'org.test:buildB:1.0'
+
+        when:
+        execute(buildA, ":jar", [])
+
+        then:
+        executed ":buildB:jar"
+
+        and:
+        def root = CollectionUtils.single(operations.roots())
+
+        def buildSrcOps = operations.all(BuildBuildSrcBuildOperationType)
+        buildSrcOps.size() == 1
+        buildSrcOps[0].displayName == "Build buildSrc"
+        // TODO should have a buildPath associated
+
+        def loadOps = operations.all(LoadBuildBuildOperationType)
+        loadOps.size() == 3
+        loadOps[0].displayName == "Load build"
+        loadOps[0].details.buildPath == ":"
+        loadOps[0].parentId == root.id
+        loadOps[1].displayName == "Load build (buildB)"
+        // TODO should have a buildPath associated
+        loadOps[1].parentId == root.id
+        loadOps[2].displayName == "Load build (:buildB:buildSrc)"
+        loadOps[2].details.buildPath == ":buildB:buildSrc"
+        loadOps[2].parentId == buildSrcOps[0].id
+
+        def configureOps = operations.all(ConfigureBuildBuildOperationType)
+        configureOps.size() == 3
+        configureOps[0].displayName == "Configure build (:buildB:buildSrc)"
+        configureOps[0].details.buildPath == ":buildB:buildSrc"
+        configureOps[0].parentId == buildSrcOps[0].id
+        configureOps[1].displayName == "Configure build (buildB)"
+        // TODO - should have a buildPath associated
+        configureOps[1].parentId == root.id
+        configureOps[2].displayName == "Configure build"
+        configureOps[2].details.buildPath == ":"
+        configureOps[2].parentId == root.id
+
+        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
+        taskGraphOps.size() == 3
+        taskGraphOps[0].displayName == "Calculate task graph (:buildB:buildSrc)"
+        taskGraphOps[0].details.buildPath == ":buildB:buildSrc"
+        taskGraphOps[0].parentId == buildSrcOps[0].id
+        taskGraphOps[1].displayName == "Calculate task graph"
+        taskGraphOps[1].details.buildPath == ":"
+        taskGraphOps[1].parentId == root.id
+        taskGraphOps[2].displayName == "Calculate task graph (:buildB)"
+        taskGraphOps[2].details.buildPath == ":buildB"
+        taskGraphOps[2].parentId == root.id
+
+        def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
+        runTasksOps.size() == 3
+        runTasksOps[0].displayName == "Run tasks (:buildB:buildSrc)"
+        runTasksOps[0].parentId == buildSrcOps[0].id
+        runTasksOps[1].displayName == "Run tasks"
+        runTasksOps[1].parentId == root.id
+        runTasksOps[2].displayName == "Run tasks (:buildB)"
+        runTasksOps[2].parentId == root.id
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.build.BuildTestFile
+
+class CompositeBuildBuildSrcIdentityIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    BuildTestFile buildB
+
+    def setup() {
+        buildB = multiProjectBuild("buildB", ['b1', 'b2']) {
+            file("buildSrc/src/main/java/Thing.java") << "class Thing { }"
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+                }
+"""
+        }
+        includedBuilds << buildB
+    }
+
+    def "includes build identifier in error message on failure to resolve dependencies of build"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.file("buildSrc/build.gradle") << """
+            dependencies { implementation "test:test:1.2" }
+        """
+
+        when:
+        fails(buildA, ":assemble")
+
+        then:
+        failure.assertHasDescription("Could not resolve all files for configuration ':buildB:buildSrc:runtimeClasspath'.")
+        // TODO - incorrect project path
+        failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
+Required by:
+    project :buildSrc""")
+    }
+
+    def "includes build identifier in task failure error message"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.file("buildSrc/build.gradle") << """
+            classes.doLast {
+                throw new RuntimeException("broken")
+            }
+        """
+
+        when:
+        fails(buildA, ":assemble")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':buildB:buildSrc:classes'.")
+        failure.assertHasCause("broken")
+    }
+
+    def "includes build identifier in dependency resolution results"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.file("buildSrc/settings.gradle") << """
+            include 'a'
+        """
+        buildB.file("buildSrc/build.gradle") << """
+            project(':a') {
+                apply plugin: 'java'
+            }
+            dependencies {
+                implementation project(':a')
+            }
+            classes.doLast {
+                def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
+                assert components.size() == 2
+                // TODO - should encode 'buildB' somewhere
+                assert components[0].build.name == 'buildSrc'
+                assert components[0].projectPath == ':'
+                assert components[0].projectName == 'buildSrc'
+                assert components[1].build.name == 'buildSrc'
+                assert components[1].projectPath == ':a'
+                assert components[1].projectName == 'a'
+            }
+        """
+
+        expect:
+        execute(buildA, ":assemble")
+    }
+}
+
+

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIntegrationTest.groovy
@@ -48,7 +48,6 @@ class CompositeBuildBuildSrcIntegrationTest extends AbstractIntegrationSpec {
         then:
         // TODO - Fix test fixtures to allow assertions on buildSrc tasks rather than relying on output scraping in tests
         outputContains(":buildSrc:assemble")
-        // TODO - Should be :someBuild:buildSrc:assemble
         outputContains(":child:buildSrc:assemble")
 
         outputContains("outer thing")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.build.BuildTestFile
+
+class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    BuildTestFile buildB
+
+    def setup() {
+        buildB = multiProjectBuild("buildB", ['b1', 'b2']) {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+                }
+"""
+        }
+        includedBuilds << buildB
+    }
+
+    def "includes build identifier in error message on failure to resolve dependencies of build"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.buildFile << """
+            dependencies { implementation "test:test:1.2" }
+        """
+
+        when:
+        fails(buildA, ":assemble")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':buildB:compileJava'.")
+        failure.assertHasCause("Could not resolve all task dependencies for configuration ':buildB:compileClasspath'.")
+        failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
+Required by:
+    project :buildB""")
+    }
+
+    def "includes build identifier in task failure error message"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.buildFile << """
+            classes.doLast {
+                throw new RuntimeException("broken")
+            }
+        """
+
+        when:
+        fails(buildA, ":assemble")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':buildB:classes'.")
+        failure.assertHasCause("broken")
+    }
+
+    def "includes build identifier in dependency resolution results"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildA.buildFile << """
+            classes.doLast {
+                def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
+                assert components.size() == 2
+                assert components[0].build.name == ':'
+                assert components[0].projectPath == ':'
+                // TODO - should be 'buildA'
+                assert components[0].projectName == ':'
+                assert components[1].build.name == 'buildB'
+                assert components[1].projectPath == ':'
+                assert components[1].projectName == 'buildB'
+            }
+        """
+
+        expect:
+        execute(buildA, ":assemble")
+    }
+}
+
+

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildParallelIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildParallelIntegrationTest.groovy
@@ -123,36 +123,4 @@ class CompositeBuildParallelIntegrationTest extends AbstractCompositeBuildIntegr
         execute(buildA, "jar", "--parallel", "--max-workers=$maxWorkers")
         operations.assertConcurrentOperationsDoNotExceed(ExecuteTaskBuildOperationType, maxWorkers, true)
     }
-
-    def "builds IDE metadata artifacts in parallel"() {
-        given:
-        server.start()
-
-        when:
-        buildA.buildFile << """
-            apply plugin: 'idea'
-        """
-
-        def included = ['buildB', 'buildC', 'buildD']
-        included.each { buildName ->
-            def build = singleProjectBuild(buildName) {
-                buildFile << """
-                    apply plugin: 'java'
-                    apply plugin: 'idea'
-
-                    ideaModule.doLast {
-                        ${server.callFromBuild(buildName)}
-                    }
-                """
-            }
-            dependency "org.test:${buildName}:1.0"
-            includeBuild build
-        }
-
-        server.expectConcurrent(included)
-
-        then:
-        execute(buildA, ":idea", "--max-workers=4")
-    }
-
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -27,7 +27,7 @@ class CompositeBuildProjectDependencyConflictResolutionIntegrationTest extends A
 
     @Override
     String getBuildId() {
-        "new org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier(projectName)"
+        "new org.gradle.api.internal.artifacts.DefaultBuildIdentifier(projectName)"
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildableCompositeBuildContext.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildableCompositeBuildContext.java
@@ -28,10 +28,8 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Pair;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,11 +53,6 @@ public class DefaultBuildableCompositeBuildContext implements CompositeBuildCont
     public LocalComponentMetadata getComponent(ProjectComponentIdentifier project) {
         RegisteredProject registeredProject = getRegisteredProject(project);
         return registeredProject != null ? registeredProject.metaData : null;
-    }
-
-    public Collection<LocalComponentArtifactMetadata> getAdditionalArtifacts(ProjectComponentIdentifier project) {
-        RegisteredProject registeredProject = getRegisteredProject(project);
-        return registeredProject != null ? registeredProject.artifacts : null;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.specs.Spec;

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
@@ -16,7 +16,6 @@
 
 package org.gradle.composite.internal;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradle.api.Project;
@@ -36,7 +35,6 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
 import java.io.File;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,11 +57,7 @@ public class IncludedBuildDependencyMetadataBuilder {
 
         ProjectComponentIdentifier componentIdentifier = newProjectId(build, project.getPath());
         LocalComponentMetadata compositeComponent = createCompositeCopy(build, componentIdentifier, originalComponent);
-        List<LocalComponentArtifactMetadata> artifacts = Lists.newArrayList();
-        for (LocalComponentArtifactMetadata artifactMetaData : localComponentRegistry.getAdditionalArtifacts(originalIdentifier)) {
-            artifacts.add(createCompositeCopy(componentIdentifier, artifactMetaData));
-        }
-        registeredProjects.put(componentIdentifier, new RegisteredProject(compositeComponent, artifacts));
+        registeredProjects.put(componentIdentifier, new RegisteredProject(compositeComponent));
     }
 
     private LocalComponentMetadata createCompositeCopy(final IncludedBuild build, final ProjectComponentIdentifier componentIdentifier, DefaultLocalComponentMetadata originalComponentMetadata) {
@@ -84,11 +78,6 @@ public class IncludedBuildDependencyMetadataBuilder {
                 return originalDependency;
             }
         });
-    }
-
-    private LocalComponentArtifactMetadata createCompositeCopy(ProjectComponentIdentifier project, LocalComponentArtifactMetadata artifactMetaData) {
-        File artifactFile = artifactMetaData.getFile();
-        return new CompositeProjectComponentArtifactMetadata(project, artifactMetaData.getName(), artifactFile, getArtifactTasks(artifactMetaData));
     }
 
     private Set<String> getArtifactTasks(ComponentArtifactMetadata artifactMetaData) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildTaskReferenceResolver.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildTaskReferenceResolver.java
@@ -19,7 +19,7 @@ package org.gradle.composite.internal;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.tasks.TaskReferenceResolver;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskInstantiationException;

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RegisteredProject.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RegisteredProject.java
@@ -16,17 +16,12 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
-
-import java.util.Collection;
 
 public class RegisteredProject {
     public final LocalComponentMetadata metaData;
-    public final Collection<LocalComponentArtifactMetadata> artifacts;
 
-    public RegisteredProject(LocalComponentMetadata metaData, Collection<LocalComponentArtifactMetadata> artifacts) {
+    public RegisteredProject(LocalComponentMetadata metaData) {
         this.metaData = metaData;
-        this.artifacts = artifacts;
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.buildsrc
+
+import org.gradle.initialization.ConfigureBuildBuildOperationType
+import org.gradle.initialization.LoadBuildBuildOperationType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.execution.ExecuteTaskBuildOperationType
+import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
+import org.gradle.util.CollectionUtils
+
+import java.util.regex.Pattern
+
+class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
+    def "includes build identifier in build operations"() {
+        given:
+        def ops = new BuildOperationsFixture(executer, temporaryFolder)
+        file("buildSrc/src/main/java/Thing.java") << "class Thing { }"
+
+        when:
+        succeeds()
+
+        then:
+        def root = CollectionUtils.single(ops.roots())
+
+        def buildSrcOps = ops.all(BuildBuildSrcBuildOperationType)
+        buildSrcOps.size() == 1
+        buildSrcOps[0].displayName == "Build buildSrc"
+        buildSrcOps[0].details.buildPath == ':'
+
+        def loadOps = ops.all(LoadBuildBuildOperationType)
+        loadOps.size() == 2
+        loadOps[0].displayName == "Load build"
+        loadOps[0].details.buildPath == ':'
+        loadOps[0].parentId == root.id
+        loadOps[1].displayName == "Load build (buildSrc)"
+        loadOps[1].details.buildPath == ':buildSrc'
+        loadOps[1].parentId == buildSrcOps[0].id
+
+        def configureOps = ops.all(ConfigureBuildBuildOperationType)
+        configureOps.size() == 2
+        configureOps[0].displayName == "Configure build (buildSrc)"
+        configureOps[0].details.buildPath == ":buildSrc"
+        configureOps[0].parentId == buildSrcOps[0].id
+        configureOps[1].displayName == "Configure build"
+        configureOps[1].details.buildPath == ":"
+        configureOps[1].parentId == root.id
+
+        def taskGraphOps = ops.all(CalculateTaskGraphBuildOperationType)
+        taskGraphOps.size() == 2
+        taskGraphOps[0].displayName == "Calculate task graph (:buildSrc)"
+        taskGraphOps[0].details.buildPath == ':buildSrc'
+        taskGraphOps[0].parentId == buildSrcOps[0].id
+        taskGraphOps[1].displayName == "Calculate task graph"
+        taskGraphOps[1].details.buildPath == ':'
+        taskGraphOps[1].parentId == root.id
+
+        def runTasksOps = ops.all(Pattern.compile("Run tasks.*"))
+        runTasksOps.size() == 2
+        runTasksOps[0].displayName == "Run tasks (:buildSrc)"
+        runTasksOps[0].parentId == buildSrcOps[0].id
+        runTasksOps[1].displayName == "Run tasks"
+        runTasksOps[1].parentId == root.id
+
+        def taskOps = ops.all(ExecuteTaskBuildOperationType)
+        taskOps.size() > 1
+        taskOps[0].details.buildPath == ':buildSrc'
+        taskOps[0].parentId == runTasksOps[0].id
+        taskOps.last().details.buildPath == ':'
+        taskOps.last().parentId == runTasksOps[1].id
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildDefinition.java
@@ -28,7 +28,7 @@ public class BuildDefinition {
     private final StartParameter startParameter;
     private final PluginRequests injectedSettingsPlugins;
 
-    public BuildDefinition(File buildRootDir, StartParameter startParameter, PluginRequests injectedSettingsPlugins) {
+    public BuildDefinition(@Nullable File buildRootDir, StartParameter startParameter, PluginRequests injectedSettingsPlugins) {
         this.buildRootDir = buildRootDir;
         this.startParameter = startParameter;
         this.injectedSettingsPlugins = injectedSettingsPlugins;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.component;
+package org.gradle.api.internal.artifacts;
 
 import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.BuildIdentifier;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildIdentity.java
@@ -20,6 +20,8 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 
+import java.io.File;
+
 public class DefaultBuildIdentity implements BuildIdentity {
     private final BuildIdentifier buildIdentifier;
 
@@ -27,7 +29,10 @@ public class DefaultBuildIdentity implements BuildIdentity {
         if (isRootBuild) {
             this.buildIdentifier = new DefaultBuildIdentifier(":");
         } else {
-            this.buildIdentifier = new DefaultBuildIdentifier(buildDefinition.getBuildRootDir().getName());
+            // Infer a build id from the containing directory
+            // Should be part of the build definition
+            File dir = buildDefinition.getBuildRootDir() == null ? buildDefinition.getStartParameter().getCurrentDir() : buildDefinition.getBuildRootDir();
+            this.buildIdentifier = new DefaultBuildIdentifier(dir.getName());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildIdentity.java
@@ -17,12 +17,18 @@
 package org.gradle.initialization;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 
 public class DefaultBuildIdentity implements BuildIdentity {
     private final BuildIdentifier buildIdentifier;
 
-    public DefaultBuildIdentity(BuildIdentifier buildIdentifier) {
-        this.buildIdentifier = buildIdentifier;
+    public DefaultBuildIdentity(BuildDefinition buildDefinition, boolean isRootBuild) {
+        if (isRootBuild) {
+            this.buildIdentifier = new DefaultBuildIdentifier(":");
+        } else {
+            this.buildIdentifier = new DefaultBuildIdentifier(buildDefinition.getBuildRootDir().getName());
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -342,7 +342,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
         }
     }
 
-
     private boolean isConfigureOnDemand() {
         return gradle.getStartParameter().isConfigureOnDemand();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -131,16 +131,20 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         return launcher;
     }
 
-    private DefaultGradleLauncher doNewInstance(BuildDefinition buildDefinition, GradleLauncher parent,
+    private DefaultGradleLauncher doNewInstance(BuildDefinition buildDefinition,
+                                                @Nullable GradleLauncher parent,
                                                 BuildCancellationToken cancellationToken,
-                                                BuildRequestMetaData requestMetaData, BuildEventConsumer buildEventConsumer,
-                                                final BuildTreeScopeServices buildTreeScopeServices, List<?> servicesToStop) {
+                                                BuildRequestMetaData requestMetaData,
+                                                BuildEventConsumer buildEventConsumer,
+                                                final BuildTreeScopeServices buildTreeScopeServices,
+                                                List<?> servicesToStop) {
         BuildScopeServices serviceRegistry = new BuildScopeServices(buildTreeScopeServices);
         serviceRegistry.add(BuildDefinition.class, buildDefinition);
         serviceRegistry.add(BuildRequestMetaData.class, requestMetaData);
         serviceRegistry.add(BuildClientMetaData.class, requestMetaData.getClient());
         serviceRegistry.add(BuildEventConsumer.class, buildEventConsumer);
         serviceRegistry.add(BuildCancellationToken.class, cancellationToken);
+        serviceRegistry.add(BuildIdentity.class, new DefaultBuildIdentity(buildDefinition, parent == null));
         NestedBuildFactoryImpl nestedBuildFactory = new NestedBuildFactoryImpl(buildTreeScopeServices);
         serviceRegistry.add(NestedBuildFactory.class, nestedBuildFactory);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -104,9 +104,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
 
         // We found the desired settings file, now build the associated buildSrc before loading settings.  This allows
         // the settings script to reference classes in the buildSrc.
-        StartParameter buildSrcStartParameter = startParameter.newBuild();
-        buildSrcStartParameter.setCurrentDir(new File(settingsLocation.getSettingsDir(), DefaultSettings.DEFAULT_BUILD_SRC_DIR));
-        ClassLoaderScope buildSourceClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(gradle, buildSrcStartParameter);
+        ClassLoaderScope buildSourceClassLoaderScope = buildSourceBuilder.buildAndCreateClassLoader(gradle, settingsLocation.getSettingsDir(), startParameter);
 
         return settingsProcessor.process(gradle, settingsLocation, buildSourceClassLoaderScope, startParameter);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildBuildSrcBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildBuildSrcBuildOperationType.java
@@ -29,6 +29,7 @@ public final class BuildBuildSrcBuildOperationType implements BuildOperationType
     @UsedByScanPlugin
     public interface Details {
         /**
+         * Returns the path of the _containing_ build.
          * @since 4.6
          */
         String getBuildPath();

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -20,7 +20,9 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildClientMetaData;
+import org.gradle.initialization.BuildIdentity;
 import org.gradle.initialization.DefaultBuildCancellationToken;
+import org.gradle.initialization.DefaultBuildIdentity;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.installation.CurrentGradleInstallation;
@@ -41,6 +43,10 @@ public class TestBuildScopeServices extends BuildScopeServices {
 
     protected BuildDefinition createBuildDefinition(StartParameter startParameter) {
         return BuildDefinition.fromStartParameter(startParameter);
+    }
+
+    protected BuildIdentity createBuildIdentity(BuildDefinition buildDefinition) {
+        return new DefaultBuildIdentity(buildDefinition, true);
     }
 
     protected BuildCancellationToken createBuildCancellationToken() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherFactoryTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.internal.service.scopes.BuildTreeScopeServices
 import org.gradle.internal.service.scopes.GlobalScopeServices
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry
 import org.gradle.internal.time.Time
+import org.gradle.plugin.management.internal.PluginRequests
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.junit.Rule
@@ -83,7 +84,7 @@ class DefaultGradleLauncherFactoryTest extends Specification {
         parent.buildListener.buildStarted(parent.gradle)
 
         expect:
-        def launcher = parent.gradle.services.get(NestedBuildFactory).nestedInstance(BuildDefinition.fromStartParameter(startParameter))
+        def launcher = parent.gradle.services.get(NestedBuildFactory).nestedInstance(BuildDefinition.fromStartParameterForBuild(startParameter, tmpDir.file("nested"), Stub(PluginRequests)))
         launcher.gradle.parent == parent.gradle
 
         def request = launcher.gradle.services.get(BuildRequestMetaData)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -54,8 +54,9 @@ class DefaultSettingsLoaderTest extends Specification {
         gradle.getServices() >> services
         gradle.getIdentityPath() >> Path.ROOT
         settingsFinder.find(startParameter) >> settingsLocation
-        1 * buildSourceBuilder.buildAndCreateClassLoader(_, _) >> { GradleInternal gradle, StartParameter sp ->
-            assert sp.currentDir == new File(settingsLocation.getSettingsDir(), DefaultSettings.DEFAULT_BUILD_SRC_DIR)
+        1 * buildSourceBuilder.buildAndCreateClassLoader(_, _, _) >> { GradleInternal gradle, File rootDir, StartParameter sp ->
+            assert rootDir == settingsLocation.getSettingsDir()
+            assert sp == startParameter
             classLoaderScope
         }
         1 * settingsProcessor.process(gradle, settingsLocation, classLoaderScope, startParameter) >> settings

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -21,7 +21,6 @@ import org.gradle.StartParameter;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.component.DefaultComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
@@ -87,7 +86,6 @@ import org.gradle.authentication.Authentication;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.initialization.BuildIdentity;
-import org.gradle.initialization.DefaultBuildIdentity;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.installation.CurrentGradleInstallation;
@@ -119,17 +117,6 @@ import java.util.List;
 class DependencyManagementBuildScopeServices {
     DependencyManagementServices createDependencyManagementServices(ServiceRegistry parent) {
         return new DefaultDependencyManagementServices(parent);
-    }
-
-    BuildIdentity createBuildIdentity(ProjectRegistry<ProjectInternal> projectRegistry) {
-        ProjectInternal rootProject = projectRegistry.getRootProject();
-        if (rootProject == null || rootProject.getGradle().getParent() == null) {
-            // BuildIdentity for a top-level build
-            return new DefaultBuildIdentity(new DefaultBuildIdentifier(":"));
-        }
-        // BuildIdentity for an included build
-        // This hard-codes the assumption that buildName == rootProject.name for included builds
-        return new DefaultBuildIdentity(new DefaultBuildIdentifier(rootProject.getName()));
     }
 
     ComponentIdentifierFactory createComponentIdentifierFactory(BuildIdentity buildIdentity) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.initialization.BuildIdentity;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -36,7 +36,7 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
     @Override
     public LocalComponentMetadata getComponent(ProjectComponentIdentifier projectIdentifier) {
         LocalComponentMetadata metaData = projects.get(projectIdentifier);
-        if (metaData !=null) {
+        if (metaData != null) {
             return metaData;
         }
         for (LocalComponentProvider provider : providers) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -17,10 +17,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -44,31 +42,6 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
             if (componentMetaData != null) {
                 projects.putIfAbsent(projectIdentifier, componentMetaData);
                 return componentMetaData;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public Iterable<LocalComponentArtifactMetadata> getAdditionalArtifacts(ProjectComponentIdentifier project) {
-        for (LocalComponentProvider provider : providers) {
-            Iterable<LocalComponentArtifactMetadata> artifacts = provider.getAdditionalArtifacts(project);
-            if (artifacts != null) {
-                return artifacts;
-            }
-        }
-        return Collections.emptyList();
-    }
-
-    /**
-     * Finds an IDE metadata artifact with the specified type. Does not execute tasks to build the artifact.
-     *
-     * IDE metadata artifacts are registered by IDE plugins via {@link org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectLocalComponentProvider#registerAdditionalArtifact(org.gradle.api.artifacts.component.ProjectComponentIdentifier, org.gradle.internal.component.local.model.LocalComponentArtifactMetadata)}
-     */
-    public LocalComponentArtifactMetadata findAdditionalArtifact(ProjectComponentIdentifier project, String type) {
-        for (LocalComponentArtifactMetadata artifactMetaData : getAdditionalArtifacts(project)) {
-            if (artifactMetaData.getName().getType().equals(type)) {
-                return artifactMetaData;
             }
         }
         return null;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -29,7 +27,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
 import static org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier.newProjectId;
@@ -37,7 +34,6 @@ import static org.gradle.internal.component.local.model.DefaultProjectComponentI
 public class DefaultProjectLocalComponentProvider implements ProjectLocalComponentProvider {
     private final ProjectRegistry<ProjectInternal> projectRegistry;
     private final LocalComponentMetadataBuilder metaDataBuilder;
-    private final ListMultimap<String, LocalComponentArtifactMetadata> registeredArtifacts = ArrayListMultimap.create();
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final BuildIdentifier thisBuild;
 
@@ -70,26 +66,6 @@ public class DefaultProjectLocalComponentProvider implements ProjectLocalCompone
         DefaultLocalComponentMetadata metaData = new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), (AttributesSchemaInternal) project.getDependencies().getAttributesSchema());
         metaDataBuilder.addConfigurations(metaData, project.getConfigurations().withType(ConfigurationInternal.class));
         return metaData;
-    }
-
-    @Override
-    public void registerAdditionalArtifact(ProjectComponentIdentifier project, LocalComponentArtifactMetadata artifact) {
-        if (!isLocalProject(project)) {
-            return;
-        }
-        registeredArtifacts.put(project.getProjectPath(), artifact);
-    }
-
-    @Override
-    public Iterable<LocalComponentArtifactMetadata> getAdditionalArtifacts(ProjectComponentIdentifier projectIdentifier) {
-        if (!isLocalProject(projectIdentifier)) {
-            return null;
-        }
-        String projectPath = projectIdentifier.getProjectPath();
-        if (registeredArtifacts.containsKey(projectPath)) {
-            return registeredArtifacts.get(projectPath);
-        }
-        return null;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentProvider.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
 /**
@@ -29,9 +28,4 @@ public interface LocalComponentProvider {
      * @return The component metadata for the supplied identifier.
      */
     LocalComponentMetadata getComponent(ProjectComponentIdentifier projectIdentifier);
-
-    /**
-     * @return The additional artifacts registered for this project, or null if none registered for this project
-     */
-    Iterable<LocalComponentArtifactMetadata> getAdditionalArtifacts(ProjectComponentIdentifier project);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
 /**
@@ -29,15 +28,4 @@ public interface LocalComponentRegistry {
      * @return The component metadata for the supplied identifier.
      */
     LocalComponentMetadata getComponent(ProjectComponentIdentifier projectIdentifier);
-
-    /**
-     * @return The additional artifacts registered for this project, if any. Never null.
-     */
-    Iterable<LocalComponentArtifactMetadata> getAdditionalArtifacts(ProjectComponentIdentifier project);
-
-    /**
-     * Finds an IDE metadata artifact with the specified type. Does not execute tasks to build the artifact.
-     */
-    LocalComponentArtifactMetadata findAdditionalArtifact(ProjectComponentIdentifier project, String type);
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectLocalComponentProvider.java
@@ -16,13 +16,9 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
-
 /**
  * Provides dependency resolution metadata for project components: these are components represented by a project
  * within the current multi-project build.
  */
 public interface ProjectLocalComponentProvider extends LocalComponentProvider {
-    void registerAdditionalArtifact(ProjectComponentIdentifier project, LocalComponentArtifactMetadata artifact);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/BuildIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/BuildIdentifierSerializer.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentIdentifier.java
@@ -20,7 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.initialization.IncludedBuild;
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.initialization.BuildIdentity;
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.component
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModule
 import org.gradle.api.internal.artifacts.Module
 import org.gradle.api.internal.artifacts.ProjectBackedModule

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
@@ -17,14 +17,13 @@
 package org.gradle.api.internal.artifacts.dsl
 
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.initialization.BuildIdentity
-import org.gradle.initialization.DefaultBuildIdentity
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import spock.lang.Specification
@@ -104,8 +103,12 @@ public class ComponentSelectorParsersTest extends Specification {
 
     def "understands project input"() {
         when:
+        def buildId = Stub(BuildIdentifier)
+        buildId.name >> "build"
+        def buildIdentity = Stub(BuildIdentity)
+        buildIdentity.currentBuild >> buildId
         def services = new DefaultServiceRegistry()
-        services.add(BuildIdentity, new DefaultBuildIdentity(new DefaultBuildIdentifier("TEST")))
+        services.add(BuildIdentity, buildIdentity)
         def project = Mock(ProjectInternal) {
             getPath() >> ":bar"
             getServices() >> services
@@ -116,6 +119,7 @@ public class ComponentSelectorParsersTest extends Specification {
         v.size() == 1
         v[0] instanceof ProjectComponentSelector
         v[0].projectPath == ":bar"
+        v[0].buildName == "build"
     }
 
     def "fails for unknown types"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -19,11 +19,9 @@ package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.initialization.BuildIdentity
-import org.gradle.initialization.DefaultBuildIdentity
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import spock.lang.Specification
@@ -85,7 +83,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
     def "can specify target project"() {
         def project = Mock(ProjectInternal)
         def services = new DefaultServiceRegistry()
-        services.add(BuildIdentity, new DefaultBuildIdentity(new DefaultBuildIdentifier("TEST")))
+        services.add(BuildIdentity, Stub(BuildIdentity))
 
         when:
         details.useTarget(project)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentIdentifierTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.internal.component.local.model
 
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
@@ -17,7 +17,7 @@ package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 
 public class TestComponentIdentifiers {
     public static ProjectComponentIdentifier newProjectId(String projectPath) {

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -5,6 +5,7 @@
             "member": "Class org.gradle.ide.visualstudio.plugins.VisualStudioPlugin",
             "acceptation": "removed internal methods from superclass",
             "changes": [
+                "org.gradle.plugins.ide.internal.IdePlugin.getCleanTask(org.gradle.api.Task)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifactMetadata(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifacts(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.postProcess(java.lang.String,org.gradle.api.Action)",
@@ -16,6 +17,7 @@
             "member": "Class org.gradle.ide.xcode.plugins.XcodePlugin",
             "acceptation": "removed internal methods from superclass",
             "changes": [
+                "org.gradle.plugins.ide.internal.IdePlugin.getCleanTask(org.gradle.api.Task)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifactMetadata(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifacts(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.postProcess(java.lang.String,org.gradle.api.Action)",
@@ -27,6 +29,7 @@
             "member": "Class org.gradle.plugins.ide.eclipse.EclipsePlugin",
             "acceptation": "removed internal methods from superclass",
             "changes": [
+                "org.gradle.plugins.ide.internal.IdePlugin.getCleanTask(org.gradle.api.Task)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifactMetadata(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifacts(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.postProcess(java.lang.String,org.gradle.api.Action)",
@@ -38,6 +41,7 @@
             "member": "Class org.gradle.plugins.ide.eclipse.EclipseWtpPlugin",
             "acceptation": "removed internal methods from superclass",
             "changes": [
+                "org.gradle.plugins.ide.internal.IdePlugin.getCleanTask(org.gradle.api.Task)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifactMetadata(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifacts(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.postProcess(java.lang.String,org.gradle.api.Action)",
@@ -49,6 +53,7 @@
             "member": "Class org.gradle.plugins.ide.idea.IdeaPlugin",
             "acceptation": "removed internal methods from superclass",
             "changes": [
+                "org.gradle.plugins.ide.internal.IdePlugin.getCleanTask(org.gradle.api.Task)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifactMetadata(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.getIdeArtifacts(java.lang.String)",
                 "org.gradle.plugins.ide.internal.IdePlugin.postProcess(java.lang.String,org.gradle.api.Action)",

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioCompositeBuildIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioCompositeBuildIntegrationTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.visualstudio
+
+import org.gradle.ide.visualstudio.fixtures.AbstractVisualStudioIntegrationSpec
+import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
+
+class VisualStudioCompositeBuildIntegrationTest extends AbstractVisualStudioIntegrationSpec {
+    def app = new CppHelloWorldApp()
+
+    def "includes a visual studio project for every project in build with a C++ component"() {
+        when:
+        settingsFile << """
+            rootProject.name = 'app'
+            include 'one', 'two', 'three'
+            includeBuild "util"
+            includeBuild "other"
+        """
+        buildFile << """
+            allprojects {
+                apply plugin: 'visual-studio'
+            }
+            project(':one') {
+                apply plugin: 'cpp-application'
+            }
+            project(':two') {
+                apply plugin: 'cpp-library'
+                dependencies {
+                    implementation "test:util:1.3"
+                }
+            }
+        """
+
+        buildTestFixture.withBuildInSubDir()
+        singleProjectBuild("util") {
+            settingsFile << "rootProject.name = 'util'"
+            buildFile << """
+                apply plugin: 'cpp-library'
+                apply plugin: 'visual-studio'
+                group = 'test'
+                version = '1.3'
+            """
+        }
+        singleProjectBuild("other") {
+            settingsFile << "rootProject.name = 'other'"
+            buildFile << """
+                apply plugin: 'cpp-application'
+                apply plugin: 'visual-studio'
+            """
+        }
+
+        and:
+        run ":visualStudio"
+
+        then:
+        result.assertTasksExecuted(":appVisualStudioSolution",
+            ":one:oneVisualStudioFilters", ":one:oneVisualStudioProject",
+            ":two:twoDllVisualStudioFilters", ":two:twoDllVisualStudioProject",
+            ":util:utilDllVisualStudioFilters", ":util:utilDllVisualStudioProject",
+            ":other:otherVisualStudioFilters", ":other:otherVisualStudioProject",
+            ":visualStudio")
+
+        and:
+        def oneProject = projectFile("one/one.vcxproj")
+        def twoProject = projectFile("two/twoDll.vcxproj")
+        def utilProject = projectFile("util/utilDll.vcxproj")
+        def otherProject = projectFile("other/other.vcxproj")
+
+        final mainSolution = solutionFile("app.sln")
+        mainSolution.assertHasProjects("one", "twoDll", "utilDll", "other")
+        mainSolution.assertReferencesProject(oneProject, projectConfigurations)
+        mainSolution.assertReferencesProject(twoProject, projectConfigurations)
+        mainSolution.assertReferencesProject(utilProject, projectConfigurations)
+        mainSolution.assertReferencesProject(otherProject, projectConfigurations)
+    }
+}

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSingleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSingleProjectIntegrationTest.groovy
@@ -25,14 +25,29 @@ import org.gradle.util.TestPrecondition
 
 
 class VisualStudioSingleProjectIntegrationTest extends AbstractVisualStudioIntegrationSpec {
-    private final Set<String> projectConfigurations = ['debug', 'release'] as Set
-
     def app = new CppHelloWorldApp()
 
     def setup() {
         buildFile << """
             apply plugin: 'visual-studio'
         """
+    }
+
+    def "create visual studio solution for project without C++ component"() {
+        when:
+        settingsFile << """
+            rootProject.name = 'app'
+        """
+
+        and:
+        run "visualStudio"
+
+        then:
+        result.assertTasksExecuted(":visualStudio", ":appVisualStudioSolution")
+
+        and:
+        final mainSolution = solutionFile("app.sln")
+        mainSolution.assertHasProjects()
     }
 
     def "create visual studio solution for single executable"() {
@@ -56,8 +71,7 @@ class VisualStudioSingleProjectIntegrationTest extends AbstractVisualStudioInteg
         run "visualStudio"
 
         then:
-        executedAndNotSkipped ":visualStudio", ":appVisualStudioSolution"
-        executedAndNotSkipped getProjectTasks("app")
+        result.assertTasksExecuted(":visualStudio", ":appVisualStudioSolution", getProjectTasks("app"))
 
         and:
         final projectFile = projectFile("app.vcxproj")
@@ -97,8 +111,7 @@ class VisualStudioSingleProjectIntegrationTest extends AbstractVisualStudioInteg
         run "visualStudio"
 
         then:
-        executedAndNotSkipped ":visualStudio", ":libVisualStudioSolution"
-        executedAndNotSkipped getProjectTasks("libDll")
+        result.assertTasksExecuted(":visualStudio", ":libVisualStudioSolution", getProjectTasks("libDll"))
 
         and:
         final projectFile = projectFile("libDll.vcxproj")
@@ -139,8 +152,7 @@ class VisualStudioSingleProjectIntegrationTest extends AbstractVisualStudioInteg
         run "visualStudio"
 
         then:
-        executedAndNotSkipped ":visualStudio", ":libVisualStudioSolution"
-        executedAndNotSkipped getProjectTasks("libLib")
+        result.assertTasksExecuted(":visualStudio", ":libVisualStudioSolution", getProjectTasks("libLib"))
 
         and:
         final projectFile = projectFile("libLib.vcxproj")
@@ -181,9 +193,7 @@ class VisualStudioSingleProjectIntegrationTest extends AbstractVisualStudioInteg
         run "visualStudio"
 
         then:
-        executedAndNotSkipped ":visualStudio", ":libVisualStudioSolution"
-        executedAndNotSkipped getProjectTasks("libLib")
-        executedAndNotSkipped getProjectTasks("libDll")
+        result.assertTasksExecuted(":visualStudio", ":libVisualStudioSolution", getProjectTasks("libLib"), getProjectTasks("libDll"))
 
         and:
         final libProjectFile = projectFile("libLib.vcxproj")
@@ -294,6 +304,9 @@ class VisualStudioSingleProjectIntegrationTest extends AbstractVisualStudioInteg
         run "visualStudio"
 
         then:
+        result.assertTasksExecuted(":visualStudio", ":appVisualStudioSolution", getProjectTasks("app"))
+
+        and:
         final projectFile = projectFile("app.vcxproj")
         projectFile.sourceFiles == ['build.gradle']
         projectFile.headerFiles == []

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/fixtures/AbstractVisualStudioIntegrationSpec.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/fixtures/AbstractVisualStudioIntegrationSpec.groovy
@@ -21,6 +21,8 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 
 abstract class AbstractVisualStudioIntegrationSpec extends AbstractInstalledToolChainIntegrationSpec {
+    final def projectConfigurations = ['debug', 'release'] as Set
+
     protected static String filePath(String... paths) {
         return (paths as List).join(';')
     }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
@@ -74,8 +74,6 @@ class XcodeCompositeBuildIntegrationTest extends AbstractXcodeIntegrationSpec {
             ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme",
             ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme",
             ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject",
-            // TODO - shouldn't be present (unless all of the other compile tasks are present as well)
-            ":util:compileDebugSwift",
             ":util:xcodeProjectWorkspaceSettings", ":util:xcodeProject", ":util:xcodeScheme",
             ":other:xcodeProjectWorkspaceSettings", ":other:xcodeProject", ":other:xcodeScheme",
             ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.xcode
+
+import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+
+@Requires(TestPrecondition.XCODE)
+class XcodeCompositeBuildIntegrationTest extends AbstractXcodeIntegrationSpec {
+
+    def "creates workspace with Xcode project for each project in build"() {
+        given:
+        settingsFile << """
+            include 'app', 'greeter', 'empty'
+            includeBuild 'util'
+            includeBuild 'other'
+        """
+
+        buildFile << """
+            allprojects {
+                apply plugin: 'xcode'
+            }
+            apply plugin: 'swift-application' 
+            project(':app') {
+                apply plugin: 'swift-application'
+                dependencies {
+                    implementation project(':greeter')
+                }
+            }
+            project(':greeter') {
+                apply plugin: 'swift-library'
+                dependencies {
+                    implementation 'test:util:1.3'
+                }
+            }
+"""
+
+        buildTestFixture.withBuildInSubDir()
+        singleProjectBuild("util") {
+            settingsFile << "rootProject.name = 'util'"
+            buildFile << """
+                apply plugin: 'swift-library'
+                apply plugin: 'xcode'
+                group = 'test'
+                version = '1.3'
+            """
+        }
+        singleProjectBuild("other") {
+            settingsFile << "rootProject.name = 'other'"
+            buildFile << """
+                apply plugin: 'swift-application'
+                apply plugin: 'xcode'
+            """
+        }
+
+        when:
+        succeeds("xcode")
+
+        then:
+        result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
+            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme", ":app:xcode",
+            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme", ":greeter:xcode",
+            ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject", ":empty:xcode",
+            // TODO - shouldn't be present (unless all of the other compile tasks are present as well)
+            ":util:compileDebugSwift",
+            ":util:xcodeProjectWorkspaceSettings", ":util:xcodeProject", ":util:xcodeScheme",
+            ":other:xcodeProjectWorkspaceSettings", ":other:xcodeProject", ":other:xcodeScheme",
+            ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
+
+        rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj', 'greeter/greeter.xcodeproj', 'empty/empty.xcodeproj', 'util/util.xcodeproj', 'other/other.xcodeproj')
+
+        xcodeProject("${rootProjectName}.xcodeproj")
+        xcodeProject("app/app.xcodeproj")
+        xcodeProject("greeter/greeter.xcodeproj")
+        xcodeProject("empty/empty.xcodeproj")
+        xcodeProject("util/util.xcodeproj")
+        xcodeProject("other/other.xcodeproj")
+    }
+}

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
@@ -39,9 +39,6 @@ class XcodeCompositeBuildIntegrationTest extends AbstractXcodeIntegrationSpec {
             apply plugin: 'swift-application' 
             project(':app') {
                 apply plugin: 'swift-application'
-                dependencies {
-                    implementation project(':greeter')
-                }
             }
             project(':greeter') {
                 apply plugin: 'swift-library'
@@ -70,13 +67,13 @@ class XcodeCompositeBuildIntegrationTest extends AbstractXcodeIntegrationSpec {
         }
 
         when:
-        succeeds("xcode")
+        succeeds(":xcode")
 
         then:
         result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
-            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme", ":app:xcode",
-            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme", ":greeter:xcode",
-            ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject", ":empty:xcode",
+            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme",
+            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme",
+            ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject",
             // TODO - shouldn't be present (unless all of the other compile tasks are present as well)
             ":util:compileDebugSwift",
             ":util:xcodeProjectWorkspaceSettings", ":util:xcodeProject", ":util:xcodeScheme",

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCppExternalSourceDependenciesIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCppExternalSourceDependenciesIntegrationTest.groovy
@@ -68,10 +68,10 @@ class XcodeCppExternalSourceDependenciesIntegrationTest extends AbstractXcodeInt
         fixture.main.writeToProject(testDirectory)
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
+        result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
@@ -117,10 +117,10 @@ class XcodeCppExternalSourceDependenciesIntegrationTest extends AbstractXcodeInt
         fixture.main.writeToProject(testDirectory)
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
+        result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
@@ -173,11 +173,11 @@ class XcodeCppExternalSourceDependenciesIntegrationTest extends AbstractXcodeInt
         """
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
-            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcode")
+        result.assertTasksExecuted(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", "app/app.xcodeproj")
 
         def appProject = xcodeProject("app/app.xcodeproj").projectFile
@@ -231,11 +231,11 @@ class XcodeCppExternalSourceDependenciesIntegrationTest extends AbstractXcodeInt
         """
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
-            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcode")
+        result.assertTasksExecuted(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", "app/app.xcodeproj")
 
         def appProject = xcodeProject("app/app.xcodeproj").projectFile

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCppExternalSourceDependenciesIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCppExternalSourceDependenciesIntegrationTest.groovy
@@ -76,6 +76,12 @@ class XcodeCppExternalSourceDependenciesIntegrationTest extends AbstractXcodeInt
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
         appProject.indexTarget.getBuildSettings().HEADER_SEARCH_PATHS == toSpaceSeparatedList(file('src/main/headers'), checkoutDir(repo.name, commit.id.name, repo.id).file('src/main/public'))
+
+        when:
+        succeeds ':xcodeProject'
+
+        then:
+        result.assertTasksExecuted(":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcodeProject")
     }
 
     def "does not add source dependencies Xcode project of main component to Xcode workspace"() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleProjectIntegrationTest.groovy
@@ -22,9 +22,80 @@ import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibrary
 class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
     def setup() {
         settingsFile << """
+            rootProject.name = 'root'
             include 'app', 'greeter'
         """
         requireSwiftToolChain()
+    }
+
+    @Override
+    protected String getRootProjectName() {
+        return "root"
+    }
+
+    def "create xcode workspace when no language plugins are applied"() {
+        given:
+        buildFile << """
+            allprojects { 
+                apply plugin: 'xcode'
+            }
+        """
+
+        when:
+        succeeds(":xcode")
+
+        then:
+        result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings",
+            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject",
+            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject",
+            ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
+
+        def workspace = rootXcodeWorkspace
+        workspace.contentFile.assertHasProjects("root.xcodeproj", "app/app.xcodeproj", "greeter/greeter.xcodeproj")
+
+        def project = rootXcodeProject.projectFile
+        project.mainGroup.assertHasChildren(['build.gradle'])
+        project.assertNoTargets()
+    }
+
+    def "creates workspace with Xcode project for each project"() {
+        given:
+        settingsFile << """
+            include 'empty'
+        """
+
+        buildFile << """
+            allprojects {
+                apply plugin: 'xcode'
+            }
+            apply plugin: 'swift-application' 
+            project(':app') {
+                apply plugin: 'swift-application'
+                dependencies {
+                    implementation project(':greeter')
+                }
+            }
+            project(':greeter') {
+                apply plugin: 'swift-library'
+            }
+"""
+
+        when:
+        succeeds("xcode")
+
+        then:
+        result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
+            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme", ":app:xcode",
+            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme", ":greeter:xcode",
+            ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject", ":empty:xcode",
+            ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
+
+        rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj', 'greeter/greeter.xcodeproj', 'empty/empty.xcodeproj')
+
+        xcodeProject("${rootProjectName}.xcodeproj")
+        xcodeProject("app/app.xcodeproj")
+        xcodeProject("greeter/greeter.xcodeproj")
+        xcodeProject("empty/empty.xcodeproj")
     }
 
     def "Gradle project with added xcode plugin are included in the workspace"() {

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleProjectIntegrationTest.groovy
@@ -81,13 +81,13 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
 """
 
         when:
-        succeeds("xcode")
+        succeeds(":xcode")
 
         then:
         result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
-            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme", ":app:xcode",
-            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme", ":greeter:xcode",
-            ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject", ":empty:xcode",
+            ":app:xcodeProjectWorkspaceSettings", ":app:xcodeProject", ":app:xcodeScheme",
+            ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeProject", ":greeter:xcodeScheme",
+            ":empty:xcodeProjectWorkspaceSettings", ":empty:xcodeProject",
             ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
 
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj', 'greeter/greeter.xcodeproj', 'empty/empty.xcodeproj')
@@ -121,10 +121,11 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
                 apply plugin: 'xcode'
             }
         """
-        succeeds("xcode")
+        succeeds(":xcode")
 
         then:
-        executedAndNotSkipped(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme", ":app:xcode",
+        result.assertTasksExecuted(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":xcodeProjectWorkspaceSettings", ":xcodeProject",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj')
 
@@ -134,11 +135,12 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
                 apply plugin: 'xcode'
             }
         """
-        succeeds("xcode")
+        succeeds(":xcode")
 
         then:
-        executedAndNotSkipped(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme", ":app:xcode",
-            ":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeScheme", ":greeter:xcode",
+        result.assertTasksExecuted(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeScheme",
+            ":xcodeProjectWorkspaceSettings", ":xcodeProject",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj', 'greeter/greeter.xcodeproj')
     }
@@ -165,11 +167,12 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
                 apply plugin: 'xcode'
             }
         """
-        succeeds("xcode")
+        succeeds(":xcode")
 
         then:
-        executedAndNotSkipped(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme", ":app:xcode",
-            ":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeScheme", ":greeter:xcode",
+        result.assertTasksExecuted(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":greeter:xcodeProject", ":greeter:xcodeProjectWorkspaceSettings", ":greeter:xcodeScheme",
+            ":xcodeProjectWorkspaceSettings", ":xcodeProject",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj', 'greeter/greeter.xcodeproj')
 
@@ -180,10 +183,11 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
                 apply plugin: 'xcode'
             }
         """
-        succeeds("xcode")
+        succeeds(":xcode")
 
         then:
-        executedAndNotSkipped(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme", ":app:xcode",
+        result.assertTasksExecuted(":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":xcodeProjectWorkspaceSettings", ":xcodeProject",
             ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", 'app/app.xcodeproj')
     }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSingleProjectIntegrationTest.groovy
@@ -19,12 +19,15 @@ package org.gradle.ide.xcode
 import org.gradle.ide.xcode.fixtures.AbstractXcodeIntegrationSpec
 
 class XcodeSingleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
-    def "create empty xcode project when no language plugins are applied"() {
+    def "create xcode workspace when no language plugins are applied"() {
         when:
         succeeds("xcode")
 
         then:
-        executedAndNotSkipped(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcode")
+        result.assertTasksExecuted(":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeWorkspaceWorkspaceSettings", ":xcodeWorkspace", ":xcode")
+
+        def workspace = rootXcodeWorkspace
+        workspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def project = rootXcodeProject.projectFile
         project.mainGroup.assertHasChildren(['build.gradle'])

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSwiftExternalSourceDependenciesIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSwiftExternalSourceDependenciesIntegrationTest.groovy
@@ -75,11 +75,20 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
+            ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
         appProject.indexTarget.getBuildSettings().SWIFT_INCLUDE_PATHS == toSpaceSeparatedList(checkoutDir(repo.name, commit.id.name, repo.id).file('build/modules/main/debug'))
+
+        when:
+        succeeds ':xcodeProject'
+
+        then:
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme")
     }
 
     def "does not add source dependencies Xcode project of main component to Xcode workspace"() {
@@ -124,7 +133,9 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
+            ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
@@ -173,7 +184,9 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
+            ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
@@ -224,7 +237,9 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme",
+            ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj")
 
         def appProject = xcodeProject("${rootProjectName}.xcodeproj").projectFile
@@ -281,8 +296,10 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":greeter:compileDebugSwift", ":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
-            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcode")
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings",
+            ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", "app/app.xcodeproj")
 
         def appProject = xcodeProject("app/app.xcodeproj").projectFile
@@ -339,8 +356,10 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         succeeds ':xcode'
 
         then:
-        executedAndNotSkipped(":greeter:compileDebugSwift", ":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
-            ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcode")
+        result.assertTasksExecuted(":greeter:compileDebugSwift",
+            ":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
+            ":xcodeProject", ":xcodeProjectWorkspaceSettings",
+            ":xcodeWorkspace", ":xcodeWorkspaceWorkspaceSettings", ":xcode")
         rootXcodeWorkspace.contentFile.assertHasProjects("${rootProjectName}.xcodeproj", "app/app.xcodeproj")
 
         def appProject = xcodeProject("app/app.xcodeproj").projectFile

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSwiftExternalSourceDependenciesIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeSwiftExternalSourceDependenciesIntegrationTest.groovy
@@ -72,7 +72,7 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         fixture.executable.writeToProject(testDirectory)
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
         executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
@@ -121,7 +121,7 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         fixture.executable.writeToProject(testDirectory)
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
         executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
@@ -170,7 +170,7 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         test.writeToProject(testDirectory)
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
         executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
@@ -221,7 +221,7 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         test.writeToProject(testDirectory)
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
         executedAndNotSkipped(":greeter:compileDebugSwift", ":xcodeProject", ":xcodeProjectWorkspaceSettings", ":xcodeScheme", ":xcode")
@@ -278,7 +278,7 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         """
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
         executedAndNotSkipped(":greeter:compileDebugSwift", ":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",
@@ -336,7 +336,7 @@ class XcodeSwiftExternalSourceDependenciesIntegrationTest extends AbstractXcodeI
         """
 
         when:
-        succeeds 'xcode'
+        succeeds ':xcode'
 
         then:
         executedAndNotSkipped(":greeter:compileDebugSwift", ":app:xcodeProject", ":app:xcodeProjectWorkspaceSettings", ":app:xcodeScheme",

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
@@ -88,7 +88,7 @@ public class VisualStudioPlugin extends IdePlugin {
             extension = (VisualStudioExtensionInternal) project.getExtensions().create(VisualStudioRootExtension.class, "visualStudio", DefaultVisualStudioRootExtension.class, project.getName(), instantiator, target.getObjects(), fileResolver, artifactRegistry);
             final VisualStudioSolution solution = ((VisualStudioRootExtension) extension).getSolution();
             getLifecycleTask().dependsOn(solution);
-            addWorkspaceOpenTask(solution);
+            addWorkspace(solution);
         } else {
             extension = (VisualStudioExtensionInternal) project.getExtensions().create(VisualStudioExtension.class, "visualStudio", DefaultVisualStudioExtension.class, instantiator, fileResolver, artifactRegistry);
             getLifecycleTask().dependsOn(extension.getProjects());

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateSolutionFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateSolutionFileTask.java
@@ -75,8 +75,7 @@ public class GenerateSolutionFileTask extends GeneratorTask<VisualStudioSolution
         public void configure(final VisualStudioSolutionFile solutionFile) {
             DefaultVisualStudioSolution solution = (DefaultVisualStudioSolution) getSolution();
 
-            solutionFile.setProjects(solution.getProjectArtifacts());
-            solutionFile.setProjectConfigurations(solution.getProjectConfigurationArtifacts());
+            solutionFile.setProjects(solution.getProjects());
 
             for (Action<? super TextProvider> textAction : solution.getSolutionFile().getTextActions()) {
                 solutionFile.getActions().add(textAction);

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioSolutionFile.groovy
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioSolutionFile.groovy
@@ -20,7 +20,7 @@ import com.google.common.collect.Maps
 import com.google.common.collect.Sets
 import org.gradle.api.Action
 import org.gradle.ide.visualstudio.TextProvider
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata
+import org.gradle.ide.visualstudio.internal.VisualStudioProjectMetadata
 import org.gradle.plugins.ide.internal.generator.AbstractPersistableConfigurationObject
 import org.gradle.util.TextUtil
 
@@ -36,18 +36,15 @@ class VisualStudioSolutionFile extends AbstractPersistableConfigurationObject {
         'default.sln'
     }
 
-    void setProjects(List<LocalComponentArtifactMetadata> projects) {
-        projects.each { LocalComponentArtifactMetadata project ->
-            this.projects[project.file] = project.name.name
-        }
-    }
-
-    void setProjectConfigurations(List<LocalComponentArtifactMetadata> projectConfigurations) {
-        projectConfigurations.each { LocalComponentArtifactMetadata projectConfiguration ->
-            if (!this.projectConfigurations.containsKey(projectConfiguration.file)) {
-                this.projectConfigurations[projectConfiguration.file] = Sets.newHashSet();
+    void setProjects(List<VisualStudioProjectMetadata> projects) {
+        projects.each { VisualStudioProjectMetadata project ->
+            this.projects[project.file] = project.name
+            project.configurations.each { String configuration ->
+                if (!this.projectConfigurations.containsKey(project.file)) {
+                    this.projectConfigurations[project.file] = Sets.newHashSet();
+                }
+                this.projectConfigurations[project.file].add(configuration)
             }
-            this.projectConfigurations[projectConfiguration.file].add(projectConfiguration.name.name)
         }
     }
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioProject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioProject.java
@@ -19,8 +19,6 @@ package org.gradle.ide.visualstudio.internal;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.XmlProvider;
-import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -29,6 +27,7 @@ import org.gradle.api.tasks.TaskDependency;
 import org.gradle.ide.visualstudio.XmlConfigFile;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.plugins.ide.internal.IdeProjectMetadata;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.VersionNumber;
 
@@ -190,8 +189,8 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
 
     @Override
     @Internal
-    public PublishArtifact getPublishArtifact() {
-        return new VisualStudioProjectArtifact();
+    public IdeProjectMetadata getPublishArtifact() {
+        return new VisualStudioProjectMetadata(this);
     }
 
     @Nested
@@ -202,17 +201,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
     @Nested
     public List<Action<? super XmlProvider>> getFiltersFileActions() {
         return filtersFile.getXmlActions();
-    }
-
-    private class VisualStudioProjectArtifact extends DefaultPublishArtifact {
-        public VisualStudioProjectArtifact() {
-            super(name, "vcxproj", ARTIFACT_TYPE, null, null, null, buildDependencies);
-        }
-
-        @Override
-        public File getFile() {
-            return projectFile.getLocation();
-        }
     }
 
     public static class DefaultConfigFile implements XmlConfigFile {

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectConfiguration.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectConfiguration.java
@@ -16,17 +16,11 @@
 
 package org.gradle.ide.visualstudio.internal;
 
-import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 
-import java.io.File;
-
 public class VisualStudioProjectConfiguration {
-    public final static String ARTIFACT_TYPE = "visualStudioProjectConfiguration";
-
     private final DefaultVisualStudioProject vsProject;
     private final String name;
     private final String configurationName;
@@ -70,24 +64,8 @@ public class VisualStudioProjectConfiguration {
         return vsProject;
     }
 
-    @Internal
-    public PublishArtifact getPublishArtifact() {
-        return new VisualStudioProjectConfigurationArtifact();
-    }
-
     @Input
     public String getBinaryOutputPath() {
         return binary.getOutputFile().getAbsolutePath();
-    }
-
-    private class VisualStudioProjectConfigurationArtifact extends DefaultPublishArtifact {
-        public VisualStudioProjectConfigurationArtifact() {
-            super(name, "vcxproj", ARTIFACT_TYPE, null, null, null, vsProject.getBuildDependencies());
-        }
-
-        @Override
-        public File getFile() {
-            return vsProject.getProjectFile().getLocation();
-        }
     }
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectInternal.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectInternal.java
@@ -16,12 +16,10 @@
 
 package org.gradle.ide.visualstudio.internal;
 
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.ide.visualstudio.VisualStudioProject;
+import org.gradle.plugins.ide.internal.IdeProjectMetadata;
 
 public interface VisualStudioProjectInternal extends VisualStudioProject {
-    String ARTIFACT_TYPE = "visualStudioProject";
-
     /**
      * Returns the name of the component associated with this project
      */
@@ -33,7 +31,7 @@ public interface VisualStudioProjectInternal extends VisualStudioProject {
     void builtBy(Object... tasks);
 
     /**
-     * Returns a {@link org.gradle.api.artifacts.PublishArtifact} associated with this project
+     * Returns a {@link IdeProjectMetadata} view of this project
      */
-    PublishArtifact getPublishArtifact();
+    IdeProjectMetadata getPublishArtifact();
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectMetadata.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectMetadata.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.visualstudio.internal;
+
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.plugins.ide.internal.IdeProjectMetadata;
+import org.gradle.util.CollectionUtils;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+public class VisualStudioProjectMetadata implements IdeProjectMetadata {
+    private final DefaultVisualStudioProject project;
+
+    public VisualStudioProjectMetadata(DefaultVisualStudioProject project) {
+        this.project = project;
+    }
+
+    public String getName() {
+        return project.getName();
+    }
+
+    public File getFile() {
+        return project.getProjectFile().getLocation();
+    }
+
+    @Override
+    public Set<? extends Task> getGeneratorTasks() {
+        return project.getBuildDependencies().getDependencies(null);
+    }
+
+    public List<String> getConfigurations() {
+        return CollectionUtils.collect(project.getConfigurations(), new Transformer<String, VisualStudioProjectConfiguration>() {
+            @Override
+            public String transform(VisualStudioProjectConfiguration configuration) {
+                return configuration.getName();
+            }
+        });
+    }
+}

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistry.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistry.java
@@ -42,7 +42,6 @@ public class VisualStudioProjectRegistry extends DefaultNamedDomainObjectSet<Def
         DefaultVisualStudioProject project = getOrCreateProject(nativeBinary.getVisualStudioProjectName(), nativeBinary.getComponentName(), nativeBinary.getVisualStudioVersion(), nativeBinary.getSdkVersion());
         VisualStudioProjectConfiguration configuration = createVisualStudioProjectConfiguration(project, nativeBinary, nativeBinary.getVisualStudioConfigurationName());
         project.addConfiguration(nativeBinary, configuration);
-        ideArtifactRegistry.registerIdeArtifact(configuration.getPublishArtifact());
         return configuration;
     }
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodeProjectMetadata.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodeProjectMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.ide.xcode.internal;
+
+import org.gradle.api.Task;
+import org.gradle.plugins.ide.internal.IdeProjectMetadata;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+public class XcodeProjectMetadata implements IdeProjectMetadata {
+    private final DefaultXcodeProject xcodeProject;
+    private final Task projectTask;
+
+    public XcodeProjectMetadata(DefaultXcodeProject xcodeProject, Task projectTask) {
+        this.xcodeProject = xcodeProject;
+        this.projectTask = projectTask;
+    }
+
+    @Override
+    public Set<? extends Task> getGeneratorTasks() {
+        return Collections.singleton(projectTask);
+    }
+
+    @Override
+    public File getFile() {
+        return xcodeProject.getLocationDir();
+    }
+}

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -112,7 +112,7 @@ public class XcodePlugin extends IdePlugin {
             xcodeProject = xcode.getProject();
             final GenerateXcodeWorkspaceFileTask workspaceTask = createWorkspaceTask(project, xcode.getWorkspace());
             lifecycleTask.dependsOn(workspaceTask);
-            addWorkspaceOpenTask(xcode.getWorkspace());
+            addWorkspace(xcode.getWorkspace());
         } else {
             DefaultXcodeExtension xcode = (DefaultXcodeExtension) project.getExtensions().create(XcodeExtension.class, "xcode", DefaultXcodeExtension.class, objectFactory);
             xcodeProject = xcode.getProject();

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistryTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistryTest.groovy
@@ -42,20 +42,17 @@ class VisualStudioProjectRegistryTest extends Specification {
 
     def "adds ide artifact when project and projectConfiguration are added"() {
         def executableBinary = targetBinary("vsConfig")
+        def metadata = null
+
         when:
         registry.addProjectConfiguration(executableBinary)
 
         then:
-        1 * ideArtifactRegistry.registerIdeArtifact(_) >> { args ->
-            assert args[0].name == "mainExe"
-            assert args[0].type == VisualStudioProjectInternal.ARTIFACT_TYPE
+        1 * ideArtifactRegistry.registerIdeArtifact(_) >> { VisualStudioProjectMetadata m ->
+            metadata = m
         }
-
-        and:
-        1 * ideArtifactRegistry.registerIdeArtifact(_) >> { args ->
-            assert args[0].name == "vsConfig|Win32"
-            assert args[0].type == VisualStudioProjectConfiguration.ARTIFACT_TYPE
-        }
+        metadata.name == "mainExe"
+        metadata.configurations == ["vsConfig|Win32"]
     }
 
     def "returns same visual studio project configuration for native binaries that share project name"() {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/CompositeBuildParallelIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/CompositeBuildParallelIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.idea
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ GradleContextualExecuter.isParallel() })
+class CompositeBuildParallelIntegrationTest extends AbstractIntegrationSpec {
+    @Rule BlockingHttpServer server = new BlockingHttpServer()
+
+    def "builds IDE metadata artifacts in parallel"() {
+        given:
+        server.start()
+        buildTestFixture.withBuildInSubDir()
+        def buildA = singleProjectBuild("buildA") {
+            buildFile << """
+                apply plugin: 'java'
+                apply plugin: 'idea'
+            """
+        }
+
+        def included = ['buildB', 'buildC', 'buildD']
+        included.each { buildName ->
+            def build = singleProjectBuild(buildName) {
+                buildFile << """
+                    apply plugin: 'java'
+                    apply plugin: 'idea'
+
+                    ideaModule.doLast {
+                        ${server.callFromBuild(buildName)}
+                    }
+                """
+            }
+            buildA.buildFile << """
+                dependencies {
+                    implementation "org.test:${buildName}:1.0" 
+                }
+            """
+            buildA.settingsFile << """
+                includeBuild "${build.toURI()}"
+            """
+        }
+
+        server.expectConcurrent(included)
+
+        expect:
+        executer.withArguments("--max-workers=4")
+        executer.inDirectory(buildA)
+        succeeds(":idea")
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeMultiProjectBuildIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeMultiProjectBuildIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,12 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIml
 import static org.gradle.plugins.ide.fixtures.IdeaFixtures.parseIpr
 
-class IdeaCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
-    def "includes module for each project in each build"() {
+class IdeMultiProjectBuildIntegrationTest extends AbstractIntegrationSpec {
+    def "includes module for each project in build"() {
         given:
         settingsFile << """
             include 'api'
             include 'shared:api', 'shared:model'
-            includeBuild 'util'
-            includeBuild 'other'
             rootProject.name = 'root'
         """
 
@@ -44,30 +42,7 @@ class IdeaCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
                     testCompile project(':shared:model')
                 }
             }
-
-            project(':shared:model') {
-                dependencies {
-                    testCompile "test:util:1.3"
-                }
-            }
         """
-        buildTestFixture.withBuildInSubDir()
-        singleProjectBuild("util") {
-            settingsFile << "rootProject.name = '${rootProjectName}'"
-            buildFile << """
-                apply plugin: 'java'
-                apply plugin: 'idea'
-                group = 'test'
-                version = '1.3'
-            """
-        }
-        singleProjectBuild("other") {
-            settingsFile << "rootProject.name = '${rootProjectName}'"
-            buildFile << """
-                apply plugin: 'java'
-                apply plugin: 'idea'
-            """
-        }
 
         when:
         succeeds ":idea"
@@ -78,32 +53,24 @@ class IdeaCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
             ":shared:ideaModule",
             ":shared:api:ideaModule",
             ":shared:model:ideaModule",
-            ":util:ideaModule",
-            ":other:ideaModule",
             ":idea")
 
         def ipr = parseIpr(file('root.ipr'))
-        ipr.modules.assertHasModules('$PROJECT_DIR$/root.iml',
+        ipr.modules.assertHasModules(
+            '$PROJECT_DIR$/root.iml',
             '$PROJECT_DIR$/api/root-api.iml',
             '$PROJECT_DIR$/shared/shared.iml',
             '$PROJECT_DIR$/shared/api/shared-api.iml',
-            '$PROJECT_DIR$/shared/model/model.iml',
-            '$PROJECT_DIR$/util/util.iml',
-            '$PROJECT_DIR$/other/other.iml')
+            '$PROJECT_DIR$/shared/model/model.iml')
 
         def apiDependencies = parseIml(file('api/root-api.iml')).dependencies
         apiDependencies.modules.size() == 2
         apiDependencies.assertHasModule('COMPILE', 'shared-api')
         apiDependencies.assertHasModule('TEST', 'model')
 
-        def modelDependencies = parseIml(file('shared/model/model.iml')).dependencies
-        modelDependencies.modules.size() == 1
-        modelDependencies.assertHasModule('TEST', 'util')
-
         parseIml(file('root.iml'))
         parseIml(file('shared/shared.iml'))
         parseIml(file('shared/api/shared-api.iml'))
-        parseIml(file('util/util.iml'))
-        parseIml(file('other/other.iml'))
+        parseIml(file('shared/model/model.iml'))
     }
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaProjectIntegrationTest.groovy
@@ -45,7 +45,7 @@ idea.project {
     @Test
     void enablesCustomizationsOnNewModel() {
         //when
-        runTask 'idea', 'include "someProjectThatWillBeExcluded", "api"', '''
+        def result = runTask ':idea', 'include "someProjectThatWillBeExcluded", "api"', '''
 allprojects {
     apply plugin: "java"
     apply plugin: "idea"
@@ -70,6 +70,10 @@ idea {
     }
 }
 '''
+        result.assertTasksExecuted(":ideaModule", ":ideaProject", ":ideaWorkspace",
+            ":api:ideaModule",
+            ":idea"
+        )
 
         //then
         def ipr = getFile([:], 'someBetterName.ipr').text

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -28,10 +28,9 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.GroovyBasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
@@ -46,6 +45,7 @@ import org.gradle.plugins.ear.EarPlugin;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.internal.AfterEvaluateHelper;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
+import org.gradle.plugins.ide.eclipse.internal.EclipseProjectMetadata;
 import org.gradle.plugins.ide.eclipse.internal.LinkedResourcesCreator;
 import org.gradle.plugins.ide.eclipse.model.BuildCommand;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
@@ -98,11 +98,9 @@ public class EclipsePlugin extends IdePlugin {
 
         EclipseModel model = project.getExtensions().create("eclipse", EclipseModel.class);
 
-        configureEclipseProject(project, model);
+        configureEclipseProject((ProjectInternal) project, model);
         configureEclipseJdt(project, model);
         configureEclipseClasspath(project, model);
-
-        registerEclipseArtifacts(project);
 
         applyEclipseWtpPluginOnWebProjects(project);
     }
@@ -113,19 +111,7 @@ public class EclipsePlugin extends IdePlugin {
         SingleMessageLogger.nagUserOfDiscontinuedMethod("performPostEvaluationActions");
     }
 
-    private void registerEclipseArtifacts(Project project) {
-        EclipseProject eclipseProject = project.getExtensions().getByType(EclipseModel.class).getProject();
-
-        artifactRegistry.registerIdeArtifact(createArtifact(eclipseProject, "project", project));
-        artifactRegistry.registerIdeArtifact(createArtifact(eclipseProject, "classpath", project));
-    }
-
-    private static PublishArtifact createArtifact(EclipseProject eclipseProject, String extension, Project project) {
-        Task byName = project.getTasks().getByName("eclipseProject");
-        return new EclipseArtifact(eclipseProject, project.getProjectDir(), extension, byName);
-    }
-
-    private void configureEclipseProject(final Project project, final EclipseModel model) {
+    private void configureEclipseProject(final ProjectInternal project, final EclipseModel model) {
         maybeAddTask(project, this, ECLIPSE_PROJECT_TASK_NAME, GenerateEclipseProject.class, new Action<GenerateEclipseProject>() {
             @Override
             public void execute(GenerateEclipseProject task) {
@@ -192,8 +178,9 @@ public class EclipsePlugin extends IdePlugin {
                     }
 
                 });
-            }
 
+                artifactRegistry.registerIdeArtifact(new EclipseProjectMetadata(projectModel, project.getProjectDir(), task));
+            }
         });
     }
 
@@ -391,26 +378,4 @@ public class EclipsePlugin extends IdePlugin {
         action.execute(task);
         plugin.addWorker(task);
     }
-
-    private static class EclipseArtifact extends DefaultPublishArtifact {
-        private final EclipseProject eclipseProject;
-        private final File projectDir;
-
-        public EclipseArtifact(EclipseProject eclipseProject, File projectDir, String extension, Object... tasks) {
-            super(null, extension, "eclipse." + extension, null, null, null, tasks);
-            this.eclipseProject = eclipseProject;
-            this.projectDir = projectDir;
-        }
-
-        @Override
-        public String getName() {
-            return eclipseProject.getName();
-        }
-
-        @Override
-        public File getFile() {
-            return new File(projectDir, "." + getExtension());
-        }
-    }
-
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipseProjectMetadata.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse.internal;
+
+import org.gradle.api.Task;
+import org.gradle.plugins.ide.eclipse.model.EclipseProject;
+import org.gradle.plugins.ide.internal.IdeProjectMetadata;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+public class EclipseProjectMetadata implements IdeProjectMetadata {
+    private final EclipseProject eclipseProject;
+    private final File projectDir;
+    private final Task generatorTask;
+
+    public EclipseProjectMetadata(EclipseProject eclipseProject, File projectDir, Task generatorTask) {
+        this.eclipseProject = eclipseProject;
+        this.projectDir = projectDir;
+        this.generatorTask = generatorTask;
+    }
+
+    public String getName() {
+        return eclipseProject.getName();
+    }
+
+    @Override
+    public File getFile() {
+        return new File(projectDir, ".project");
+    }
+
+    @Override
+    public Set<? extends Task> getGeneratorTasks() {
+        return Collections.singleton(generatorTask);
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -20,10 +20,12 @@ import com.google.common.base.Preconditions;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory;
 import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.util.ConfigureUtil;
 
 import java.io.File;
@@ -313,9 +315,8 @@ public class EclipseClasspath {
      * Calculates, resolves and returns dependency entries of this classpath.
      */
     public List<ClasspathEntry> resolveDependencies() {
-        ClasspathFactory classpathFactory = new ClasspathFactory(this);
-        List<ClasspathEntry> entries = classpathFactory.createEntries();
-        return entries;
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ((ProjectInternal) project).getServices().get(IdeArtifactRegistry.class));
+        return classpathFactory.createEntries();
     }
 
     public void mergeXmlClasspath(Classpath xmlClasspath) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
@@ -23,6 +23,7 @@ import org.gradle.plugins.ide.eclipse.model.Container;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
 import org.gradle.plugins.ide.eclipse.model.Output;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,9 +33,9 @@ public class ClasspathFactory {
     private final EclipseClasspath classpath;
     private final EclipseDependenciesCreator dependenciesCreator;
 
-    public ClasspathFactory(EclipseClasspath classpath) {
+    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry) {
         this.classpath = classpath;
-        this.dependenciesCreator = new EclipseDependenciesCreator(classpath);
+        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry);
     }
 
     public List<ClasspathEntry> createEntries() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -27,11 +27,8 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier;
-import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;
@@ -39,6 +36,7 @@ import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
 import org.gradle.plugins.ide.eclipse.model.FileReference;
 import org.gradle.plugins.ide.eclipse.model.Library;
 import org.gradle.plugins.ide.eclipse.model.Variable;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencySet;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencyVisitor;
 import org.gradle.plugins.ide.internal.resolver.UnresolvedIdeDependencyHandler;
@@ -56,10 +54,9 @@ public class EclipseDependenciesCreator {
     private final EclipseClasspath classpath;
     private final ProjectDependencyBuilder projectDependencyBuilder;
 
-    public EclipseDependenciesCreator(EclipseClasspath classpath) {
+    public EclipseDependenciesCreator(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry) {
         this.classpath = classpath;
-        ServiceRegistry serviceRegistry = ((ProjectInternal) classpath.getProject()).getServices();
-        this.projectDependencyBuilder = new ProjectDependencyBuilder(serviceRegistry.get(LocalComponentRegistry.class));
+        this.projectDependencyBuilder = new ProjectDependencyBuilder(ideArtifactRegistry);
     }
 
     public List<AbstractClasspathEntry> createDependencyEntries() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -17,15 +17,15 @@
 package org.gradle.plugins.ide.eclipse.model.internal;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
 public class ProjectDependencyBuilder {
-    private final LocalComponentRegistry localComponentRegistry;
+    private final IdeArtifactRegistry ideArtifactRegistry;
 
-    public ProjectDependencyBuilder(LocalComponentRegistry localComponentRegistry) {
-        this.localComponentRegistry = localComponentRegistry;
+    public ProjectDependencyBuilder(IdeArtifactRegistry ideArtifactRegistry) {
+        this.ideArtifactRegistry = ideArtifactRegistry;
     }
 
     public ProjectDependency build(ProjectComponentIdentifier id) {
@@ -37,7 +37,7 @@ public class ProjectDependencyBuilder {
     }
 
     public String determineTargetProjectName(ProjectComponentIdentifier id) {
-        ComponentArtifactMetadata eclipseProjectArtifact = localComponentRegistry.findAdditionalArtifact(id, "eclipse.project");
+        ComponentArtifactMetadata eclipseProjectArtifact = ideArtifactRegistry.getIdeArtifactMetadata(id, "eclipse.project");
         return eclipseProjectArtifact == null ? id.getProjectName() : eclipseProjectArtifact.getName().getName();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -17,7 +17,7 @@
 package org.gradle.plugins.ide.eclipse.model.internal;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.plugins.ide.eclipse.internal.EclipseProjectMetadata;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
@@ -37,8 +37,8 @@ public class ProjectDependencyBuilder {
     }
 
     public String determineTargetProjectName(ProjectComponentIdentifier id) {
-        ComponentArtifactMetadata eclipseProjectArtifact = ideArtifactRegistry.getIdeArtifactMetadata(id, "eclipse.project");
-        return eclipseProjectArtifact == null ? id.getProjectName() : eclipseProjectArtifact.getName().getName();
+        EclipseProjectMetadata eclipseProject = ideArtifactRegistry.getIdeArtifactMetadata(EclipseProjectMetadata.class, id);
+        return eclipseProject == null ? id.getProjectName() : eclipseProject.getName();
     }
 
     private ProjectDependency buildProjectDependency(String path) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier;
@@ -32,6 +31,7 @@ import org.gradle.plugins.ide.eclipse.model.WbDependentModule;
 import org.gradle.plugins.ide.eclipse.model.WbModuleEntry;
 import org.gradle.plugins.ide.eclipse.model.WbResource;
 import org.gradle.plugins.ide.eclipse.model.WtpComponent;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencySet;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencyVisitor;
 import org.gradle.plugins.ide.internal.resolver.UnresolvedIdeDependencyHandler;
@@ -45,7 +45,7 @@ public class WtpComponentFactory {
     private final ProjectDependencyBuilder projectDependencyBuilder;
 
     public WtpComponentFactory(Project project) {
-        projectDependencyBuilder = new ProjectDependencyBuilder(((ProjectInternal) project).getServices().get(LocalComponentRegistry.class));
+        projectDependencyBuilder = new ProjectDependencyBuilder(((ProjectInternal) project).getServices().get(IdeArtifactRegistry.class));
     }
 
     public void configure(final EclipseWtpComponent wtp, WtpComponent component) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -224,7 +224,7 @@ public class IdeaPlugin extends IdePlugin {
 
             addWorker(projectTask);
 
-            addWorkspaceOpenTask(ideaProject);
+            addWorkspace(ideaProject);
         }
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaModuleMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaModuleMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.idea.internal;
+
+import org.gradle.api.Task;
+import org.gradle.plugins.ide.idea.model.IdeaModule;
+import org.gradle.plugins.ide.internal.IdeProjectMetadata;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+public class IdeaModuleMetadata implements IdeProjectMetadata {
+    private final IdeaModule ideaModule;
+    private final Task generatorTask;
+
+    public IdeaModuleMetadata(IdeaModule ideaModule, Task generatorTask) {
+        this.ideaModule = ideaModule;
+        this.generatorTask = generatorTask;
+    }
+
+    public String getName() {
+        return ideaModule.getName();
+    }
+
+    @Override
+    public File getFile() {
+        return ideaModule.getOutputFile();
+    }
+
+    @Override
+    public Set<? extends Task> getGeneratorTasks() {
+        return Collections.singleton(generatorTask);
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.language.scala.ScalaPlatform;
 import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
 import java.io.File;
 import java.util.Collection;
@@ -529,7 +530,7 @@ public class IdeaModule {
      */
     public Set<Dependency> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) project;
-        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal.getServices());
+        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal.getServices().get(IdeArtifactRegistry.class));
         return ideaDependenciesProvider.provide(this);
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
@@ -20,16 +20,17 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.initialization.ProjectPathRegistry;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.plugins.ide.IdeWorkspace;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
+import org.gradle.plugins.ide.idea.internal.IdeaModuleMetadata;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
 import java.io.File;
@@ -349,13 +350,13 @@ public class IdeaProject implements IdeWorkspace {
 
     private void configureModulePaths(Project xmlProject) {
         ProjectComponentIdentifier thisProjectId = projectPathRegistry.getProjectComponentIdentifier(((ProjectInternal) project).getIdentityPath());
-        for (LocalComponentArtifactMetadata imlArtifact : artifactRegistry.getIdeArtifactMetadata("iml")) {
-            ProjectComponentIdentifier otherProjectId = (ProjectComponentIdentifier) imlArtifact.getComponentId();
-            if (thisProjectId.getBuild().equals(otherProjectId.getBuild())) {
+        for (IdeArtifactRegistry.Reference<IdeaModuleMetadata> reference : artifactRegistry.getIdeArtifactMetadata(IdeaModuleMetadata.class)) {
+            BuildIdentifier otherBuildId = reference.getOwningProject().getBuild();
+            if (thisProjectId.getBuild().equals(otherBuildId)) {
                 // IDEA Module for project in current build: handled via `modules` model elements.
                 continue;
             }
-            xmlProject.addModulePath(imlArtifact.getFile());
+            xmlProject.addModulePath(reference.get().getFile());
         }
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -27,14 +27,13 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier;
-import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.plugins.ide.idea.model.Dependency;
 import org.gradle.plugins.ide.idea.model.FilePath;
 import org.gradle.plugins.ide.idea.model.IdeaModule;
 import org.gradle.plugins.ide.idea.model.Path;
 import org.gradle.plugins.ide.idea.model.SingleEntryModuleLibrary;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencySet;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencyVisitor;
 import org.gradle.plugins.ide.internal.resolver.UnresolvedIdeDependencyHandler;
@@ -53,8 +52,8 @@ public class IdeaDependenciesProvider {
     private final ModuleDependencyBuilder moduleDependencyBuilder;
     private final IdeaDependenciesOptimizer optimizer;
 
-    public IdeaDependenciesProvider(ServiceRegistry serviceRegistry) {
-        moduleDependencyBuilder = new ModuleDependencyBuilder(serviceRegistry.get(LocalComponentRegistry.class));
+    public IdeaDependenciesProvider(IdeArtifactRegistry artifactRegistry) {
+        moduleDependencyBuilder = new ModuleDependencyBuilder(artifactRegistry);
         optimizer = new IdeaDependenciesOptimizer();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilder.java
@@ -17,15 +17,15 @@
 package org.gradle.plugins.ide.idea.model.internal;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.plugins.ide.idea.model.ModuleDependency;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
 class ModuleDependencyBuilder {
-    private final LocalComponentRegistry localComponentRegistry;
+    private final IdeArtifactRegistry ideArtifactRegistry;
 
-    public ModuleDependencyBuilder(LocalComponentRegistry localComponentRegistry) {
-        this.localComponentRegistry = localComponentRegistry;
+    public ModuleDependencyBuilder(IdeArtifactRegistry ideArtifactRegistry) {
+        this.ideArtifactRegistry = ideArtifactRegistry;
     }
 
     public ModuleDependency create(ProjectComponentIdentifier id, String scope) {
@@ -33,7 +33,7 @@ class ModuleDependencyBuilder {
     }
 
     private String determineProjectName(ProjectComponentIdentifier id) {
-        ComponentArtifactMetadata imlArtifact = localComponentRegistry.findAdditionalArtifact(id, "iml");
+        ComponentArtifactMetadata imlArtifact = ideArtifactRegistry.getIdeArtifactMetadata(id, "iml");
         return imlArtifact == null ? id.getProjectName() : imlArtifact.getName().getName();
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilder.java
@@ -17,7 +17,7 @@
 package org.gradle.plugins.ide.idea.model.internal;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.plugins.ide.idea.internal.IdeaModuleMetadata;
 import org.gradle.plugins.ide.idea.model.ModuleDependency;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
@@ -33,7 +33,7 @@ class ModuleDependencyBuilder {
     }
 
     private String determineProjectName(ProjectComponentIdentifier id) {
-        ComponentArtifactMetadata imlArtifact = ideArtifactRegistry.getIdeArtifactMetadata(id, "iml");
-        return imlArtifact == null ? id.getProjectName() : imlArtifact.getName().getName();
+        IdeaModuleMetadata moduleMetadata = ideArtifactRegistry.getIdeArtifactMetadata(IdeaModuleMetadata.class, id);
+        return moduleMetadata == null ? id.getProjectName() : moduleMetadata.getName();
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -33,6 +33,7 @@ import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMet
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -59,6 +60,12 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
     public void registerIdeArtifact(PublishArtifact ideArtifact) {
         ProjectComponentIdentifier projectId = newProjectId(buildIdentity.getCurrentBuild(), domainObjectContext.getProjectPath().getPath());
         projectComponentProvider.registerAdditionalArtifact(projectId, new PublishArtifactLocalArtifactMetadata(projectId, ideArtifact));
+    }
+
+    @Nullable
+    @Override
+    public LocalComponentArtifactMetadata getIdeArtifactMetadata(ProjectComponentIdentifier project, String type) {
+        return localComponentRegistry.findAdditionalArtifact(project, type);
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -23,8 +23,6 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DomainObjectContext;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectLocalComponentProvider;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -43,18 +41,14 @@ import static org.gradle.internal.component.local.model.DefaultProjectComponentI
 
 public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
     private final IdeArtifactStore store;
-    private final ProjectLocalComponentProvider projectComponentProvider;
     private final ProjectPathRegistry projectPathRegistry;
-    private final LocalComponentRegistry localComponentRegistry;
     private final DomainObjectContext domainObjectContext;
     private final BuildIdentity buildIdentity;
     private final FileOperations fileOperations;
 
-    public DefaultIdeArtifactRegistry(IdeArtifactStore store, ProjectLocalComponentProvider projectComponentProvider, ProjectPathRegistry projectPathRegistry, LocalComponentRegistry localComponentRegistry, FileOperations fileOperations, DomainObjectContext domainObjectContext, BuildIdentity buildIdentity) {
+    public DefaultIdeArtifactRegistry(IdeArtifactStore store, ProjectPathRegistry projectPathRegistry, FileOperations fileOperations, DomainObjectContext domainObjectContext, BuildIdentity buildIdentity) {
         this.store = store;
-        this.projectComponentProvider = projectComponentProvider;
         this.projectPathRegistry = projectPathRegistry;
-        this.localComponentRegistry = localComponentRegistry;
         this.fileOperations = fileOperations;
         this.domainObjectContext = domainObjectContext;
         this.buildIdentity = buildIdentity;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -17,8 +17,8 @@
 package org.gradle.plugins.ide.internal;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.Task;
 import org.gradle.api.Transformer;
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -26,10 +26,12 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectLocalComponentProvider;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.tasks.AbstractTaskDependency;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.tasks.TaskDependency;
+import org.gradle.composite.internal.IncludedBuildTaskReference;
 import org.gradle.initialization.BuildIdentity;
 import org.gradle.initialization.ProjectPathRegistry;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
-import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.Path;
 
@@ -40,6 +42,7 @@ import java.util.concurrent.Callable;
 import static org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier.newProjectId;
 
 public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
+    private final IdeArtifactStore store;
     private final ProjectLocalComponentProvider projectComponentProvider;
     private final ProjectPathRegistry projectPathRegistry;
     private final LocalComponentRegistry localComponentRegistry;
@@ -47,60 +50,126 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
     private final BuildIdentity buildIdentity;
     private final FileOperations fileOperations;
 
-    public DefaultIdeArtifactRegistry(ProjectLocalComponentProvider projectComponentProvider, ProjectPathRegistry projectPathRegistry, LocalComponentRegistry localComponentRegistry, DomainObjectContext domainObjectContext, BuildIdentity buildIdentity, FileOperations fileOperations) {
+    public DefaultIdeArtifactRegistry(IdeArtifactStore store, ProjectLocalComponentProvider projectComponentProvider, ProjectPathRegistry projectPathRegistry, LocalComponentRegistry localComponentRegistry, FileOperations fileOperations, DomainObjectContext domainObjectContext, BuildIdentity buildIdentity) {
+        this.store = store;
         this.projectComponentProvider = projectComponentProvider;
         this.projectPathRegistry = projectPathRegistry;
         this.localComponentRegistry = localComponentRegistry;
+        this.fileOperations = fileOperations;
         this.domainObjectContext = domainObjectContext;
         this.buildIdentity = buildIdentity;
-        this.fileOperations = fileOperations;
     }
 
     @Override
-    public void registerIdeArtifact(PublishArtifact ideArtifact) {
+    public void registerIdeArtifact(final IdeProjectMetadata ideProjectMetadata) {
         ProjectComponentIdentifier projectId = newProjectId(buildIdentity.getCurrentBuild(), domainObjectContext.getProjectPath().getPath());
-        projectComponentProvider.registerAdditionalArtifact(projectId, new PublishArtifactLocalArtifactMetadata(projectId, ideArtifact));
+        store.put(projectId, ideProjectMetadata);
     }
 
     @Nullable
     @Override
-    public LocalComponentArtifactMetadata getIdeArtifactMetadata(ProjectComponentIdentifier project, String type) {
-        return localComponentRegistry.findAdditionalArtifact(project, type);
+    public <T extends IdeProjectMetadata> T getIdeArtifactMetadata(Class<T> type, ProjectComponentIdentifier project) {
+        for (IdeProjectMetadata ideProjectMetadata : store.get(project)) {
+            if (type.isInstance(ideProjectMetadata)) {
+                return type.cast(ideProjectMetadata);
+            }
+        }
+        return null;
     }
 
     @Override
-    public List<LocalComponentArtifactMetadata> getIdeArtifactMetadata(String type) {
-        List<LocalComponentArtifactMetadata> result = Lists.newArrayList();
-
+    public <T extends IdeProjectMetadata> List<Reference<T>> getIdeArtifactMetadata(Class<T> type) {
+        List<Reference<T>> result = Lists.newArrayList();
         for (Path projectPath : projectPathRegistry.getAllExplicitProjectPaths()) {
-            ProjectComponentIdentifier projectId = projectPathRegistry.getProjectComponentIdentifier(projectPath);
-            Iterable<LocalComponentArtifactMetadata> additionalArtifacts = localComponentRegistry.getAdditionalArtifacts(projectId);
-            for (LocalComponentArtifactMetadata artifactMetadata : additionalArtifacts) {
-                if (artifactMetadata.getName().getType().equals(type)) {
-                    result.add(artifactMetadata);
+            final ProjectComponentIdentifier projectId = projectPathRegistry.getProjectComponentIdentifier(projectPath);
+            for (IdeProjectMetadata ideProjectMetadata : store.get(projectId)) {
+                if (type.isInstance(ideProjectMetadata)) {
+                    final T metadata = type.cast(ideProjectMetadata);
+                    // Need to use different APIs to reference a required task from outside the current build
+                    // There should be one mechanism rather than two.
+                    if (projectId.getBuild().equals(buildIdentity.getCurrentBuild())) {
+                        result.add(new MetadataFromThisBuild<T>(metadata, projectId));
+                    } else {
+                        result.add(new MetadataFromOtherBuild<T>(metadata, projectId));
+                    }
                 }
             }
         }
-
         return result;
     }
 
     @Override
-    public FileCollection getIdeArtifacts(final String type) {
+    public FileCollection getIdeArtifacts(final Class<? extends IdeProjectMetadata> type) {
         return fileOperations.files(new Callable<List<FileCollection>>() {
             @Override
             public List<FileCollection> call() {
                 return CollectionUtils.collect(
                     getIdeArtifactMetadata(type),
-                    new Transformer<FileCollection, LocalComponentArtifactMetadata>() {
+                    new Transformer<FileCollection, Reference<?>>() {
                         @Override
-                        public FileCollection transform(LocalComponentArtifactMetadata metadata) {
-                            ConfigurableFileCollection result = fileOperations.files(metadata.getFile());
-                            result.builtBy(metadata.getBuildDependencies());
-                            return result;
+                        public FileCollection transform(Reference<?> result) {
+                            ConfigurableFileCollection singleton = fileOperations.files(result.get().getFile());
+                            singleton.builtBy(result.getBuildDependencies());
+                            return singleton;
                         }
                     });
             }
         });
+    }
+
+    private static abstract class AbstractReference<T extends IdeProjectMetadata> implements Reference<T> {
+        private final T metadata;
+        private final ProjectComponentIdentifier projectId;
+
+        AbstractReference(T metadata, ProjectComponentIdentifier projectId) {
+            this.metadata = metadata;
+            this.projectId = projectId;
+        }
+
+        @Override
+        public T get() {
+            return metadata;
+        }
+
+        @Override
+        public ProjectComponentIdentifier getOwningProject() {
+            return projectId;
+        }
+    }
+
+    private static class MetadataFromThisBuild<T extends IdeProjectMetadata> extends AbstractReference<T> {
+        MetadataFromThisBuild(T metadata, ProjectComponentIdentifier projectId) {
+            super(metadata, projectId);
+        }
+
+        @Override
+        public TaskDependency getBuildDependencies() {
+            return new AbstractTaskDependency() {
+                @Override
+                public void visitDependencies(TaskDependencyResolveContext context) {
+                    for (Task task : get().getGeneratorTasks()) {
+                        context.add(task);
+                    }
+                }
+            };
+        }
+    }
+
+    private static class MetadataFromOtherBuild<T extends IdeProjectMetadata> extends AbstractReference<T> {
+        MetadataFromOtherBuild(T metadata, ProjectComponentIdentifier projectId) {
+            super(metadata, projectId);
+        }
+
+        @Override
+        public TaskDependency getBuildDependencies() {
+            return new AbstractTaskDependency() {
+                @Override
+                public void visitDependencies(TaskDependencyResolveContext context) {
+                    for (Task task : get().getGeneratorTasks()) {
+                        context.add(new IncludedBuildTaskReference(getOwningProject().getBuild().getName(), task.getPath()));
+                    }
+                }
+            };
+        }
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeArtifactRegistry.java
@@ -17,15 +17,29 @@
 package org.gradle.plugins.ide.internal;
 
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.FileCollection;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public interface IdeArtifactRegistry {
     void registerIdeArtifact(PublishArtifact ideArtifact);
 
+    /**
+     * Finds an IDE metadata artifact with the specified type. Does not execute tasks to build the artifact.
+     */
+    @Nullable
+    LocalComponentArtifactMetadata getIdeArtifactMetadata(ProjectComponentIdentifier project, String type);
+
+    /**
+     * Finds all known IDE metadata artifacts with the specified type, in all builds. Does not execute tasks to build the artifact.
+     */
     List<LocalComponentArtifactMetadata> getIdeArtifactMetadata(String type);
 
+    /**
+     * Returns a {@link FileCollection} containing all metadata artifacts with the specified type, in all builds.
+     */
     FileCollection getIdeArtifacts(String type);
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeArtifactRegistry.java
@@ -16,30 +16,37 @@
 
 package org.gradle.plugins.ide.internal;
 
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.FileCollection;
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
+import org.gradle.api.tasks.TaskDependency;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
 public interface IdeArtifactRegistry {
-    void registerIdeArtifact(PublishArtifact ideArtifact);
+    void registerIdeArtifact(IdeProjectMetadata ideProjectMetadata);
 
     /**
      * Finds an IDE metadata artifact with the specified type. Does not execute tasks to build the artifact.
      */
     @Nullable
-    LocalComponentArtifactMetadata getIdeArtifactMetadata(ProjectComponentIdentifier project, String type);
+    <T extends IdeProjectMetadata> T getIdeArtifactMetadata(Class<T> type, ProjectComponentIdentifier project);
 
     /**
      * Finds all known IDE metadata artifacts with the specified type, in all builds. Does not execute tasks to build the artifact.
      */
-    List<LocalComponentArtifactMetadata> getIdeArtifactMetadata(String type);
+    <T extends IdeProjectMetadata> List<Reference<T>> getIdeArtifactMetadata(Class<T> type);
 
     /**
      * Returns a {@link FileCollection} containing all metadata artifacts with the specified type, in all builds.
      */
-    FileCollection getIdeArtifacts(String type);
+    FileCollection getIdeArtifacts(Class<? extends IdeProjectMetadata> type);
+
+    interface Reference<T extends IdeProjectMetadata> {
+        T get();
+
+        TaskDependency getBuildDependencies();
+
+        ProjectComponentIdentifier getOwningProject();
+    }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeArtifactStore.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeArtifactStore.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+
+/**
+ * This is separate from {@link DefaultIdeArtifactRegistry} so that the data can be shared across a build tree, while the {@link DefaultIdeArtifactRegistry} is scoped to a particular consuming project.
+ */
+public class IdeArtifactStore {
+    private final ListMultimap<ProjectComponentIdentifier, IdeProjectMetadata> metadata = ArrayListMultimap.create();
+
+    public void put(ProjectComponentIdentifier projectId, IdeProjectMetadata ideProjectMetadata) {
+        metadata.put(projectId, ideProjectMetadata);
+    }
+
+    public Iterable<? extends IdeProjectMetadata> get(ProjectComponentIdentifier project) {
+        return metadata.get(project);
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdePlugin.java
@@ -84,10 +84,6 @@ public abstract class IdePlugin implements Plugin<Project> {
         return cleanTask;
     }
 
-    public Task getCleanTask(Task worker) {
-        return project.getTasks().getByName(cleanName(worker.getName()));
-    }
-
     protected String cleanName(String taskName) {
         return String.format("clean%s", StringUtils.capitalize(taskName));
     }
@@ -108,7 +104,7 @@ public abstract class IdePlugin implements Plugin<Project> {
     protected void onApply(Project target) {
     }
 
-    protected Task addWorkspaceOpenTask(final IdeWorkspace workspace) {
+    protected void addWorkspace(final IdeWorkspace workspace) {
         lifecycleTask.doLast(new Action<Task>() {
             @Override
             public void execute(Task task) {
@@ -139,7 +135,6 @@ public abstract class IdePlugin implements Plugin<Project> {
                 }
             }
         });
-        return openTask;
     }
 
     protected abstract String getLifecycleTaskName();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeProjectMetadata.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeProjectMetadata.java
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradle.ide.visualstudio.internal;
+package org.gradle.plugins.ide.internal;
 
-import org.gradle.ide.visualstudio.VisualStudioSolution;
+import org.gradle.api.Task;
 
-import java.util.List;
+import java.io.File;
+import java.util.Set;
 
-public interface VisualStudioSolutionInternal extends VisualStudioSolution {
-    /**
-     * The list of project artifacts included in this solution.
-     */
-    List<VisualStudioProjectMetadata> getProjects();
+/**
+ * Details of an IDE project shared across Gradle project boundaries.
+ */
+public interface IdeProjectMetadata {
+    File getFile();
 
-    /**
-     * Adds tasks required to build this component.
-     */
-    void builtBy(Object... tasks);
+    Set<? extends Task> getGeneratorTasks();
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeServices.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdeServices.java
@@ -21,6 +21,11 @@ import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 
 public class IdeServices extends AbstractPluginServiceRegistry {
     @Override
+    public void registerBuildTreeServices(ServiceRegistration registration) {
+        registration.add(IdeArtifactStore.class);
+    }
+
+    @Override
     public void registerProjectServices(ServiceRegistration registration) {
         registration.add(DefaultIdeArtifactRegistry.class);
     }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugins.ide.eclipse.model.internal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
@@ -26,7 +27,7 @@ class EclipseDependenciesCreatorTest extends AbstractProjectBuilderSpec{
     private final ProjectInternal project = TestUtil.createRootProject(temporaryFolder.testDirectory)
     private final ProjectInternal childProject = TestUtil.createChildProject(project, "child", new File("."))
     private final EclipseClasspath eclipseClasspath = new EclipseClasspath(project)
-    private final dependenciesProvider = new EclipseDependenciesCreator(eclipseClasspath)
+    private final dependenciesProvider = new EclipseDependenciesCreator(eclipseClasspath, project.services.get(IdeArtifactRegistry))
 
     def "compile dependency on child project"() {
         applyPluginToProjects()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
@@ -15,18 +15,17 @@
  */
 package org.gradle.plugins.ide.eclipse.model.internal
 
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata
 import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 
 class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
-    def ProjectComponentIdentifier projectId = newProjectId(":nested:project-name")
-    def localComponentRegistry = Mock(LocalComponentRegistry)
-    def ProjectDependencyBuilder builder = new ProjectDependencyBuilder(localComponentRegistry)
+    def projectId = newProjectId(":nested:project-name")
+    def artifactRegistry = Mock(IdeArtifactRegistry)
+    def builder = new ProjectDependencyBuilder(artifactRegistry)
 
     def "should create dependency using project name for project without eclipse plugin applied"() {
         when:
@@ -36,7 +35,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
         dependency.path == "/project-name"
 
         and:
-        localComponentRegistry.getAdditionalArtifacts(_) >> []
+        artifactRegistry.getIdeArtifactMetadata(_, "eclipse.project") >> null
     }
 
     def "should create dependency using eclipse projectName"() {
@@ -44,7 +43,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
         def projectArtifact = Stub(LocalComponentArtifactMetadata) {
             getName() >> new DefaultIvyArtifactName("foo", "eclipse.project", "project", null)
         }
-        localComponentRegistry.findAdditionalArtifact(projectId, "eclipse.project") >> projectArtifact
+        artifactRegistry.getIdeArtifactMetadata(projectId, "eclipse.project") >> projectArtifact
 
         when:
         def dependency = builder.build(projectId)

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
@@ -15,8 +15,7 @@
  */
 package org.gradle.plugins.ide.eclipse.model.internal
 
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata
-import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.plugins.ide.eclipse.internal.EclipseProjectMetadata
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
@@ -35,15 +34,15 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
         dependency.path == "/project-name"
 
         and:
-        artifactRegistry.getIdeArtifactMetadata(_, "eclipse.project") >> null
+        artifactRegistry.getIdeArtifactMetadata(_, _) >> null
     }
 
     def "should create dependency using eclipse projectName"() {
         given:
-        def projectArtifact = Stub(LocalComponentArtifactMetadata) {
-            getName() >> new DefaultIvyArtifactName("foo", "eclipse.project", "project", null)
+        def projectMetadata = Stub(EclipseProjectMetadata) {
+            getName() >> "foo"
         }
-        artifactRegistry.getIdeArtifactMetadata(projectId, "eclipse.project") >> projectArtifact
+        artifactRegistry.getIdeArtifactMetadata(EclipseProjectMetadata, projectId) >> projectMetadata
 
         when:
         def dependency = builder.build(projectId)

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModelTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModelTest.groovy
@@ -18,14 +18,14 @@ package org.gradle.plugins.ide.idea.model
 
 import org.gradle.api.Action
 import org.gradle.api.XmlProvider
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.composite.internal.IncludedBuildTaskGraph
 import org.gradle.initialization.BuildIdentity
 import org.gradle.initialization.ProjectPathRegistry
-import org.gradle.composite.internal.IncludedBuildTaskGraph
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.plugins.ide.api.XmlFileContentMerger
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import spock.lang.Specification
 
 class IdeaModelTest extends Specification {
@@ -66,7 +66,7 @@ class IdeaModelTest extends Specification {
         def gradleProject = Stub(ProjectInternal) {
             getServices() >> Stub(ServiceRegistry) {
                 get(ProjectPathRegistry) >> (ProjectPathRegistry) null
-                get(LocalComponentRegistry) >> (LocalComponentRegistry) null
+                get(IdeArtifactRegistry) >> (IdeArtifactRegistry) null
                 get(IncludedBuildTaskGraph) >> (IncludedBuildTaskGraph) null
                 get(BuildIdentity) >> (BuildIdentity) null
             }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -17,27 +17,18 @@
 package org.gradle.plugins.ide.idea.model.internal
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.internal.artifacts.component.DefaultBuildIdentifier
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.composite.internal.IncludedBuildTaskGraph
-import org.gradle.initialization.BuildIdentity
-import org.gradle.initialization.DefaultBuildIdentity
-import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.Dependency
 import org.gradle.plugins.ide.idea.model.SingleEntryModuleLibrary
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
     private final ProjectInternal project = TestUtil.createRootProject(temporaryFolder.testDirectory)
     private final ProjectInternal childProject = TestUtil.createChildProject(project, "child", new File("."))
-    def serviceRegistry = new DefaultServiceRegistry()
-        .add(LocalComponentRegistry, Stub(LocalComponentRegistry))
-        .add(IncludedBuildTaskGraph, Stub(IncludedBuildTaskGraph))
-        .add(BuildIdentity, new DefaultBuildIdentity(new DefaultBuildIdentifier("foo")))
-    private final dependenciesProvider = new IdeaDependenciesProvider(serviceRegistry)
+    private final dependenciesProvider = new IdeaDependenciesProvider(Stub(IdeArtifactRegistry))
 
     def "no dependencies test"() {
         applyPluginToProjects()
@@ -222,7 +213,7 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         applyPluginToProjects()
         project.apply(plugin: 'java')
 
-        def dependenciesProvider = new IdeaDependenciesProvider(serviceRegistry)
+        def dependenciesProvider = new IdeaDependenciesProvider(Stub(IdeArtifactRegistry))
         def module = project.ideaModule.module // Mock(IdeaModule)
         module.offline = true
         def extraConfiguration = project.configurations.create('extraConfiguration')

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugins.ide.idea.model.internal
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.Dependency
 import org.gradle.plugins.ide.idea.model.SingleEntryModuleLibrary
@@ -26,9 +25,16 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
-    private final ProjectInternal project = TestUtil.createRootProject(temporaryFolder.testDirectory)
-    private final ProjectInternal childProject = TestUtil.createChildProject(project, "child", new File("."))
-    private final dependenciesProvider = new IdeaDependenciesProvider(Stub(IdeArtifactRegistry))
+    private final project = TestUtil.createRootProject(temporaryFolder.testDirectory)
+    private final childProject = TestUtil.createChildProject(project, "child", new File("."))
+    private final artifactRegistry = Stub(IdeArtifactRegistry)
+    private final dependenciesProvider = new IdeaDependenciesProvider(artifactRegistry)
+
+    def setup() {
+        _ * artifactRegistry.getIdeArtifactMetadata(_, _) >> { Class c, def m ->
+            return Stub(c)
+        }
+    }
 
     def "no dependencies test"() {
         applyPluginToProjects()
@@ -213,7 +219,7 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         applyPluginToProjects()
         project.apply(plugin: 'java')
 
-        def dependenciesProvider = new IdeaDependenciesProvider(Stub(IdeArtifactRegistry))
+        def dependenciesProvider = new IdeaDependenciesProvider(artifactRegistry)
         def module = project.ideaModule.module // Mock(IdeaModule)
         module.offline = true
         def extraConfiguration = project.configurations.create('extraConfiguration')

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilderTest.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.plugins.ide.idea.model.internal
 
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata
 import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import spock.lang.Specification
 
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
@@ -26,8 +26,8 @@ import static org.gradle.internal.component.local.model.TestComponentIdentifiers
 class ModuleDependencyBuilderTest extends Specification {
 
     def projectId = newProjectId(":nested:project-name")
-    def localComponentRegistry = Mock(LocalComponentRegistry)
-    def builder = new ModuleDependencyBuilder(localComponentRegistry)
+    def artifactRegistry = Mock(IdeArtifactRegistry)
+    def builder = new ModuleDependencyBuilder(artifactRegistry)
 
     def "builds dependency for nonIdea project"() {
         when:
@@ -38,7 +38,7 @@ class ModuleDependencyBuilderTest extends Specification {
         dependency.name == "project-name"
 
         and:
-        localComponentRegistry.getAdditionalArtifacts(_) >> []
+        artifactRegistry.getIdeArtifactMetadata(_, "iml") >> null
     }
 
     def "builds dependency for nonIdea root project"() {
@@ -50,7 +50,7 @@ class ModuleDependencyBuilderTest extends Specification {
         dependency.name == "build-1"
 
         and:
-        localComponentRegistry.getAdditionalArtifacts(_) >> []
+        artifactRegistry.getIdeArtifactMetadata(_, "iml") >> null
     }
 
     def "builds dependency for project"() {
@@ -67,6 +67,6 @@ class ModuleDependencyBuilderTest extends Specification {
         dependency.name == 'foo'
 
         and:
-        localComponentRegistry.findAdditionalArtifact(projectId, "iml") >> imlArtifact
+        artifactRegistry.getIdeArtifactMetadata(projectId, "iml") >> imlArtifact
     }
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilderTest.groovy
@@ -16,8 +16,7 @@
 
 package org.gradle.plugins.ide.idea.model.internal
 
-import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata
-import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.plugins.ide.idea.internal.IdeaModuleMetadata
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry
 import spock.lang.Specification
 
@@ -38,7 +37,7 @@ class ModuleDependencyBuilderTest extends Specification {
         dependency.name == "project-name"
 
         and:
-        artifactRegistry.getIdeArtifactMetadata(_, "iml") >> null
+        artifactRegistry.getIdeArtifactMetadata(_, _) >> null
     }
 
     def "builds dependency for nonIdea root project"() {
@@ -50,13 +49,13 @@ class ModuleDependencyBuilderTest extends Specification {
         dependency.name == "build-1"
 
         and:
-        artifactRegistry.getIdeArtifactMetadata(_, "iml") >> null
+        artifactRegistry.getIdeArtifactMetadata(_, _) >> null
     }
 
     def "builds dependency for project"() {
         given:
-        def imlArtifact = Stub(LocalComponentArtifactMetadata) {
-            getName() >> new DefaultIvyArtifactName("foo", "iml", "iml", null)
+        def moduleMetadata = Stub(IdeaModuleMetadata) {
+            getName() >> "foo"
         }
 
         when:
@@ -67,6 +66,6 @@ class ModuleDependencyBuilderTest extends Specification {
         dependency.name == 'foo'
 
         and:
-        artifactRegistry.getIdeArtifactMetadata(projectId, "iml") >> imlArtifact
+        artifactRegistry.getIdeArtifactMetadata(IdeaModuleMetadata, projectId) >> moduleMetadata
     }
 }

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaFixtures.groovy
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaFixtures.groovy
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.fixtures
 
 class IdeaFixtures {
     static parseFile(File file) {
+        assert file.file
         new XmlSlurper().parse(file)
     }
 

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -18,8 +18,11 @@ package org.gradle.integtests.tooling.fixture
 
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
+import org.gradle.initialization.BuildIdentity
 import org.gradle.initialization.DefaultBuildRequestMetaData
 import org.gradle.initialization.GradleLauncherFactory
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -97,6 +100,12 @@ class ToolingApiDistributionResolver {
         def buildSessionServices = new BuildSessionScopeServices(gradleUserHomeServices, startParameter, buildRequestMetadata, ClassPath.EMPTY)
         def buildTreeScopeServices = new BuildTreeScopeServices(buildSessionServices)
         def topLevelRegistry = new BuildScopeServices(buildTreeScopeServices)
+        topLevelRegistry.add(BuildIdentity, new BuildIdentity() {
+            @Override
+            BuildIdentifier getCurrentBuild() {
+                return new DefaultBuildIdentifier(":")
+            }
+        })
         def projectRegistry = new ProjectScopeServices(topLevelRegistry, TestUtil.create(TestNameTestDirectoryProvider.newInstance()).rootProject(), topLevelRegistry.getFactory(LoggingManagerInternal))
 
         def workerLeaseService = buildSessionServices.get(WorkerLeaseService)

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.initialization.ConfigureBuildBuildOperationType
+import org.gradle.initialization.LoadBuildBuildOperationType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
+import org.gradle.util.CollectionUtils
+import org.gradle.vcs.fixtures.GitFileRepository
+import org.junit.Rule
+
+import java.util.regex.Pattern
+
+class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    GitFileRepository repo = new GitFileRepository('dep', temporaryFolder.getTestDirectory())
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "generates configure, task graph and run tasks operations for source dependency build"() {
+        given:
+        repo.file("settings.gradle") << """
+            rootProject.name = 'buildB'
+        """
+        repo.file("build.gradle") << """
+            apply plugin: 'java'
+            group = 'org.test'
+            version = '1.2'
+        """
+        repo.commit("initial version")
+        repo.createLightWeightTag("1.2")
+
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:buildB") {
+                        from(GitVersionControlSpec) {
+                            url = uri("${repo.url}")
+                        }
+                    }
+                }
+            }
+        """
+        buildFile << """
+            apply plugin: 'java'
+            dependencies { implementation 'org.test:buildB:1.2' }
+        """
+
+        when:
+        succeeds("assemble")
+
+        then:
+        def root = CollectionUtils.single(operations.roots())
+
+        def loadOps = operations.all(LoadBuildBuildOperationType)
+        loadOps.size() == 2
+        loadOps[0].displayName == "Load build"
+        loadOps[0].details.buildPath == ":"
+        loadOps[0].parentId == root.id
+        loadOps[1].displayName == "Load build (dep)"
+        // TODO - should have a buildPath associated
+        loadOps[1].parentId == root.id
+
+        def configureOps = operations.all(ConfigureBuildBuildOperationType)
+        configureOps.size() == 2
+        configureOps[0].displayName == "Configure build"
+        configureOps[0].details.buildPath == ":"
+        configureOps[0].parentId == root.id
+        configureOps[1].displayName == "Configure build (dep)"
+        // TODO - should have a buildPath associated
+        configureOps[1].parentId == root.id
+
+        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
+        taskGraphOps.size() == 2
+        taskGraphOps[0].displayName == "Calculate task graph"
+        taskGraphOps[0].details.buildPath == ":"
+        taskGraphOps[0].parentId == root.id
+        taskGraphOps[1].displayName == "Calculate task graph (:buildB)"
+        taskGraphOps[1].details.buildPath == ":buildB"
+        taskGraphOps[1].parentId == root.id
+
+        def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
+        runTasksOps.size() == 2
+        runTasksOps[0].displayName == "Run tasks"
+        runTasksOps[0].parentId == root.id
+        runTasksOps[1].displayName == "Run tasks (:buildB)"
+        runTasksOps[1].parentId == root.id
+    }
+}

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.vcs.fixtures.GitFileRepository
+import org.junit.Rule
+
+
+class SourceDependencyIdentityIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    GitFileRepository repo = new GitFileRepository('dep', temporaryFolder.getTestDirectory())
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'buildA'
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:buildB") {
+                        from(GitVersionControlSpec) {
+                            url = uri("${repo.url}")
+                        }
+                    }
+                }
+            }
+        """
+        buildFile << """
+            apply plugin: 'java'
+            dependencies { implementation 'org.test:buildB:1.2' }
+        """
+
+        repo.file("settings.gradle") << """
+            rootProject.name = 'buildB'
+        """
+        repo.file("build.gradle") << """
+            apply plugin: 'java'
+            group = 'org.test'
+            version = '1.2'
+        """
+    }
+
+    def "includes build identifier in error message on failure to resolve dependencies of build"() {
+        repo.file("build.gradle") << """
+            dependencies { implementation "test:test:1.2" }
+        """
+        repo.commit("initial version")
+        repo.createLightWeightTag("1.2")
+
+        when:
+        fails(":assemble")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':buildB:compileJava'.")
+        failure.assertHasCause("Could not resolve all task dependencies for configuration ':buildB:compileClasspath'.")
+        // TODO - incorrect project path
+        failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
+Required by:
+    project :dep""")
+    }
+
+    def "includes build identifier in task failure error message"() {
+        repo.file("build.gradle") << """
+            classes.doLast {
+                throw new RuntimeException("broken")
+            }
+        """
+        repo.commit("initial version")
+        repo.createLightWeightTag("1.2")
+
+        when:
+        fails(":assemble")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':buildB:classes'.")
+        failure.assertHasCause("broken")
+    }
+
+    def "includes build identifier in dependency resolution results"() {
+        repo.commit("initial version")
+        repo.createLightWeightTag("1.2")
+
+        buildFile << """
+            classes.doLast {
+                def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
+                assert components.size() == 2
+                assert components[0].build.name == ':'
+                assert components[0].projectPath == ':'
+                // TODO - should be 'buildA'
+                assert components[0].projectName == ':'
+                assert components[1].build.name == 'buildB'
+                assert components[1].projectPath == ':'
+                assert components[1].projectName == 'buildB'
+            }
+        """
+
+        expect:
+        succeeds( ":assemble")
+    }
+}


### PR DESCRIPTION
### Context

Previously, the IDEA plugin assumed that the user would only ever run `./gradlew idea` and generated an IDEA project by coincidence. Running `./gradlew :idea` would generate IDEA modules for projects in included builds, but not in the projects of the current build. This would leave the generated IDEA project in a non-functional state. Fixing this makes `./gradlew openIdea` and any other task that depends on `:idea` work correctly.

This change fixes the Xcode plugin so that it does not compile Swift libraries from included builds, to make this consistent with how it handles Swift libraries from the main build.

This change reworks how the IDE plugins communicate across project boundaries, using strongly typed model objects rather than attempting to encode the model into file names and `PublishArtifact` properties. The IDE plugins now all use the same service to communicate rather than implementing the same logic in a bunch of different ways.

This change moves creation of a `BuildIdentifier` so that it happens as soon as a build is created, before anything else happens with the build. Previously, this happened at arbitrary times during the build, and could result in a different identifier for a build depending on _when_ the identifier was queried. For example, if an init script happened to do some dependency resolution, every build in the build tree would end up with the same identifier.

This change adds a bunch of test coverage for the IDE plugins + composite builds, and also fixes a race condition in nested build execution that was exposed by these tests.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
