### PR TITLE
Add support for mutating capabilities

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
+import org.gradle.api.artifacts.dsl.CapabilitiesHandler;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 
 import java.util.List;
@@ -73,5 +74,14 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      * @since 4.5
      */
     void allVariants(Action<? super VariantMetadata> action);
+
+    /**
+     * Add a rule for adjusting the capabilities of a component
+     *
+     * @param action the action to be executed on the capabilities handler
+     *
+     * @since 4.7
+     */
+    void withCapabilities(Action<? super CapabilitiesHandler> action);
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/CapabilityHandler.java
@@ -18,6 +18,9 @@ package org.gradle.api.artifacts.dsl;
 import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
+import javax.annotation.Nullable;
+import java.util.Collection;
+
 /**
  * A single capability handler. A capability is provided by one or more modules.
  * A component <i>may</i> express a preference, but this is not required.
@@ -27,6 +30,13 @@ import org.gradle.internal.HasInternalProtocol;
 @Incubating
 @HasInternalProtocol
 public interface CapabilityHandler {
+    /**
+     * Overwrites the list of providers for this capability
+     * @param moduleIdentifiers the list of module identifiers
+     * @return this handler
+     */
+    CapabilityHandler setProvidedBy(Collection<String> moduleIdentifiers);
+
     /**
      * Declares that this capability is provided by a module.
      *
@@ -39,17 +49,19 @@ public interface CapabilityHandler {
      * to use the specified module. This is used to disambiguate whenever multiple modules
      * supplying the same capability are found in a dependency graph.
      *
-     * @param moduleIdentifer the module identifier of the preferred module for this capability
+     * @param moduleIdentifer the module identifier of the preferred module for this capability. If null, removes the preference.
+     *
      * @return the preference
      */
-    CapabilityHandler prefer(String moduleIdentifer);
+    CapabilityHandler prefer(@Nullable String moduleIdentifer);
 
     /**
      * Declares a custom reason why this component sets a preference.
-     * @param reason the reason why this component declares a preference
+     *
+     * @param reason the reason why this component declares a preference. If null, removes the reason.
      *
      * @return this preference
      */
-    CapabilityHandler because(String reason);
+    CapabilityHandler because(@Nullable String reason);
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CapabilitiesRulesIntegrationTest.groovy
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+
+class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def "can declare capabilities using a component metadata rule"() {
+        given:
+        repository {
+            'cglib:cglib:3.2.5'()
+            'cglib:cglib-nodep:3.2.5'()
+        }
+
+        buildFile << """
+            dependencies {
+               conf "cglib:cglib-nodep:3.2.5"
+               conf "cglib:cglib:3.2.5"
+            
+               components {
+                  withModule('cglib:cglib') {
+                     withCapabilities {
+                         capability('cglib') {
+                             providedBy 'cglib:cglib'
+                             providedBy 'cglib:cglib-nodep'
+                             prefer 'cglib:cglib'
+                         }
+                     }
+                  }
+               }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'cglib:cglib-nodep:3.2.5' {
+                expectGetMetadata()
+            }
+            'cglib:cglib:3.2.5' {
+                expectResolve()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('cglib:cglib:3.2.5').byReason('capability cglib is provided by cglib:cglib and cglib:cglib-nodep')
+                edge('cglib:cglib-nodep:3.2.5', 'cglib:cglib:3.2.5').byReason('capability cglib is provided by cglib:cglib and cglib:cglib-nodep')
+            }
+        }
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "can remove preference set in published metadata"() {
+        given:
+        repository {
+            'cglib:cglib:3.2.5' {
+                capability('cglib') {
+                    providedBy 'cglib:cglib'
+                    prefer 'cglib:cglib'
+                }
+            }
+            'cglib:cglib-nodep:3.2.5' {
+                capability('cglib') {
+                    providedBy 'cglib:cglib-nodep'
+                    prefer 'cglib:cglib-nodep'
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+               conf "cglib:cglib-nodep:3.2.5"
+               conf "cglib:cglib:3.2.5"
+            
+               components {
+                  withModule('cglib:cglib-nodep') {
+                     withCapabilities {
+                         capability('cglib') {
+                             prefer(null)
+                             because "reason when preference is null is not used"
+                         }
+                     }
+                  }
+               }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'cglib:cglib-nodep:3.2.5' {
+                expectGetMetadata()
+            }
+            'cglib:cglib:3.2.5' {
+                expectResolve()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('cglib:cglib:3.2.5').byReason('capability cglib is provided by cglib:cglib and cglib:cglib-nodep')
+                edge('cglib:cglib-nodep:3.2.5', 'cglib:cglib:3.2.5').byReason('capability cglib is provided by cglib:cglib and cglib:cglib-nodep')
+            }
+        }
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "can overwrite the providers of a capability"() {
+        given:
+        repository {
+            'cglib:cglib:3.2.5' {
+                capability('cglib') {
+                    prefer 'cglib:cglib'
+                }
+            }
+            'cglib:cglib-nodep:3.2.5' {
+                capability('cglib') {
+                    prefer 'cglib:cglib-nodep'
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+               conf "cglib:cglib-nodep:3.2.5"
+               conf "cglib:cglib:3.2.5"
+            
+               components {
+                  withModule('cglib:cglib') {
+                     withCapabilities {
+                         capability('cglib') {
+                             providedBy = ['cglib:cglib', 'cglib:cglib-nodep']
+                         }
+                     }
+                  }
+                  withModule('cglib:cglib-nodep') {
+                     withCapabilities {
+                         capability('cglib') {
+                             // sets a different list of modules but it shouldn't interfere
+                             // with the ones from cglib:cglib
+                             providedBy = ['cglib:cglib']
+                         }
+                     }
+                  }
+               }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'cglib:cglib-nodep:3.2.5' {
+                expectGetMetadata()
+            }
+            'cglib:cglib:3.2.5' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause('Module cglib:cglib:3.2.5 prefers module cglib:cglib for capability \'cglib\' but another module prefers cglib:cglib-nodep')
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultCapability.java
@@ -23,6 +23,7 @@ import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.typeconversion.NotationParser;
 
+import java.util.Collection;
 import java.util.Set;
 
 class DefaultCapability implements CapabilityHandler, CapabilityInternal {
@@ -36,6 +37,15 @@ class DefaultCapability implements CapabilityHandler, CapabilityInternal {
     DefaultCapability(NotationParser<Object, ModuleIdentifier> notationParser, String id) {
         this.id = id;
         this.notationParser = notationParser;
+    }
+
+    @Override
+    public CapabilityHandler setProvidedBy(Collection<String> moduleIdentifiers) {
+        providedBy.clear();
+        for (String moduleIdentifier : moduleIdentifiers) {
+            providedBy(moduleIdentifier);
+        }
+        return this;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ResolutionScopeCapabilitiesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ResolutionScopeCapabilitiesHandler.java
@@ -22,9 +22,9 @@ import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.dsl.CapabilityHandler;
+import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
-import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
@@ -172,6 +173,11 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
+        public List<? extends CapabilityDescriptor> getCapabilities() {
+            return delegate.getCapabilities();
+        }
+
+        @Override
         public AttributeContainer getAttributes() {
             return delegate.getAttributes();
         }
@@ -179,7 +185,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
 
     private static class ClientModuleConfigurationMetadata extends DefaultConfigurationMetadata {
         ClientModuleConfigurationMetadata(ModuleComponentIdentifier componentId, String name, ModuleComponentArtifactMetadata artifact, List<ModuleDependencyMetadata> dependencies) {
-            super(componentId, name, true, true, ImmutableList.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of());
+            super(componentId, name, true, true, ImmutableList.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableList.<CapabilityDescriptor>of());
             setDependencies(dependencies);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -114,7 +114,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         this.graphVariants = metadata.graphVariants;
     }
 
-    private DefaultConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions, Map<String, DefaultConfigurationMetadata> configurations) {
+    private DefaultConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions, Map<String, DefaultConfigurationMetadata> configurations, ImmutableList<? extends CapabilityDescriptor> capabilities) {
         DefaultConfigurationMetadata populated = configurations.get(name);
         if (populated != null) {
             return populated;
@@ -128,7 +128,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         ImmutableList<String> hierarchy = constructHierarchy(descriptorConfiguration);
         boolean transitive = descriptorConfiguration.isTransitive();
         boolean visible = descriptorConfiguration.isVisible();
-        populated = createConfiguration(componentIdentifier, name, transitive, visible, hierarchy, variantMetadataRules);
+        populated = createConfiguration(componentIdentifier, name, transitive, visible, hierarchy, variantMetadataRules, capabilities);
         configurations.put(name, populated);
         return populated;
     }
@@ -153,7 +153,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     /**
      * Creates a {@link org.gradle.internal.component.model.ConfigurationMetadata} implementation for this component.
      */
-    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules);
+    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules, ImmutableList<? extends CapabilityDescriptor> capabilities);
 
     /**
      * If there are no variants defined in the metadata, but the implementation knows how to provide variants it can do that here.
@@ -256,7 +256,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
     @Override
     public synchronized ConfigurationMetadata getConfiguration(final String name) {
-        return populateConfigurationFromDescriptor(name, configurationDefinitions, configurations);
+        return populateConfigurationFromDescriptor(name, configurationDefinitions, configurations, capabilities);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -86,6 +86,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         this.variants = metadata.getVariants();
         this.attributesFactory = metadata.getAttributesFactory();
         this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
+        this.capabilities = metadata.getCapabilities();
     }
 
     private static AttributeContainerInternal defaultAttributes(ImmutableAttributesFactory attributesFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -48,6 +48,8 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     private final VariantMetadataRules componentMetadataRules;
     private final ImmutableList<ExcludeMetadata> excludes;
     private final ImmutableAttributes attributes;
+    private final ImmutableList<? extends CapabilityDescriptor> capabilities;
+
 
     // Should be final, and set in constructor
     private ImmutableList<ModuleDependencyMetadata> configDependencies;
@@ -59,8 +61,9 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     protected DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
                                            ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                            VariantMetadataRules componentMetadataRules,
-                                           ImmutableList<ExcludeMetadata> excludes) {
-        this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, ImmutableAttributes.EMPTY, null);
+                                           ImmutableList<ExcludeMetadata> excludes,
+                                           ImmutableList<? extends CapabilityDescriptor> capabilities) {
+        this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, ImmutableAttributes.EMPTY, null, capabilities);
     }
 
     private DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
@@ -68,7 +71,8 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
                                          VariantMetadataRules componentMetadataRules,
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes attributes,
-                                         ImmutableList<ModuleDependencyMetadata> configDependencies) {
+                                         ImmutableList<ModuleDependencyMetadata> configDependencies,
+                                         ImmutableList<? extends CapabilityDescriptor> capabilities) {
         this.componentId = componentId;
         this.name = name;
         this.transitive = transitive;
@@ -79,6 +83,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
         this.excludes = excludes;
         this.attributes = attributes;
         this.configDependencies = configDependencies;
+        this.capabilities = capabilities;
     }
 
     @Override
@@ -163,11 +168,11 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     }
 
     protected DefaultConfigurationMetadata withAttributes(ImmutableAttributes attributes) {
-        return new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, attributes, configDependencies);
+        return new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, attributes, configDependencies, capabilities);
     }
 
     @Override
     public ImmutableList<? extends CapabilityDescriptor> getCapabilities() {
-        return ImmutableList.of();
+        return capabilities;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.external.descriptor.Artifact;
@@ -85,11 +86,11 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
     }
 
     @Override
-    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules) {
+    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules, ImmutableList<? extends CapabilityDescriptor> capabilities) {
         ImmutableList<ModuleComponentArtifactMetadata> artifacts = filterArtifacts(name, hierarchy);
         ImmutableList<ExcludeMetadata> excludesForConfiguration = filterExcludes(hierarchy);
 
-        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), componentMetadataRules, excludesForConfiguration);
+        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), componentMetadataRules, excludesForConfiguration, capabilities);
         configuration.setDependencies(filterDependencies(configuration));
         return configuration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -82,9 +83,9 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     }
 
     @Override
-    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> parents, VariantMetadataRules componentMetadataRules) {
+    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> parents, VariantMetadataRules componentMetadataRules, ImmutableList<? extends CapabilityDescriptor> capabilities) {
         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = getArtifactsForConfiguration(name);
-        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of());
+        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of(), capabilities);
         configuration.setDependencies(filterDependencies(configuration));
         return configuration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -207,6 +207,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
+    public List<? extends CapabilityDescriptor> getCapabilities() {
+        return capabilitiesHandler.listCapabilities();
+    }
+
+    @Override
     public ComponentIdentifier getComponentId() {
         return componentIdentifier;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.HasAttributes;
+import org.gradle.api.component.CapabilityDescriptor;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
@@ -93,4 +94,5 @@ public interface ComponentResolveMetadata extends HasAttributes {
 
     List<String> getStatusScheme();
 
+    List<? extends CapabilityDescriptor> getCapabilities();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -51,7 +51,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
-    def gradleMetadata
+    MutableMavenModuleResolveMetadata gradleMetadata
     def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
     def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
     def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
@@ -116,6 +116,25 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         1 * dependenciesRule.execute(_)
         1 * constraintsRule.execute(_)
         0 * _
+    }
+
+    def "can update the capabilities of a component"() {
+        when:
+        adapterOnGradleMetadata.withCapabilities {
+            it.capability('foo') {
+                it.providedBy('foo')
+                it.providedBy('bar')
+                it.prefer('bar')
+                it.because('test case')
+            }
+        }
+
+        then:
+        gradleMetadata.capabilities.size() == 1
+        gradleMetadata.capabilities[0].name == 'foo'
+        gradleMetadata.capabilities[0].providedBy == ['foo', 'bar']
+        gradleMetadata.capabilities[0].prefer == 'bar'
+        gradleMetadata.capabilities[0].reason == 'test case'
     }
 
     def "treats ivy configurations as variants"() {


### PR DESCRIPTION
### Context

This pull request builds on top of #4384 .

This commit introduces capability metadata rules. Those rules let a build
author mutate the capabilities of a published component through a rule. This
makes it possible to associate capabilities to modules which are not using
Gradle metadata. There's however a difference with declaring those capabilities
in the `dependencies { capabilities { ... } }` block:

- rules are only for the current project
- the mutated capabilities are never published (like any other rule, it's
meant for fixups)

So the line should be that if the capabilities are meant for publishing and
consumption by other modules, then they should be defined in a `dependencies`
block, otherwise, if they are meant to fix published capabilities, they should
be declared as rules.

Those rules can typically be used to fix the problem when 2 different modules
say a preference on a capability: this is an error case, that needs the user
input. With a rule, the preference declared by a module can be removed.
