### PR TITLE
 Closes #2844: gradle wrapper distribution unique id now configurable

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -97,6 +97,7 @@ public class Wrapper extends DefaultTask {
     private String distributionPath;
     private PathBase distributionBase = PathBase.GRADLE_USER_HOME;
     private String distributionUrl;
+    private String distributionUid;
     private String distributionSha256Sum;
     private GradleVersion gradleVersion;
     private DistributionType distributionType = DistributionType.BIN;
@@ -177,6 +178,11 @@ public class Wrapper extends DefaultTask {
     private void writeProperties(File propertiesFileDestination) {
         Properties wrapperProperties = new Properties();
         wrapperProperties.put(WrapperExecutor.DISTRIBUTION_URL_PROPERTY, getDistributionUrl());
+        
+        if (distributionUid != null) {
+            wrapperProperties.put(WrapperExecutor.DISTRIBUTION_UID_PROPERTY, distributionUid);
+        }
+        
         if (distributionSha256Sum != null) {
             wrapperProperties.put(WrapperExecutor.DISTRIBUTION_SHA_256_SUM, distributionSha256Sum);
         }
@@ -402,6 +408,11 @@ public class Wrapper extends DefaultTask {
     public void setDistributionSha256Sum(@Nullable String distributionSha256Sum) {
         this.distributionSha256Sum = distributionSha256Sum;
     }
+    
+    
+    
+    
+    
 
     /**
      * The distribution base specifies whether the unpacked wrapper distribution should be stored in the project or in
@@ -452,5 +463,32 @@ public class Wrapper extends DefaultTask {
      */
     public void setArchiveBase(PathBase archiveBase) {
         this.archiveBase = archiveBase;
+    }
+    
+    
+   
+    /**
+     * The user supplied distribution unique id if set.
+     *
+     * <p>If not set, then internally the hash of the distribution url is used {@link #getDistributionUrl()}, and
+     * null is returned
+     * 
+     * <p>The default is almost always the required behaviour you want.
+     * 
+     */
+    @Optional
+    @Input
+    public String getDistributionUid() {
+        return distributionUid;
+    }
+
+    
+    /**
+     * The distribution unique id overrides default internal id generation.
+     * @param uid the id
+     */
+    @Option(option = "gradle-distribution-uid", description = "The unique id for storing the Gradle distribution.")
+    public void setDistributionUid(@Nullable String uid) {
+        this.distributionUid = uid;
     }
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -43,6 +43,7 @@ class WrapperTest extends AbstractTaskTest {
         new File(getProject().getProjectDir(), targetWrapperJarPath).mkdirs()
         wrapper.setDistributionPath("somepath")
         wrapper.setDistributionSha256Sum("somehash")
+        wrapper.setDistributionUid("someid")
     }
 
     AbstractTask getTask() {
@@ -64,6 +65,7 @@ class WrapperTest extends AbstractTaskTest {
         Wrapper.PathBase.GRADLE_USER_HOME == wrapper.getArchiveBase()
         wrapper.getDistributionUrl() != null
         wrapper.getDistributionSha256Sum() == null
+        wrapper.getDistributionUid() == null
     }
 
     def "determines Windows script path from unix script path"() {
@@ -128,6 +130,15 @@ class WrapperTest extends AbstractTaskTest {
         expect:
         "somehash" == wrapper.getDistributionSha256Sum()
     }
+    
+    
+    def "uses explicitly defined distribution unique id"() {
+        given:
+        wrapper.setDistributionUid("someid")
+
+        expect:
+        "someid" == wrapper.getDistributionUid()
+    }
 
     def "execute with non extant wrapper jar parent directory"() {
         when:
@@ -144,13 +155,14 @@ class WrapperTest extends AbstractTaskTest {
         properties.getProperty(WrapperExecutor.DISTRIBUTION_PATH_PROPERTY) == wrapper.getDistributionPath()
         properties.getProperty(WrapperExecutor.ZIP_STORE_BASE_PROPERTY) == wrapper.getArchiveBase().toString()
         properties.getProperty(WrapperExecutor.ZIP_STORE_PATH_PROPERTY) == wrapper.getArchivePath()
+        properties.getProperty(WrapperExecutor.DISTRIBUTION_UID_PROPERTY) == wrapper.getDistributionUid()
     }
 
     def "check inputs"() {
         expect:
         TaskPropertyTestUtils.getProperties(wrapper).keySet() == WrapUtil.toSet(
             "distributionBase", "distributionPath", "distributionUrl", "distributionSha256Sum",
-            "distributionType", "archiveBase", "archivePath", "gradleVersion")
+            "distributionType", "archiveBase", "archivePath", "gradleVersion", "distributionUid")
     }
 
     def "execute with extant wrapper jar parent directory and extant wraper jar"() {
@@ -177,6 +189,7 @@ class WrapperTest extends AbstractTaskTest {
         properties.getProperty(WrapperExecutor.DISTRIBUTION_PATH_PROPERTY) == wrapper.getDistributionPath()
         properties.getProperty(WrapperExecutor.ZIP_STORE_BASE_PROPERTY) == wrapper.getArchiveBase().toString()
         properties.getProperty(WrapperExecutor.ZIP_STORE_PATH_PROPERTY) == wrapper.getArchivePath()
+        properties.getProperty(WrapperExecutor.DISTRIBUTION_UID_PROPERTY) == wrapper.getDistributionUid()
     }
 
     def "distributionUrl should not contain small dotless I letter when locale has small dotless I letter"() {

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.wrapper.Wrapper.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.wrapper.Wrapper.xml
@@ -25,6 +25,10 @@
                 <td><literal>'wrapper/dists'</literal></td>
             </tr>
             <tr>
+                <td>distributionUid</td>
+                <td><literal>Hash of the distribution url</literal></td>
+            </tr>
+            <tr>
                 <td>distributionBase</td>
                 <td><literal>PathBase.GRADLE_USER_HOME</literal></td>
             </tr>

--- a/subprojects/docs/src/docs/userguide/gradleWrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/gradleWrapper.adoc
@@ -86,6 +86,10 @@ The full URL pointing to Gradle distribution ZIP file. Using this option makes `
 `--gradle-distribution-sha256-sum`::
 The SHA256 hash sum used for <<sec:verification,verifying the downloaded Gradle distribution>>.
 
+`--gradle-distribution-uid`::
+The unique id used to store the distribution under. The default behaviour is almost always what you want, however this allows overriding for specific use cases. 
+
+
 Let’s assume the following use case to illustrate the use of the command line options. You would like to generate the Wrapper with version 4.0 and use the `-all` distribution to enable your IDE to enable code-completion and being able to navigate to the Gradle source code. Those requirements are captured by the following command line execution:
 
 ++++

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
@@ -45,9 +45,13 @@ public class PathAssembler {
         return new LocalDistribution(distDir, distZip);
     }
 
-    private String rootDirName(String distName, WrapperConfiguration configuration) {
-        String urlHash = getHash(configuration.getDistribution().toString());
-        return distName + "/" + urlHash;
+    
+    private String rootDirName(String distName, WrapperConfiguration config) {
+        String id = config.getDistributionUid();
+        if (id == null || id.isEmpty()) {
+            id = getHash(config.getDistribution().toString());
+        }
+        return distName + "/" + id;
     }
 
     /**

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -19,11 +19,32 @@ import java.net.URI;
 
 public class WrapperConfiguration {
     private URI distribution;
+    private String distributionUid;
     private String distributionBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String distributionPath = Install.DEFAULT_DISTRIBUTION_PATH;
     private String distributionSha256Sum;
     private String zipBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String zipPath = Install.DEFAULT_DISTRIBUTION_PATH;
+    
+    
+    
+     
+    /**
+     * Gets the distributions unique id.
+     * @return the id
+     */
+    public String getDistributionUid() {
+        return distributionUid;
+    }
+
+    /**
+     * Set the unique id for the distribution.
+     * @param id the unique id
+     */
+    public void setDistributionUid(String id) {
+        this.distributionUid = id;
+    }
+    
 
     public URI getDistribution() {
         return distribution;

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.util.Properties;
 
 public class WrapperExecutor {
+    public static final String DISTRIBUTION_UID_PROPERTY = "distributionUid";
     public static final String DISTRIBUTION_URL_PROPERTY = "distributionUrl";
     public static final String DISTRIBUTION_BASE_PROPERTY = "distributionBase";
     public static final String DISTRIBUTION_PATH_PROPERTY = "distributionPath";
@@ -52,6 +53,7 @@ public class WrapperExecutor {
             try {
                 loadProperties(propertiesFile, properties);
                 config.setDistribution(prepareDistributionUri());
+                config.setDistributionUid(getProperty(DISTRIBUTION_UID_PROPERTY, null, false));
                 config.setDistributionBase(getProperty(DISTRIBUTION_BASE_PROPERTY, config.getDistributionBase()));
                 config.setDistributionPath(getProperty(DISTRIBUTION_PATH_PROPERTY, config.getDistributionPath()));
                 config.setDistributionSha256Sum(getProperty(DISTRIBUTION_SHA_256_SUM, config.getDistributionSha256Sum(), false));

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/PathAssemblerTest.java
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/PathAssemblerTest.java
@@ -37,6 +37,17 @@ public class PathAssemblerTest {
         configuration.setZipPath("somePath");
     }
     
+    
+    @Test
+    public void distributionDirWithUid() throws Exception {
+        final String suri = "../../server/dist/gradle-0.9-bin.zip";
+        configuration.setDistribution(new URI(suri));
+        configuration.setDistributionUid("uidemn8ua2x0re2y4jlewhnxhasz");
+        File distributionDir = pathAssembler.getDistribution(configuration).getDistributionDir();
+        assertThat(distributionDir.getName(), equalTo("uidemn8ua2x0re2y4jlewhnxhasz"));
+        assertThat(distributionDir.getParentFile(), equalTo(file(TEST_GRADLE_USER_HOME + "/somePath/gradle-0.9-bin")));
+    }
+    
     @Test
     public void distributionDirWithGradleUserHomeBase() throws Exception {
         configuration.setDistribution(new URI("http://server/dist/gradle-0.9-bin.zip"));

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
@@ -32,7 +32,6 @@ class WrapperExecutorTest extends Specification {
     def setup() {
         projectDir = tmpDir.testDirectory
         propertiesFile = tmpDir.file('gradle/wrapper/gradle-wrapper.properties')
-
         properties.distributionUrl = 'http://server/test/gradle.zip'
         properties.distributionBase = 'testDistBase'
         properties.distributionPath = 'testDistPath'
@@ -48,6 +47,7 @@ class WrapperExecutorTest extends Specification {
 
         expect:
         wrapper.distribution == new URI('http://server/test/gradle.zip')
+        wrapper.configuration.distributionUid == null
         wrapper.configuration.distribution == new URI('http://server/test/gradle.zip')
         wrapper.configuration.distributionBase == 'testDistBase'
         wrapper.configuration.distributionPath == 'testDistPath'
@@ -61,6 +61,7 @@ class WrapperExecutorTest extends Specification {
 
         expect:
         wrapper.distribution == new URI('http://server/test/gradle.zip')
+        wrapper.configuration.distributionUid == null
         wrapper.configuration.distribution == new URI('http://server/test/gradle.zip')
         wrapper.configuration.distributionBase == 'testDistBase'
         wrapper.configuration.distributionPath == 'testDistPath'
@@ -74,6 +75,7 @@ class WrapperExecutorTest extends Specification {
 
         expect:
         wrapper.distribution == null
+        wrapper.configuration.distributionUid == null
         wrapper.configuration.distribution == null
         wrapper.configuration.distributionBase == PathAssembler.GRADLE_USER_HOME_STRING
         wrapper.configuration.distributionPath == Install.DEFAULT_DISTRIBUTION_PATH
@@ -92,6 +94,7 @@ class WrapperExecutorTest extends Specification {
 
         expect:
         wrapper.distribution == new URI("http://server/test/gradle.zip")
+        wrapper.configuration.distributionUid == null
         wrapper.configuration.distribution == new URI("http://server/test/gradle.zip")
         wrapper.configuration.distributionBase == PathAssembler.GRADLE_USER_HOME_STRING
         wrapper.configuration.distributionPath == Install.DEFAULT_DISTRIBUTION_PATH
@@ -167,5 +170,20 @@ class WrapperExecutorTest extends Specification {
         //distribution uri should resolve into absolute path
         wrapper.distribution.schemeSpecificPart != 'some/relative/url/to/bin.zip'
         wrapper.distribution.schemeSpecificPart.endsWith 'some/relative/url/to/bin.zip'
+    }
+    
+    
+    def "supports custom storage distribution uid"() {
+        given:
+        properties.distributionUrl = 'some/relative/url/to/bin.zip'
+        properties.distributionUid = 'testUid'
+        propertiesFile.withOutputStream { properties.store(it, 'header') }
+
+        when:
+        WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile)
+
+        then:
+        //distribution uid should be the one supplied
+        wrapper.configuration.distributionUid == 'testUid'
     }
 }


### PR DESCRIPTION
       - The gradle wrapper unique id/hash that is used as the name of
         the directory to store the distribution in is now configurable so
         that users can override it custom use cases. Most notably it helps
         in the case when using relative paths which results in duplication
         of the same gradle distributions for each project.

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
