### PR TITLE
Fix link to building cpp libraries

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -105,7 +105,7 @@
                             <li><a class="nav-dropdown" data-toggle="collapse" href="#building-cpp-projects" aria-expanded="false" aria-controls="building-cpp-projects">C++</a>
                                 <ul id="building-cpp-projects">
                                     <li><a href="https://guides.gradle.org/building-cpp-executables/">Building C++ Executables</a></li>
-                                    <li><a href="https://guides.gradle.org/building-cpp-executables/">Building C++ Libraries</a></li>
+                                    <li><a href="https://guides.gradle.org/building-cpp-libraries/">Building C++ Libraries</a></li>
                                 </ul>
                             </li>
                             <li><a class="nav-dropdown" data-toggle="collapse" href="#building-groovy-projects" aria-expanded="false" aria-controls="building-groovy-projects">Groovy</a>


### PR DESCRIPTION
C++ entries were linking twice to build cpp executables.
Fixed the libraries entry to point to the right guide.