### PR TITLE
Simplify VisualStudio incrementality to track the generated xml

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -976,8 +976,6 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        buildFile.makeOlder()
-
         when:
         run 'myTask'
 
@@ -986,7 +984,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
         file('build/tmp/myTask/output.txt').text == "hello"
 
         when:
-        buildFile.text = buildFile.text.replace('it.text = "hello"', 'it.text = "changed"')
+        buildFile.replace('it.text = "hello"', 'it.text = "changed"')
         run 'myTask', '--info'
 
         then:

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelIncrementalIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioSoftwareModelIncrementalIntegrationTest.groovy
@@ -218,8 +218,8 @@ class VisualStudioSoftwareModelIncrementalIntegrationTest extends AbstractVisual
         run "visualStudio"
 
         then:
-        executedAndNotSkipped ":appVisualStudioSolution"
-        executedAndNotSkipped getComponentTasks("main")
+        skipped getFiltersTask("main")
+        executedAndNotSkipped ":appVisualStudioSolution", getProjectTask("main")
 
         and:
         final projectFile = projectFile("mainExe.vcxproj")
@@ -261,8 +261,8 @@ class VisualStudioSoftwareModelIncrementalIntegrationTest extends AbstractVisual
         run "visualStudio"
 
         then:
-        skipped ":appVisualStudioSolution"
-        executedAndNotSkipped getComponentTasks("main")
+        skipped ":appVisualStudioSolution", getFiltersTask("main")
+        executedAndNotSkipped getProjectTask("main")
 
         and:
         final projectFile = projectFile("mainExe.vcxproj")

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateFiltersFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateFiltersFileTask.java
@@ -19,13 +19,14 @@ package org.gradle.ide.visualstudio.tasks;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.XmlProvider;
-import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Input;
 import org.gradle.ide.visualstudio.VisualStudioProject;
 import org.gradle.ide.visualstudio.internal.DefaultVisualStudioProject;
 import org.gradle.ide.visualstudio.tasks.internal.RelativeFileNameTransformer;
 import org.gradle.ide.visualstudio.tasks.internal.VisualStudioFiltersFile;
 import org.gradle.plugins.ide.api.XmlGeneratorTask;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 
 /**
@@ -44,9 +45,16 @@ public class GenerateFiltersFileTask extends XmlGeneratorTask<VisualStudioFilter
         this.visualStudioProject = (DefaultVisualStudioProject) vsProject;
     }
 
-    @Nested
-    public VisualStudioProject getVisualStudioProject() {
-        return visualStudioProject;
+    /**
+     * Returns the xml string that will be written to the filter file.
+     *
+     * @since 4.7
+     */
+    @Input
+    public String getFilterFileXml() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        getDomainObject().store(out);
+        return out.toString();
     }
 
     @Override

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateProjectFileTask.java
@@ -22,7 +22,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.ide.visualstudio.VisualStudioProject;
@@ -34,6 +33,7 @@ import org.gradle.plugins.ide.api.XmlGeneratorTask;
 import org.gradle.plugins.ide.internal.IdePlugin;
 
 import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.concurrent.Callable;
 
@@ -80,9 +80,16 @@ public class GenerateProjectFileTask extends XmlGeneratorTask<VisualStudioProjec
         this.visualStudioProject = (DefaultVisualStudioProject) vsProject;
     }
 
-    @Nested
-    public VisualStudioProject getVisualStudioProject() {
-        return visualStudioProject;
+    /**
+     * Returns the xml string that will be written to the project file.
+     *
+     * @since 4.7
+     */
+    @Input
+    public String getProjectFileXml() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        getDomainObject().store(out);
+        return out.toString();
     }
 
     @Override

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateSolutionFileTask.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/GenerateSolutionFileTask.java
@@ -18,8 +18,8 @@ package org.gradle.ide.visualstudio.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.ide.visualstudio.TextProvider;
 import org.gradle.ide.visualstudio.VisualStudioSolution;
@@ -28,6 +28,7 @@ import org.gradle.ide.visualstudio.tasks.internal.VisualStudioSolutionFile;
 import org.gradle.plugins.ide.api.GeneratorTask;
 import org.gradle.plugins.ide.internal.generator.generator.PersistableConfigurationObjectGenerator;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 
 /**
@@ -50,9 +51,21 @@ public class GenerateSolutionFileTask extends GeneratorTask<VisualStudioSolution
         this.solution = (DefaultVisualStudioSolution) solution;
     }
 
-    @Nested
+    @Internal
     public VisualStudioSolution getSolution() {
         return solution;
+    }
+
+    /**
+     * Returns the content that will be written to the solution file.
+     *
+     * @since 4.7
+     */
+    @Input
+    public String getSolutionFileContent() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        getDomainObject().store(out);
+        return out.toString();
     }
 
     @Override

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioProject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioProject.java
@@ -19,9 +19,6 @@ package org.gradle.ide.visualstudio;
 import org.gradle.api.Buildable;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -53,20 +50,10 @@ public interface VisualStudioProject extends Named, Buildable {
     /**
      * Configuration for the generated project file.
      */
-    @Internal
     XmlConfigFile getProjectFile();
 
     /**
      * Configuration for the generated filters file.
      */
-    @Internal
     XmlConfigFile getFiltersFile();
-
-    @Override
-    @Internal
-    TaskDependency getBuildDependencies();
-
-    @Override
-    @Input
-    String getName();
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioSolution.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioSolution.java
@@ -21,8 +21,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.plugins.ide.IdeWorkspace;
 
@@ -53,25 +51,11 @@ public interface VisualStudioSolution extends Named, Buildable, IdeWorkspace {
     /**
      * Configuration for the generated solution file.
      */
-    @Internal
     TextConfigFile getSolutionFile();
 
     /**
      * Returns the location of the generated solution file.
      */
     @Override
-    @Internal
     Provider<RegularFile> getLocation();
-
-    @Override
-    @Internal
-    TaskDependency getBuildDependencies();
-
-    @Override
-    @Internal
-    String getName();
-
-    @Override
-    @Internal
-    String getDisplayName();
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioProject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioProject.java
@@ -17,12 +17,8 @@
 package org.gradle.ide.visualstudio.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.Transformer;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.ide.visualstudio.XmlConfigFile;
 import org.gradle.internal.file.PathToFileResolver;
@@ -39,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-
-import static org.gradle.util.CollectionUtils.collect;
 
 /**
  * A VisualStudio project represents a set of binaries for a component that may vary in build type and target platform.
@@ -66,7 +60,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
     }
 
     @Override
-    @Input
     public String getComponentName() {
         return componentName;
     }
@@ -89,7 +82,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
         return "{" + UUID.nameUUIDFromBytes(projectFile.getAbsolutePath().getBytes()).toString().toUpperCase() + "}";
     }
 
-    @Internal
     public Set<File> getSourceFiles() {
         Set<File> allSources = new LinkedHashSet<File>();
         for (VisualStudioTargetBinary binary : configurations.keySet()) {
@@ -99,17 +91,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
         return allSources;
     }
 
-    @Input
-    public Set<String> getSourceFilePaths() {
-        return collect(getSourceFiles(), new Transformer<String, File>() {
-            @Override
-            public String transform(File file) {
-                return file.getAbsolutePath();
-            }
-        });
-    }
-
-    @Internal
     public Set<File> getResourceFiles() {
         Set<File> allResources = new LinkedHashSet<File>();
         for (VisualStudioTargetBinary binary : configurations.keySet()) {
@@ -118,17 +99,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
         return allResources;
     }
 
-    @Input
-    public Set<String> getResourceFilePaths() {
-        return collect(getResourceFiles(), new Transformer<String, File>() {
-            @Override
-            public String transform(File file) {
-                return file.getAbsolutePath();
-            }
-        });
-    }
-
-    @Internal
     public Set<File> getHeaderFiles() {
         Set<File> allHeaders = new LinkedHashSet<File>();
         for (VisualStudioTargetBinary binary : configurations.keySet()) {
@@ -137,17 +107,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
         return allHeaders;
     }
 
-    @Input
-    public Set<String> getHeaderFilePaths() {
-        return collect(getHeaderFiles(), new Transformer<String, File>() {
-            @Override
-            public String transform(File file) {
-                return file.getAbsolutePath();
-            }
-        });
-    }
-
-    @Nested
     public List<VisualStudioProjectConfiguration> getConfigurations() {
         return CollectionUtils.toList(configurations.values());
     }
@@ -159,7 +118,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
         builtBy(nativeBinary.getHeaderFiles());
     }
 
-    @Internal
     public VisualStudioProjectConfiguration getConfiguration(VisualStudioTargetBinary nativeBinary) {
         return configurations.get(nativeBinary);
     }
@@ -188,19 +146,8 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
     }
 
     @Override
-    @Internal
     public IdeProjectMetadata getPublishArtifact() {
         return new VisualStudioProjectMetadata(this);
-    }
-
-    @Nested
-    public List<Action<? super XmlProvider>> getProjectFileActions() {
-        return projectFile.getXmlActions();
-    }
-
-    @Nested
-    public List<Action<? super XmlProvider>> getFiltersFileActions() {
-        return filtersFile.getXmlActions();
     }
 
     public static class DefaultConfigFile implements XmlConfigFile {
@@ -225,7 +172,6 @@ public class DefaultVisualStudioProject implements VisualStudioProjectInternal {
             actions.add(action);
         }
 
-        @Nested
         public List<Action<? super XmlProvider>> getXmlActions() {
             return actions;
         }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioSolution.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioSolution.java
@@ -24,9 +24,6 @@ import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.ide.visualstudio.TextConfigFile;
 import org.gradle.ide.visualstudio.TextProvider;
@@ -37,9 +34,7 @@ import org.gradle.util.CollectionUtils;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 public class DefaultVisualStudioSolution implements VisualStudioSolutionInternal {
@@ -84,7 +79,6 @@ public class DefaultVisualStudioSolution implements VisualStudioSolutionInternal
     }
 
     @Override
-    @Internal
     public List<VisualStudioProjectMetadata> getProjects() {
         return CollectionUtils.collect(ideArtifactRegistry.getIdeArtifactMetadata(VisualStudioProjectMetadata.class), new Transformer<VisualStudioProjectMetadata, IdeArtifactRegistry.Reference<VisualStudioProjectMetadata>>() {
             @Override
@@ -92,30 +86,6 @@ public class DefaultVisualStudioSolution implements VisualStudioSolutionInternal
                 return reference.get();
             }
         });
-    }
-
-    @Input
-    public List<String> getProjectFilePaths() {
-        return CollectionUtils.collect(getProjects(), new Transformer<String, VisualStudioProjectMetadata>() {
-            @Override
-            public String transform(VisualStudioProjectMetadata metadata) {
-                return metadata.getFile().getAbsolutePath();
-            }
-        });
-    }
-
-    @Input
-    public Set<String> getConfigurationNames() {
-        Set<String> configurations = new LinkedHashSet<String>();
-        for (VisualStudioProjectMetadata projectMetadata : getProjects()) {
-            configurations.addAll(projectMetadata.getConfigurations());
-        }
-        return configurations;
-    }
-
-    @Nested
-    public List<Action<? super TextProvider>> getSolutionFileActions() {
-        return solutionFile.getTextActions();
     }
 
     @Override
@@ -139,7 +109,6 @@ public class DefaultVisualStudioSolution implements VisualStudioSolutionInternal
             this.location = defaultLocation;
         }
 
-        @Internal
         public File getLocation() {
             return fileResolver.resolve(location);
         }
@@ -152,7 +121,6 @@ public class DefaultVisualStudioSolution implements VisualStudioSolutionInternal
             actions.add(action);
         }
 
-        @Nested
         public List<Action<? super TextProvider>> getTextActions() {
             return actions;
         }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectConfiguration.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectConfiguration.java
@@ -16,10 +16,6 @@
 
 package org.gradle.ide.visualstudio.internal;
 
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
-
 public class VisualStudioProjectConfiguration {
     private final DefaultVisualStudioProject vsProject;
     private final String name;
@@ -34,38 +30,27 @@ public class VisualStudioProjectConfiguration {
         this.binary = binary;
     }
 
-    @Input
     public String getName() {
         return name;
     }
 
-    @Input
     public String getConfigurationName() {
         return configurationName;
     }
 
-    @Input
     public String getPlatformName() {
         return platformName;
     }
 
-    @Nested
     public VisualStudioTargetBinary getTargetBinary() {
         return binary;
     }
 
-    @Internal
     public final String getType() {
         return "Makefile";
     }
 
-    @Internal
     public DefaultVisualStudioProject getProject() {
         return vsProject;
-    }
-
-    @Input
-    public String getBinaryOutputPath() {
-        return binary.getOutputFile().getAbsolutePath();
     }
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioTargetBinary.java
@@ -18,8 +18,6 @@ package org.gradle.ide.visualstudio.internal;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.util.VersionNumber;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
 
 import java.io.File;
 import java.util.List;
@@ -32,25 +30,21 @@ public interface VisualStudioTargetBinary {
     /**
      * Returns the Gradle project path for this binary
      */
-    @Input
     String getProjectPath();
 
     /**
      * Returns the name of the Gradle component associated with this binary
      */
-    @Input
     String getComponentName();
 
     /**
      * Returns the visual studio project name associated with this binary
      */
-    @Input
     String getVisualStudioProjectName();
 
     /**
      * Returns the visual studio project configuration name associated with this binary
      */
-    @Input
     String getVisualStudioConfigurationName();
 
     /**
@@ -66,73 +60,61 @@ public interface VisualStudioTargetBinary {
     /**
      * Returns the project suffix to use when naming Visual Studio projects
      */
-    @Input
     ProjectType getProjectType();
 
     /**
      * Returns the variant dimensions associated with this binary
      */
-    @Input
     List<String> getVariantDimensions();
 
     /**
      * Returns the source files associated with this binary
      */
-    @Internal
     FileCollection getSourceFiles();
 
     /**
      * Returns the resource files associated with this binary
      */
-    @Internal
     FileCollection getResourceFiles();
 
     /**
      * Returns the header files associated with this binary
      */
-    @Internal
     FileCollection getHeaderFiles();
 
     /**
      * Returns whether or not this binary represents an executable
      */
-    @Input
     boolean isExecutable();
 
     /**
      * Returns a task that can be used to build this binary
      */
-    @Input
     String getBuildTaskPath();
 
     /**
      * Returns a task that can be used to clean the outputs of this binary
      */
-    @Input
     String getCleanTaskPath();
 
     /**
      * Returns whether or not this binary is a debuggable variant
      */
-    @Input
     boolean isDebuggable();
 
     /**
      * Returns the main product of this binary (i.e. executable or library file)
      */
-    @Internal
     File getOutputFile();
 
     /**
      * Returns the compiler definitions that should be used with this binary
      */
-    @Input
     List<String> getCompilerDefines();
 
     /**
      * Returns the include paths that should be used with this binary
      */
-    @Internal
     Set<File> getIncludePaths();
 
     enum ProjectType {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/api/GeneratorTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.specs.Specs;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -71,7 +72,7 @@ public class GeneratorTask<T> extends ConventionTask {
      *
      * @since 4.7
      */
-    @Internal
+    @Input
     @Incubating
     protected boolean getIncremental() {
         return false;
@@ -80,6 +81,17 @@ public class GeneratorTask<T> extends ConventionTask {
     @SuppressWarnings("UnusedDeclaration")
     @TaskAction
     void generate() {
+        generator.write(getDomainObject(), getOutputFile());
+    }
+
+    /**
+     * Returns the domain object produced by this generator task
+     *
+     * @since 4.7
+     */
+    @Internal
+    @Incubating
+    protected T getDomainObject() {
         File inputFile = getInputFileIfExists();
         if (inputFile != null) {
             try {
@@ -87,7 +99,7 @@ public class GeneratorTask<T> extends ConventionTask {
             } catch (RuntimeException e) {
                 throw new GradleException(String.format("Cannot parse file '%s'.\n"
                         + "       Perhaps this file was tinkered with? In that case try delete this file and then retry.",
-                        inputFile), e);
+                    inputFile), e);
             }
         } else {
             domainObject = generator.defaultInstance();
@@ -96,7 +108,7 @@ public class GeneratorTask<T> extends ConventionTask {
         generator.configure(domainObject);
         afterConfigured.execute(domainObject);
 
-        generator.write(domainObject, getOutputFile());
+        return domainObject;
     }
 
     @Inject


### PR DESCRIPTION
This is a follow up from #4531.  It simplifies the up-to-date tracking for Visual Studio metadata generation tasks by tracking the generated xml rather than trying to track the domain objects that serve as inputs to the xml.