### PR TITLE
Improvements to the resolution engine

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -16,9 +16,9 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StringVersioned;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
@@ -33,7 +33,7 @@ public interface ComponentResolutionState extends StringVersioned {
      * @return null if the meta-data is not available due to some failure.
      */
     @Nullable
-    ComponentResolveMetadata getMetaData();
+    ComponentResolveMetadata getMetadata();
 
     ResolvedVersionConstraint getVersionConstraint();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
@@ -131,7 +131,7 @@ class LatestModuleConflictResolver implements ModuleConflictResolver {
                 details.select(component);
                 return;
             }
-            ComponentResolveMetadata metaData = component.getMetaData();
+            ComponentResolveMetadata metaData = component.getMetadata();
             if (metaData != null && "release".equals(metaData.getStatus())) {
                 details.select(component);
                 return;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ProjectDependencyForcingResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ProjectDependencyForcingResolver.java
@@ -39,7 +39,7 @@ class ProjectDependencyForcingResolver implements ModuleConflictResolver {
         T foundProjectCandidate = null;
         // fine one or more project dependencies among conflicting modules
         for (T candidate : details.getCandidates()) {
-            ComponentResolveMetadata metaData = candidate.getMetaData();
+            ComponentResolveMetadata metaData = candidate.getMetadata();
             if (metaData != null && metaData.getComponentId() instanceof ProjectComponentIdentifier) {
                 if (foundProjectCandidate == null) {
                     // found the first project dependency

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphComponent.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphComponent.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**
@@ -25,6 +26,12 @@ import java.util.Collection;
  * Additional fields in this interface are not required to reconstitute the serialized graph.
  */
 public interface DependencyGraphComponent extends ComponentResult {
+    /**
+     * Returns the meta-data for the component. Resolves if not already resolved.
+     *
+     * @return null if the meta-data is not available due to some failure.
+     */
+    @Nullable
     ComponentResolveMetadata getMetadata();
 
     Collection<? extends DependencyGraphComponent> getDependents();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -141,7 +141,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
      *
      * @return true if it has been resolved in a cheap way
      */
-    public boolean fastResolve() {
+    public boolean alreadyResolved() {
         if (metaData != null || failure != null) {
             return true;
         }
@@ -159,7 +159,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     public void resolve() {
-        if (fastResolve()) {
+        if (alreadyResolved()) {
             return;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -47,6 +47,7 @@ import java.util.Set;
  * Resolution state for a given component
  */
 public class ComponentState implements ComponentResolutionState, DependencyGraphComponent, ComponentStateWithDependents<ComponentState> {
+    private final ComponentIdentifier componentIdentifier;
     private final ModuleVersionIdentifier id;
     private final ComponentMetaDataResolver resolver;
     private final VariantNameBuilder variantNameBuilder;
@@ -63,10 +64,11 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private DependencyGraphBuilder.VisitState visitState = DependencyGraphBuilder.VisitState.NotSeen;
     List<SelectorState> allResolvers;
 
-    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentMetaDataResolver resolver, VariantNameBuilder variantNameBuilder) {
+    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver, VariantNameBuilder variantNameBuilder) {
         this.resultId = resultId;
         this.module = module;
         this.id = id;
+        this.componentIdentifier = componentIdentifier;
         this.resolver = resolver;
         this.variantNameBuilder = variantNameBuilder;
         this.implicitCapability = new ImmutableCapability(id.getGroup(), id.getName(), id.getVersion());
@@ -117,9 +119,27 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return module;
     }
 
+    // TODO:DAZ WTF???
     @Override
     public ComponentResolveMetadata getMetadata() {
         return metaData;
+    }
+
+    @Override
+    public ComponentResolveMetadata getMetaData() {
+        if (metaData == null) {
+            resolve();
+        }
+        return metaData;
+    }
+
+    @Override
+    public ComponentIdentifier getComponentId() {
+        // TODO:DAZ Makes it work for snapshot id
+        if (metaData != null) {
+            return metaData.getComponentId();
+        }
+        return componentIdentifier;
     }
 
     public void restart(ComponentState selected) {
@@ -174,14 +194,6 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         metaData = result.getMetaData();
     }
 
-    @Override
-    public ComponentResolveMetadata getMetaData() {
-        if (metaData == null) {
-            resolve();
-        }
-        return metaData;
-    }
-
     public ResolvedVersionConstraint getVersionConstraint() {
         return selectedBy == null ? null : selectedBy.getVersionConstraint();
     }
@@ -213,11 +225,6 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     public void setRoot() {
         selectionReason.setCause(VersionSelectionReasons.ROOT);
-    }
-
-    @Override
-    public ComponentIdentifier getComponentId() {
-        return getMetaData().getComponentId();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -60,9 +60,10 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     private ComponentSelectionState state = ComponentSelectionState.Selectable;
     private ModuleVersionResolveException failure;
-    private SelectorState selectedBy;
+    // The first selector that resolved this component
+    private SelectorState firstSelectedBy;
+    private List<SelectorState> selectedBy;
     private DependencyGraphBuilder.VisitState visitState = DependencyGraphBuilder.VisitState.NotSeen;
-    List<SelectorState> allResolvers;
 
     ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver, VariantNameBuilder variantNameBuilder) {
         this.resultId = resultId;
@@ -127,7 +128,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     @Override
     public ComponentIdentifier getComponentId() {
-        // TODO:DAZ Makes it work for snapshot id
+        // Use the resolved component id if available: this ensures that Maven Snapshot ids are correctly reported
         if (metaData != null) {
             return metaData.getComponentId();
         }
@@ -140,12 +141,19 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         }
     }
 
-    public void selectedBy(SelectorState resolver) {
-        if (selectedBy == null) {
-            selectedBy = resolver;
-            allResolvers = Lists.newLinkedList();
+    public void selectedBy(SelectorState resolver, ComponentIdResolveResult idResolveResult) {
+        if (firstSelectedBy == null) {
+            firstSelectedBy = resolver;
+            selectedBy = Lists.newLinkedList();
         }
-        allResolvers.add(resolver);
+        selectedBy.add(resolver);
+        if (!alreadyResolved()) {
+            metaData = idResolveResult.getMetaData();
+        }
+    }
+
+    public List<SelectorState> getSelectedBy() {
+        return selectedBy;
     }
 
     /**
@@ -154,20 +162,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
      * @return true if it has been resolved in a cheap way
      */
     public boolean alreadyResolved() {
-        if (metaData != null || failure != null) {
-            return true;
-        }
-
-        ComponentIdResolveResult idResolveResult = selectedBy.getResolveResult();
-        if (idResolveResult.getFailure() != null) {
-            failure = idResolveResult.getFailure();
-            return true;
-        }
-        if (idResolveResult.getMetaData() != null) {
-            metaData = idResolveResult.getMetaData();
-            return true;
-        }
-        return false;
+        return metaData != null || failure != null;
     }
 
     public void resolve() {
@@ -175,10 +170,8 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
             return;
         }
 
-        ComponentIdResolveResult idResolveResult = selectedBy.getResolveResult();
-
         DefaultBuildableComponentResolveResult result = new DefaultBuildableComponentResolveResult();
-        resolver.resolve(idResolveResult.getId(), DefaultComponentOverrideMetadata.forDependency(selectedBy.getDependencyMetadata()), result);
+        resolver.resolve(componentIdentifier, DefaultComponentOverrideMetadata.forDependency(firstSelectedBy.getDependencyMetadata()), result);
         if (result.getFailure() != null) {
             failure = result.getFailure();
             return;
@@ -187,7 +180,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     public ResolvedVersionConstraint getVersionConstraint() {
-        return selectedBy == null ? null : selectedBy.getVersionConstraint();
+        return firstSelectedBy == null ? null : firstSelectedBy.getVersionConstraint();
     }
 
     @Override
@@ -291,7 +284,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     @Override
     public boolean isFromPendingNode() {
-        return selectedBy != null && selectedBy.getDependencyMetadata().isPending();
+        return firstSelectedBy != null && firstSelectedBy.getDependencyMetadata().isPending();
     }
 
     public boolean isSelected() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -119,17 +119,9 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return module;
     }
 
-    // TODO:DAZ WTF???
     @Override
     public ComponentResolveMetadata getMetadata() {
-        return metaData;
-    }
-
-    @Override
-    public ComponentResolveMetadata getMetaData() {
-        if (metaData == null) {
-            resolve();
-        }
+        resolve();
         return metaData;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -245,9 +245,9 @@ public class DependencyGraphBuilder {
             }
         }
 
-        final Collection<SelectorState> selectedBy = candidate.allResolvers;
+        final Collection<SelectorState> selectedBy = candidate.getSelectedBy();
         if (currentlySelected != null && currentlySelected != candidate) {
-            if (allSelectorsAgreeWith(candidate.allResolvers, currentlySelected.getVersion(), ALL_SELECTORS)) {
+            if (allSelectorsAgreeWith(selectedBy, currentlySelected.getVersion(), ALL_SELECTORS)) {
                 // if this selector agrees with the already selected version, don't bother and pick it
                 return true;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DownloadMetadataOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DownloadMetadataOperation.java
@@ -28,7 +28,7 @@ class DownloadMetadataOperation implements RunnableBuildOperation {
 
     @Override
     public void run(BuildOperationContext context) {
-        state.getMetaData();
+        state.getMetadata();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -134,7 +134,7 @@ class EdgeState implements DependencyGraphEdge {
     private void calculateTargetConfigurations() {
         targetNodes.clear();
         targetNodeSelectionFailure = null;
-        ComponentResolveMetadata targetModuleVersion = targetModuleRevision.getMetaData();
+        ComponentResolveMetadata targetModuleVersion = targetModuleRevision.getMetadata();
         if (targetModuleVersion == null) {
             // Broken version
             return;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CandidateModule;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -162,10 +163,10 @@ class ModuleResolveState implements CandidateModule {
         unattachedDependencies.remove(edge);
     }
 
-    public ComponentState getVersion(ModuleVersionIdentifier id) {
+    public ComponentState getVersion(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier) {
         ComponentState moduleRevision = versions.get(id);
         if (moduleRevision == null) {
-            moduleRevision = new ComponentState(idGenerator.generateId(), this, id, metaDataResolver, variantNameBuilder);
+            moduleRevision = new ComponentState(idGenerator.generateId(), this, id, componentIdentifier, metaDataResolver, variantNameBuilder);
             versions.put(id, moduleRevision);
         }
         return moduleRevision;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -25,11 +25,13 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Modul
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +148,7 @@ class NodeState implements DependencyGraphNode {
 
         // Check if this node is still included in the graph, by looking at incoming edges.
         boolean hasIncomingEdges = !incomingEdges.isEmpty();
-        List<EdgeState> transitiveIncoming = findTransitiveIncomingEdges(hasIncomingEdges);
+        List<EdgeState> transitiveIncoming = getTransitiveIncomingEdges();
 
         // Check if there are any transitive incoming edges at all. Don't traverse if not.
         if (transitiveIncoming.isEmpty() && !isRoot()) {
@@ -225,33 +227,26 @@ class NodeState implements DependencyGraphNode {
         return dependencyState;
     }
 
-    private List<EdgeState> findTransitiveIncomingEdges(boolean hasIncomingEdges) {
-        if (!hasIncomingEdges) {
-            return Collections.emptyList();
+    /**
+     * Returns the set of incoming edges that are transitive. Most edges are transitive, so the implementation is optimized for this case.
+     */
+    private List<EdgeState> getTransitiveIncomingEdges() {
+        if (isRoot()) {
+            return incomingEdges;
         }
-
-        int size = incomingEdges.size();
-        if (size == 1) {
-            return findSingleIncomingEdge();
-        }
-
-        List<EdgeState> transitiveIncoming = Lists.newArrayListWithCapacity(size);
-        for (EdgeState edge : incomingEdges) {
-            if (edge.isTransitive()) {
-                transitiveIncoming.add(edge);
+        for (EdgeState incomingEdge : incomingEdges) {
+            if (!incomingEdge.isTransitive()) {
+                // Have a non-transitive edge: return a filtered list
+                return CollectionUtils.filter(incomingEdges, new Spec<EdgeState>() {
+                    @Override
+                    public boolean isSatisfiedBy(EdgeState edge) {
+                        return edge.isTransitive();
+                    }
+                });
             }
         }
-        return transitiveIncoming;
-
-    }
-
-    private List<EdgeState> findSingleIncomingEdge() {
-        EdgeState edgeState = incomingEdges.iterator().next();
-        if (edgeState.isTransitive()) {
-            return Collections.singletonList(edgeState);
-        } else {
-            return Collections.emptyList();
-        }
+        // All edges are transitive, no need to construct a filtered list.
+        return incomingEdges;
     }
 
     private boolean isExcluded(ModuleExclusion selector, DependencyState dependencyState) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -212,7 +212,11 @@ class NodeState implements DependencyGraphNode {
         }
     }
 
-    // TODO:DAZ This should be done as a decorator on ConfigurationMetadata.getDependencies() ???
+    /**
+     * Execute any dependency substitution rules that apply to this dependency.
+     *
+     * This may be better done as a decorator on ConfigurationMetadata.getDependencies()
+     */
     private DependencyState maybeSubstitute(DependencyState dependencyState) {
         DependencySubstitutionApplicator.SubstitutionResult substitutionResult = resolveState.getDependencySubstitutionApplicator().apply(dependencyState.getDependency());
         if (substitutionResult.hasFailure()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -46,6 +46,12 @@ import java.util.Set;
  */
 class NodeState implements DependencyGraphNode {
     private static final Logger LOGGER = LoggerFactory.getLogger(DependencyGraphBuilder.class);
+    private static final Spec<EdgeState> TRANSITIVE_EDGES = new Spec<EdgeState>() {
+        @Override
+        public boolean isSatisfiedBy(EdgeState edge) {
+            return edge.isTransitive();
+        }
+    };
 
     private final Long resultId;
     private final ComponentState component;
@@ -241,12 +247,7 @@ class NodeState implements DependencyGraphNode {
         for (EdgeState incomingEdge : incomingEdges) {
             if (!incomingEdge.isTransitive()) {
                 // Have a non-transitive edge: return a filtered list
-                return CollectionUtils.filter(incomingEdges, new Spec<EdgeState>() {
-                    @Override
-                    public boolean isSatisfiedBy(EdgeState edge) {
-                        return edge.isTransitive();
-                    }
-                });
+                return CollectionUtils.filter(incomingEdges, TRANSITIVE_EDGES);
             }
         }
         // All edges are transitive, no need to construct a filtered list.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
@@ -81,7 +82,7 @@ class ResolveState {
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributesFactory = attributesFactory;
         this.dependencySubstitutionApplicator = dependencySubstitutionApplicator;
-        ComponentState rootVersion = getRevision(rootResult.getId());
+        ComponentState rootVersion = getRevision(rootResult.getComponentIdentifier(), rootResult.getId());
         rootVersion.setMetaData(rootResult.getMetaData());
         final ResolvedConfigurationIdentifier id = new ResolvedConfigurationIdentifier(rootVersion.getId(), rootConfigurationName);
         ConfigurationMetadata configurationMetadata = rootVersion.getMetadata().getConfiguration(id.getConfiguration());
@@ -113,8 +114,8 @@ class ResolveState {
         return module;
     }
 
-    public ComponentState getRevision(ModuleVersionIdentifier id) {
-        return getModule(id.getModule()).getVersion(id);
+    public ComponentState getRevision(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier id) {
+        return getModule(id.getModule()).getVersion(id, componentIdentifier);
     }
 
     public Collection<NodeState> getNodes() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -124,7 +124,7 @@ class SelectorState implements DependencyGraphSelector {
             return null;
         }
 
-        selected = resolveState.getRevision(idResolveResult.getModuleVersionId());
+        selected = resolveState.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId());
         selected.selectedBy(this);
         selected.addCause(idResolveResult.getSelectionDescription());
         if (dependencyState.getRuleDescriptor() != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -132,7 +132,7 @@ class SelectorState implements DependencyGraphSelector {
         versionConstraint = idResolveResult.getResolvedVersionConstraint();
 
         // We should never select a component for a different module, but the JVM software model dependency resolution is doing this.
-        // TODO:DAZ Ditch the JVM Software Model plugins and re-add this assertion
+        // TODO Ditch the JVM Software Model plugins and re-add this assertion
 //        assert selected.getModule() == targetModule;
 
         return selected;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -59,6 +59,7 @@ class SelectorState implements DependencyGraphSelector {
         this.resolver = resolver;
         this.resolveState = resolveState;
         this.targetModule = resolveState.getModule(targetModuleId);
+        targetModule.addSelector(this);
     }
 
     @Override
@@ -129,7 +130,6 @@ class SelectorState implements DependencyGraphSelector {
         if (dependencyState.getRuleDescriptor() != null) {
             selected.addCause(dependencyState.getRuleDescriptor());
         }
-        targetModule.addSelector(this);
         versionConstraint = idResolveResult.getResolvedVersionConstraint();
 
         // We should never select a component for a different module, but the JVM software model dependency resolution is doing this.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -164,7 +164,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
     private void doListModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
         ModuleIdentifier module = moduleIdentifierFactory.module(dependency.getSelector().getGroup(), dependency.getSelector().getModule());
 
-        // TODO:DAZ Provide an abstraction for accessing resources within the same module (maven-metadata, directory listing, etc)
+        // TODO: Provide an abstraction for accessing resources within the same module (maven-metadata, directory listing, etc)
         // That way we can avoid passing `ivyPatterns` and `artifactPatterns` around everywhere
         ResourceVersionLister versionLister = new ResourceVersionLister(repository);
         List<ResourcePattern> completeIvyPatterns = filterComplete(this.ivyPatterns, module);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionLister.java
@@ -54,7 +54,7 @@ public class ResourceVersionLister implements VersionLister {
         for (ResourcePattern pattern : patterns) {
             visit(pattern, artifact, module, collector, result);
         }
-        // TODO:DAZ Be a bit smarter about this
+        // Could be a bit smarter about this
         if (!collector.isEmpty()) {
             result.listed(collector);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionLister.java
@@ -54,7 +54,6 @@ public class ResourceVersionLister implements VersionLister {
         for (ResourcePattern pattern : patterns) {
             visit(pattern, artifact, module, collector, result);
         }
-        // Could be a bit smarter about this
         if (!collector.isEmpty()) {
             result.listed(collector);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentResolveResult.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.resolve.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
@@ -27,6 +28,12 @@ import javax.annotation.Nullable;
  * <p>Very similar to {@link org.gradle.internal.resolve.result.ComponentIdResolveResult}, could probably merge these.
  */
 public interface ComponentResolveResult extends ResolveResult {
+
+    /**
+     * Returns the identifier of the component.
+     */
+    ComponentIdentifier getComponentIdentifier();
+
     /**
      * Returns the module version id of the component.
      *

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResult.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.resolve.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -45,6 +46,12 @@ public class DefaultBuildableComponentResolveResult extends DefaultResourceAware
     public void setMetaData(ComponentResolveMetadata metaData) {
         assertResolved();
         this.metaData = metaData;
+    }
+
+    @Override
+    public ComponentIdentifier getComponentIdentifier() {
+        assertResolved();
+        return metaData.getComponentId();
     }
 
     public ModuleVersionIdentifier getId() throws ModuleVersionResolveException {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -119,7 +119,7 @@ abstract class AbstractConflictResolverTest extends Specification {
         }
 
         @Override
-        ComponentResolveMetadata getMetaData() {
+        ComponentResolveMetadata getMetadata() {
             metaData
         }
 

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -155,7 +155,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
      */
     private LocalOriginDependencyMetadata dependencyMetadataFor(ComponentSelector selector, String usageConfigurationName, String mappedUsageConfiguration) {
         return new LocalComponentDependencyMetadata(
-            new OpaqueComponentIdentifier("TODO"), // TODO:DAZ
+            new OpaqueComponentIdentifier("TODO"),
             selector, usageConfigurationName, null, mappedUsageConfiguration,
             ImmutableList.<IvyArtifactName>of(),
             EXCLUDE_RULES,


### PR DESCRIPTION
This is a bunch of refactorings that came about as I spike the improved resolution of version constraints. In particular, we need to detangle the graph (SelectorState, ComponentState, etc) from the actual resolution of dependency metadata.