### PR TITLE
Fix annotation-processors cache

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDeclarationSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDeclarationSerializer.java
@@ -22,6 +22,11 @@ import org.gradle.internal.serialize.Encoder;
 import java.io.EOFException;
 
 class AnnotationProcessorDeclarationSerializer implements org.gradle.internal.serialize.Serializer<AnnotationProcessorDeclaration> {
+    public static final AnnotationProcessorDeclarationSerializer INSTANCE = new AnnotationProcessorDeclarationSerializer();
+
+    private AnnotationProcessorDeclarationSerializer() {
+    }
+
     @Override
     public AnnotationProcessorDeclaration read(Decoder decoder) throws EOFException, Exception {
         String name = decoder.readString();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
@@ -56,7 +56,7 @@ public class AnnotationProcessorDetector {
     private final boolean logStackTraces;
 
     public AnnotationProcessorDetector(FileContentCacheFactory cacheFactory, Logger logger, boolean logStackTraces) {
-        this.cache = cacheFactory.newCache("annotation-processors", 20000, new ProcessorServiceLocator(), new ListSerializer<AnnotationProcessorDeclaration>(new AnnotationProcessorDeclarationSerializer()));
+        this.cache = cacheFactory.newCache("annotation-processors", 20000, new ProcessorServiceLocator(), new ListSerializer<AnnotationProcessorDeclaration>(AnnotationProcessorDeclarationSerializer.INSTANCE));
         this.logger = logger;
         this.logStackTraces = logStackTraces;
     }


### PR DESCRIPTION
### Context
There is a problem with the 'annotation-processors' cache since gradle 4.6.
This cache created by the constructor `AnnotationProcessorDetector` uses the `newCache` method of the `DefaultCacheAccess` class. This one does some verifications when the cache already exists, checking that the ValueSerializer is equal to the one already present in the cache. As since gradle 4.6 the `AnnotationProcessorDetector` creates a new `AnnotationProcessorDeclarationSerializer` instance each times it is called, an error occurs if the `AnnotationProcessorDetector` constructor is called twice (there are no equals override on `AnnotationProcessorDeclarationSerializer`).
Thanks to a static variable this problem can be solved.

A project sample that reproduce the error can be found here : https://github.com/philippeagra/gradle-cache-error
The branch 4.5.1 in this project shows that there is no error before gradle 4.6.

An unit test class can also be found here : https://github.com/philippeagra/gradle-cache-error/blob/test/src/test/kotlin/Test.kt