### PR TITLE
Remove `OperatorWrap` checkstyle rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -44,7 +44,6 @@
         <module name="MethodParamPad"/>
         <module name="NoWhitespaceBefore"/>
         <module name="NoWhitespaceAfter"/>
-        <module name="OperatorWrap"/>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter">


### PR DESCRIPTION
### Context

This rule is deeply annoying, as it forces the operators on newlines. Code generation typically
uses the opposite pattern, making it extremely simple to break the rule. Since it doesn't really
matter, disable the rule and let us work.
