### PR TITLE
Add function isFreeBsd() and isSolaris()

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -440,7 +440,7 @@ public abstract class OperatingSystem {
         protected String getArch() {
             String arch = System.getProperty("os.arch");
             if (arch.equals("i386") || arch.equals("x86")) {
-                return "i386";
+                return "x86";
             }
             return super.getArch();
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -105,6 +105,14 @@ public abstract class OperatingSystem {
         return false;
     }
 
+    public boolean isFreeBsd() {
+        return false;
+    }
+
+    public boolean isSolaris() {
+        return false;
+    }
+
     public abstract String getNativePrefix();
 
     public abstract String getScriptName(String scriptPath);
@@ -406,9 +414,18 @@ public abstract class OperatingSystem {
     }
 
     static class FreeBSD extends Unix {
+        @Override
+        public boolean isFreeBsd() {
+            return true;
+        }
     }
 
     static class Solaris extends Unix {
+        @Override
+        public boolean isSolaris() {
+            return true;
+        }
+
         @Override
         public String getFamilyName() {
             return "solaris";
@@ -423,7 +440,7 @@ public abstract class OperatingSystem {
         protected String getArch() {
             String arch = System.getProperty("os.arch");
             if (arch.equals("i386") || arch.equals("x86")) {
-                return "x86";
+                return "i386";
             }
             return super.getArch();
         }


### PR DESCRIPTION
Add function isFreeBsd() and isSolaris() + getArch() now always return 'i386' if on a 32b

### Context
<!--- Why do you believe many users will benefit from this change? -->
isWindows(), isLinux and isUnix() already exist... Why don't add the others?
isUnix() we still return true on FreeBSD and Solaris.

<!--- Link to relevant issues or forum discussions here -->
https://stackoverflow.com/questions/11235614/how-to-detect-the-current-os-from-gradle

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
