### PR TITLE
Make it possible to fail on capability version conflict

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -284,7 +284,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 fixConflict ? expectResolve() : expectGetMetadata()
             }
             'org.apache:groovy-all:1.0' {
-                if (!fixConflict)  { expectGetMetadata() }
+                if (!fixConflict) {
+                    expectGetMetadata()
+                }
             }
         }
 
@@ -328,7 +330,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll
-    def "published module can declare relocation (first in graph = #first, second in graph = #second)"() {
+    def "published module can declare relocation (first in graph = #first, second in graph = #second, failOnVersionConflict=#failOnVersionConflict)"() {
         given:
         repository {
             // // there's an implicit capability for every component, corresponding to the component coordinates
@@ -345,6 +347,10 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                conf "$first"
                conf "$second"
             }
+            
+            if ($failOnVersionConflict) {
+               configurations.conf.resolutionStrategy.failOnVersionConflict()
+            }
         """
 
         when:
@@ -353,23 +359,34 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 expectGetMetadata()
             }
             'org.ow2.asm:asm:4.0' {
-                expectResolve()
+                failOnVersionConflict ? expectGetMetadata() : expectResolve()
             }
         }
-        run ":checkDeps"
+        if (failOnVersionConflict) {
+            fails ':checkDeps'
+        } else {
+            run ":checkDeps"
+        }
 
         then:
-        resolve.expectGraph {
-            root(":", ":test:") {
-                edge('asm:asm:3.0', 'org.ow2.asm:asm:4.0')
-                    .byConflictResolution()
-                module('org.ow2.asm:asm:4.0')
+        if (failOnVersionConflict) {
+            failure.assertHasCause("Cannot choose between asm:asm:3.0 and org.ow2.asm:asm:4.0 because they provide the same capability: asm:asm:3.0, asm:asm:4.0")
+        } else {
+            resolve.expectGraph {
+                root(":", ":test:") {
+                    edge('asm:asm:3.0', 'org.ow2.asm:asm:4.0')
+                        .byConflictResolution()
+                    module('org.ow2.asm:asm:4.0')
+                }
             }
         }
 
         where:
-        first << ['asm:asm:3.0', 'org.ow2.asm:asm:4.0']
-        second << ['org.ow2.asm:asm:4.0', 'asm:asm:3.0']
+        first                 | second                | failOnVersionConflict
+        'asm:asm:3.0'         | 'org.ow2.asm:asm:4.0' | false
+        'org.ow2.asm:asm:4.0' | 'asm:asm:3.0'         | false
+        'asm:asm:3.0'         | 'org.ow2.asm:asm:4.0' | true
+        'org.ow2.asm:asm:4.0' | 'asm:asm:3.0'         | true
     }
 
     /**
@@ -418,7 +435,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 fixConflict ? expectResolve() : expectGetMetadata()
             }
             'org:testA:1.0' {
-                if (!fixConflict) { expectGetMetadata() }
+                if (!fixConflict) {
+                    expectGetMetadata()
+                }
             }
         }
         if (fixConflict) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -33,11 +33,10 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CapabilitiesConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultCapabilitiesConflictHandler;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.LastCandidateCapabilityResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ModuleConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.PotentialConflict;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.UpgradeCapabilityResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
@@ -77,11 +76,13 @@ public class DependencyGraphBuilder {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
     private final ImmutableAttributesFactory attributesFactory;
-    private final DefaultCapabilitiesConflictHandler capabilitiesConflictHandler;
+    private final CapabilitiesConflictHandler capabilitiesConflictHandler;
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
-                                  ModuleConflictHandler moduleConflictHandler, Spec<? super DependencyMetadata> edgeFilter,
+                                  ModuleConflictHandler moduleConflictHandler,
+                                  CapabilitiesConflictHandler capabilitiesConflictHandler,
+                                  Spec<? super DependencyMetadata> edgeFilter,
                                   AttributesSchemaInternal attributesSchema,
                                   ModuleExclusions moduleExclusions,
                                   BuildOperationExecutor buildOperationExecutor, ModuleReplacementsData moduleReplacementsData,
@@ -99,14 +100,7 @@ public class DependencyGraphBuilder {
         this.dependencySubstitutionApplicator = dependencySubstitutionApplicator;
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributesFactory = attributesFactory;
-        this.capabilitiesConflictHandler = createCapabilitiesHandler();
-    }
-
-    private DefaultCapabilitiesConflictHandler createCapabilitiesHandler() {
-        DefaultCapabilitiesConflictHandler handler = new DefaultCapabilitiesConflictHandler();
-        handler.registerResolver(new UpgradeCapabilityResolver());
-        handler.registerResolver(new LastCandidateCapabilityResolver());
-        return handler;
+        this.capabilitiesConflictHandler = capabilitiesConflictHandler;
     }
 
     public void resolve(final ResolveContext resolveContext, final DependencyGraphVisitor modelVisitor) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultCapabilitiesConflictHandler
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictHandler
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
@@ -100,6 +101,9 @@ class DependencyGraphBuilderTest extends Specification {
         }
     }
 
+    def moduleConflictHandler = new DefaultConflictHandler(conflictResolver, moduleReplacements)
+    def capabilitiesConflictHandler = new DefaultCapabilitiesConflictHandler()
+
     DependencyGraphBuilder builder
 
     def setup() {
@@ -107,7 +111,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -554,7 +558,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, new DefaultConflictHandler(conflictResolver, moduleReplacements), spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
 
         def a = revision('a')
         def b = revision('b')


### PR DESCRIPTION
### Context

This is a follow up of #4639 , built on top of #4722. It makes capabilities conflict resolution honor the `failOnVersionConflict` configuration parameter.
