### PR TITLE
Simpler fix to avoid services gradle org lookups

### DIFF
--- a/subprojects/distributions/binary-compatibility.gradle
+++ b/subprojects/distributions/binary-compatibility.gradle
@@ -31,7 +31,8 @@ repositories {
             name 'Gradle distributions'
             url 'https://services.gradle.org'
             layout 'pattern', {
-                ivy '[module]-ivy.xml'
+                // Dummy 'ivy' pattern: Ivy files do not exist on services.gradle.org
+                ivy '[module]-[revision]-ivy.xml'
                 artifact "/${distUrl}/[module]-[revision]-bin(.[ext])"
             }
         }

--- a/subprojects/distributions/binary-compatibility.gradle
+++ b/subprojects/distributions/binary-compatibility.gradle
@@ -25,6 +25,19 @@ import org.gradle.binarycompatibility.AcceptedApiChanges
 import org.gradle.binarycompatibility.CleanAcceptedApiChanges
 import org.gradle.gradlebuild.ProjectGroups
 
+repositories {
+    ['distributions', 'distributions-snapshots'].each { distUrl ->
+        ivy {
+            name 'Gradle distributions'
+            url 'https://services.gradle.org'
+            layout 'pattern', {
+                ivy '[module]-ivy.xml'
+                artifact "/${distUrl}/[module]-[revision]-bin(.[ext])"
+            }
+        }
+    }
+}
+
 ext {
     apiChangesJsonFile = project.file("src/changes/accepted-public-api-changes.json")
     acceptedViolations = AcceptedApiChanges.parse(apiChangesJsonFile.text)
@@ -41,42 +54,6 @@ configurations {
         attributes.attribute(ARTIFACT_TYPE, 'gradle-classpath')
     }
 }
-
-/**
- * This method temporarily creates new repositories that are only used during the resolution
- * of the configuration passed as parameter. The reason we do this is that defining a repository
- * for the lifetime of the project introduced overhead when resolving other, unrelated configurations.
- * In particular, the layout of the repositories we create here implies a lot of misses when resolving
- * traditional dependencies.
- * @param conf the configuration to add repositories for
- */
-void createResolutionTimeOnlyRepositories(Configuration conf) {
-    def repos = []
-    conf.incoming.beforeResolve {
-        // Before resolving the configuration, we create our repositories
-        repositories {
-            ['distributions', 'distributions-snapshots'].each { distUrl ->
-                repos << ivy {
-                    name 'Gradle distributions'
-                    url 'https://services.gradle.org'
-                    layout 'pattern', {
-                        ivy '[module]-ivy.xml'
-                        artifact "/${distUrl}/[module]-[revision]-bin(.[ext])"
-                    }
-                }
-            }
-        }
-    }
-    conf.incoming.afterResolve {
-        // and once resolution is done, we remove them. It's ugly, but it's faster than
-        // leaving them around and getting misses when resolving other configurations
-        repos.each {
-            repositories.remove(it)
-        }
-    }
-}
-
-createResolutionTimeOnlyRepositories(configurations.baselineClasspath)
 
 def projects = ProjectGroups.INSTANCE.getPublicProjects(project).collect { it.archivesBaseName - 'gradle-' }
 
@@ -112,12 +89,10 @@ dependencies {
 def baselineConfigurations = []
 projects.each { projectName ->
     def appendixName = projectName.split('-')*.capitalize().join('')
-    def conf = configurations.create("japicmp-baseline-${appendixName}") {
+    baselineConfigurations << configurations.create("japicmp-baseline-${appendixName}") {
         extendsFrom configurations.baseline
         attributes.attribute(ARTIFACT_TYPE, projectName)
     }
-    baselineConfigurations << conf
-    createResolutionTimeOnlyRepositories(conf)
 }
 
 task checkBinaryCompatibility(type: JapicmpTask) {


### PR DESCRIPTION
This PR reverts the [hotfix](https://github.com/gradle/gradle/commit/ff8ed703499fc1fff9f0ceabf3706cb5346dab88) for gradle/gradle-private#1137 in favour of a simpler approach. By simply adding the missing `revision` token to the ivy pattern for repositories that access `services.gradle.org`, no remote requests will be made for constraints with no version defined.