### PR TITLE
Lock in plugin-resolve performance improvement

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -46,6 +46,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
     }
 
     def setup() {
+        runner.targetVersions = ["4.7-20180303002443+0000"]
         runner.warmUpRuns = 5
         runner.runs = 15
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
@@ -69,7 +70,6 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
         given:
         runner.tasksToRun = ['resolveDependencies']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
-        runner.targetVersions = ["4.6-20180125002142+0000"]
         runner.args = ['-I', 'init.gradle', "-PmirrorPath=${repoDir.absolutePath}", "-PmavenRepoURL=http://localhost:${serverPort}/"]
 
         when:
@@ -89,7 +89,6 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
         given:
         runner.tasksToRun = ['resolveDependencies']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
-        runner.targetVersions = ["4.6-20180125002142+0000"]
         runner.args = ['-I', 'init.gradle', "-PmirrorPath=${repoDir.absolutePath}", "-PmavenRepoURL=http://localhost:${serverPort}/", '--parallel']
 
         when:


### PR DESCRIPTION
The change in https://github.com/gradle/gradle/commit/e5c7bdf modified
plugin resolution so that declared buildscript repositories are
searched first. Previously we were first trying the plugin portal.

This reduced the time required to resolve plugins in
[`ParallelDownloadsPerformanceTest`](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/11413211:id/report-performance-performance-tests.zip%21/report/tests/resolves-dependencies-from-external-repository-(parallel).html), allowing this test to be
re-baselined.