### PR TITLE
De-incubate Google repository

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -221,7 +221,6 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * @return the added resolver
      * @since 4.0
      */
-    @Incubating
     MavenArtifactRepository google();
 
     /**

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -46,7 +46,7 @@ The following are the features that have been promoted in this Gradle release.
 
 ### De-incubation of Google repository shortcut method
 
-The method `RepositoryHandler.google()` was introduced with Gradle 4.0. The Android community wholehearted started to use it and has become an essential building block of many Android builds. With this release of Gradle, the incubation status has been removed.
+The method `RepositoryHandler.google()` has been promoted.
 
 ## Fixed issues
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -44,6 +44,10 @@ The following are the features that have been promoted in this Gradle release.
 ### Example promoted
 -->
 
+### De-incubation of Google repository shortcut method
+
+The method `RepositoryHandler.google()` was introduced with Gradle 4.0. The Android community wholehearted started to use it and has become an essential building block of many Android builds. With this release of Gradle, the incubation status has been removed.
+
 ## Fixed issues
 
 ## Deprecations


### PR DESCRIPTION
### Context

The method was introduced with Gradle 4.0. After 6 releases and millions of Android users relying on it I think it's time to de-incubate.