### PR TITLE
Fix for broken publication in docs project

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -502,3 +502,16 @@ task docs {
 task docsZip(type: Zip) {
     from project.outputs.docs
 }
+
+// Temporary hack in order to get new wrapper published with fix (this will be removed almost immediately
+// once the wrapper is updated to the fixed version)
+uploadArchives {
+    def cssArtifacts = []
+    doFirst {
+        cssArtifacts.addAll(configurations.cssElements.artifacts)
+        configurations.cssElements.artifacts.clear()
+    }
+    doLast {
+        configurations.cssElements.artifacts.addAll(cssArtifacts)
+    }
+}

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -190,11 +190,14 @@ task css(type: Sync, dependsOn: configureCss) {
     include "*.svg"
 }
 
-
 artifacts {
     // declare that the generated css directory is an output of cssElements
     cssElements file: css.destinationDir, builtBy: css
 }
+
+// TODO This is a hack pending a solution to https://github.com/gradle/gradle/issues/4612
+// Don't publish the CSS artifacts when calling uploadArchives
+configurations.archives.artifacts.removeAll(configurations.cssElements.artifacts)
 
 ext.cssFiles = fileTree(css.destinationDir) {
     builtBy css


### PR DESCRIPTION
When we added configurations to the docs project to allow other
projects to consume the css directory via publications, we broke
the repository publication of this project as it tries to publish
the css directory as an artifact and blows up.

There is an issue out there to look at how to deal with this problem 
long term in https://github.com/gradle/gradle/issues/4612.  This PR
is a work around to fix our nightly promotion builds.

This fix works around the issue by removing the cssElements
artifacts from the archives configuration to prevent it from being
published.  This only gets us part of the way, though, as we 
validate that all artifacts of any configuration (published or not) are 
not directories when generating the artifact metadata.  So we deal 
with this by removing any directory artifacts from the generated 
metadata file and only erroring out if the directory artifact is actually 
a part of the configuration being published.
