### PR TITLE
Declare optional `DefaultFileOperations` arguments as `@Nullable`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractPublishArtifact.java
@@ -21,10 +21,12 @@ import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.tasks.TaskDependency;
 
+import javax.annotation.Nullable;
+
 public abstract class AbstractPublishArtifact implements PublishArtifact {
     private final DefaultTaskDependency taskDependency;
 
-    public AbstractPublishArtifact(TaskResolver resolver, Object... tasks) {
+    public AbstractPublishArtifact(@Nullable TaskResolver resolver, Object... tasks) {
         taskDependency = new DefaultTaskDependency(resolver, ImmutableSet.copyOf(tasks));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -52,13 +52,16 @@ import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.JavaExecAction;
 import org.gradle.util.GFileUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.util.Map;
 
 public class DefaultFileOperations implements FileOperations, ProcessOperations {
     private final FileResolver fileResolver;
+    @Nullable
     private final TaskResolver taskResolver;
+    @Nullable
     private final TemporaryFileProvider temporaryFileProvider;
     private final Instantiator instantiator;
     private final Deleter deleter;
@@ -70,7 +73,7 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
     private final FileSystem fileSystem;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public DefaultFileOperations(FileResolver fileResolver, TaskResolver taskResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory) {
+    public DefaultFileOperations(FileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory) {
         this.fileResolver = fileResolver;
         this.taskResolver = taskResolver;
         this.temporaryFileProvider = temporaryFileProvider;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
@@ -25,6 +25,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.WorkResult;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.util.Map;
@@ -34,6 +35,7 @@ public interface FileOperations {
 
     File file(Object path, PathValidation validation);
 
+    @Nullable
     URI uri(Object path);
 
     FileResolver getFileResolver();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -38,23 +39,23 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     private final PathToFileResolver resolver;
     private final DefaultTaskDependency buildDependency;
 
-    public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, TaskResolver taskResolver) {
+    public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
         this("file collection", fileResolver, taskResolver, null);
     }
 
-    public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, TaskResolver taskResolver, Collection<?> files) {
+    public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, Collection<?> files) {
         this("file collection", fileResolver, taskResolver, files);
     }
 
-    public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, TaskResolver taskResolver, Object[] files) {
+    public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, Object[] files) {
         this("file collection", fileResolver, taskResolver, Arrays.asList(files));
     }
 
-    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, TaskResolver taskResolver) {
+    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
         this(displayName, fileResolver, taskResolver, null);
     }
 
-    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, TaskResolver taskResolver, Collection<?> files) {
+    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, Collection<?> files) {
         this.displayName = displayName;
         this.resolver = fileResolver;
         this.files = new LinkedHashSet<Object>();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileTree.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.util.ConfigureUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
@@ -46,11 +47,11 @@ public class DefaultConfigurableFileTree extends CompositeFileTree implements Co
     private final DefaultTaskDependency buildDependency;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public DefaultConfigurableFileTree(Object dir, FileResolver resolver, TaskResolver taskResolver, FileCopier fileCopier, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public DefaultConfigurableFileTree(Object dir, FileResolver resolver, @Nullable TaskResolver taskResolver, FileCopier fileCopier, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this(Collections.singletonMap("dir", dir), resolver, taskResolver, fileCopier, directoryFileTreeFactory);
     }
 
-    public DefaultConfigurableFileTree(Map<String, ?> args, FileResolver resolver, TaskResolver taskResolver, FileCopier fileCopier, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public DefaultConfigurableFileTree(Map<String, ?> args, FileResolver resolver, @Nullable TaskResolver taskResolver, FileCopier fileCopier, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.resolver = resolver;
         this.fileCopier = fileCopier;
         this.directoryFileTreeFactory = directoryFileTreeFactory;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
+import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -58,11 +59,11 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
         this(null);
     }
 
-    public DefaultTaskDependency(TaskResolver resolver) {
+    public DefaultTaskDependency(@Nullable TaskResolver resolver) {
         this(resolver, ImmutableSet.of());
     }
 
-    public DefaultTaskDependency(TaskResolver resolver, ImmutableSet<Object> immutableValues) {
+    public DefaultTaskDependency(@Nullable TaskResolver resolver, ImmutableSet<Object> immutableValues) {
         this.resolver = resolver;
         this.immutableValues = immutableValues;
     }


### PR DESCRIPTION
`DefaultFileOperations` is used by the `kotlin-dsl` and Kotlin won't
allow non nullable parameters to be given null arguments.

Feedback build: https://builds.gradle.org/viewLog.html?buildId=11596139 ✅ 