### PR TITLE
Use own cache directory for testkit sample

### DIFF
--- a/subprojects/docs/src/docs/userguide/testKit.adoc
+++ b/subprojects/docs/src/docs/userguide/testKit.adoc
@@ -233,3 +233,13 @@ To enable the <<build_cache,Build Cache>> in your tests, you can pass the `--bui
     <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="functional-test-build-cache"/>
 </sample>
 ++++
+
+Note that TestKit re-uses a Gradle user home between tests (see api:org.gradle.testkit.runner.GradleRunner#withTestKitDir[]) which contains the default location for the local build cache.
+For testing with the build cache, the build cache directory should be cleaned between tests.
+The easiest way to accomplish this is to configure the local build cache to us a temporary directory.
+
+++++
+<sample id="testKitFunctionalTestSpockBuildCacheCleanBuildCache" dir="testKit/gradleRunner/testKitFunctionalTestSpockBuildCache/src/test/groovy/org/gradle/sample" title="Clean build cache between tests">
+    <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="clean-build-cache"/>
+</sample>
+++++

--- a/subprojects/docs/src/samples/testKit/gradleRunner/testKitFunctionalTestSpockBuildCache/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/testKitFunctionalTestSpockBuildCache/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -27,9 +27,18 @@ class BuildLogicFunctionalTest extends Specification {
 
     @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
     File buildFile
+    File localBuildCacheDirectory
 
     def setup() {
         buildFile = testProjectDir.newFile('build.gradle')
+        localBuildCacheDirectory = testProjectDir.newFolder('local-cache')
+        testProjectDir.newFile('settings.gradle') << """
+            buildCache {
+                local {
+                    directory '${localBuildCacheDirectory.toURI().toString()}'
+                }
+            }
+        """
     }
 
     // START SNIPPET functional-test-build-cache

--- a/subprojects/docs/src/samples/testKit/gradleRunner/testKitFunctionalTestSpockBuildCache/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/testKitFunctionalTestSpockBuildCache/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -25,21 +25,23 @@ import static org.gradle.testkit.runner.TaskOutcome.*
 
 class BuildLogicFunctionalTest extends Specification {
 
+    // START SNIPPET clean-build-cache
     @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
     File buildFile
     File localBuildCacheDirectory
 
     def setup() {
-        buildFile = testProjectDir.newFile('build.gradle')
         localBuildCacheDirectory = testProjectDir.newFolder('local-cache')
         testProjectDir.newFile('settings.gradle') << """
             buildCache {
                 local {
-                    directory '${localBuildCacheDirectory.toURI().toString()}'
+                    directory '${localBuildCacheDirectory.toURI()}'
                 }
             }
         """
+        buildFile = testProjectDir.newFile('build.gradle')
     }
+    // END SNIPPET clean-build-cache
 
     // START SNIPPET functional-test-build-cache
     def "cacheableTask is loaded from cache"() {


### PR DESCRIPTION
The test would fail on the second run, since it would use the Gradle
user home test directory.
