### PR TITLE
Show welcome message and changelog URL after wrapper dist download

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -37,6 +37,6 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         then:
         result.output.contains("Welcome to Gradle ${distribution.version.version}!")
-        result.output.contains("See what's new at https://gradle.org/releases/${distribution.version.version}")
+        result.output.contains("See what's new at https://gradle.org/releases#${distribution.version.version}")
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -17,18 +17,26 @@
 package org.gradle.integtests
 
 class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
-    def "wrapper does not output anything when executed in quiet mode"() {
-        given:
-        file("build.gradle") << """
-task emptyTask
-        """
-        prepareWrapper()
+    def setup() {
+        file("build.gradle") << "task emptyTask"
+        prepareWrapper(distribution.binDistribution.toURI())
+    }
 
+    def "wrapper does not output anything when executed in quiet mode"() {
         when:
         args '-q'
         def result = wrapperExecuter.withTasks("emptyTask").run()
 
         then:
         result.output.empty
+    }
+
+    def "wrapper prints release information in normal mode"() {
+        when:
+        def result = wrapperExecuter.withTasks("emptyTask").run()
+
+        then:
+        result.output.contains("Welcome to Gradle ${distribution.version.version}!")
+        result.output.contains("See what's new at https://gradle.org/releases/${distribution.version.version}")
     }
 }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -58,9 +58,10 @@ public class GradleWrapperMain {
         Logger logger = logger(options);
 
         WrapperExecutor wrapperExecutor = WrapperExecutor.forWrapperPropertiesFile(propertiesFile);
+        String appVersion = wrapperVersion();
         wrapperExecutor.execute(
                 args,
-                new Install(logger, new Download(logger, "gradlew", wrapperVersion()), new PathAssembler(gradleUserHome)),
+                new Install(logger, new Download(logger, "gradlew", appVersion), new PathAssembler(gradleUserHome), appVersion),
                 new BootstrapMainStarter());
     }
 

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -106,7 +106,7 @@ public class Install {
         if (gradleVersion != null) { // appVersion could be null in custom distributions
             logger.log("");
             logger.log("Welcome to Gradle " + gradleVersion + "!");
-            logger.log("See what's new at https://gradle.org/releases/" + gradleVersion);
+            logger.log("See what's new at https://gradle.org/releases#" + gradleVersion);
             logger.log("");
         }
     }


### PR DESCRIPTION
This change removes the wrapper logs for unzipping and setting
permissions, changing them to only log when something went wrong.

A welcome to Gradle message is displayed with a link to the releases
page for the new release.

Issue: #4623

### Before

```
Downloading https://services.gradle.org/distributions/gradle-4.6-bin.zip
........................................................................
Unzipping /Users/eric/.gradle/wrapper/dists/gradle-4.6-bin/6nscg4yape751pc62922nodvq/gradle-4.6-bin.zip to /Users/eric/.gradle/wrapper/dists/gradle-4.6-bin/6nscg4yape751pc62922nodvq
Set executable permissions for: /Users/eric/.gradle/wrapper/dists/gradle-4.6-bin/6nscg4yape751pc62922nodvq/gradle-4.6/bin/gradle
Starting a Gradle Daemon (subsequent builds will be faster)
Generating JAR file 'gradle-api-4.6.jar'
<other logs>
```

### After

```
Downloading https://services.gradle.org/distributions/gradle-4.7-bin.zip
........................................................................

Welcome to Gradle 4.7!
See what's new at https://gradle.org/releases/4.7

Starting a Gradle Daemon (subsequent builds will be faster)
Generating JAR file 'gradle-api-4.6.jar'
<other logs>
```

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
