### PR TITLE
Embolden help.gradle.org URL in build failure suggestions

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -213,7 +213,8 @@ public class BuildExceptionReporter extends BuildAdapter implements Action<Throw
 
     private void writeGeneralTips(StyledTextOutput resolution) {
         resolution.println();
-        resolution.text("* Get more help at https://help.gradle.org");
+        resolution.text("* Get more help at ");
+        resolution.withStyle(UserInput).text("https://help.gradle.org");
         resolution.println();
     }
 


### PR DESCRIPTION
This is intended to encourage more folks to leverage that resource
as we invest more into it.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->