### PR TITLE
Attach a "plain console" as a part of logging initialization

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -175,8 +175,10 @@ task sleep {
         then:
         getLogs(executer.daemonBaseDir).size() == 0 //we should connect to the foreground daemon so no log was created
 
-        daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
-        daemon.standardOutput.count("info me!") == 1
+        poll(5) {
+            assert daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
+            assert daemon.standardOutput.count("info me!") == 1
+        }
 
         infoBuild.output.count("debug me!") == 0
         infoBuild.output.count("info me!") == 1
@@ -185,8 +187,10 @@ task sleep {
         def debugBuild = executer.withArguments("-d", "-Dorg.gradle.jvmargs=-ea").run()
 
         then:
-        daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
-        daemon.standardOutput.count("debug me!") == 1
+        poll(5) {
+            assert daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
+            assert daemon.standardOutput.count("debug me!") == 1
+        }
 
         debugBuild.output.count("debug me!") == 1
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -175,10 +175,8 @@ task sleep {
         then:
         getLogs(executer.daemonBaseDir).size() == 0 //we should connect to the foreground daemon so no log was created
 
-        poll(5) {
-            assert daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
-            assert daemon.standardOutput.count("info me!") == 1
-        }
+        daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
+        daemon.standardOutput.count("info me!") == 1
 
         infoBuild.output.count("debug me!") == 0
         infoBuild.output.count("info me!") == 1
@@ -187,10 +185,8 @@ task sleep {
         def debugBuild = executer.withArguments("-d", "-Dorg.gradle.jvmargs=-ea").run()
 
         then:
-        poll(5) {
-            assert daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
-            assert daemon.standardOutput.count("debug me!") == 1
-        }
+        daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
+        daemon.standardOutput.count("debug me!") == 1
 
         debugBuild.output.count("debug me!") == 1
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/PlainConsoleGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/PlainConsoleGroupedTaskFunctionalTest.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import static org.gradle.api.logging.configuration.ConsoleOutput.Plain
+
+class PlainConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec {
+    def setup() {
+        executer.withConsole(Plain)
+    }
+
+    def "output from tasks is grouped with a header"() {
+        buildFile << """
+            task foo {
+                doFirst {
+                    logger.quiet 'foo First line of text'
+                    logger.quiet 'foo Second line of text'
+                }
+            }
+            
+            task bar(dependsOn: foo) {
+                doFirst {
+                    logger.quiet 'bar First line of text'
+                    logger.quiet 'bar Second line of text'
+                }
+            }
+        """
+
+        when:
+        succeeds('bar')
+
+        then:
+        result.groupedOutput.task(':foo').output == "foo First line of text\nfoo Second line of text"
+        result.groupedOutput.task(':bar').output == "bar First line of text\nbar Second line of text"
+    }
+
+    def "output from outside of tasks are present"() {
+        given:
+        buildFile << """Thread.start { 
+            println 'bar'
+            println 'baz'
+        }
+        
+        task foo {
+            doLast {
+                logger.quiet 'foo'
+            }
+        }
+        """
+
+        when:
+        succeeds('foo')
+
+        then:
+        result.groupedOutput.task(':foo').output == "foo"
+        output.contains('bar')
+        output.contains('baz')
+    }
+
+    def "tasks run in parallel have their output grouped with a header"() {
+        settingsFile << """
+            include ':foo', ':bar'
+        """
+        buildFile << """
+            subprojects {
+                task baz {
+                    doLast {
+                        logger.quiet "logged from " + project.name
+                        logger.quiet "also logged from " + project.name
+                    }
+                }
+            }
+        """
+
+        when:
+        args("--parallel")
+        succeeds('baz')
+
+        then:
+        result.groupedOutput.task(':foo:baz').output == "logged from foo\nalso logged from foo"
+        result.groupedOutput.task(':bar:baz').output == "logged from bar\nalso logged from bar"
+    }
+
+    def "tasks that log to both stdout and stderr are grouped with a header"() {
+        buildFile << """
+            task foo {
+                doFirst {
+                    logger.quiet 'foo First line of text'
+                    logger.error 'foo Second line of text'
+                }
+            }
+            
+            task bar(dependsOn: foo) {
+                doFirst {
+                    logger.error 'bar First line of text'
+                    logger.quiet 'bar Second line of text'
+                }
+            }
+        """
+
+        when:
+        succeeds('bar')
+
+        then:
+        result.groupedOutput.task(':foo').output == "foo First line of text\nfoo Second line of text"
+        result.groupedOutput.task(':bar').output == "bar First line of text\nbar Second line of text"
+    }
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/PlainConsoleGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/PlainConsoleGroupedTaskFunctionalTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
+import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 import static org.gradle.api.logging.configuration.ConsoleOutput.Plain
@@ -25,6 +26,7 @@ class PlainConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec {
         executer.withConsole(Plain)
     }
 
+    @NotYetImplemented
     def "output from tasks is grouped with a header"() {
         buildFile << """
             task foo {
@@ -50,6 +52,7 @@ class PlainConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec {
         result.groupedOutput.task(':bar').output == "bar First line of text\nbar Second line of text"
     }
 
+    @NotYetImplemented
     def "output from outside of tasks are present"() {
         given:
         buildFile << """Thread.start { 
@@ -73,6 +76,7 @@ class PlainConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec {
         output.contains('baz')
     }
 
+    @NotYetImplemented
     def "tasks run in parallel have their output grouped with a header"() {
         settingsFile << """
             include ':foo', ':bar'
@@ -97,6 +101,7 @@ class PlainConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec {
         result.groupedOutput.task(':bar:baz').output == "logged from bar\nalso logged from bar"
     }
 
+    @NotYetImplemented
     def "tasks that log to both stdout and stderr are grouped with a header"() {
         buildFile << """
             task foo {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
@@ -49,6 +49,11 @@ public interface LoggingOutputInternal extends LoggingOutput {
      */
     void attachAnsiConsole(OutputStream outputStream);
 
+    /**
+     * Adds the given {@link StandardOutputListener} objects as logging destinations.  The output will include plain text only, with no color or dynamic text.
+     *
+     * <p>Removes standard output and/or error as a side-effect.
+     */
     void attachPlainConsole(StandardOutputListener outputListener, StandardOutputListener errorListener);
 
     /**

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging;
 
 import org.gradle.api.logging.LoggingOutput;
+import org.gradle.api.logging.StandardOutputListener;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -47,6 +48,8 @@ public interface LoggingOutputInternal extends LoggingOutput {
      * <p>Removes standard output and/or error as a side-effect.
      */
     void attachAnsiConsole(OutputStream outputStream);
+
+    void attachPlainConsole(StandardOutputListener outputListener, StandardOutputListener errorListener);
 
     /**
      * Adds the given {@link java.io.OutputStream} as a logging destination. The stream receives stdout logging formatted according to the current logging settings and

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ThrottlingOutputEventListener.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ThrottlingOutputEventListener.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging.console;
 
 import org.gradle.internal.logging.events.EndOutputEvent;
+import org.gradle.internal.logging.events.FlushOutputEvent;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.UpdateNowEvent;
@@ -67,6 +68,11 @@ public class ThrottlingOutputEventListener implements OutputEventListener {
     public void onOutput(OutputEvent newEvent) {
         synchronized (lock) {
             queue.add(newEvent);
+
+            if (newEvent instanceof FlushOutputEvent) {
+                renderNow(clock.getCurrentTime());
+                return;
+            }
 
             if (newEvent instanceof EndOutputEvent) {
                 // Flush and clean up

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/FlushOutputEvent.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/FlushOutputEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.events;
+
+import org.gradle.api.logging.LogLevel;
+
+import javax.annotation.Nullable;
+
+/**
+ * Notifies output consumers that might be queueing messages to immediately flush their queues.
+ */
+public class FlushOutputEvent extends OutputEvent {
+    @Nullable
+    @Override
+    public LogLevel getLogLevel() {
+        return null;
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
@@ -35,36 +35,44 @@ public class ConsoleConfigureAction {
             configureRichConsole(renderer, false);
         } else if (consoleOutput == ConsoleOutput.Verbose) {
             configureRichConsole(renderer, true);
+        } else if (consoleOutput == ConsoleOutput.Plain) {
+            configurePlainConsole(renderer);
         }
     }
 
     private static void configureRichConsole(OutputEventRenderer renderer, boolean verbose) {
         ConsoleDetector consoleDetector = NativeServices.getInstance().get(ConsoleDetector.class);
         ConsoleMetaData consoleMetaData = consoleDetector.getConsole();
-        configureConsole(renderer, consoleMetaData, consoleMetaData == null, verbose);
+        configureRichConsole(renderer, consoleMetaData, consoleMetaData == null, verbose);
     }
 
     private static void configureAutoConsole(OutputEventRenderer renderer) {
         ConsoleDetector consoleDetector = NativeServices.getInstance().get(ConsoleDetector.class);
         ConsoleMetaData consoleMetaData = consoleDetector.getConsole();
         if (consoleMetaData != null) {
-            configureConsole(renderer, consoleMetaData, false, false);
+            configureRichConsole(renderer, consoleMetaData, false, false);
+        } else {
+            configurePlainConsole(renderer);
         }
     }
 
-    private static void configureConsole(OutputEventRenderer renderer, ConsoleMetaData consoleMetaData, boolean force, boolean verbose) {
+    private static void configurePlainConsole(OutputEventRenderer renderer) {
+        renderer.addPlainConsole();
+    }
+
+    private static void configureRichConsole(OutputEventRenderer renderer, ConsoleMetaData consoleMetaData, boolean force, boolean verbose) {
         consoleMetaData = consoleMetaData == null ? FallbackConsoleMetaData.INSTANCE : consoleMetaData;
         if (consoleMetaData.isStdOut()) {
             OutputStream originalStdOut = renderer.getOriginalStdOut();
             OutputStreamWriter outStr = new OutputStreamWriter(force ? originalStdOut : AnsiConsoleUtil.wrapOutputStream(originalStdOut));
             Console console = new AnsiConsole(outStr, outStr, renderer.getColourMap(), consoleMetaData, force);
-            renderer.addConsole(console, true, consoleMetaData.isStdErr(), consoleMetaData, verbose);
+            renderer.addRichConsole(console, true, consoleMetaData.isStdErr(), consoleMetaData, verbose);
         } else if (consoleMetaData.isStdErr()) {
             // Only stderr is connected to a terminal
             OutputStream originalStdErr = renderer.getOriginalStdErr();
             OutputStreamWriter errStr = new OutputStreamWriter(force ? originalStdErr : AnsiConsoleUtil.wrapOutputStream(originalStdErr));
             Console console = new AnsiConsole(errStr, errStr, renderer.getColourMap(), consoleMetaData, force);
-            renderer.addConsole(console, false, true, consoleMetaData, verbose);
+            renderer.addRichConsole(console, false, true, consoleMetaData, verbose);
         }
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/LogEventDispatcher.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/LogEventDispatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.sink;
+
+import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.logging.events.OutputEvent;
+import org.gradle.internal.logging.events.OutputEventListener;
+
+import javax.annotation.Nullable;
+
+public class LogEventDispatcher implements OutputEventListener {
+    private final OutputEventListener stdoutChain;
+    private final OutputEventListener stderrChain;
+
+    public LogEventDispatcher(@Nullable OutputEventListener stdoutChain, @Nullable OutputEventListener stderrChain) {
+        this.stdoutChain = stdoutChain;
+        this.stderrChain = stderrChain;
+    }
+
+    @Override
+    public void onOutput(OutputEvent event) {
+        if (event.getLogLevel() == null) {
+            dispatch(event, stdoutChain);
+            dispatch(event, stderrChain);
+        } else if (event.getLogLevel() == LogLevel.ERROR) {
+            dispatch(event, stderrChain);
+        } else {
+            dispatch(event, stdoutChain);
+        }
+    }
+
+    private void dispatch(OutputEvent event, OutputEventListener listener) {
+        if (listener != null) {
+            listener.onOutput(event);
+        }
+    }
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -37,6 +37,7 @@ import org.gradle.internal.logging.console.UserInputConsoleRenderer;
 import org.gradle.internal.logging.console.UserInputStandardOutputRenderer;
 import org.gradle.internal.logging.console.WorkInProgressRenderer;
 import org.gradle.internal.logging.events.EndOutputEvent;
+import org.gradle.internal.logging.events.FlushOutputEvent;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
@@ -133,6 +134,10 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
         return colourMap;
     }
 
+    private void flush() {
+        onOutput(new FlushOutputEvent());
+    }
+
     public OutputStream getOriginalStdOut() {
         return originalStdOut;
     }
@@ -195,6 +200,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     private void removeStandardOutputListener() {
         synchronized (lock) {
+            flush();
             if (stdOutListener != null) {
                 stdoutListeners.remove(stdOutListener);
                 stdOutListener = null;
@@ -204,6 +210,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     private void removeStandardErrorListener() {
         synchronized (lock) {
+            flush();
             if (stdErrListener != null) {
                 stderrListeners.remove(stdErrListener);
                 stdErrListener = null;
@@ -213,12 +220,14 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     public void addOutputEventListener(OutputEventListener listener) {
         synchronized (lock) {
+            flush();
             formatters.add(listener);
         }
     }
 
     public void removeOutputEventListener(OutputEventListener listener) {
         synchronized (lock) {
+            flush();
             formatters.remove(listener);
         }
     }
@@ -289,12 +298,14 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     public void addStandardErrorListener(StandardOutputListener listener) {
         synchronized (lock) {
+            flush();
             stderrListeners.add(listener);
         }
     }
 
     public void addStandardOutputListener(StandardOutputListener listener) {
         synchronized (lock) {
+            flush();
             stdoutListeners.add(listener);
         }
     }
@@ -310,12 +321,14 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     public void removeStandardOutputListener(StandardOutputListener listener) {
         synchronized (lock) {
+            flush();
             stdoutListeners.remove(listener);
         }
     }
 
     public void removeStandardErrorListener(StandardOutputListener listener) {
         synchronized (lock) {
+            flush();
             stderrListeners.remove(listener);
         }
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -77,22 +77,18 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     public OutputEventRenderer(final Clock clock) {
         this.clock = clock;
-        OutputEventListener stdOutChain = new LazyListener(new Factory<OutputEventListener>() {
-            @Override
-            public OutputEventListener create() {
-                return new UserInputStandardOutputRenderer(new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stdoutListeners.getSource())), clock);
-            }
-        });
-        OutputEventListener stdErrChain = new LazyListener(new Factory<OutputEventListener>() {
-            @Override
-            public OutputEventListener create() {
-                return new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stderrListeners.getSource()));
-            }
-        });
         formatters.add(
-            new BuildLogLevelFilterRenderer(
-                new ProgressLogEventGenerator(new LogEventDispatcher(stdOutChain, stdErrChain), false)
-            )
+            new LazyListener(new Factory<OutputEventListener>() {
+                @Override
+                public OutputEventListener create() {
+                    OutputEventListener stdOutChain = new UserInputStandardOutputRenderer(new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stdoutListeners.getSource())), clock);
+                    OutputEventListener stdErrChain = new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stderrListeners.getSource()));
+
+                    return new BuildLogLevelFilterRenderer(
+                        new ProgressLogEventGenerator(new LogEventDispatcher(stdOutChain, stdErrChain), false)
+                    );
+                }
+            })
         );
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleFunctionalTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ConsoleFunctionalTest.groovy
@@ -46,7 +46,7 @@ class ConsoleFunctionalTest extends Specification {
     def setup() {
         renderer = new OutputEventRenderer(timeProvider)
         renderer.configure(LogLevel.INFO)
-        renderer.addConsole(console, true, true, metaData)
+        renderer.addRichConsole(console, true, true, metaData)
         _ * metaData.getRows() >> 10
         _ * metaData.getCols() >> 36
         _ * timeProvider.getCurrentTime() >> { currentTimeMs }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/LogEventDispatcherTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/LogEventDispatcherTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.sink
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.internal.logging.events.LogEvent
+import org.gradle.internal.logging.events.OutputEventListener
+import spock.lang.Specification
+
+class LogEventDispatcherTest extends Specification {
+    OutputEventListener stdoutChain = Mock(OutputEventListener)
+    OutputEventListener stderrChain = Mock(OutputEventListener)
+    LogEventDispatcher dispatcher = new LogEventDispatcher(stdoutChain, stderrChain)
+
+    def "QUIET and below are dispatched to the stdout chain"() {
+        when:
+        dispatcher.onOutput(event(logLevel))
+
+        then:
+        1 * stdoutChain.onOutput(_)
+        0 * stderrChain.onOutput(_)
+
+        where:
+        logLevel << LogLevel.values() - LogLevel.ERROR
+    }
+
+    def "ERROR is dispatched to the stderr chain"() {
+        when:
+        dispatcher.onOutput(event(LogLevel.ERROR))
+
+        then:
+        0 * stdoutChain.onOutput(_)
+        1 * stderrChain.onOutput(_)
+    }
+
+    def "event without log level is dispatched to both chains"() {
+        when:
+        dispatcher.onOutput(event(null))
+
+        then:
+        1 * stdoutChain.onOutput(_)
+        1 * stderrChain.onOutput(_)
+    }
+
+    def "dispatches only to stdout when stderr is null"() {
+        when:
+        dispatcher = new LogEventDispatcher(stdoutChain, null)
+        LogLevel.values().each { logLevel ->
+            dispatcher.onOutput(event(logLevel))
+        }
+
+        then:
+        5 * stdoutChain.onOutput(_) >> { args -> assert args[0].logLevel != LogLevel.ERROR }
+        0 * stderrChain.onOutput(_)
+    }
+
+    def "dispatches only to stderr when stdout is null"() {
+        when:
+        dispatcher = new LogEventDispatcher(null, stderrChain)
+        LogLevel.values().each { logLevel ->
+            dispatcher.onOutput(event(logLevel))
+        }
+
+        then:
+        0 * stdoutChain.onOutput(_)
+        1 * stderrChain.onOutput(_) >> { args -> assert args[0].logLevel == LogLevel.ERROR }
+    }
+
+    LogEvent event(level) {
+        LogEvent event = Stub(LogEvent)
+        event.logLevel >> level
+        return event
+    }
+}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -257,7 +257,7 @@ class OutputEventRendererTest extends OutputSpecification {
 
     def rendersLogEventsWhenStdOutAndStdErrAreConsole() {
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, true, true, metaData)
+        renderer.addRichConsole(console, true, true, metaData)
 
         when:
         renderer.onOutput(start(loggingHeader: 'description', buildOperationStart: true, buildOperationId: 1L, buildOperationCategory: BuildOperationCategory.TASK))
@@ -272,7 +272,7 @@ class OutputEventRendererTest extends OutputSpecification {
 
     def rendersLogEventsWhenOnlyStdOutIsConsole() {
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, true, false, metaData)
+        renderer.addRichConsole(console, true, false, metaData)
 
         when:
         renderer.onOutput(start(loggingHeader: 'description', buildOperationStart: true, buildOperationId: 1L, buildOperationCategory: BuildOperationCategory.TASK))
@@ -287,7 +287,7 @@ class OutputEventRendererTest extends OutputSpecification {
 
     def rendersLogEventsWhenOnlyStdErrIsConsole() {
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, false, true, metaData)
+        renderer.addRichConsole(console, false, true, metaData)
 
         when:
         renderer.onOutput(start('description'))
@@ -303,7 +303,7 @@ class OutputEventRendererTest extends OutputSpecification {
     def rendersLogEventsInConsoleWhenLogLevelIsDebug() {
         renderer.configure(LogLevel.DEBUG)
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, true, true, metaData)
+        renderer.addRichConsole(console, true, true, metaData)
 
         when:
         renderer.onOutput(event(tenAm, 'info', LogLevel.INFO))
@@ -318,7 +318,7 @@ class OutputEventRendererTest extends OutputSpecification {
         when:
         renderer.attachSystemOutAndErr()
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, true, true, metaData)
+        renderer.addRichConsole(console, true, true, metaData)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
         renderer.restore(snapshot) // close console to flush
@@ -333,7 +333,7 @@ class OutputEventRendererTest extends OutputSpecification {
         when:
         renderer.attachSystemOutAndErr()
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, true, false, metaData)
+        renderer.addRichConsole(console, true, false, metaData)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
         renderer.restore(snapshot) // close console to flush
@@ -348,7 +348,7 @@ class OutputEventRendererTest extends OutputSpecification {
         when:
         renderer.attachSystemOutAndErr()
         def snapshot = renderer.snapshot()
-        renderer.addConsole(console, false, true, metaData)
+        renderer.addRichConsole(console, false, true, metaData)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
         renderer.restore(snapshot) // close console to flush

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.StandardOutputListener
 import org.gradle.internal.logging.OutputSpecification
 import org.gradle.internal.logging.console.ConsoleStub
+import org.gradle.internal.logging.events.FlushOutputEvent
 import org.gradle.internal.logging.events.LogEvent
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
@@ -211,6 +212,7 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.onOutput(event)
 
         then:
+        1 * listener.onOutput(_ as FlushOutputEvent)
         0 * listener._
     }
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayMultiProjectReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayMultiProjectReloadIntegrationTest.groovy
@@ -170,7 +170,7 @@ var message = "Hello JS";
         fails()
         !executedTasks.contains(':primary:runPlayBinary')
         errorPageHasTaskFailure(":submodule:compilePlayBinaryScala")
-        serverStartCount == 1
+        serverStarted()
 
         when:
         fixBadScala("submodule/app")
@@ -179,7 +179,7 @@ var message = "Hello JS";
         succeeds()
         appIsRunningAndDeployed()
         runningApp.playUrl().text
-        serverStartCount > 1
+        serverRestart()
     }
 
     def addBadScala(path) {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayMultiProjectReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayMultiProjectReloadIntegrationTest.groovy
@@ -170,7 +170,7 @@ var message = "Hello JS";
         fails()
         !executedTasks.contains(':primary:runPlayBinary')
         errorPageHasTaskFailure(":submodule:compilePlayBinaryScala")
-        serverStarted()
+        serverStartCount == 1
 
         when:
         fixBadScala("submodule/app")

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayReloadIntegrationTest.groovy
@@ -18,14 +18,23 @@ package org.gradle.play.integtest.fixtures
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.test.fixtures.ConcurrentTestUtil
+
+import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
 @TargetCoverage({ JavaVersion.current().isJava8Compatible() ? PlayCoverage.PLAY23_OR_LATER : PlayCoverage.PLAY23_OR_EARLIER })
 abstract class AbstractMultiVersionPlayReloadIntegrationTest extends AbstractMultiVersionPlayContinuousBuildIntegrationTest {
-    protected serverRestart() {
-        ConcurrentTestUtil.poll {
+    protected boolean serverRestart() {
+        poll {
             assert serverStartCount > 1
         }
+        return true
+    }
+
+    protected boolean serverStarted() {
+        poll {
+            assert serverStartCount == 1
+        }
+        return true
     }
 
     protected noServerRestart() {

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -54,6 +54,9 @@ public class SecurityManagerTest {
 '''
 
         expect:
+        // This test causes the test process to exit ungracefully without closing connections.  This can sometimes
+        // cause connection errors to show up in stderr.
+        executer.withStackTraceChecksDisabled()
         fails('test')
         result.error.contains("Process 'Gradle Test Executor 1' finished with non-zero exit value 1")
         result.error.contains("Please refer to the test execution section in the user guide at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_plugin.html#sec:test_execution")


### PR DESCRIPTION
This is a first step towards providing task grouping for the plain console.  This PR does two things:

1. It merges the standard output and standard error chains into a single output event chain with a dispatch that sends the output to either stdout or stderr listeners.
1. It attaches a "plain console" which is a throttled output event chain similar to the event chain for the rich console.

Currently, the plain console does not change the output at all, but this is pre-work for eventually adding task grouping to the plain console.