### PR TITLE
Avoid deadlock between output event renderer and listener manager

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/userinput/DefaultUserInputHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/userinput/DefaultUserInputHandler.java
@@ -19,25 +19,25 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.UserInputRequestEvent;
 import org.gradle.internal.logging.events.UserInputResumeEvent;
-import org.gradle.internal.logging.sink.OutputEventRenderer;
 
 import java.util.List;
 
 public class DefaultUserInputHandler implements UserInputHandler {
     private static final List<String> YES_NO_CHOICES = Lists.newArrayList("yes", "no");
-    private final OutputEventRenderer outputEventRenderer;
+    private final OutputEventListener outputEventBroadcaster;
     private final UserInputReader userInputReader;
 
-    public DefaultUserInputHandler(OutputEventRenderer outputEventRenderer, UserInputReader userInputReader) {
-        this.outputEventRenderer = outputEventRenderer;
+    public DefaultUserInputHandler(OutputEventListener outputEventBroadcaster, UserInputReader userInputReader) {
+        this.outputEventBroadcaster = outputEventBroadcaster;
         this.userInputReader = userInputReader;
     }
 
     @Override
     public Boolean askYesNoQuestion(String question) {
-        outputEventRenderer.onOutput(new UserInputRequestEvent(createPrompt(question)));
+        outputEventBroadcaster.onOutput(new UserInputRequestEvent(createPrompt(question)));
 
         try {
             while (true) {
@@ -54,7 +54,7 @@ public class DefaultUserInputHandler implements UserInputHandler {
                 }
             }
         } finally {
-            outputEventRenderer.onOutput(new UserInputResumeEvent());
+            outputEventBroadcaster.onOutput(new UserInputResumeEvent());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
@@ -198,10 +198,10 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
                 throw UncheckedException.throwAsUncheckedException(failure, true);
             }
 
-            LOGGER.debug("Build operation '{}' completed", descriptor.getDisplayName());
         } finally {
             setCurrentBuildOperation(parentOperation);
             newOperation.setRunning(false);
+            LOGGER.debug("Build operation '{}' completed", descriptor.getDisplayName());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.operations.logging;
 
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.CategorisedOutputEvent;
 import org.gradle.internal.logging.events.LogEvent;
 import org.gradle.internal.logging.events.OutputEvent;
@@ -25,6 +24,7 @@ import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.ProgressStartEvent;
 import org.gradle.internal.logging.events.RenderableOutputEvent;
 import org.gradle.internal.logging.events.StyledTextOutputEvent;
+import org.gradle.internal.logging.sink.OutputEventListenerManager;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationProgressEvent;
@@ -58,14 +58,14 @@ import org.gradle.internal.operations.OperationProgressEvent;
  */
 public class LoggingBuildOperationProgressBroadcaster implements Stoppable, OutputEventListener {
 
-    private final LoggingManagerInternal loggingManagerInternal;
+    private final OutputEventListenerManager outputEventListenerManager;
     private final BuildOperationListener buildOperationListener;
 
-    public LoggingBuildOperationProgressBroadcaster(LoggingManagerInternal loggingManagerInternal, BuildOperationListener buildOperationListener) {
-        this.loggingManagerInternal = loggingManagerInternal;
+    public LoggingBuildOperationProgressBroadcaster(OutputEventListenerManager outputEventListenerManager, BuildOperationListener buildOperationListener) {
+        this.outputEventListenerManager = outputEventListenerManager;
         this.buildOperationListener = buildOperationListener;
 
-        loggingManagerInternal.addOutputEventListener(this);
+        outputEventListenerManager.addListener(this);
     }
 
     @Override
@@ -99,6 +99,6 @@ public class LoggingBuildOperationProgressBroadcaster implements Stoppable, Outp
 
     @Override
     public void stop() {
-        loggingManagerInternal.removeOutputEventListener(this);
+        outputEventListenerManager.removeListener(this);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
@@ -65,7 +65,7 @@ public class LoggingBuildOperationProgressBroadcaster implements Stoppable, Outp
         this.outputEventListenerManager = outputEventListenerManager;
         this.buildOperationListener = buildOperationListener;
 
-        outputEventListenerManager.addListener(this);
+        outputEventListenerManager.setListener(this);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
@@ -133,11 +133,7 @@ public final class BuildOperationRecord {
 
     public boolean hasDetailsOfType(Class<?> clazz) throws ClassNotFoundException {
         Class<?> detailsType = getDetailsType();
-        if (detailsType == null) {
-            return false;
-        } else {
-            return clazz.isAssignableFrom(detailsType);
-        }
+        return detailsType != null && clazz.isAssignableFrom(detailsType);
     }
 
     public Class<?> getDetailsType() throws ClassNotFoundException {
@@ -178,6 +174,15 @@ public final class BuildOperationRecord {
             }
 
             return map;
+        }
+
+        public Class<?> getDetailsType() throws ClassNotFoundException {
+            return detailsClassName == null ? null : getClass().getClassLoader().loadClass(detailsClassName);
+        }
+
+        public boolean hasDetailsOfType(Class<?> clazz) throws ClassNotFoundException {
+            Class<?> detailsType = getDetailsType();
+            return detailsType != null && clazz.isAssignableFrom(detailsType);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -146,9 +146,13 @@ public class BuildOperationTrace implements Stoppable {
     }
 
     private void writeDetailTree(List<BuildOperationRecord> roots) throws IOException {
-        String rawJson = JsonOutput.toJson(BuildOperationTree.serialize(roots));
-        String prettyJson = JsonOutput.prettyPrint(rawJson);
-        Files.asCharSink(file(basePath, "-tree.json"), Charsets.UTF_8).write(prettyJson);
+        try {
+            String rawJson = JsonOutput.toJson(BuildOperationTree.serialize(roots));
+            String prettyJson = JsonOutput.prettyPrint(rawJson);
+            Files.asCharSink(file(basePath, "-tree.json"), Charsets.UTF_8).write(prettyJson);
+        } catch (OutOfMemoryError e) {
+            System.err.println("Failed to write build operation trace JSON due to out of memory.");
+        }
     }
 
     private void writeSummaryTree(final List<BuildOperationRecord> roots) throws IOException {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -145,7 +145,7 @@ import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
-import org.gradle.internal.logging.sink.OutputEventRenderer;
+import org.gradle.internal.logging.sink.OutputEventListenerManager;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory;
 import org.gradle.internal.operations.logging.DefaultBuildOperationLoggerFactory;
@@ -455,12 +455,12 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return registry;
     }
 
-    protected UserInputHandler createUserInputHandler(StartParameter startParameter, OutputEventRenderer outputEventRenderer) {
+    protected UserInputHandler createUserInputHandler(StartParameter startParameter, OutputEventListenerManager outputEventListenerManager) {
         if (!startParameter.isInteractive()) {
             return new NonInteractiveUserInputHandler();
         }
 
-        return new DefaultUserInputHandler(outputEventRenderer, new DefaultUserInputReader());
+        return new DefaultUserInputHandler(outputEventListenerManager.getBroadcaster(), new DefaultUserInputReader());
     }
 
     protected BuildScanUserInputHandler createBuildScanUserInputHandler(UserInputHandler userInputHandler) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
@@ -25,18 +25,20 @@ import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.logging.services.DefaultLoggingManagerFactory;
+import org.gradle.internal.logging.sink.OutputEventListenerManager;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.DefaultBuildOperationExecutor;
 import org.gradle.internal.operations.DefaultBuildOperationListenerManager;
 import org.gradle.internal.operations.DefaultBuildOperationQueueFactory;
+import org.gradle.internal.operations.DelegatingBuildOperationExecutor;
 import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 import org.gradle.internal.operations.notify.BuildOperationNotificationBridge;
 import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.progress.BuildProgressLogger;
-import org.gradle.internal.operations.DelegatingBuildOperationExecutor;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
@@ -64,7 +66,7 @@ public class CrossBuildSessionScopeServices implements Closeable {
     private final BuildOperationTrace buildOperationTrace;
     private final BuildOperationNotificationBridge buildOperationNotificationBridge;
     private final LoggingBuildOperationProgressBroadcaster loggingBuildOperationProgressBroadcaster;
-    private final DefaultBuildOperationListenerManager buildOperationListenerManager;
+    private final BuildOperationListenerManager buildOperationListenerManager;
 
     private final Services services;
 
@@ -76,7 +78,9 @@ public class CrossBuildSessionScopeServices implements Closeable {
         this.buildOperationListenerManager = new DefaultBuildOperationListenerManager(crossSessionListenerManager);
         this.buildOperationTrace = new BuildOperationTrace(startParameter, globalListenerManager);
         this.buildOperationNotificationBridge = new BuildOperationNotificationBridge(buildOperationListenerManager, globalListenerManager);
-        this.loggingBuildOperationProgressBroadcaster = new LoggingBuildOperationProgressBroadcaster(parent.get(LoggingManagerInternal.class), buildOperationListenerManager.getBroadcaster());
+
+        LoggingManagerInternal rootLoggingManager = parent.get(DefaultLoggingManagerFactory.class).getRoot();
+        this.loggingBuildOperationProgressBroadcaster = new LoggingBuildOperationProgressBroadcaster(parent.get(OutputEventListenerManager.class), buildOperationListenerManager.getBroadcaster());
     }
 
     GradleLauncherFactory createGradleLauncherFactory() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/userinput/DefaultUserInputHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/userinput/DefaultUserInputHandlerTest.groovy
@@ -16,27 +16,27 @@
 
 package org.gradle.api.internal.tasks.userinput
 
+import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.events.UserInputRequestEvent
 import org.gradle.internal.logging.events.UserInputResumeEvent
-import org.gradle.internal.logging.sink.OutputEventRenderer
 import spock.lang.Specification
 import spock.lang.Subject
 
 class DefaultUserInputHandlerTest extends Specification {
 
     private static final String TEXT = 'Accept license?'
-    def outputEventRenderer = Mock(OutputEventRenderer)
+    def outputEventBroadcaster = Mock(OutputEventListener)
     def userInputReader = Mock(UserInputReader)
-    @Subject def userInputHandler = new DefaultUserInputHandler(outputEventRenderer, userInputReader)
+    @Subject def userInputHandler = new DefaultUserInputHandler(outputEventBroadcaster, userInputReader)
 
     def "can read sanitized input to yes/no question"() {
         when:
         def input = userInputHandler.askYesNoQuestion(TEXT)
 
         then:
-        1 * outputEventRenderer.onOutput(_ as UserInputRequestEvent)
-        1 * outputEventRenderer.onOutput(_ as UserInputResumeEvent)
-        0 * outputEventRenderer._
+        1 * outputEventBroadcaster.onOutput(_ as UserInputRequestEvent)
+        1 * outputEventBroadcaster.onOutput(_ as UserInputResumeEvent)
+        0 * outputEventBroadcaster._
         1 * userInputReader.readInput() >> enteredUserInput
         input == sanitizedUserInput
 
@@ -54,11 +54,11 @@ class DefaultUserInputHandlerTest extends Specification {
         def input = userInputHandler.askYesNoQuestion(TEXT)
 
         then:
-        1 * outputEventRenderer.onOutput(_ as UserInputRequestEvent)
-        0 * outputEventRenderer._
+        1 * outputEventBroadcaster.onOutput(_ as UserInputRequestEvent)
+        0 * outputEventBroadcaster._
         1 * userInputReader.readInput() >> 'bla'
         1 * userInputReader.readInput() >> 'no'
-        1 * outputEventRenderer.onOutput(_ as UserInputResumeEvent)
+        1 * outputEventBroadcaster.onOutput(_ as UserInputResumeEvent)
         input == false
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
@@ -76,7 +76,7 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
         def loggingBuildOperationNotificationBridge = new LoggingBuildOperationProgressBroadcaster(outputEventListenerManager, buildOperationListener)
 
         then:
-        outputEventListenerManager.addListener(loggingBuildOperationNotificationBridge)
+        outputEventListenerManager.setListener(loggingBuildOperationNotificationBridge)
 
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.internal.operations.logging
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.events.LogEvent
 import org.gradle.internal.logging.events.ProgressStartEvent
 import org.gradle.internal.logging.events.StyledTextOutputEvent
+import org.gradle.internal.logging.sink.OutputEventListenerManager
 import org.gradle.internal.operations.BuildOperationCategory
 import org.gradle.internal.operations.BuildOperationListener
 import org.gradle.internal.operations.OperationIdentifier
@@ -30,13 +30,13 @@ import spock.lang.Unroll
 
 class LoggingBuildOperationProgressBroadcasterTest extends Specification {
 
-    def loggingManagerInternal = Mock(LoggingManagerInternal)
+    def outputEventListenerManager = Mock(OutputEventListenerManager)
     def buildOperationListener = Mock(BuildOperationListener)
 
     @Shared
     def operationId = Mock(OperationIdentifier)
 
-    LoggingBuildOperationProgressBroadcaster bridge = new LoggingBuildOperationProgressBroadcaster(loggingManagerInternal, buildOperationListener)
+    LoggingBuildOperationProgressBroadcaster bridge = new LoggingBuildOperationProgressBroadcaster(outputEventListenerManager, buildOperationListener)
 
     @Unroll
     def "forwards #eventType with operationId"() {
@@ -73,17 +73,17 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
 
     def "registers / unregisters itself as output listener"() {
         when:
-        def loggingBuildOperationNotificationBridge = new LoggingBuildOperationProgressBroadcaster(loggingManagerInternal, buildOperationListener)
+        def loggingBuildOperationNotificationBridge = new LoggingBuildOperationProgressBroadcaster(outputEventListenerManager, buildOperationListener)
 
         then:
-        loggingManagerInternal.addOutputEventListener(loggingBuildOperationNotificationBridge)
+        outputEventListenerManager.addListener(loggingBuildOperationNotificationBridge)
 
 
         when:
         loggingBuildOperationNotificationBridge.stop()
 
         then:
-        loggingManagerInternal.removeOutputEventListener(loggingBuildOperationNotificationBridge)
+        outputEventListenerManager.removeListener(loggingBuildOperationNotificationBridge)
     }
 
     private ProgressStartEvent progressStartEvent(OperationIdentifier operationId, String header = 'header') {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -50,6 +50,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
 import org.gradle.internal.time.Clock;
+import org.gradle.internal.time.Time;
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
@@ -1357,8 +1358,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private static LoggingServiceRegistry newCommandLineProcessLogging() {
         LoggingServiceRegistry loggingServices = new LoggingServiceRegistry() {
             @Override
-            protected OutputEventRenderer createOutputEventRenderer(Clock clock) {
-                return new VerboseAwareOutputEventRenderer(clock);
+            protected OutputEventRenderer makeOutputEventRenderer() {
+                return new VerboseAwareOutputEventRenderer(Time.clock());
             }
         };
         LoggingManagerInternal rootLoggingManager = loggingServices.get(DefaultLoggingManagerFactory.class).getRoot();

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
@@ -19,6 +19,7 @@ package org.gradle.internal.logging.services;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineConverter;
+import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.logging.LoggingCommandLineConverter;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.config.LoggingSourceSystem;
@@ -26,6 +27,7 @@ import org.gradle.internal.logging.config.LoggingSystemAdapter;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.logging.sink.OutputEventListenerManager;
 import org.gradle.internal.logging.sink.OutputEventRenderer;
 import org.gradle.internal.logging.slf4j.Slf4jLoggingConfigurer;
 import org.gradle.internal.logging.source.DefaultStdErrLoggingSystem;
@@ -41,24 +43,28 @@ import org.gradle.internal.time.Time;
  * A {@link org.gradle.internal.service.ServiceRegistry} implementation that provides the logging services. To use this:
  *
  * <ol>
- *     <li>Create an instance using one of the static factory methods below.</li>
- *     <li>Create an instance of {@link LoggingManagerInternal}.</li>
- *     <li>Configure the logging manager as appropriate.</li>
- *     <li>Start the logging manager using {@link LoggingManagerInternal#start()}.</li>
- *     <li>When finished, stop the logging manager using {@link LoggingManagerInternal#stop()}.</li>
+ * <li>Create an instance using one of the static factory methods below.</li>
+ * <li>Create an instance of {@link LoggingManagerInternal}.</li>
+ * <li>Configure the logging manager as appropriate.</li>
+ * <li>Start the logging manager using {@link LoggingManagerInternal#start()}.</li>
+ * <li>When finished, stop the logging manager using {@link LoggingManagerInternal#stop()}.</li>
  * </ol>
  */
 public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
+    private final OutputEventListenerManager outputEventListenerManager = new OutputEventListenerManager(new DefaultListenerManager());
     private TextStreamOutputEventListener stdoutListener;
+
+    private OutputEventRenderer renderer;
+
 
     /**
      * Creates a set of logging services which are suitable to use globally in a process. In particular:
      *
      * <ul>
-     *     <li>Replaces System.out and System.err with implementations that route output through the logging system as per {@link LoggingManagerInternal#captureSystemSources()}.</li>
-     *     <li>Configures slf4j, log4j and java util logging to route log messages through the logging system.</li>
-     *     <li>Routes logging output to the original System.out and System.err as per {@link LoggingManagerInternal#attachSystemOutAndErr()}.</li>
-     *     <li>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</li>
+     * <li>Replaces System.out and System.err with implementations that route output through the logging system as per {@link LoggingManagerInternal#captureSystemSources()}.</li>
+     * <li>Configures slf4j, log4j and java util logging to route log messages through the logging system.</li>
+     * <li>Routes logging output to the original System.out and System.err as per {@link LoggingManagerInternal#attachSystemOutAndErr()}.</li>
+     * <li>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</li>
      * </ul>
      *
      * <p>Does nothing until started.</p>
@@ -77,16 +83,16 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
      * Creates a set of logging services which are suitable to use embedded in another application. In particular:
      *
      * <ul>
-     *     <li>Configures slf4j and log4j to route log messages through the logging system.</li>
-     *     <li>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</li>
+     * <li>Configures slf4j and log4j to route log messages through the logging system.</li>
+     * <li>Sets log level to {@link org.gradle.api.logging.LogLevel#LIFECYCLE}.</li>
      * </ul>
      *
      * <p>Does not:</p>
      *
      * <ul>
-     *     <li>Replace System.out and System.err to capture output written to these destinations. Use {@link LoggingManagerInternal#captureSystemSources()} to enable this.</li>
-     *     <li>Configure java util logging. Use {@link LoggingManagerInternal#captureSystemSources()} to enable this.</li>
-     *     <li>Route logging output to the original System.out and System.err. Use {@link LoggingManagerInternal#attachSystemOutAndErr()} to enable this.</li>
+     * <li>Replace System.out and System.err to capture output written to these destinations. Use {@link LoggingManagerInternal#captureSystemSources()} to enable this.</li>
+     * <li>Configure java util logging. Use {@link LoggingManagerInternal#captureSystemSources()} to enable this.</li>
+     * <li>Route logging output to the original System.out and System.err. Use {@link LoggingManagerInternal#attachSystemOutAndErr()} to enable this.</li>
      * </ul>
      *
      * <p>Does nothing until started.</p>
@@ -119,7 +125,7 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
 
     protected TextStreamOutputEventListener getStdoutListener() {
         if (stdoutListener == null) {
-            stdoutListener = new TextStreamOutputEventListener(get(OutputEventListener.class));
+            stdoutListener = new TextStreamOutputEventListener(get(OutputEventListenerManager.class).getBroadcaster());
         }
         return stdoutListener;
     }
@@ -129,35 +135,59 @@ public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
     }
 
     protected DefaultLoggingManagerFactory createLoggingManagerFactory() {
-        OutputEventRenderer renderer = get(OutputEventRenderer.class);
+        OutputEventListenerManager outputEventListenerManager = get(OutputEventListenerManager.class);
+        OutputEventListener outputEventBroadcaster = outputEventListenerManager.getBroadcaster();
+        OutputEventRenderer renderer = getOutputEventRenderer();
+
         LoggingSourceSystem stdout = new DefaultStdOutLoggingSystem(getStdoutListener(), get(Clock.class));
         stdout.setLevel(LogLevel.QUIET);
-        LoggingSourceSystem stderr = new DefaultStdErrLoggingSystem(new TextStreamOutputEventListener(get(OutputEventListener.class)), get(Clock.class));
+        LoggingSourceSystem stderr = new DefaultStdErrLoggingSystem(new TextStreamOutputEventListener(outputEventBroadcaster), get(Clock.class));
         stderr.setLevel(LogLevel.ERROR);
         return new DefaultLoggingManagerFactory(
             renderer,
-            new LoggingSystemAdapter(new Slf4jLoggingConfigurer(renderer)),
+            new LoggingSystemAdapter(new Slf4jLoggingConfigurer(outputEventBroadcaster)),
             new JavaUtilLoggingSystem(),
             stdout,
             stderr);
     }
 
-    protected OutputEventRenderer createOutputEventRenderer(Clock clock) {
-        return new OutputEventRenderer(clock);
+    protected OutputEventListener createOutputEventListener(OutputEventListenerManager manager) {
+        return manager.getBroadcaster();
+    }
+
+    protected OutputEventListenerManager createOutputEventListenerManager() {
+        return outputEventListenerManager;
+    }
+
+    // Intentionally not a service registry create method.
+    // We do not want to expose this to consumers.
+    protected final OutputEventRenderer getOutputEventRenderer() {
+        if (renderer == null) {
+            renderer = makeOutputEventRenderer();
+            outputEventListenerManager.addListener(renderer);
+        }
+
+        return renderer;
+    }
+
+    protected OutputEventRenderer makeOutputEventRenderer() {
+        return new OutputEventRenderer(Time.clock());
     }
 
     private static class CommandLineLogging extends LoggingServiceRegistry {
     }
 
     private static class NestedLogging extends LoggingServiceRegistry {
+
         protected DefaultLoggingManagerFactory createLoggingManagerFactory() {
-            OutputEventRenderer renderer = get(OutputEventRenderer.class);
             // Don't configure anything
-            return new DefaultLoggingManagerFactory(renderer,
+            return new DefaultLoggingManagerFactory(
+                getOutputEventRenderer(),
                 new NoOpLoggingSystem(),
                 new NoOpLoggingSystem(),
                 new NoOpLoggingSystem(),
-                new NoOpLoggingSystem());
+                new NoOpLoggingSystem()
+            );
         }
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventListenerManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventListenerManager.java
@@ -45,18 +45,12 @@ public class OutputEventListenerManager {
     }
 
     public void setListener(OutputEventListener listener) {
-        if (other != null) {
-            throw new IllegalStateException("Listener is already set to " + other);
-        }
-
         other = listener;
     }
 
     public void removeListener(OutputEventListener listener) {
         if (other == listener) {
             other = null;
-        } else {
-            throw new IllegalStateException("Cannot unset listener " + listener + " because the listener is " + other);
         }
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventListenerManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventListenerManager.java
@@ -19,19 +19,23 @@ package org.gradle.internal.logging.sink;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 
+/**
+ * Manages dispatch of output events to the renderer and at most one other arbitrary listener.
+ *
+ * This is a degeneralisation of the standard ListenerManager pattern as a performance optimisation.
+ * Builds generate many output events, and an extra layer of generic listener manager overhead,
+ * on top of OutputEventRenderer noticeably degraded performance.
+ */
 public class OutputEventListenerManager {
 
     private final OutputEventRenderer renderer;
+
     private OutputEventListener other;
 
     private final OutputEventListener broadcaster = new OutputEventListener() {
         @Override
         public void onOutput(OutputEvent event) {
-            try {
-                renderer.onOutput(event);
-            } catch (Exception e) {
-                // TODO what here?
-            }
+            renderer.onOutput(event);
 
             OutputEventListener otherRef = other;
             if (otherRef != null) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventListenerManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventListenerManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.sink;
+
+import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.logging.events.OutputEventListener;
+
+public class OutputEventListenerManager {
+
+    private final ListenerManager listenerManager;
+    private final OutputEventListener broadcaster;
+
+    public OutputEventListenerManager(ListenerManager listenerManager) {
+        this.listenerManager = listenerManager;
+        this.broadcaster = listenerManager.getBroadcaster(OutputEventListener.class);
+    }
+
+    public void addListener(OutputEventListener listener) {
+        listenerManager.addListener(listener);
+    }
+
+    public void removeListener(OutputEventListener listener) {
+        listenerManager.removeListener(listener);
+    }
+
+    public OutputEventListener getBroadcaster() {
+        return broadcaster;
+    }
+}


### PR DESCRIPTION
The addition of emitting build operation notifications for output events caused deadlock between OutputEventRenderer and the ListenerManager (an output listener now tries to notify other listeners). This change avoids the deadlock by not requiring acquisition of the listener manager lock to notify build operation listeners. Instead, we use a bespoke listener management implementation.

CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Favoid-logging-buildop-deadlock