### PR TITLE
Deprecate Task.deleteAllActions()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -421,7 +421,10 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * <p>Removes all the actions of this task.</p>
      *
      * @return the task object this method is applied to
+     *
+     * @deprecated Don't use this.
      */
+    @Deprecated
     Task deleteAllActions();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionTimeTaskConfigurationIntegrationTest.groovy
@@ -69,7 +69,6 @@ class ExecutionTimeTaskConfigurationIntegrationTest extends AbstractIntegrationS
         "actions.clear()"                                           | "Task.getActions().clear()"
         "def iter = actions.iterator(); iter.next(); iter.remove()" | "Task.getActions().remove()"
         "actions = []"                                              | "Task.setActions(List<Action>)"
-        "deleteAllActions()"                                        | "Task.deleteAllActions()"
         "onlyIf { }"                                                | "Task.onlyIf(Closure)"
         "onlyIf({ } as Spec)"                                       | "Task.onlyIf(Spec)"
         "setOnlyIf({ })"                                            | "Task.setOnlyIf(Closure)"
@@ -93,5 +92,42 @@ class ExecutionTimeTaskConfigurationIntegrationTest extends AbstractIntegrationS
         "outputs.files('a')"                                        | "TaskOutputs.files(Object...)"
         "outputs.dirs(['prop':'a'])"                                | "TaskOutputs.dirs(Object...)"
         "outputs.dir('a')"                                          | "TaskOutputs.dir(Object)"
+    }
+
+    def "fails when task is configured using deleteAllActions() during execution time"() {
+        buildFile.text = """
+            def anAction = {} as Action
+
+            task broken {
+                doLast {
+                deleteAllActions()
+                }
+            }
+
+            task broken2 << {
+                deleteAllActions()
+            }
+
+            task broken3 << { }
+
+            task broken4 {
+                dependsOn broken3
+                doLast {
+                    broken3.configure {
+                        deleteAllActions()
+                    }
+                }
+            }
+        """
+
+        when:
+        executer.withArgument("--continue")
+        executer.expectDeprecationWarnings(2)
+        fails("broken", "broken2", "broken4")
+
+        then:
+        failure.assertHasCause("Cannot call Task.deleteAllActions() on task ':broken' after task has started execution.")
+        failure.assertHasCause("Cannot call Task.deleteAllActions() on task ':broken2' after task has started execution. Check the configuration of task ':broken2' as you may have misused '<<' at task declaration.")
+        failure.assertHasCause("Cannot call Task.deleteAllActions() on task ':broken3' after task has started execution.")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -375,6 +375,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Task deleteAllActions() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("Task.deleteAllActions()");
         taskMutator.mutate("Task.deleteAllActions()",
             new Runnable() {
                 public void run() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -53,6 +53,8 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
+* `Task.deleteAllActions()` is deprecated without replacement.
+
 ## Potential breaking changes
 
 ### Changes in the caching of missing versions

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -770,4 +770,18 @@ task someTask(dependsOn: [someDep, someOtherDep])
         "setting" | ".executer = null"
     }
 
+    def "calling `Task.deleteAllActions()` is deprecated"() {
+        buildFile << """
+            task myTask {
+                deleteAllActions()
+            }
+        """
+
+        when:
+        executer.expectDeprecationWarning()
+        succeeds "myTask"
+
+        then:
+        output.contains("The Task.deleteAllActions() method has been deprecated and is scheduled to be removed in Gradle 5.0.")
+    }
 }


### PR DESCRIPTION
Removing task actions is a bad idea, we shouldn't support it. This is a step towards making it impossible to remove actions already added to a task.
