### PR TITLE
Implicitly add a capability for each component

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
@@ -20,7 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.attributes.HasConfigurableAttributes;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 
 import java.util.Collection;
 
@@ -84,5 +84,5 @@ public interface ConfigurationPublications extends HasConfigurableAttributes<Con
      *
      * @since 4.7
      */
-    Collection<? extends CapabilityDescriptor> getCapabilities();
+    Collection<? extends Capability> getCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/capabilities/CapabilitiesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/capabilities/CapabilitiesMetadata.java
@@ -30,5 +30,5 @@ public interface CapabilitiesMetadata {
      * Returns an immutable view of the capabilities.
      * @return the list of capabilities. Immutable.
      */
-    List<? extends CapabilityDescriptor> getCapabilities();
+    List<? extends Capability> getCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/capabilities/Capability.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/capabilities/Capability.java
@@ -24,7 +24,7 @@ import org.gradle.api.Incubating;
  * @since 4.7
  */
 @Incubating
-public interface CapabilityDescriptor {
+public interface Capability {
     String getGroup();
     String getName();
     String getVersion();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 
 import java.util.Set;
 
@@ -32,5 +32,5 @@ public interface UsageContext extends HasAttributes, Named {
     Set<? extends PublishArtifact> getArtifacts();
     Set<? extends ModuleDependency> getDependencies();
     Set<? extends DependencyConstraint> getDependencyConstraints();
-    Set<? extends CapabilityDescriptor> getCapabilities();
+    Set<? extends Capability> getCapabilities();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -36,17 +36,10 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
                conf "cglib:cglib:3.2.5"
             
                components {
-                  withModule('cglib:cglib') {
+                  withModule('cglib:cglib-nodep') { details ->
                      allVariants {
                          withCapabilities {
-                             addCapability('cglib', 'cglib', '3.2.5')
-                         }
-                     }
-                  }
-                  withModule('cglib:cglib-nodep') {
-                     allVariants {
-                         withCapabilities {
-                             addCapability('cglib', 'cglib', '3.2.5')
+                             addCapability('cglib', 'cglib', details.id.version)
                          }
                      }
                   }
@@ -82,17 +75,10 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
                conf "cglib:cglib:3.2.5"
             
                components {
-                  withModule('cglib:cglib') {
+                  withModule('cglib:cglib-nodep') { details ->
                      allVariants {
                          withCapabilities {
-                             addCapability('cglib', 'cglib', '3.2.5')
-                         }
-                     }
-                  }
-                  withModule('cglib:cglib-nodep') {
-                     allVariants {
-                         withCapabilities {
-                             addCapability('cglib', 'cglib', '3.2.4')
+                             addCapability('cglib', 'cglib', details.id.version)
                          }
                      }
                   }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -51,13 +51,6 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                conf "cglib:cglib:3.2.5"
             
                components {
-                  withModule('cglib:cglib') { details -> 
-                     allVariants {
-                         withCapabilities {
-                             addCapability('cglib', 'cglib', details.id.version)
-                         }
-                     }
-                  }
                   withModule('cglib:cglib-nodep') { details ->
                      allVariants {
                          withCapabilities {
@@ -149,20 +142,6 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                conf "org:b:1.0"
             
                components {
-                  withModule('org.apache:groovy') { details ->
-                     allVariants {
-                        withCapabilities {
-                            addCapability('org.apache', 'groovy', details.id.version)
-                        }
-                     }
-                  }
-                  withModule('org.apache:groovy-json') { details ->
-                     allVariants {
-                        withCapabilities {
-                            addCapability('org.apache', 'groovy-json', details.id.version)
-                        }
-                     }
-                  }
                   withModule('org.apache:groovy-all') { details ->
                      allVariants {
                         withCapabilities {
@@ -269,20 +248,6 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                conf "org:b:1.0"
             
                components {
-                  withModule('org.apache:groovy') { details ->
-                     allVariants {
-                        withCapabilities {
-                            addCapability('org.apache', 'groovy', details.id.version)
-                        }
-                     }
-                  }
-                  withModule('org.apache:groovy-json') { details ->
-                     allVariants {
-                        withCapabilities {
-                            addCapability('org.apache', 'groovy-json', details.id.version)
-                        }
-                     }
-                  }
                   withModule('org.apache:groovy-all') { details ->
                      allVariants {
                         withCapabilities {
@@ -366,15 +331,11 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
     def "published module can declare relocation (first in graph = #first, second in graph = #second)"() {
         given:
         repository {
-            'asm:asm:3.0' {
-                variant('runtime') {
-                    capability('asm', 'asm', '3.0')
-                }
-            }
+            // // there's an implicit capability for every component, corresponding to the component coordinates
+            'asm:asm:3.0'()
             'org.ow2.asm:asm:4.0' {
                 variant('runtime') {
                     capability('asm', 'asm', '4.0') // upgrades the asm capability
-                    capability('org.ow2.asm', 'asm', '4.0') // self capability
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -284,7 +284,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 fixConflict ? expectResolve() : expectGetMetadata()
             }
             'org.apache:groovy-all:1.0' {
-                if (!fixConflict)  { expectGetMetadata() }
+                if (!fixConflict) {
+                    expectGetMetadata()
+                }
             }
         }
 
@@ -328,7 +330,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll
-    def "published module can declare relocation (first in graph = #first, second in graph = #second)"() {
+    def "published module can declare relocation (first in graph = #first, second in graph = #second, failOnVersionConflict=#failOnVersionConflict)"() {
         given:
         repository {
             // // there's an implicit capability for every component, corresponding to the component coordinates
@@ -345,6 +347,10 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                conf "$first"
                conf "$second"
             }
+            
+            if ($failOnVersionConflict) {
+               configurations.conf.resolutionStrategy.failOnVersionConflict()
+            }
         """
 
         when:
@@ -353,23 +359,34 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 expectGetMetadata()
             }
             'org.ow2.asm:asm:4.0' {
-                expectResolve()
+                failOnVersionConflict ? expectGetMetadata() : expectResolve()
             }
         }
-        run ":checkDeps"
+        if (failOnVersionConflict) {
+            fails ':checkDeps'
+        } else {
+            run ":checkDeps"
+        }
 
         then:
-        resolve.expectGraph {
-            root(":", ":test:") {
-                edge('asm:asm:3.0', 'org.ow2.asm:asm:4.0')
-                    .byConflictResolution()
-                module('org.ow2.asm:asm:4.0')
+        if (failOnVersionConflict) {
+            failure.assertHasCause("Cannot choose between asm:asm:3.0 and org.ow2.asm:asm:4.0 because they provide the same capability: asm:asm:3.0, asm:asm:4.0")
+        } else {
+            resolve.expectGraph {
+                root(":", ":test:") {
+                    edge('asm:asm:3.0', 'org.ow2.asm:asm:4.0')
+                        .byConflictResolution()
+                    module('org.ow2.asm:asm:4.0')
+                }
             }
         }
 
         where:
-        first << ['asm:asm:3.0', 'org.ow2.asm:asm:4.0']
-        second << ['org.ow2.asm:asm:4.0', 'asm:asm:3.0']
+        first                 | second                | failOnVersionConflict
+        'asm:asm:3.0'         | 'org.ow2.asm:asm:4.0' | false
+        'org.ow2.asm:asm:4.0' | 'asm:asm:3.0'         | false
+        'asm:asm:3.0'         | 'org.ow2.asm:asm:4.0' | true
+        'org.ow2.asm:asm:4.0' | 'asm:asm:3.0'         | true
     }
 
     /**
@@ -418,7 +435,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 fixConflict ? expectResolve() : expectGetMetadata()
             }
             'org:testA:1.0' {
-                if (!fixConflict) { expectGetMetadata() }
+                if (!fixConflict) {
+                    expectGetMetadata()
+                }
             }
         }
         if (fixConflict) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -29,16 +29,11 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
     def "can consume published capabilities"() {
         given:
         repository {
-            'cglib:cglib:3.2.5' {
-                variant("runtime") {
-                    capability('cglib', 'cglib', '3.2.5')
-                }
-            }
+            'cglib:cglib:3.2.5'()
             'cglib:cglib-nodep:3.2.5' {
                 variant("runtime") {
                     capability('cglib', 'cglib', '3.2.5')
                 }
-
             }
         }
 
@@ -67,11 +62,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
     def "can detect conflict with capability in different versions and upgrade automatically to latest version"() {
         given:
         repository {
-            'cglib:cglib:3.2.5' {
-                variant("runtime") {
-                    capability('cglib', 'cglib', '3.2.5')
-                }
-            }
+            'cglib:cglib:3.2.5'()
             'cglib:cglib-nodep:3.2.4' {
                 variant("runtime") {
                     capability('cglib', 'cglib', '3.2.4')

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -37,7 +37,7 @@ public class Configurations {
         return names;
     }
 
-    public static Set<CapabilityDescriptor> collectCapabilities(Configuration configuration, Set<CapabilityDescriptor> out, Set<Configuration> visited) {
+    public static Set<Capability> collectCapabilities(Configuration configuration, Set<Capability> out, Set<Configuration> visited) {
         if (visited.add(configuration)) {
             out.addAll(configuration.getOutgoing().getCapabilities());
             for (Configuration parent : configuration.getExtendsFrom()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -47,7 +47,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
@@ -142,7 +142,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private final BuildOperationExecutor buildOperationExecutor;
     private final Instantiator instantiator;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
-    private final NotationParser<Object, CapabilityDescriptor> capabilityNotationParser;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ProjectAccessListener projectAccessListener;
     private final ProjectFinder projectFinder;
     private Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
@@ -204,7 +204,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                                 BuildOperationExecutor buildOperationExecutor,
                                 Instantiator instantiator,
                                 NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
-                                NotationParser<Object, CapabilityDescriptor> capabilityNotationParser,
+                                NotationParser<Object, Capability> capabilityNotationParser,
                                 ImmutableAttributesFactory attributesFactory,
                                 RootComponentMetadataBuilder rootComponentMetadataBuilder
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnknownConfigurationException;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
@@ -63,7 +63,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     private final FileCollectionFactory fileCollectionFactory;
     private final BuildOperationExecutor buildOperationExecutor;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
-    private final NotationParser<Object, CapabilityDescriptor> capabilityNotationParser;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ImmutableAttributesFactory attributesFactory;
 
     private int detachedConfigurationDefaultNameCounter = 1;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -28,7 +28,7 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -52,12 +52,12 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     private final AttributeContainerInternal attributes;
     private final Instantiator instantiator;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
-    private final NotationParser<Object, CapabilityDescriptor> capabilityNotationParser;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
     private final FileCollectionFactory fileCollectionFactory;
     private final ImmutableAttributesFactory attributesFactory;
     private FactoryNamedDomainObjectContainer<ConfigurationVariant> variants;
     private ConfigurationVariantFactory variantFactory;
-    private List<CapabilityDescriptor> capabilities;
+    private List<Capability> capabilities;
     private boolean canCreate = true;
 
     public DefaultConfigurationPublications(DisplayName displayName,
@@ -66,7 +66,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
                                             AttributeContainerInternal parentAttributes,
                                             Instantiator instantiator,
                                             NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
-                                            NotationParser<Object, CapabilityDescriptor> capabilityNotationParser,
+                                            NotationParser<Object, Capability> capabilityNotationParser,
                                             FileCollectionFactory fileCollectionFactory,
                                             ImmutableAttributesFactory attributesFactory) {
         this.displayName = displayName;
@@ -161,7 +161,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     @Override
     public void capability(Object notation) {
         if (canCreate) {
-            CapabilityDescriptor descriptor = capabilityNotationParser.parseNotation(notation);
+            Capability descriptor = capabilityNotationParser.parseNotation(notation);
             if (capabilities == null) {
                 capabilities = Lists.newArrayListWithExpectedSize(1); // it's rare that a component would declare more than 1 capability
             }
@@ -172,8 +172,8 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     }
 
     @Override
-    public Collection<? extends CapabilityDescriptor> getCapabilities() {
-        return capabilities == null ? Collections.<CapabilityDescriptor>emptyList() : ImmutableList.copyOf(capabilities);
+    public Collection<? extends Capability> getCapabilities() {
+        return capabilities == null ? Collections.<Capability>emptyList() : ImmutableList.copyOf(capabilities);
     }
 
     void preventFromFurtherMutation() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
@@ -29,11 +29,11 @@ import org.gradle.internal.typeconversion.TypedNotationConverter;
 
 import javax.annotation.Nullable;
 
-public class CapabilityNotationParserFactory implements Factory<NotationParser<Object, CapabilityDescriptor>> {
-    private final static NotationParser<Object, CapabilityDescriptor> SINGLETON_CONVERTER = createSingletonConverter();
+public class CapabilityNotationParserFactory implements Factory<NotationParser<Object, Capability>> {
+    private final static NotationParser<Object, Capability> SINGLETON_CONVERTER = createSingletonConverter();
 
-    private static NotationParser<Object, CapabilityDescriptor> createSingletonConverter() {
-        return NotationParserBuilder.toType(CapabilityDescriptor.class)
+    private static NotationParser<Object, Capability> createSingletonConverter() {
+        return NotationParserBuilder.toType(Capability.class)
             .converter(new StringNotationParser())
             .converter(new CapabilityMapNotationParser())
             .toComposite();
@@ -41,19 +41,19 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
 
     @Nullable
     @Override
-    public NotationParser<Object, CapabilityDescriptor> create() {
+    public NotationParser<Object, Capability> create() {
         // Currently the converter is stateless, doesn't need any external context, so for performance we return a singleton
         return SINGLETON_CONVERTER;
     }
 
-    private static class StringNotationParser extends TypedNotationConverter<String, CapabilityDescriptor> {
+    private static class StringNotationParser extends TypedNotationConverter<String, Capability> {
 
         StringNotationParser() {
             super(String.class);
         }
 
         @Override
-        protected CapabilityDescriptor parseType(String notation) {
+        protected Capability parseType(String notation) {
             String[] parts = notation.split(":");
             if (parts.length != 3) {
                 reportInvalidNotation(notation);
@@ -73,15 +73,15 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
         }
     }
 
-    private static class CapabilityMapNotationParser extends MapNotationConverter<CapabilityDescriptor> {
+    private static class CapabilityMapNotationParser extends MapNotationConverter<Capability> {
         @Override
         public void describe(DiagnosticsVisitor visitor) {
             visitor.candidate("Maps").example("[group: 'org.group', name: 'capability', version: '1.0']");
         }
 
-        protected CapabilityDescriptor parseMap(@MapKey("group") String group,
-                                                @MapKey("name") String name,
-                                                @MapKey("version") String version) {
+        protected Capability parseMap(@MapKey("group") String group,
+                                      @MapKey("name") String name,
+                                      @MapKey("version") String version) {
             return new ImmutableCapability(group, name, version);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleComponentSelectorSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
@@ -127,7 +127,7 @@ public class ModuleMetadataSerializer {
                 writeVariantDependencies(variant.getDependencies());
                 writeVariantConstraints(variant.getDependencyConstraints());
                 writeVariantFiles(variant.getFiles());
-                writeVariantCapabilities(variant.getCapabilitiesMetadata().getCapabilities());
+                writeVariantCapabilities(variant.getCapabilities().getCapabilities());
             }
         }
 
@@ -168,9 +168,9 @@ public class ModuleMetadataSerializer {
             }
         }
 
-        private void writeVariantCapabilities(List<? extends CapabilityDescriptor> capabilities) throws IOException {
+        private void writeVariantCapabilities(List<? extends Capability> capabilities) throws IOException {
             encoder.writeSmallInt(capabilities.size());
-            for (CapabilityDescriptor capability : capabilities) {
+            for (Capability capability : capabilities) {
                 encoder.writeString(capability.getGroup());
                 encoder.writeString(capability.getName());
                 encoder.writeString(capability.getVersion());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.Configurations;
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
@@ -60,7 +60,7 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
         Set<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
         // Presence of capabilities is bound to the definition of a capabilities extension to the project
         ImmutableCapabilities capabilities =
-            asImmutable(Configurations.collectCapabilities(configuration, Sets.<CapabilityDescriptor>newHashSet(), Sets.<Configuration>newHashSet()));
+            asImmutable(Configurations.collectCapabilities(configuration, Sets.<Capability>newHashSet(), Sets.<Configuration>newHashSet()));
         return metaData.addConfiguration(configuration.getName(),
             configuration.getDescription(),
             extendsFrom,
@@ -73,12 +73,12 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
             capabilities);
     }
 
-    private static ImmutableCapabilities asImmutable(Collection<? extends CapabilityDescriptor> descriptors) {
+    private static ImmutableCapabilities asImmutable(Collection<? extends Capability> descriptors) {
         if (descriptors.isEmpty()) {
             return ImmutableCapabilities.EMPTY;
         }
         ImmutableList.Builder<ImmutableCapability> builder = new ImmutableList.Builder<ImmutableCapability>();
-        for (CapabilityDescriptor descriptor : descriptors) {
+        for (Capability descriptor : descriptors) {
             builder.add(new ImmutableCapability(descriptor.getGroup(), descriptor.getName(), descriptor.getVersion()));
         }
         return new ImmutableCapabilities(builder.build());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
@@ -360,33 +360,33 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
 
-    public void forEachCapability(Action<? super CapabilityDescriptor> action) {
+    public void forEachCapability(Action<? super Capability> action) {
         // check conflict for each target node
         for (NodeState target : nodes) {
-            List<? extends CapabilityDescriptor> capabilities = target.getMetadata().getCapabilitiesMetadata().getCapabilities();
+            List<? extends Capability> capabilities = target.getMetadata().getCapabilities().getCapabilities();
             // The isEmpty check is not required, might look innocent, but Guava's performance bad for an empty immutable list
             // because it still creates an inner class for an iterator, which delegates to an Array iterator, which does... nothing.
             // so just adding this check has a significant impact because most components do not declare any capability
             if (!capabilities.isEmpty()) {
-                for (CapabilityDescriptor capability : capabilities) {
+                for (Capability capability : capabilities) {
                     action.execute(capability);
                 }
             }
         }
     }
 
-    public CapabilityDescriptor findCapability(String group, String name) {
+    public Capability findCapability(String group, String name) {
         if (id.getGroup().equals(group) && id.getName().equals(name)) {
             return implicitCapability;
         }
         return findCapabilityOnTarget(group, name);
     }
 
-    private CapabilityDescriptor findCapabilityOnTarget(String group, String name) {
+    private Capability findCapabilityOnTarget(String group, String name) {
         for (NodeState target : nodes) {
-            List<? extends CapabilityDescriptor> capabilities = target.getMetadata().getCapabilitiesMetadata().getCapabilities();
+            List<? extends Capability> capabilities = target.getMetadata().getCapabilities().getCapabilities();
             if (!capabilities.isEmpty()) { // Not required, but Guava's performance bad for an empty immutable list
-                for (CapabilityDescriptor capability : capabilities) {
+                for (Capability capability : capabilities) {
                     if (capability.getGroup().equals(group) && capability.getName().equals(name)) {
                         return capability;
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -361,9 +361,6 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
 
     public void forEachCapability(Action<? super CapabilityDescriptor> action) {
-        // first, implicitly add a capability corresponding to the module
-        action.execute(implicitCapability);
-
         // check conflict for each target node
         for (NodeState target : nodes) {
             List<? extends CapabilityDescriptor> capabilities = target.getMetadata().getCapabilitiesMetadata().getCapabilities();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -33,11 +33,10 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CapabilitiesConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultCapabilitiesConflictHandler;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.LastCandidateCapabilityResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ModuleConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.PotentialConflict;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.UpgradeCapabilityResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
@@ -77,11 +76,13 @@ public class DependencyGraphBuilder {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
     private final ImmutableAttributesFactory attributesFactory;
-    private final DefaultCapabilitiesConflictHandler capabilitiesConflictHandler;
+    private final CapabilitiesConflictHandler capabilitiesConflictHandler;
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
-                                  ModuleConflictHandler moduleConflictHandler, Spec<? super DependencyMetadata> edgeFilter,
+                                  ModuleConflictHandler moduleConflictHandler,
+                                  CapabilitiesConflictHandler capabilitiesConflictHandler,
+                                  Spec<? super DependencyMetadata> edgeFilter,
                                   AttributesSchemaInternal attributesSchema,
                                   ModuleExclusions moduleExclusions,
                                   BuildOperationExecutor buildOperationExecutor, ModuleReplacementsData moduleReplacementsData,
@@ -99,14 +100,7 @@ public class DependencyGraphBuilder {
         this.dependencySubstitutionApplicator = dependencySubstitutionApplicator;
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributesFactory = attributesFactory;
-        this.capabilitiesConflictHandler = createCapabilitiesHandler();
-    }
-
-    private DefaultCapabilitiesConflictHandler createCapabilitiesHandler() {
-        DefaultCapabilitiesConflictHandler handler = new DefaultCapabilitiesConflictHandler();
-        handler.registerResolver(new UpgradeCapabilityResolver());
-        handler.registerResolver(new LastCandidateCapabilityResolver());
-        return handler;
+        this.capabilitiesConflictHandler = capabilitiesConflictHandler;
     }
 
     public void resolve(final ResolveContext resolveContext, final DependencyGraphVisitor modelVisitor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -175,7 +175,7 @@ public class DependencyGraphBuilder {
             }
 
             // A new module revision. Check for conflict
-            PotentialConflict c = moduleConflictHandler.registerModule(module);
+            PotentialConflict c = moduleConflictHandler.registerCandidate(module);
             if (!c.conflictExists()) {
                 // No conflict. Select it for now
                 LOGGER.debug("Selecting new module version {}", moduleRevision);
@@ -207,7 +207,7 @@ public class DependencyGraphBuilder {
                         break;
                     }
                 }
-                PotentialConflict c = capabilitiesConflictHandler.registerModule(
+                PotentialConflict c = capabilitiesConflictHandler.registerCandidate(
                     DefaultCapabilitiesConflictHandler.candidate(moduleRevision, capability, implicitProvidersForCapability)
                 );
                 if (c.conflictExists()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -23,7 +23,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
@@ -193,9 +193,9 @@ public class DependencyGraphBuilder {
     }
 
     private void registerCapabilities(final ResolveState resolveState, final ComponentState moduleRevision) {
-        moduleRevision.forEachCapability(new Action<CapabilityDescriptor>() {
+        moduleRevision.forEachCapability(new Action<Capability>() {
             @Override
-            public void execute(CapabilityDescriptor capability) {
+            public void execute(Capability capability) {
                 // This is a performance optimization. Most modules do not declare capabilities. So, instead of systematically registering
                 // an implicit capability for each module that we see, we only consider modules which _declare_ capabilities. If they do,
                 // then we try to find a module which provides the same capability. It that module has been found, then we register it.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
 
 import java.util.Collection;
@@ -24,13 +24,13 @@ import java.util.Collection;
 public interface CapabilitiesConflictHandler extends ConflictHandler<CapabilitiesConflictHandler.Candidate, ConflictResolutionResult, CapabilitiesConflictHandler.Resolver> {
     interface Candidate {
         ComponentState getComponent();
-        CapabilityDescriptor getCapabilityDescriptor();
+        Capability getCapability();
         Collection<ComponentState> getImplicitCapabilityProviders();
     }
 
     interface ResolutionDetails extends ConflictResolutionResult {
-        Collection<? extends CapabilityDescriptor> getCapabilityVersions();
-        Collection<? extends CandidateDetails> getCandidates(CapabilityDescriptor capability);
+        Collection<? extends Capability> getCapabilityVersions();
+        Collection<? extends CandidateDetails> getCandidates(Capability capability);
         boolean hasResult();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
@@ -25,6 +25,7 @@ public interface CapabilitiesConflictHandler extends ConflictHandler<Capabilitie
     interface Candidate {
         ComponentState getComponent();
         CapabilityDescriptor getCapabilityDescriptor();
+        Collection<ComponentState> getImplicitCapabilityProviders();
     }
 
     interface ResolutionDetails extends ConflictResolutionResult {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictHandler.java
@@ -23,7 +23,7 @@ public interface ConflictHandler<CANDIDATE, RESULT, RESOLVER> {
     /**
      * Registers new module and returns information about any potential conflict
      */
-    PotentialConflict registerModule(CANDIDATE newModule);
+    PotentialConflict registerCandidate(CANDIDATE candidate);
 
     /**
      * Informs whether there is any conflict at present

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.internal.component.external.model.CapabilityInternal;
@@ -44,10 +44,10 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
 
     @Override
     public PotentialConflict registerModule(CapabilitiesConflictHandler.Candidate newModule) {
-        CapabilityInternal capabilityDescriptor = (CapabilityInternal) newModule.getCapabilityDescriptor();
-        String group = capabilityDescriptor.getGroup();
-        String name = capabilityDescriptor.getName();
-        final Set<ComponentState> components = findComponentsFor(capabilityDescriptor);
+        CapabilityInternal capability = (CapabilityInternal) newModule.getCapability();
+        String group = capability.getGroup();
+        String name = capability.getName();
+        final Set<ComponentState> components = findComponentsFor(capability);
         components.addAll(newModule.getImplicitCapabilityProviders());
         if (components.add(newModule.getComponent()) && components.size() > 1) {
             // The registered components may contain components which are no longer selected.
@@ -116,18 +116,18 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         resolvers.add(conflictResolver);
     }
 
-    public static CapabilitiesConflictHandler.Candidate candidate(ComponentState component, CapabilityDescriptor capabilityDescriptor, Collection<ComponentState> implicitCapabilityProviders) {
-        return new Candidate(component, capabilityDescriptor, implicitCapabilityProviders);
+    public static CapabilitiesConflictHandler.Candidate candidate(ComponentState component, Capability capability, Collection<ComponentState> implicitCapabilityProviders) {
+        return new Candidate(component, capability, implicitCapabilityProviders);
     }
 
     private static class Candidate implements CapabilitiesConflictHandler.Candidate {
         private final ComponentState component;
-        private final CapabilityDescriptor capabilityDescriptor;
+        private final Capability capability;
         private final Collection<ComponentState> implicitCapabilityProviders;
 
-        public Candidate(ComponentState component, CapabilityDescriptor capabilityDescriptor, Collection<ComponentState> implicitCapabilityProviders) {
+        public Candidate(ComponentState component, Capability capability, Collection<ComponentState> implicitCapabilityProviders) {
             this.component = component;
-            this.capabilityDescriptor = capabilityDescriptor;
+            this.capability = capability;
             this.implicitCapabilityProviders = implicitCapabilityProviders;
         }
 
@@ -135,8 +135,8 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             return component;
         }
 
-        public CapabilityDescriptor getCapabilityDescriptor() {
-            return capabilityDescriptor;
+        public Capability getCapability() {
+            return capability;
         }
 
         @Override
@@ -156,19 +156,19 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         }
 
         @Override
-        public Collection<? extends CapabilityDescriptor> getCapabilityVersions() {
+        public Collection<? extends Capability> getCapabilityVersions() {
             return conflict.descriptors;
         }
 
         @Override
-        public Collection<? extends CandidateDetails> getCandidates(CapabilityDescriptor capability) {
+        public Collection<? extends CandidateDetails> getCandidates(Capability capability) {
             ImmutableList.Builder<CandidateDetails> candidates = new ImmutableList.Builder<CandidateDetails>();
             String group = capability.getGroup();
             String name = capability.getName();
             String version = capability.getVersion();
             for (final ComponentState component : conflict.components) {
                 if (!evicted.contains(component)) {
-                    CapabilityDescriptor componentCapability = component.findCapability(group, name);
+                    Capability componentCapability = component.findCapability(group, name);
                     if (componentCapability != null && componentCapability.getVersion().equals(version)) {
                         candidates.add(new CandidateDetails() {
                             @Override
@@ -217,13 +217,13 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
     private static class CapabilityConflict {
 
         private final Collection<ComponentState> components;
-        private final Set<CapabilityDescriptor> descriptors;
+        private final Set<Capability> descriptors;
 
         private CapabilityConflict(String group, String name, Collection<ComponentState> components) {
             this.components = components;
-            final ImmutableSet.Builder<CapabilityDescriptor> builder = new ImmutableSet.Builder<CapabilityDescriptor>();
+            final ImmutableSet.Builder<Capability> builder = new ImmutableSet.Builder<Capability>();
             for (final ComponentState component : components) {
-                CapabilityDescriptor capability = component.findCapability(group, name);
+                Capability capability = component.findCapability(group, name);
                 if (capability != null) {
                     builder.add(capability);
                 }
@@ -235,7 +235,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
 
     private static String prettifyCapabilities(CapabilityConflict conflict) {
         TreeSet<String> capabilities = Sets.newTreeSet();
-        for (CapabilityDescriptor c : conflict.descriptors) {
+        for (Capability c : conflict.descriptors) {
             capabilities.add(c.getGroup() + ":" + c.getName() + ":" + c.getVersion());
         }
         return Joiner.on(", ").join(capabilities);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -43,13 +43,13 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
     private final Deque<CapabilityConflict> conflicts = new ArrayDeque<CapabilityConflict>();
 
     @Override
-    public PotentialConflict registerModule(CapabilitiesConflictHandler.Candidate newModule) {
-        CapabilityInternal capability = (CapabilityInternal) newModule.getCapability();
+    public PotentialConflict registerCandidate(CapabilitiesConflictHandler.Candidate candidate) {
+        CapabilityInternal capability = (CapabilityInternal) candidate.getCapability();
         String group = capability.getGroup();
         String name = capability.getName();
         final Set<ComponentState> components = findComponentsFor(capability);
-        components.addAll(newModule.getImplicitCapabilityProviders());
-        if (components.add(newModule.getComponent()) && components.size() > 1) {
+        components.addAll(candidate.getImplicitCapabilityProviders());
+        if (components.add(candidate.getComponent()) && components.size() > 1) {
             // The registered components may contain components which are no longer selected.
             // We don't remove them from the list in the first place because it proved to be
             // slower than filtering as needed.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -48,6 +48,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         String group = capabilityDescriptor.getGroup();
         String name = capabilityDescriptor.getName();
         final Set<ComponentState> components = findComponentsFor(capabilityDescriptor);
+        components.addAll(newModule.getImplicitCapabilityProviders());
         if (components.add(newModule.getComponent()) && components.size() > 1) {
             // The registered components may contain components which are no longer selected.
             // We don't remove them from the list in the first place because it proved to be
@@ -85,8 +86,8 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         if (componentStates == null) {
             componentStates = Sets.newHashSet();
             capabilityWithoutVersionToComponents.put(capabilityId, componentStates);
-            return componentStates;
         }
+
         return componentStates;
     }
 
@@ -115,17 +116,19 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         resolvers.add(conflictResolver);
     }
 
-    public static CapabilitiesConflictHandler.Candidate candidate(ComponentState component, CapabilityDescriptor capabilityDescriptor) {
-        return new Candidate(component, capabilityDescriptor);
+    public static CapabilitiesConflictHandler.Candidate candidate(ComponentState component, CapabilityDescriptor capabilityDescriptor, Collection<ComponentState> implicitCapabilityProviders) {
+        return new Candidate(component, capabilityDescriptor, implicitCapabilityProviders);
     }
 
     private static class Candidate implements CapabilitiesConflictHandler.Candidate {
         private final ComponentState component;
         private final CapabilityDescriptor capabilityDescriptor;
+        private final Collection<ComponentState> implicitCapabilityProviders;
 
-        public Candidate(ComponentState component, CapabilityDescriptor capabilityDescriptor) {
+        public Candidate(ComponentState component, CapabilityDescriptor capabilityDescriptor, Collection<ComponentState> implicitCapabilityProviders) {
             this.component = component;
             this.capabilityDescriptor = capabilityDescriptor;
+            this.implicitCapabilityProviders = implicitCapabilityProviders;
         }
 
         public ComponentState getComponent() {
@@ -134,6 +137,11 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
 
         public CapabilityDescriptor getCapabilityDescriptor() {
             return capabilityDescriptor;
+        }
+
+        @Override
+        public Collection<ComponentState> getImplicitCapabilityProviders() {
+            return implicitCapabilityProviders;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
@@ -49,10 +49,10 @@ public class DefaultConflictHandler implements ModuleConflictHandler {
      * Registers new newModule and returns an instance of a conflict if conflict exists.
      */
     @Nullable
-    public PotentialConflict registerModule(CandidateModule newModule) {
-        ModuleReplacementsData.Replacement replacement = moduleReplacements.getReplacementFor(newModule.getId());
+    public PotentialConflict registerCandidate(CandidateModule candidate) {
+        ModuleReplacementsData.Replacement replacement = moduleReplacements.getReplacementFor(candidate.getId());
         ModuleIdentifier replacedBy = replacement == null ? null : replacement.getTarget();
-        return potentialConflict(conflicts.newElement(newModule.getId(), newModule.getVersions(), replacedBy));
+        return potentialConflict(conflicts.newElement(candidate.getId(), candidate.getVersions(), replacedBy));
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/LastCandidateCapabilityResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/LastCandidateCapabilityResolver.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 
 import java.util.Collection;
 
@@ -25,9 +25,9 @@ import java.util.Collection;
 public class LastCandidateCapabilityResolver implements CapabilitiesConflictHandler.Resolver {
     @Override
     public void resolve(CapabilitiesConflictHandler.ResolutionDetails details) {
-        Collection<? extends CapabilityDescriptor> capabilityVersions = details.getCapabilityVersions();
+        Collection<? extends Capability> capabilityVersions = details.getCapabilityVersions();
         CapabilitiesConflictHandler.CandidateDetails single = null;
-        for (CapabilityDescriptor capabilityVersion : capabilityVersions) {
+        for (Capability capabilityVersion : capabilityVersions) {
             Collection<? extends CapabilitiesConflictHandler.CandidateDetails> candidates = details.getCandidates(capabilityVersion);
             int size = candidates.size();
             if (size >= 1) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/UpgradeCapabilityResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/UpgradeCapabilityResolver.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
 import com.google.common.collect.Sets;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.util.VersionNumber;
 
 import java.util.Collection;
@@ -30,11 +30,11 @@ import java.util.Set;
 public class UpgradeCapabilityResolver implements CapabilitiesConflictHandler.Resolver {
     @Override
     public void resolve(CapabilitiesConflictHandler.ResolutionDetails details) {
-        Collection<? extends CapabilityDescriptor> capabilityVersions = details.getCapabilityVersions();
+        Collection<? extends Capability> capabilityVersions = details.getCapabilityVersions();
         if (capabilityVersions.size() > 1) {
-            Set<CapabilityDescriptor> sorted = Sets.newTreeSet(new Comparator<CapabilityDescriptor>() {
+            Set<Capability> sorted = Sets.newTreeSet(new Comparator<Capability>() {
                 @Override
-                public int compare(CapabilityDescriptor o1, CapabilityDescriptor o2) {
+                public int compare(Capability o1, Capability o2) {
                     VersionNumber v1 = VersionNumber.parse(o1.getVersion());
                     VersionNumber v2 = VersionNumber.parse(o2.getVersion());
                     return v2.compareTo(v1);
@@ -42,9 +42,9 @@ public class UpgradeCapabilityResolver implements CapabilitiesConflictHandler.Re
             });
             sorted.addAll(capabilityVersions);
             boolean first = true;
-            for (CapabilityDescriptor capabilityDescriptor : sorted) {
+            for (Capability capability : sorted) {
                 if (!first) {
-                    Collection<? extends CapabilitiesConflictHandler.CandidateDetails> candidates = details.getCandidates(capabilityDescriptor);
+                    Collection<? extends CapabilitiesConflictHandler.CandidateDetails> candidates = details.getCandidates(capability);
                     for (CapabilitiesConflictHandler.CandidateDetails candidate : candidates) {
                         candidate.evict();
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -503,7 +503,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
 
         @Override
-        public CapabilitiesMetadata getCapabilitiesMetadata() {
+        public CapabilitiesMetadata getCapabilities() {
             return capabilities;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/CapabilityInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/CapabilityInternal.java
@@ -15,8 +15,8 @@
  */
 package org.gradle.internal.component.external.model;
 
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 
-public interface CapabilityInternal extends CapabilityDescriptor{
+public interface CapabilityInternal extends Capability {
     String getCapabilityId();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/CapabilityInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/CapabilityInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.capabilities.CapabilityDescriptor;
+
+public interface CapabilityInternal extends CapabilityDescriptor{
+    String getCapabilityId();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -151,7 +151,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     }
 
     @Override
-    public CapabilitiesMetadata getCapabilitiesMetadata() {
+    public CapabilitiesMetadata getCapabilities() {
         if (computedCapabilities == null) {
             computedCapabilities = componentMetadataRules.applyCapabilitiesRules(this, capabilities);
         }
@@ -160,7 +160,7 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
 
     @Override
     public Set<? extends VariantResolveMetadata> getVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilitiesMetadata()));
+        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -17,7 +17,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 
 import java.util.List;
 
@@ -35,7 +35,7 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
     }
 
     @Override
-    public List<? extends CapabilityDescriptor> getCapabilities() {
+    public List<? extends Capability> getCapabilities() {
         return capabilities;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -22,11 +22,13 @@ public class ImmutableCapability implements CapabilityDescriptor {
     private final String group;
     private final String name;
     private final String version;
+    private final int hashCode;
 
     public ImmutableCapability(String group, String name, String version) {
         this.group = group;
         this.name = name;
         this.version = version;
+        this.hashCode = Objects.hashCode(group, name, version);
     }
 
     @Override
@@ -60,7 +62,7 @@ public class ImmutableCapability implements CapabilityDescriptor {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(group, name, version);
+        return hashCode;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -16,19 +16,21 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
-import org.gradle.api.capabilities.CapabilityDescriptor;
 
-public class ImmutableCapability implements CapabilityDescriptor {
+public class ImmutableCapability implements CapabilityInternal {
+
     private final String group;
     private final String name;
     private final String version;
     private final int hashCode;
+    private final String cachedId;
 
     public ImmutableCapability(String group, String name, String version) {
         this.group = group;
         this.name = name;
         this.version = version;
         this.hashCode = Objects.hashCode(group, name, version);
+        this.cachedId = group + ":" + name;
     }
 
     @Override
@@ -71,5 +73,10 @@ public class ImmutableCapability implements CapabilityDescriptor {
             + "group='" + group + '\''
             + ", name='" + name + '\''
             + ", version='" + version + '\'';
+    }
+
+    @Override
+    public String getCapabilityId() {
+        return cachedId;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -29,7 +29,19 @@ public class ImmutableCapability implements CapabilityInternal {
         this.group = group;
         this.name = name;
         this.version = version;
+
+        // Pre-compute and cache hashCode, which is going to be computed in any case
         this.hashCode = Objects.hashCode(group, name, version);
+
+        // Using a string instead of a plain ID here might look strange, but this turned out to be
+        // the fastest of several experiments, including:
+        //
+        //    using ModuleIdentifier (initial implementation)
+        //    using ModuleIdentifier through ImmutableModuleIdentifierFactory (for interning)
+        //    using a 2-level map (by group, then by name)
+        //    using an interned string for the cachedId (interning turned out to cost as much as what we gain from faster checks in maps)
+        //
+        // And none of them reached the performance of just using a good old string
         this.cachedId = group + ":" + name;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -130,8 +130,8 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     }
 
     @Override
-    public CapabilitiesMetadata getCapabilitiesMetadata() {
-        return variant.getCapabilitiesMetadata();
+    public CapabilitiesMetadata getCapabilities() {
+        return variant.getCapabilities();
     }
 
     @Override
@@ -212,9 +212,9 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         }
 
         @Override
-        public CapabilitiesMetadata getCapabilitiesMetadata() {
+        public CapabilitiesMetadata getCapabilities() {
             if (computedCapabilities == null) {
-                computedCapabilities = variantMetadataRules.applyCapabilitiesRules(delegate, delegate.getCapabilitiesMetadata());
+                computedCapabilities = variantMetadataRules.applyCapabilitiesRules(delegate, delegate.getCapabilities());
             }
             return computedCapabilities;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -26,7 +26,7 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.capabilities.MutableCapabilitiesMetadata;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -152,15 +152,15 @@ public class VariantMetadataRules {
     }
 
     private static class MutableCapabilities implements MutableCapabilitiesMetadata {
-        private final List<CapabilityDescriptor> descriptors;
+        private final List<Capability> descriptors;
 
-        private MutableCapabilities(List<CapabilityDescriptor> descriptors) {
+        private MutableCapabilities(List<Capability> descriptors) {
             this.descriptors = descriptors;
         }
 
         @Override
         public void addCapability(String group, String name, String version) {
-            for (CapabilityDescriptor descriptor : descriptors) {
+            for (Capability descriptor : descriptors) {
                 if (descriptor.getGroup().equals(group) && descriptor.getName().equals(name) && !descriptor.getVersion().equals(version)) {
                     throw new InvalidUserDataException("Cannot add capability " + group + ":" + name + " with version " + version + " because it's already defined with version " + descriptor.getVersion());
                 }
@@ -170,9 +170,9 @@ public class VariantMetadataRules {
 
         @Override
         public void removeCapability(String group, String name) {
-            Iterator<CapabilityDescriptor> it = descriptors.iterator();
+            Iterator<Capability> it = descriptors.iterator();
             while (it.hasNext()) {
-                CapabilityDescriptor next = it.next();
+                Capability next = it.next();
                 if (next.getGroup().equals(group) && next.getName().equals(name)) {
                     it.remove();
                 }
@@ -186,7 +186,7 @@ public class VariantMetadataRules {
         }
 
         @Override
-        public List<? extends CapabilityDescriptor> getCapabilities() {
+        public List<? extends Capability> getCapabilities() {
             return ImmutableList.copyOf(descriptors);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -102,7 +102,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             for (ComponentArtifactMetadata oldArtifact : oldVariant.getArtifacts()) {
                 newArtifacts.add(copyArtifact((LocalComponentArtifactMetadata) oldArtifact, artifacts, transformedArtifacts));
             }
-            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.asDescribable(), oldVariant.getAttributes(), newArtifacts, oldVariant.getCapabilitiesMetadata()));
+            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.asDescribable(), oldVariant.getAttributes(), newArtifacts, oldVariant.getCapabilities()));
         }
 
         for (DefaultLocalConfigurationMetadata configuration : allConfigurations.values()) {
@@ -463,7 +463,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         }
 
         @Override
-        public CapabilitiesMetadata getCapabilitiesMetadata() {
+        public CapabilitiesMetadata getCapabilities() {
             return capabilities;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -89,5 +89,5 @@ public interface ConfigurationMetadata extends HasAttributes {
      */
     ComponentArtifactMetadata artifact(IvyArtifactName artifact);
 
-    CapabilitiesMetadata getCapabilitiesMetadata();
+    CapabilitiesMetadata getCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -56,7 +56,7 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
     }
 
     @Override
-    public CapabilitiesMetadata getCapabilitiesMetadata() {
+    public CapabilitiesMetadata getCapabilities() {
         return capabilitiesMetadata;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -34,5 +34,5 @@ public interface VariantResolveMetadata {
 
     List<? extends ComponentArtifactMetadata> getArtifacts();
 
-    CapabilitiesMetadata getCapabilitiesMetadata();
+    CapabilitiesMetadata getCapabilities();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactoryTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.dsl
 
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.capabilities.CapabilityDescriptor
+import org.gradle.api.capabilities.Capability
 import org.gradle.internal.typeconversion.NotationParser
 import spock.lang.Specification
 import spock.lang.Subject
@@ -25,7 +25,7 @@ import spock.lang.Unroll
 
 class CapabilityNotationParserFactoryTest extends Specification {
     @Subject
-    private NotationParser<Object, CapabilityDescriptor> parser = new CapabilityNotationParserFactory().create()
+    private NotationParser<Object, Capability> parser = new CapabilityNotationParserFactory().create()
 
     def "can parse string notation"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultCapabilitiesConflictHandler
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictHandler
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
@@ -100,6 +101,9 @@ class DependencyGraphBuilderTest extends Specification {
         }
     }
 
+    def moduleConflictHandler = new DefaultConflictHandler(conflictResolver, moduleReplacements)
+    def capabilitiesConflictHandler = new DefaultCapabilitiesConflictHandler()
+
     DependencyGraphBuilder builder
 
     def setup() {
@@ -107,7 +111,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -554,7 +558,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
@@ -38,8 +38,8 @@ class DefaultConflictHandlerTest extends Specification {
         def b = candidate("org", "b")
 
         expect:
-        !handler.registerModule(a).conflictExists()
-        !handler.registerModule(b).conflictExists()
+        !handler.registerCandidate(a).conflictExists()
+        !handler.registerCandidate(b).conflictExists()
         !handler.hasConflicts()
     }
 
@@ -48,8 +48,8 @@ class DefaultConflictHandlerTest extends Specification {
         def b = candidate("org", "b", "1")
 
         when:
-        def aX = handler.registerModule(a)
-        def bX = handler.registerModule(b)
+        def aX = handler.registerCandidate(a)
+        def bX = handler.registerCandidate(b)
 
         then:
         aX.conflictExists()
@@ -64,8 +64,8 @@ class DefaultConflictHandlerTest extends Specification {
         replacements.getReplacementFor(DefaultModuleIdentifier.newId("org", "a")) >> new ModuleReplacementsData.Replacement(DefaultModuleIdentifier.newId("org", "b"), null)
 
         when:
-        def aX = handler.registerModule(a)
-        def bX = handler.registerModule(b)
+        def aX = handler.registerCandidate(a)
+        def bX = handler.registerCandidate(b)
 
         then:
         aX.conflictExists()
@@ -75,7 +75,7 @@ class DefaultConflictHandlerTest extends Specification {
 
     def "resolves conflict"() {
         def a = candidate("org", "a", "1", "2")
-        handler.registerModule(a)
+        handler.registerCandidate(a)
 
         when:
         details.getCandidates() >> { a.versions.findAll { it.id.version in ['1', '2']} }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -41,7 +41,7 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
     Set usages = []
 }
 
-class TestCapability implements CapabilityDescriptor {
+class TestCapability implements Capability {
     String group
     String name
     String version

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Collections;
@@ -98,7 +98,7 @@ public class DefaultUsageContext implements UsageContext, Named {
     }
 
     @Override
-    public Set<? extends CapabilityDescriptor> getCapabilities() {
+    public Set<? extends Capability> getCapabilities() {
         return Collections.emptySet();
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -43,7 +43,7 @@ class TestVariant implements org.gradle.api.internal.component.SoftwareComponent
     Set usages = []
 }
 
-class TestCapability implements CapabilityDescriptor {
+class TestCapability implements Capability {
     String group
     String name
     String version

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishCustomComponentIntegTest.groovy
@@ -162,7 +162,7 @@ class MavenPublishCustomComponentIntegTest extends AbstractMavenPublishIntegTest
                     Set<PublishArtifact> artifacts = [ publishedArtifact ]
                     Set<ModuleDependency> dependencies = [ publishedDependency ]
                     Set<DependencyConstraint> dependencyConstraints = []
-                    Set<CapabilityDescriptor> capabilities = []
+                    Set<Capability> capabilities = []
                 }
             }
             class MyComponentWithVariants extends MySoftwareComponent implements ComponentWithVariants {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -28,7 +28,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.configurations.Configurations;
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -135,7 +135,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
     private class RuntimeUsageContext extends AbstractUsageContext {
         private DomainObjectSet<ModuleDependency> dependencies;
         private DomainObjectSet<DependencyConstraint> dependencyConstraints;
-        private Set<? extends CapabilityDescriptor> capabilities;
+        private Set<? extends Capability> capabilities;
 
         RuntimeUsageContext(String usageName) {
             super(usageName);
@@ -163,10 +163,10 @@ public class JavaLibrary implements SoftwareComponentInternal {
         }
 
         @Override
-        public Set<? extends CapabilityDescriptor> getCapabilities() {
+        public Set<? extends Capability> getCapabilities() {
             if (capabilities == null) {
                 this.capabilities = ImmutableSet.copyOf(Configurations.collectCapabilities(configurations.getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME),
-                    Sets.<CapabilityDescriptor>newHashSet(),
+                    Sets.<Capability>newHashSet(),
                     Sets.<Configuration>newHashSet()));
             }
             return capabilities;
@@ -176,7 +176,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
     private class CompileUsageContext extends AbstractUsageContext {
         private DomainObjectSet<ModuleDependency> dependencies;
         private DomainObjectSet<DependencyConstraint> dependencyConstraints;
-        private Set<? extends CapabilityDescriptor> capabilities;
+        private Set<? extends Capability> capabilities;
 
         CompileUsageContext(String usageName) {
             super(usageName);
@@ -204,10 +204,10 @@ public class JavaLibrary implements SoftwareComponentInternal {
         }
 
         @Override
-        public Set<? extends CapabilityDescriptor> getCapabilities() {
+        public Set<? extends Capability> getCapabilities() {
             if (capabilities == null) {
                 this.capabilities = ImmutableSet.copyOf(Configurations.collectCapabilities(configurations.getByName(API_ELEMENTS_CONFIGURATION_NAME),
-                    Sets.<CapabilityDescriptor>newHashSet(),
+                    Sets.<Capability>newHashSet(),
                     Sets.<Configuration>newHashSet()));
             }
             return capabilities;
@@ -238,7 +238,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
         }
 
         @Override
-        public Set<? extends CapabilityDescriptor> getCapabilities() {
+        public Set<? extends Capability> getCapabilities() {
             return Collections.emptySet();
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -83,7 +83,7 @@ public class WebApplication implements SoftwareComponentInternal {
         }
 
         @Override
-        public Set<? extends CapabilityDescriptor> getCapabilities() {
+        public Set<? extends Capability> getCapabilities() {
             return Collections.emptySet();
         }
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -32,7 +32,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.CapabilityDescriptor;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ComponentWithCoordinates;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
@@ -454,11 +454,11 @@ public class ModuleMetadataFileGenerator {
     }
 
     private void writeCapabilities(UsageContext variant, JsonWriter jsonWriter) throws IOException {
-        Set<? extends CapabilityDescriptor> capabilities = variant.getCapabilities();
+        Set<? extends Capability> capabilities = variant.getCapabilities();
         if (!capabilities.isEmpty()) {
             jsonWriter.name("capabilities");
             jsonWriter.beginArray();
-            for (CapabilityDescriptor capability : capabilities) {
+            for (Capability capability : capabilities) {
                 jsonWriter.beginObject();
                 jsonWriter.name("group").value(capability.getGroup());
                 jsonWriter.name("name").value(capability.getName());

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.capabilities.CapabilityDescriptor
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -642,12 +642,12 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def component = Stub(TestComponent)
         def publication = publication(component, id)
 
-        def c1 = Stub(CapabilityDescriptor) {
+        def c1 = Stub(Capability) {
             getGroup() >> 'org.test'
             getName() >> 'foo'
             getVersion() >> '1'
         }
-        def c2 = Stub(CapabilityDescriptor) {
+        def c2 = Stub(Capability) {
             getGroup() >> 'org.test'
             getName() >> 'bar'
             getVersion() >> '2'


### PR DESCRIPTION
### Context

This pull request builds on top of #4639 and adds an implicit capability to each component, corresponding to their GAV. This, as the changes in test cases illustrate, greatly simplifies some rules, but it comes at a price: there's a regression in resolution of large dependency graphs, because we need to register more conflicts. I however managed to reduce the regression to less than 1.5%, which I think is reasonable. If so, we should rebaseline, as apparently the performance tests will sometimes fail (because we're closer to the regression limit).
