### PR TITLE
Lint Kotlin code in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
 
 plugins {
     `kotlin-dsl`
-    id("org.gradle.kotlin.ktlint-convention") version "0.1.2" apply false
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.4" apply false
 }
 
 subprojects {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,6 +23,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
 
 plugins {
     `kotlin-dsl`
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.1" apply false
 }
 
 subprojects {
@@ -65,7 +66,10 @@ subprojects {
         }
     }
     if (file("src/main/kotlin").isDirectory || file("src/test/kotlin").isDirectory) {
-        apply { plugin("kotlin") }
+        apply {
+            plugin("kotlin")
+            plugin("org.gradle.kotlin.ktlint-convention")
+        }
 
         tasks.withType<KotlinCompile> {
             kotlinOptions {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
 
 plugins {
     `kotlin-dsl`
-    id("org.gradle.kotlin.ktlint-convention") version "0.1.1" apply false
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.2" apply false
 }
 
 subprojects {

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/AddVerifyProductionEnvironmentTaskPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/AddVerifyProductionEnvironmentTaskPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.nio.charset.Charset
 
+
 open class AddVerifyProductionEnvironmentTaskPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         tasks.create("verifyIsProductionBuildEnvironment") {

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/CiReportingPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/CiReportingPlugin.kt
@@ -14,6 +14,7 @@ import org.gradle.testing.DistributedPerformanceTest
 import org.gradle.gradlebuild.test.integrationtests.DistributionTest
 import java.io.File
 
+
 /**
  * When run from a Continuous Integration environment, we only want to archive a subset of reports, mostly for
  * failing tasks only, to not use up unnecessary disk space on Team City. This also improves the performance of

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/DependencyVulnerabilitiesPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/DependencyVulnerabilitiesPlugin.kt
@@ -23,6 +23,7 @@ import org.gradle.kotlin.dsl.*
 
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 
+
 open class DependencyVulnerabilitiesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/NoResolutionAtConfigurationTimePlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/NoResolutionAtConfigurationTimePlugin.kt
@@ -38,7 +38,5 @@ open class NoResolutionAtConfigurationTimePlugin : Plugin<Project> {
                 }
             }
         }
-
     }
 }
-

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/TaskPropertyValidationPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/TaskPropertyValidationPlugin.kt
@@ -24,7 +24,8 @@ import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.tasks.testing.Test
 import org.gradle.plugin.devel.tasks.ValidateTaskProperties
 
-import accessors.*
+import accessors.java
+import accessors.reporting
 
 import org.gradle.kotlin.dsl.*
 
@@ -58,7 +59,7 @@ fun Project.validateTaskPropertiesForConfiguration(configuration: Configuration)
         // TODO Add a comment on why those projects.
         when (this) {
             coreProject -> addValidateTask()
-            else        -> {
+            else -> {
                 configuration.dependencies.withType<ProjectDependency>()
                     .matching { it.dependencyProject == coreProject }
                     .all {

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/Classycle.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/Classycle.kt
@@ -140,6 +140,7 @@ fun GroovyBuilderScope.withFilesetOf(classesDirs: FileCollection, excludePattern
         }
     }
 
+
 private
 fun clickableUrl(file: File) =
     URI("file", "", file.toURI().path, null, null).toString()

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/ClassycleExtension.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/classycle/ClassycleExtension.kt
@@ -21,6 +21,7 @@ import org.gradle.api.provider.ListProperty
 
 import org.gradle.kotlin.dsl.*
 
+
 open class ClassycleExtension(project: Project) {
 
     val excludePatterns: ListProperty<String> = project.objects.listProperty()

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/testfiles/TestFilesCleanUpPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/testfiles/TestFilesCleanUpPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.EmptyDirectoryCheck
 import org.gradle.kotlin.dsl.*
 
+
 /**
  * Generate a report showing which tests in a subproject are leaving
  * files around.
@@ -18,20 +19,19 @@ open class TestFilesCleanUpPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
         val verifyTestFilesCleanup by tasks.creating(EmptyDirectoryCheck::class) {
-            targetDir = fileTree("${buildDir}/tmp/test files")
-            report = file("${buildDir}/reports/remains.txt")
+            targetDir = fileTree("$buildDir/tmp/test files")
+            report = file("$buildDir/reports/remains.txt")
             isErrorWhenNotEmpty = true
         }
         extensions.create<TestFileCleanUpExtension>("testFilesCleanup", verifyTestFilesCleanup)
     }
 }
 
+
 open class TestFileCleanUpExtension(val verifyTestFilesCleanup: EmptyDirectoryCheck) {
     var isErrorWhenNotEmpty: Boolean
         get() = verifyTestFilesCleanup.isErrorWhenNotEmpty
-
         set(value) {
             verifyTestFilesCleanup.isErrorWhenNotEmpty = value
         }
 }
-

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanUpCaches.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanUpCaches.kt
@@ -24,6 +24,7 @@ import org.gradle.util.GradleVersion
 
 import java.io.File
 
+
 open class CleanUpCaches : DefaultTask() {
 
     @TaskAction

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanUpDaemons.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanUpDaemons.kt
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.testing.TestResult
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentHashMap.newKeySet
 
+
 open class CleanUpDaemons : DefaultTask() {
 
     private

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/Cleanup.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/Cleanup.kt
@@ -126,4 +126,3 @@ fun Project.removeDaemonLogFiles(dir: File) {
         delete(daemonLogFiles)
     }
 }
-

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanupPlugin.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanupPlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.api.Project
 import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.kotlin.dsl.*
 
+
 class CleanupPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/KillLeakingJavaProcesses.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/KillLeakingJavaProcesses.kt
@@ -19,6 +19,7 @@ package org.gradle.gradlebuild.testing.integrationtests.cleanup
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
+
 open class KillLeakingJavaProcesses : DefaultTask() {
 
     @TaskAction

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/Process.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/Process.kt
@@ -109,4 +109,3 @@ fun forEachLineIn(s: String, action: (String) -> Unit) =
 
 fun Project.isMe(process: String) =
     process.contains(gradle.gradleHomeDir!!.path)
-

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/testing/LeakingProcessKillPattern.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/testing/LeakingProcessKillPattern.kt
@@ -18,6 +18,7 @@ package org.gradle.testing
 
 import java.util.regex.Pattern
 
+
 object LeakingProcessKillPattern {
 
     @JvmStatic

--- a/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
 import org.gradle.kotlin.dsl.*
@@ -47,10 +46,12 @@ fun Project.libraryReason(name: String): String? =
 fun Project.testLibrary(name: String): Any =
     testLibraries[name]!!
 
+
 // TODO:kotlin-dsl Remove work around for https://github.com/gradle/kotlin-dsl/issues/639 once fixed
 @Suppress("unchecked_cast")
 fun Project.testLibraries(name: String): List<Any> =
     testLibraries[name]!! as List<Any>
+
 
 val Project.maxParallelForks: Int
     get() {
@@ -58,10 +59,12 @@ val Project.maxParallelForks: Int
             findProperty("maxParallelForks")?.let { Integer.valueOf(it.toString(), 10) }) ?: 4
     }
 
+
 val Project.useAllDistribution: Boolean
     get() {
         return ifProperty("useAllDistribution", true) ?: false
     }
+
 
 private
 fun <T> Project.ifProperty(name: String, then: T): T? =

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
@@ -3,6 +3,7 @@ package org.gradle.gradlebuild
 import org.gradle.api.JavaVersion
 import org.gradle.internal.os.OperatingSystem
 
+
 object BuildEnvironment {
     val isCiServer = "CI" in System.getenv()
     val gradleKotlinDslVersion = "0.16.2"
@@ -19,5 +20,4 @@ object BuildEnvironment {
             }
             return 1
         }
-
 }

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -20,7 +20,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
-import org.gradle.kotlin.dsl.dependencies
+
+import org.gradle.kotlin.dsl.*
+
 
 open class DependenciesMetadataRulesPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
@@ -96,6 +98,7 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
     }
 }
 
+
 fun ComponentMetadataHandler.withLibraryDependencies(module: String, action: DirectDependenciesMetadata.() -> Any) {
     withModule(module) {
         allVariants {
@@ -105,6 +108,7 @@ fun ComponentMetadataHandler.withLibraryDependencies(module: String, action: Dir
         }
     }
 }
+
 
 fun ComponentMetadataHandler.replaceJCLWithAdapter(module: String) {
     withModule(module) {
@@ -119,6 +123,7 @@ fun ComponentMetadataHandler.replaceJCLWithAdapter(module: String) {
     }
 }
 
+
 fun ComponentMetadataHandler.replaceJCLConstraintWithAdapter(module: String) {
     withModule(module) {
         allVariants {
@@ -131,6 +136,7 @@ fun ComponentMetadataHandler.replaceJCLConstraintWithAdapter(module: String) {
         }
     }
 }
+
 
 fun ComponentMetadataHandler.replaceLog4JWithAdapter(module: String) {
     withModule(module) {
@@ -145,6 +151,7 @@ fun ComponentMetadataHandler.replaceLog4JWithAdapter(module: String) {
     }
 }
 
+
 fun ComponentMetadataHandler.replaceGoogleCollectionsWithGuava(module: String) {
     withModule(module) {
         allVariants {
@@ -157,6 +164,7 @@ fun ComponentMetadataHandler.replaceGoogleCollectionsWithGuava(module: String) {
         }
     }
 }
+
 
 fun ComponentMetadataHandler.replaceJunitDepWithJunit(module: String) {
     withModule(module) {
@@ -171,6 +179,7 @@ fun ComponentMetadataHandler.replaceJunitDepWithJunit(module: String) {
     }
 }
 
+
 fun ComponentMetadataHandler.replaceAsmWithOW2Asm(module: String) {
     withModule(module) {
         allVariants {
@@ -183,6 +192,7 @@ fun ComponentMetadataHandler.replaceAsmWithOW2Asm(module: String) {
         }
     }
 }
+
 
 fun ComponentMetadataHandler.replaceBeanshellWithApacheBeanshell(module: String) {
     withModule(module) {
@@ -197,6 +207,7 @@ fun ComponentMetadataHandler.replaceBeanshellWithApacheBeanshell(module: String)
     }
 }
 
+
 fun ComponentMetadataHandler.downgradeIvy(module: String) {
     withModule(module) {
         allVariants {
@@ -209,6 +220,7 @@ fun ComponentMetadataHandler.downgradeIvy(module: String) {
         }
     }
 }
+
 
 fun ComponentMetadataHandler.downgradeTestNG(module: String) {
     withModule(module) {
@@ -223,6 +235,7 @@ fun ComponentMetadataHandler.downgradeTestNG(module: String) {
     }
 }
 
+
 fun ComponentMetadataHandler.downgradeXmlApis(module: String) {
     withModule(module) {
         allVariants {
@@ -235,4 +248,3 @@ fun ComponentMetadataHandler.downgradeXmlApis(module: String) {
         }
     }
 }
-

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -10,6 +10,7 @@ import org.gradle.jvm.toolchain.internal.LocalJavaInstallation
 import org.slf4j.LoggerFactory
 import java.io.File
 
+
 class DefaultJavaInstallation(val current: Boolean, private val javaHome: File) : LocalJavaInstallation {
     private
     lateinit var name: String
@@ -27,17 +28,25 @@ class DefaultJavaInstallation(val current: Boolean, private val javaHome: File) 
     override fun setJavaHome(javaHome: File) { throw UnsupportedOperationException("JavaHome cannot be changed") }
     val toolsJar: File? by lazy { Jvm.forHome(javaHome).toolsJar }
 
-    override fun toString(): String = "${displayName} (${javaHome.absolutePath})"
+    override fun toString(): String = "$displayName (${javaHome.absolutePath})"
 }
+
 
 private
 const val java7HomePropertyName = "java7Home"
+
+
 private
 const val testJavaHomePropertyName = "testJavaHome"
+
+
 private
 const val oracleJdk8 = "Oracle JDK 8"
+
+
 private
 const val oracleJdk7 = "Oracle JDK 7"
+
 
 open class AvailableJavaInstallations(project: Project, private val javaInstallationProbe: JavaInstallationProbe) {
     private
@@ -98,7 +107,7 @@ open class AvailableJavaInstallations(project: Project, private val javaInstalla
     fun validateCompilationJdks(): Collection<String> {
         val jdkForCompilation = javaInstallations.values.firstOrNull()
         return mapOf(
-            "Must set project or system property '${java7HomePropertyName}' to the path of an ${oracleJdk7}, is currently unset." to (jdkForCompilation == null),
+            "Must set project or system property '$java7HomePropertyName' to the path of an $oracleJdk7, is currently unset." to (jdkForCompilation == null),
             validationMessage(java7HomePropertyName, jdkForCompilation, oracleJdk7) to (jdkForCompilation != null && jdkForCompilation.displayName != oracleJdk7),
             "Must use Oracle JDK 8 to perform this build. Is currently ${currentJavaInstallation.displayName} at ${currentJavaInstallation.javaHome}." to
                 (currentJavaInstallation.displayName != oracleJdk8)

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
@@ -1,12 +1,11 @@
 package org.gradle.gradlebuild.java
 
-import accessors.java
-
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.create
+
 
 // TODO We should not add this to the root project but a single instace to every subproject
 open class AvailableJavaInstallationsPlugin : Plugin<Project> {

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/project-groups.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/project-groups.kt
@@ -2,6 +2,7 @@ package org.gradle.gradlebuild
 
 import org.gradle.api.Project
 
+
 object ProjectGroups {
     val excludedFromVulnerabilityCheck = setOf(
         ":buildScanPerformance",
@@ -61,8 +62,8 @@ object ProjectGroups {
         get() = setOf(rootProject.project(":testingJunitPlatform"))
 
     val Project.publicProjects
-       get() = pluginProjects +
-           implementationPluginProjects +
-           publicJavaProjects -
-           setOf(":smokeTest", ":soak").map { rootProject.project(it) }
+        get() = pluginProjects +
+            implementationPluginProjects +
+            publicJavaProjects -
+            setOf(":smokeTest", ":soak").map { rootProject.project(it) }
 }

--- a/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/PegDown.kt
+++ b/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/PegDown.kt
@@ -1,13 +1,20 @@
 package org.gradle.gradlebuild.docs
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 
 import org.pegdown.PegDownProcessor
 
 import java.io.File
 import java.nio.charset.Charset
 import java.nio.charset.Charset.defaultCharset
+
 
 @CacheableTask
 open class PegDown : DefaultTask() {

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdeExtension.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdeExtension.kt
@@ -17,7 +17,7 @@ package org.gradle.gradlebuild.ide
 
 import org.gradle.api.Project
 
-import accessors.*
+import accessors.idea
 
 
 open class IdeExtension(private val project: Project) {

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -15,7 +15,9 @@
  */
 package org.gradle.gradlebuild.ide
 
-import accessors.*
+import accessors.base
+import accessors.eclipse
+import accessors.idea
 import org.gradle.api.Action
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
@@ -45,6 +47,7 @@ import java.io.File
 
 private
 const val ideConfigurationBaseName = "ideConfiguration"
+
 
 open class IdePlugin : Plugin<Project> {
 
@@ -353,7 +356,8 @@ open class IdePlugin : Plugin<Project> {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun getDefaultJunitVmParameter(docsProject: Project): String {
+    private
+    fun getDefaultJunitVmParameter(docsProject: Project): String {
         val rootProject = docsProject.rootProject
         val releaseNotesMarkdown: PegDown by docsProject.tasks
         val releaseNotes: Copy by docsProject.tasks
@@ -422,6 +426,7 @@ const val GRADLE_CONFIGURATION = """
     </configuration>
 """
 
+
 private
 fun Element.configureCodeStyleSettings() {
     val config = appendElement("component")
@@ -471,12 +476,14 @@ fun Element.configureCodeStyleSettings() {
     }
 }
 
+
 private
 fun Element.option(name: String, value: String) {
     appendElement("option")
         .attr("name", name)
         .attr("value", value)
 }
+
 
 private
 fun XmlProvider.withJsoup(function: (Document) -> Unit) {
@@ -485,6 +492,7 @@ fun XmlProvider.withJsoup(function: (Document) -> Unit) {
     xml.replace(0, xml.length, document)
 }
 
+
 private
 fun modifyXmlDocument(xml: StringBuilder, function: (Document) -> Unit): String {
     val document = Jsoup.parse(xml.toString(), "", Parser.xmlParser())
@@ -492,6 +500,7 @@ fun modifyXmlDocument(xml: StringBuilder, function: (Document) -> Unit): String 
     document.outputSettings().escapeMode(Entities.EscapeMode.xhtml)
     return document.toString()
 }
+
 
 private
 fun Element.createOrEmptyOutChildElement(childName: String): Element {
@@ -503,6 +512,7 @@ fun Element.createOrEmptyOutChildElement(childName: String): Element {
         children().remove()
     }
 }
+
 
 private
 fun Element.removeBySelector(selector: String): Element =

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesExtension.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesExtension.kt
@@ -34,5 +34,6 @@ open class TestFixturesExtension {
     val origins: MutableList<TestFixturesOrigin> = mutableListOf()
 }
 
+
 internal
 data class TestFixturesOrigin(val projectPath: String, val sourceSetName: String)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/CrossVersionTestsPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/CrossVersionTestsPlugin.kt
@@ -23,6 +23,7 @@ import org.gradle.gradlebuild.test.fixtures.TestFixturesPlugin
 import org.gradle.kotlin.dsl.*
 import releasedVersions
 
+
 class CrossVersionTestsPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         val sourceSet = addSourceSet(TestType.CROSSVERSION)
@@ -36,7 +37,8 @@ class CrossVersionTestsPlugin : Plugin<Project> {
         configureTestFixturesForCrossVersionTests()
     }
 
-    private fun Project.configureTestFixturesForCrossVersionTests() {
+    private
+    fun Project.configureTestFixturesForCrossVersionTests() {
         plugins.withType<TestFixturesPlugin> {
             configure<TestFixturesExtension> {
                 from(":toolingApi")

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
@@ -31,6 +31,7 @@ import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
 
+
 class DistributionTestingPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
@@ -48,7 +49,8 @@ class DistributionTestingPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.addSetUpAndTearDownActions(distributionTest: DistributionTest) {
+    private
+    fun Project.addSetUpAndTearDownActions(distributionTest: DistributionTest) {
         lateinit var daemonListener: Any
 
         // TODO Why don't we register with the test listener of the test task
@@ -67,7 +69,8 @@ class DistributionTestingPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.setDedicatedTestOutputDirectoryPerTask(distributionTest: DistributionTest) {
+    private
+    fun Project.setDedicatedTestOutputDirectoryPerTask(distributionTest: DistributionTest) {
         distributionTest.reports.junitXml.destination = File(java.testResultsDir, distributionTest.name)
         // TODO Confirm that this is not needed
         afterEvaluate {
@@ -75,7 +78,8 @@ class DistributionTestingPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configureGradleTestEnvironment(distributionTest: DistributionTest): Unit = distributionTest.run {
+    private
+    fun Project.configureGradleTestEnvironment(distributionTest: DistributionTest): Unit = distributionTest.run {
         gradleInstallationForTest.run {
             val intTestImage: Sync by tasks
             val toolingApiShadedJar: Zip by rootProject.project(":toolingApi").tasks
@@ -93,14 +97,16 @@ class DistributionTestingPlugin : Plugin<Project> {
         }
     }
 
-    private fun DistributionTest.setJvmArgsOfTestJvm() {
+    private
+    fun DistributionTest.setJvmArgsOfTestJvm() {
         jvmArgs("-Xmx512m", "-XX:+HeapDumpOnOutOfMemoryError")
         if (!javaVersion.isJava8Compatible) {
             jvmArgs("-XX:MaxPermSize=768m")
         }
     }
 
-    private fun DistributionTest.setSystemPropertiesOfTestJVM(project: Project) {
+    private
+    fun DistributionTest.setSystemPropertiesOfTestJVM(project: Project) {
         // use -PtestVersions=all or -PtestVersions=1.2,1.3…
         val integTestVersionsSysProp = "org.gradle.integtest.versions"
         if (project.hasProperty("testVersions")) {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -86,4 +86,3 @@ class UserguideIntegrationTestEnvironmentProvider(private val samplesInternal: U
     override fun getName() =
         "userguide"
 }
-

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTestsPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTestsPlugin.kt
@@ -19,6 +19,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.*
 
+
 class IntegrationTestsPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         val sourceSet = addSourceSet(TestType.INTEGRATION)
@@ -30,4 +31,3 @@ class IntegrationTestsPlugin : Plugin<Project> {
         val integTestTasks by extra { tasks.withType<IntegrationTest>() }
     }
 }
-

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/SoakTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/SoakTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.gradlebuild.test.integrationtests
 
+
 /**
  * A test aimed at verifying behavior under heavy load.
  */

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
@@ -1,6 +1,8 @@
 package org.gradle.gradlebuild.test.integrationtests
 
-import org.gradle.api.JavaVersion.*
+import org.gradle.api.JavaVersion.VERSION_1_10
+import org.gradle.api.JavaVersion.VERSION_1_9
+
 
 internal
 val excludedTests = listOf(
@@ -16,7 +18,7 @@ val excludedTests = listOf(
     "InterfaceBackedManagedTypeIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
 
     // Cannot obtain Jvm arguments via java.lang.management.ManagementFactory.runtimeMXBean.inputArguments module java.management does not export sun.management to unnamed module @6427ecb
-    "BuildEnvironmentModelCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10),  // "informs about java args as in the build script"
+    "BuildEnvironmentModelCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10), // "informs about java args as in the build script"
     "JavaConfigurabilityCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10), // "customized java args are reflected in the inputArguments and the build model", "tooling api provided jvm args take precedence over gradle.properties"
     "GradlePropertiesToolingApiCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10), // "tooling api honours jvm args specified in gradle.properties"
 
@@ -104,4 +106,3 @@ val excludedTests = listOf(
     //Changes in Javadoc generation
     "SamplesJavaMultiProjectIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10)
 )
-

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -12,10 +12,12 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
 
+
 enum class TestType(val prefix: String, val executers: List<String>, val libRepoRequired: Boolean) {
-    INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel"),  false),
+    INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel"), false),
     CROSSVERSION("crossVersion", listOf("embedded", "forking"), true)
 }
+
 
 internal
 fun Project.addDependenciesAndConfigurations(testType: TestType) {
@@ -39,6 +41,7 @@ fun Project.addDependenciesAndConfigurations(testType: TestType) {
     }
 }
 
+
 internal
 fun Project.addSourceSet(testType: TestType): SourceSet {
     val prefix = testType.prefix
@@ -48,6 +51,7 @@ fun Project.addSourceSet(testType: TestType): SourceSet {
         runtimeClasspath += main.output
     }
 }
+
 
 internal
 fun Project.createTasks(sourceSet: SourceSet, testType: TestType) {
@@ -64,6 +68,7 @@ fun Project.createTasks(sourceSet: SourceSet, testType: TestType) {
     tasks["check"].dependsOn("${prefix}Test")
 }
 
+
 internal
 fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet, testType: TestType): IntegrationTest {
 
@@ -78,13 +83,16 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
     }
 }
 
+
 private
 fun IntegrationTest.addBaseConfigurationForIntegrationAndCrossVersionTestTasks(currentTestJavaVersion: JavaVersion) {
     group = "verification"
     exclude(testExcluder.excludesForJavaVersion(currentTestJavaVersion))
 }
 
-private fun IntegrationTest.addDebugProperties() {
+
+private
+fun IntegrationTest.addDebugProperties() {
     // TODO Move magic property out
     if (project.hasProperty("org.gradle.integtest.debug")) {
         systemProperties["org.gradle.integtest.debug"] = "true"
@@ -99,6 +107,7 @@ private fun IntegrationTest.addDebugProperties() {
         systemProperties["org.gradle.integtest.launcher.debug"] = "true"
     }
 }
+
 
 internal
 fun Project.configureIde(testType: TestType) {
@@ -130,8 +139,10 @@ fun Project.configureIde(testType: TestType) {
     }
 }
 
+
 internal
 val testExcluder = TestExcluder(excludedTests)
+
 
 internal
 val Project.currentTestJavaVersion
@@ -157,4 +168,3 @@ class TestExcluder(excludeInputs: List<Pair<String, List<JavaVersion>>>) {
 
     fun excludesForJavaVersion(version: JavaVersion) = excludeRules[version] ?: emptySet()
 }
-

--- a/buildSrc/subprojects/integration-testing/src/test/kotlin/org/gradle/gradlebuild/test/integrationtests/ExcludedTestsTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/test/kotlin/org/gradle/gradlebuild/test/integrationtests/ExcludedTestsTest.kt
@@ -15,11 +15,15 @@
  */
 package org.gradle.gradlebuild.test.integrationtests
 
-import org.gradle.api.JavaVersion.*
+import org.gradle.api.JavaVersion.VERSION_1_6
+import org.gradle.api.JavaVersion.VERSION_1_8
+import org.gradle.api.JavaVersion.VERSION_1_9
+import org.gradle.api.JavaVersion.VERSION_1_10
 import org.hamcrest.CoreMatchers.hasItems
 import org.junit.Test
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
+
 
 class ExcludedTestsTest {
     internal

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream.kt
@@ -1,12 +1,8 @@
 package org.gradle.kotlin.dsl
 
-import org.gradle.api.Action
-import org.gradle.api.Incubating
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.file.ContentFilterable
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionContainer
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskContainer
 
@@ -24,6 +20,7 @@ import java.io.FilterReader
 inline
 fun <reified T : Any> ExtensionContainer.create(name: String, vararg constructionArguments: Any?): T =
     create(name, T::class.java, *constructionArguments)
+
 
 /**
  * Looks for the task of a given name and casts it to the expected type [T].

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyPlugin.kt
@@ -21,6 +21,7 @@ import org.gradle.api.attributes.Attribute
 
 import org.gradle.kotlin.dsl.*
 
+
 /**
  * A map from artifact name to a set of class name prefixes that should be kept.
  * Artifacts matched by this map will be minified to only contain the specified
@@ -75,13 +76,9 @@ open class MinifyPlugin : Plugin<Project> {
                         if (!attributes.isEmpty) {
                             attributes.attribute(minified, true)
                         }
-
                     }
                 }
             }
         }
     }
 }
-
-
-

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyTransform.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyTransform.kt
@@ -9,7 +9,8 @@ import java.io.File
 
 
 open class MinifyTransform @Inject constructor(
-    private val keepClassesByArtifact: Map<String, Set<String>>) : ArtifactTransform() {
+    private val keepClassesByArtifact: Map<String, Set<String>>
+) : ArtifactTransform() {
 
     override fun transform(artifact: File) =
         keepClassesByArtifact.asSequence()
@@ -17,7 +18,8 @@ open class MinifyTransform @Inject constructor(
             ?.value?.let { keepClasses -> listOf(minify(artifact, keepClasses)) }
             ?: listOf(artifact)
 
-    private fun minify(artifact: File, keepClasses: Set<String>): File {
+    private
+    fun minify(artifact: File, keepClasses: Set<String>): File {
         val jarFile = outputDirectory.resolve("${Files.getNameWithoutExtension(artifact.path)}-min.jar")
         val classesDir = outputDirectory.resolve("classes")
         val analysisFile = outputDirectory.resolve("analysis.txt")

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarCreator.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarCreator.kt
@@ -38,7 +38,8 @@ open class ShadedJarCreator(
     private val shadowPackage: String,
     private val keepPackages: Set<String>,
     private val unshadedPackages: Set<String>,
-    private val ignorePackages: Set<String>) {
+    private val ignorePackages: Set<String>
+) {
 
     fun createJar() {
         val start = System.currentTimeMillis()
@@ -83,18 +84,18 @@ open class ShadedJarCreator(
             override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
                 writer.print("${file.fileName}: ")
                 when {
-                    file.isClassFilePath()              -> {
+                    file.isClassFilePath() -> {
                         visitClassFile(file)
                     }
                     file.isUnshadedPropertiesFilePath() -> {
                         writer.println("include")
                         classes.addResource(ResourceDetails(file.toString(), file.toFile()))
                     }
-                    file.isUnseenManifestFilePath()     -> {
+                    file.isUnseenManifestFilePath() -> {
                         seenManifest = true
                         classes.manifest = ResourceDetails(file.toString(), file.toFile())
                     }
-                    else                                -> {
+                    else -> {
                         writer.println("skipped")
                     }
                 }
@@ -181,7 +182,8 @@ open class ShadedJarCreator(
         jarOutputStream: JarOutputStream,
         writer: PrintWriter,
         prefix: String,
-        visited: MutableSet<ClassDetails>) {
+        visited: MutableSet<ClassDetails>
+    ) {
 
         if (!visited.add(classDetails)) {
             return
@@ -214,7 +216,8 @@ class ClassGraph(
     private val keepPackages: PackagePatterns,
     val unshadedPackages: PackagePatterns,
     private val ignorePackages: PackagePatterns,
-    shadowPackage: String) {
+    shadowPackage: String
+) {
 
     private
     val classes: MutableMap<String, ClassDetails> = linkedMapOf()
@@ -244,8 +247,10 @@ class ClassGraph(
         }
 }
 
+
 private
 class ResourceDetails(val resourceName: String, val sourceFile: File)
+
 
 private
 class ClassDetails(val className: String, val outputClassName: String) {
@@ -254,6 +259,7 @@ class ClassDetails(val className: String, val outputClassName: String) {
     val outputClassFilename
         get() = "$outputClassName.class"
 }
+
 
 private
 class PackagePatterns(givenPrefixes: Set<String>) {
@@ -284,6 +290,7 @@ class PackagePatterns(givenPrefixes: Set<String>) {
         return false
     }
 }
+
 
 @Contextual
 class ClassAnalysisException(message: String, cause: Throwable) : RuntimeException(message, cause)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/ClasspathManifest.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/ClasspathManifest.kt
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
-import accessors.*
+import accessors.base
 import gradlebuildJava
 import org.gradle.kotlin.dsl.*
 
@@ -85,4 +85,3 @@ open class ClasspathManifest : DefaultTask() {
     fun <T : Any> Iterable<T>.joinForProperties(transform: ((T) -> CharSequence)? = null) =
         joinToString(",", transform = transform)
 }
-

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/tools/ResumeBuildPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/tools/ResumeBuildPlugin.kt
@@ -19,14 +19,16 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-class ResumeBuildPlugin: Plugin<Project> {
-    override fun apply(project: Project): Unit = project.run {
-        val resumeTask = project.property("resume")
 
+class ResumeBuildPlugin : Plugin<Project> {
+
+    override fun apply(project: Project): Unit = project.run {
+
+        val resumeTask = project.property("resume")
         if (resumeTask != null) {
             gradle.taskGraph.whenReady {
                 val allTasks = allTasks
-                    val resumeIndex = allTasks.indexOfFirst { it.path == resumeTask }
+                val resumeIndex = allTasks.indexOfFirst { it.path == resumeTask }
                 if (resumeIndex < 0) throw GradleException("Can't resume from $resumeTask because no such task is scheduled for execution")
                 allTasks.subList(0, resumeIndex).forEach { it.enabled = false }
             }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -20,8 +20,16 @@ import accessors.java
 import availableJavaInstallations
 import library
 import maxParallelForks
-import org.gradle.api.*
-import org.gradle.api.JavaVersion.*
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.JavaVersion
+import org.gradle.api.JavaVersion.VERSION_1_1
+import org.gradle.api.JavaVersion.VERSION_1_5
+import org.gradle.api.JavaVersion.VERSION_1_6
+import org.gradle.api.JavaVersion.VERSION_1_7
+import org.gradle.api.JavaVersion.VERSION_1_8
+import org.gradle.api.Named
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.CompileOptions
@@ -39,6 +47,7 @@ import testLibraries
 import testLibrary
 import java.util.jar.Attributes
 
+
 enum class ModuleType(val source: JavaVersion, val target: JavaVersion) {
     UNDEFINED(VERSION_1_1, VERSION_1_1),
     ENTRY_POINT(VERSION_1_5, VERSION_1_5),
@@ -48,6 +57,7 @@ enum class ModuleType(val source: JavaVersion, val target: JavaVersion) {
     INTERNAL(VERSION_1_7, VERSION_1_7),
     REQUIRES_JAVA_8(VERSION_1_8, VERSION_1_8)
 }
+
 
 class UnitTestAndCompilePlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
@@ -126,7 +136,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.addCompileAllTask() {
+    private
+    fun Project.addCompileAllTask() {
         tasks.create("compileAll") {
             val compileTasks = project.tasks.matching {
                 it is JavaCompile || it is GroovyCompile
@@ -135,7 +146,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configureJarTasks() {
+    private
+    fun Project.configureJarTasks() {
         tasks.withType<Jar>().all {
             version = rootProject.extra["baseVersion"] as String
             manifest.attributes(mapOf(
@@ -144,7 +156,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configureTests() {
+    private
+    fun Project.configureTests() {
         val javaInstallationForTest = rootProject.availableJavaInstallations.javaInstallationForTest
 
         tasks.withType<Test>().all {
@@ -166,7 +179,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         }
     }
 
-    private fun createCiEnvironmentProvider(test: Test): CommandLineArgumentProvider {
+    private
+    fun createCiEnvironmentProvider(test: Test): CommandLineArgumentProvider {
         return object : CommandLineArgumentProvider, Named {
             override fun getName() = "ciEnvironment"
 
@@ -186,6 +200,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         }
     }
 }
+
 
 open class UnitTestAndCompileExtension(val project: Project) {
     val generatedResourcesDir = project.file("${project.buildDir}/generated-resources/main")
@@ -208,7 +223,7 @@ open class UnitTestAndCompileExtension(val project: Project) {
     init {
         project.afterEvaluate {
             if (this@UnitTestAndCompileExtension.moduleType == ModuleType.UNDEFINED) {
-                throw InvalidUserDataException("gradlebuild.moduletype must be set for project ${project}")
+                throw InvalidUserDataException("gradlebuild.moduletype must be set for project $project")
             }
         }
     }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/ClasspathManifestPatcher.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/ClasspathManifestPatcher.kt
@@ -24,7 +24,8 @@ open class ClasspathManifestPatcher(
     private val project: Project,
     private val temporaryDir: File,
     private val runtime: Configuration,
-    private val moduleNames: Set<String>) {
+    private val moduleNames: Set<String>
+) {
 
     fun writePatchedFilesTo(outputDir: File) =
         resolveExternalModuleJars().forEach {

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/JarPatcher.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/JarPatcher.kt
@@ -38,7 +38,8 @@ class JarPatcher(
     private val project: Project,
     private val temporaryDir: File,
     private val runtime: Configuration,
-    private val jarFile: String) {
+    private val jarFile: String
+) {
 
     private
     var excludedEntries = mutableListOf<String>()
@@ -97,4 +98,3 @@ class JarPatcher(
         }
     }
 }
-

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -79,7 +79,8 @@ fun Project.insertBuildTypeTasksInto(
     taskList: MutableList<String>,
     index: Int,
     buildType: BuildType,
-    subproject: String) {
+    subproject: String
+) {
 
     fun insert(task: String) =
         taskList.add(index, task)
@@ -88,7 +89,7 @@ fun Project.insertBuildTypeTasksInto(
         buildType.tasks.reversed().forEach(act)
 
     when {
-        subproject.isEmpty()            ->
+        subproject.isEmpty() ->
             forEachBuildTypeTask(::insert)
 
         findProject(subproject) != null ->
@@ -100,8 +101,9 @@ fun Project.insertBuildTypeTasksInto(
                     println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it does not exist.")
                 }
             }
-        else                            ->
+        else -> {
             println("Skipping execution of build type '${buildType.name}'. Project '$subproject' not found in root project '$name'.")
+        }
     }
 
     if (taskList.isEmpty()) {
@@ -113,6 +115,6 @@ fun Project.insertBuildTypeTasksInto(
 fun Project.setOrCreateProperty(propertyName: String, value: Any) {
     when {
         hasProperty(propertyName) -> setProperty(propertyName, value)
-        else                      -> extra.set(propertyName, value)
+        else -> extra.set(propertyName, value)
     }
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/jsoup/JsoupCopyExtension.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/jsoup/JsoupCopyExtension.kt
@@ -24,6 +24,7 @@ import org.jsoup.nodes.Document
 
 import org.gradle.kotlin.dsl.*
 
+
 private
 val DEFAULT_TRANSFORM_EXTENSIONS = listOf("html")
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/jsoup/JsoupFilterReader.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/jsoup/JsoupFilterReader.kt
@@ -65,4 +65,3 @@ class DeferringReader(private val source: Reader) : Reader() {
 
     override fun close() = Unit
 }
-

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -5,11 +5,15 @@ import accessors.java
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.testing.junit.JUnitOptions
 import org.gradle.internal.hash.HashUtil
-import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.eclipse.model.EclipseModel
 import org.gradle.plugins.ide.idea.IdeaPlugin
@@ -17,10 +21,18 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.testing.DistributedPerformanceTest
 import org.gradle.testing.PerformanceTest
 import org.gradle.testing.RebaselinePerformanceTests
-import org.gradle.testing.performance.generator.tasks.*
+import org.gradle.testing.performance.generator.tasks.AbstractProjectGeneratorTask
+import org.gradle.testing.performance.generator.tasks.JavaExecProjectGeneratorTask
+import org.gradle.testing.performance.generator.tasks.JvmProjectGeneratorTask
+import org.gradle.testing.performance.generator.tasks.ProjectGeneratorTask
+import org.gradle.testing.performance.generator.tasks.RemoteProject
+import org.gradle.testing.performance.generator.tasks.TemplateProjectGeneratorTask
+
 import org.w3c.dom.Document
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
+
+import org.gradle.kotlin.dsl.*
 
 
 private
@@ -92,7 +104,8 @@ class PerformanceTestPlugin : Plugin<Project> {
         configureIdePlugins(performanceTestSourceSet)
     }
 
-    private fun Project.createRebaselineTask(performanceTestSourceSet: SourceSet) {
+    private
+    fun Project.createRebaselineTask(performanceTestSourceSet: SourceSet) {
         project.tasks.create<RebaselinePerformanceTests>("rebaselinePerformanceTests") {
             source(performanceTestSourceSet.allSource)
         }
@@ -220,7 +233,8 @@ class PerformanceTestPlugin : Plugin<Project> {
     fun Project.createLocalPerformanceTestTasks(
         performanceSourceSet: SourceSet,
         prepareSamplesTask: Task,
-        performanceReportTask: PerformanceReport) {
+        performanceReportTask: PerformanceReport
+    ) {
 
         fun create(name: String, configure: PerformanceTest.() -> Unit = {}) {
             createLocalPerformanceTestTask(name, performanceSourceSet, prepareSamplesTask, performanceReportTask)
@@ -247,7 +261,8 @@ class PerformanceTestPlugin : Plugin<Project> {
     fun Project.createDistributedPerformanceTestTasks(
         performanceSourceSet: SourceSet,
         prepareSamplesTask: Task,
-        performanceReportTask: PerformanceReport) {
+        performanceReportTask: PerformanceReport
+    ) {
 
         fun create(name: String, configure: PerformanceTest.() -> Unit = {}) {
             createDistributedPerformanceTestTask(name, performanceSourceSet, prepareSamplesTask, performanceReportTask)
@@ -303,7 +318,8 @@ class PerformanceTestPlugin : Plugin<Project> {
         name: String,
         performanceSourceSet: SourceSet,
         prepareSamplesTask: Task,
-        performanceReportTask: PerformanceReport): DistributedPerformanceTest =
+        performanceReportTask: PerformanceReport
+    ): DistributedPerformanceTest =
 
         tasks.create<DistributedPerformanceTest>(name) {
             configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask, performanceReportTask)
@@ -328,7 +344,8 @@ class PerformanceTestPlugin : Plugin<Project> {
         name: String,
         performanceSourceSet: SourceSet,
         prepareSamplesTask: Task,
-        performanceReportTask: PerformanceReport): PerformanceTest {
+        performanceReportTask: PerformanceReport
+    ): PerformanceTest {
 
         val cleanTaskName = "clean${name.capitalize()}"
 
@@ -395,7 +412,8 @@ class PerformanceTestPlugin : Plugin<Project> {
         task: PerformanceTest,
         performanceSourceSet: SourceSet,
         prepareSamplesTask: Task,
-        performanceReportTask: PerformanceReport) {
+        performanceReportTask: PerformanceReport
+    ) {
 
         task.apply {
             group = "verification"
@@ -467,4 +485,3 @@ fun parseXmlFile(file: File): Document =
 private
 fun sha1StringFor(file: File) =
     HashUtil.createHash(file, "sha1").asHexString()
-

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/publish/GeneratePom.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/publish/GeneratePom.kt
@@ -9,13 +9,17 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer
 import org.gradle.api.plugins.MavenRepositoryHandlerConvention
 import org.gradle.api.specs.Specs
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.Upload
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getting
 import org.gradle.kotlin.dsl.withConvention
 import org.gradle.kotlin.dsl.withType
 import org.gradle.kotlin.dsl.*
 import java.io.File
+
 
 open class GeneratePom : DefaultTask() {
     @OutputFile
@@ -30,7 +34,7 @@ open class GeneratePom : DefaultTask() {
     init {
         // Subprojects assign dependencies to publishCompile to indicate that they should be part of the published pom.
         // Therefore compile needs to contain those dependencies and extend publishCompile
-        project.configurations.getByName("compile")  {
+        project.configurations.getByName("compile") {
             extendsFrom(publishCompile)
         }
         // Never up to date; we don't understand the data structures.

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/publish/PublishPublicLibrariesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/publish/PublishPublicLibrariesPlugin.kt
@@ -30,6 +30,7 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.*
 import java.util.*
 
+
 open class PublishPublicLibrariesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
@@ -59,7 +60,8 @@ open class PublishPublicLibrariesPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configureUploadArchivesTask(generatePom: GeneratePom) {
+    private
+    fun Project.configureUploadArchivesTask(generatePom: GeneratePom) {
         tasks.getByName<Upload>("uploadArchives") {
             // TODO Add magic property to upcoming configuration interface
             onlyIf { !project.hasProperty("noUpload") }
@@ -111,7 +113,9 @@ open class PublishPublicLibrariesPlugin : Plugin<Project> {
         get() = java.sourceSets["main"]
 }
 
+
 const val GRADLE_REPO = "https://gradle.artifactoryonline.com/gradle"
+
 
 fun createArtifactPattern(isSnapshot: Boolean, group: String, artifactName: String): String {
     assert(group.isNotEmpty())
@@ -122,6 +126,3 @@ fun createArtifactPattern(isSnapshot: Boolean, group: String, artifactName: Stri
     val groupId = group.toString().replace(".", "/")
     return "$repoUrl/$groupId/$artifactName/[revision]/[artifact]-[revision](-[classifier]).[ext]"
 }
-
-
-

--- a/buildSrc/subprojects/plugins/src/main/kotlin/plugins-extensions.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/plugins-extensions.kt
@@ -22,15 +22,18 @@ import org.gradle.kotlin.dsl.*
 
 // This file contains Kotlin extensions for the gradle/gradle build
 
+
 fun Project.availableJavaInstallations(configure: AvailableJavaInstallations.() -> Unit): Unit =
     extensions.configure("availableJavaInstallations", configure)
+
 
 fun Project.gradlebuildJava(configure: UnitTestAndCompileExtension.() -> Unit): Unit =
     extensions.configure("gradlebuildJava", configure)
 
+
 val Project.availableJavaInstallations
     get() = extensions.getByName<AvailableJavaInstallations>("availableJavaInstallations")
 
+
 val Project.gradlebuildJava
     get() = extensions.getByName<UnitTestAndCompileExtension>("gradlebuildJava")
-

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/performance/PerformanceTestPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/performance/PerformanceTestPluginTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
+
 class PerformanceTestPluginTest {
 
     @JvmField

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/publish/ArtifactPatternTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/publish/ArtifactPatternTest.kt
@@ -18,6 +18,7 @@ package org.gradle.plugins.publish
 import org.junit.Assert
 import org.junit.Test
 
+
 class ArtifactPatternTest {
     @Test
     fun `given snapshot library and typical other values it returns a correct URL`() {
@@ -63,5 +64,4 @@ class ArtifactPatternTest {
         // given:
         createArtifactPattern(false, "foo", "")
     }
-
 }

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/JmhPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/JmhPlugin.kt
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 
 import org.gradle.kotlin.dsl.*
 
+
 open class JmhPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
@@ -36,5 +37,3 @@ open class JmhPlugin : Plugin<Project> {
         }
     }
 }
-
-

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -198,9 +198,10 @@ open class BuildScanPlugin : Plugin<Project> {
         }
 }
 
+
 fun Project.buildScan(configure: BuildScanExtension.() -> Unit): Unit =
     configure(configure)
 
+
 val Project.buildScan
     get() = the<BuildScanExtension>()
-

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/Visitor.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/Visitor.kt
@@ -21,6 +21,7 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.classloader.ClassLoaderVisitor
 import java.net.URLClassLoader
 
+
 class Visitor(private val buildScan: BuildScanExtension, private val hasher: ClassLoaderHierarchyHasher, private val prefix: String) : ClassLoaderVisitor() {
     private
     var counter = 0
@@ -46,4 +47,3 @@ class Visitor(private val buildScan: BuildScanExtension, private val hasher: Cla
         super.visit(classLoader)
     }
 }
-

--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/UpdateVersionsPlugin.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/UpdateVersionsPlugin.kt
@@ -19,12 +19,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.build.ReleasedVersion
 import org.gradle.build.UpdateReleasedVersions
-import org.gradle.build.remote.DefaultRemoteGradleVersionResolver
 import org.gradle.build.remote.VersionType
 import com.google.gson.Gson
 import org.gradle.kotlin.dsl.*
 import java.net.URL
 import java.util.concurrent.Callable
+
 
 // TODO Don't use Gson for Json. Extract
 class UpdateVersionsPlugin : Plugin<Project> {
@@ -55,6 +55,7 @@ class UpdateVersionsPlugin : Plugin<Project> {
         }
     }
 }
+
 
 private
 class VersionBuildTimeInfo(val version: String, val buildTime: String)

--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/WrapperPlugin.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/WrapperPlugin.kt
@@ -65,5 +65,6 @@ class WrapperPlugin : Plugin<Project> {
     }
 }
 
+
 private
 data class VersionDownloadInfo(val version: String, val downloadUrl: String)

--- a/buildSrc/subprojects/versioning/src/main/kotlin/versioning-extensions.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/versioning-extensions.kt
@@ -18,7 +18,6 @@ import org.gradle.api.Project
 import org.gradle.build.ReleasedVersionsFromVersionControl
 import java.io.File
 
+
 val Project.releasedVersions
     get() = ReleasedVersionsFromVersionControl(File(rootDir, "released-versions.json"))
-
-


### PR DESCRIPTION
Using the experimental [org.gradle.kotlin.ktlint-convention](https://plugins.gradle.org/plugin/org.gradle.kotlin.ktlint-convention) convention plugin. Its source can be found in the [`:plugins-experiments`](https://github.com/gradle/kotlin-dsl/tree/develop/plugins-experiments) project of the `gradle/kotlin-dsl` repository. Linting tasks are cacheable, see [here](https://github.com/gradle/kotlin-dsl/blob/5f1740de6e3129f1b37120243d9afe682405fe77/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt#L31) and [here](https://scans.gradle.com/s/hgowxnomgosky/timeline?cacheableFilter=CACHEABLE&typeFilter=org.gradle.api.tasks.JavaExec).

This pull-request applies the plugin to `buildSrc` sub projects that include Kotlin sources and then fix all linting errors.
