### PR TITLE
De-duplicate target confs selected by Ivy dependency

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
@@ -168,7 +168,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                         } else {
                             if (GradleMetadataResolveRunner.useIvy()) {
                                 // Ivy doesn't derive any variant
-                                expectedTargetVariant = 'runtime+compile+default+customVariant'
+                                expectedTargetVariant = 'default+customVariant'
                                 expectedAttributes = [:]
                             } else {
                                 // for Maven, we derive variants for compile/runtime. Variants are then used during selection, and are subject

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
@@ -224,13 +224,10 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromComponent = Stub(ComponentIdentifier)
         def toComponent = Stub(ComponentResolveMetadata)
         def fromConfig = Stub(ConfigurationMetadata)
-        def toConfig1 = Stub(ConfigurationMetadata)
-        def toConfig2 = Stub(ConfigurationMetadata)
-        def toConfig3 = Stub(ConfigurationMetadata)
         fromConfig.hierarchy >> ["from"]
-        toConfig1.visible >> true
-        toConfig2.visible >> true
-        toConfig3.visible >> false
+        def toConfig1 = config('to-1', true)
+        def toConfig2 = config('to-2', true)
+        def toConfig3 = config('to-3', false)
         toComponent.getConfigurationNames() >> ["to-1", "to-2", "to-3"]
         toComponent.getConfiguration("to-1") >> toConfig1
         toComponent.getConfiguration("to-2") >> toConfig2
@@ -244,6 +241,14 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         expect:
         def metadata = new IvyDependencyDescriptor(requested, "12", true, true, false, configMapping, [], [])
         metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent) as List == [toConfig1, toConfig2]
+    }
+
+    private ConfigurationMetadata config(name, visible) {
+        def toConfig1 = Stub(ConfigurationMetadata)
+        toConfig1.visible >> visible
+        toConfig1.name >> name
+        toConfig1.getHierarchy() >> [name]
+        toConfig1
     }
 
     def "configuration mapping can use all-except-wildcard on LHS"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -287,19 +287,19 @@ org:leaf:2.0 -> 1.0
         then:
         output.contains """
 org:leaf:1.0
-   variant "runtime+compile+default"
+   variant "default"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:[1.0,2.0] -> 1.0
-   variant "runtime+compile+default"
+   variant "default"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:latest.integration -> 1.0
-   variant "runtime+compile+default"
+   variant "default"
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
@@ -582,20 +582,20 @@ org:foo:1.0 -> 2.0
         then:
         output.contains """
 org:leaf:1.6
-   variant "runtime+compile+default"
+   variant "default"
 
 org:leaf:1.+ -> 1.6
-   variant "runtime+compile+default"
+   variant "default"
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:[1.5,1.9] -> 1.6
-   variant "runtime+compile+default"
+   variant "default"
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:latest.integration -> 1.6
-   variant "runtime+compile+default"
+   variant "default"
 \\--- org:top:1.0
      \\--- conf
 """


### PR DESCRIPTION
For a dependency declared in an Ivy descriptor file, one or more
target configurations will be chosen for the selected component,
based on the 'confMapping' attribute of the dependency.

In some cases, one chosen configuration may be extended by another
chosen configuration, rendering the first configuration redundant.
With this change, these redundant configurations are removed from
the resolution result.

There is a breaking change here, in that the 'resolved configuration'
resolution result will contain fewer configuration nodes. It will
still contain the same modules and artifacts, in the same order.
A similar change was made for Maven modules in 9df4ba294cd39aff3b55bbe402bb7b7870a24bf4.
