### PR TITLE
Ensure that all children TestState are completed()

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
@@ -164,6 +164,10 @@ class TestNgTestClassExecutionResult implements TestClassExecutionResult {
         this
     }
 
+    int getTestSkippedCount() {
+        throw new UnsupportedOperationException("Unsupported.  Implement if you need it.")
+    }
+
     TestClassExecutionResult assertTestFailed(String name, Matcher<? super String>... messageMatchers) {
         def testMethodNode = findTestMethod(name)
         assert testMethodNode.@status as String == 'FAIL'

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
@@ -115,6 +115,15 @@ class DefaultTestExecutionResult implements TestExecutionResult {
             this
         }
 
+        int getTestSkippedCount() {
+            List<Integer> counts = testClassResults*.testSkippedCount
+            List<Integer> uniques = counts.unique()
+            if (uniques.size() == 1) {
+                return uniques.first()
+            }
+            throw new IllegalStateException("Multiple different test counts ${counts}")
+        }
+
         TestClassExecutionResult assertTestPassed(String name) {
             testClassResults*.assertTestPassed(removeParentheses(name))
             this

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -165,6 +165,10 @@ class HtmlTestExecutionResult implements TestExecutionResult {
             return this
         }
 
+        int getTestSkippedCount() {
+            return testsSkipped.size()
+        }
+
         TestClassExecutionResult assertTestPassed(String name) {
             assert testsSucceeded.contains(new TestCase(name))
             return this

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -157,6 +157,12 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
         return assertTestPassed(name)
     }
 
+    int getTestSkippedCount() {
+        return findTests().findAll { name, element ->
+            element."skipped".size() > 0 // Include only skipped test.
+        }.size()
+    }
+
     TestClassExecutionResult assertConfigMethodPassed(String name) {
         throw new UnsupportedOperationException();
     }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
@@ -33,6 +33,8 @@ public interface TestClassExecutionResult {
      */
     TestClassExecutionResult assertTestsSkipped(String... testNames);
 
+    int getTestSkippedCount();
+
     /**
      * Asserts that the given test passed.
      */

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessor.java
@@ -24,8 +24,8 @@ import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +55,7 @@ public class StateTrackingTestResultProcessor implements TestResultProcessor {
     }
 
     private void ensureChildrenCompleted(Object testId, long endTime) {
-        List<Object> incompleteChildren = new LinkedList<Object>();
+        List<Object> incompleteChildren = new ArrayList<Object>();
         for (Map.Entry<Object, TestState> entry : executing.entrySet()) {
             if (testId.equals(entry.getValue().startEvent.getParentId())) {
                 incompleteChildren.add(entry.getKey());

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
@@ -85,7 +85,7 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
         gradleHandle.waitForFailure()
         def result = new DefaultTestExecutionResult(testDirectory)
         result.testClass('pkg.FailedTest').assertTestFailed('failTest', Matchers.anything())
-        result.testClass('pkg.OtherTest').assertTestCount(0, 0, 0)
+        result.testClass('pkg.OtherTest').assertTestSkipped('passingTest')
 
         where:
         description       | taskList                   | buildConfig
@@ -109,8 +109,11 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
         gradleHandle.waitForFailure()
         def result = new DefaultTestExecutionResult(testDirectory)
         assert 1 == resourceForTest.keySet().count { result.testClassExists(it) && result.testClass(it).testFailed('failedTest', Matchers.anything()) }
-        assert 1 == resourceForTest.keySet().count { result.testClassExists(it) && result.testClass(it).testCount != 0 }
-        assert testOmitted >= resourceForTest.keySet().count { result.testClassExists(it) && result.testClass(it).testCount == 0 }
+        assert testOmitted == resourceForTest.keySet().with {
+            count { !result.testClassExists(it) } +
+                count { result.testClassExists(it) && result.testClass(it).testCount == 0 } +
+                count { result.testClassExists(it) && result.testClass(it).testSkippedCount == 1 }
+        }
 
         where:
         forkEvery | maxWorkers | testOmitted
@@ -161,6 +164,23 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
 
         testExecution.release(FAILED_RESOURCE)
         gradleHandle.waitForFailure()
+    }
+
+    def "fail fast works with --tests filter"() {
+        given:
+        buildFile.text = generator.initBuildFile()
+        def resourceForTest = generator.withFailingTests(5)
+        def testExecution = server.expectOptionalAndBlock(DEFAULT_MAX_WORKERS, resourceForTest.values() as String[])
+
+        when:
+        def gradleHandle = executer.withTasks('test', '--fail-fast', '--tests=*OtherTest_*').start()
+        testExecution.waitForAllPendingCalls()
+
+        then:
+        testExecution.release(DEFAULT_MAX_WORKERS)
+        gradleHandle.waitForFailure()
+
+        assert !gradleHandle.errorOutput.contains('No tests found for given includes:')
     }
 
     abstract String testAnnotationClass()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailFastIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailFastIntegrationTest.groovy
@@ -65,8 +65,11 @@ class TestNGFailFastIntegrationTest extends AbstractJvmFailFastIntegrationSpec {
         gradleHandle.waitForFailure()
         def result = new DefaultTestExecutionResult(testDirectory)
         assert 1 == resourceForTest.keySet().count { result.testClassExists(it) && result.testClass(it).testFailed('failedTest', Matchers.anything()) }
-        assert 1 == resourceForTest.keySet().count { result.testClassExists(it) && result.testClass(it).testCount != 0 }
-        assert 5 >= resourceForTest.keySet().count { result.testClassExists(it) && result.testClass(it).testCount == 0 }
+        assert 5 == resourceForTest.keySet().with {
+            count { !result.testClassExists(it) } +
+                count { result.testClassExists(it) && result.testClass(it).testCount == 0 } +
+                count { result.testClassExists(it) && result.testClass(it).testSkippedCount == 1 }
+        }
 
         where:
         parallel    | threadCount | maxWorkers


### PR DESCRIPTION
With fail fast for tests enabled, some of the `TestState`s tracked
by the `StateTrackingTestResultProcessor` may never receive the
`completed()` call.  When this happens, the parent/ancester
`TestState` will not include the test count and failure information.
When combined with a `--tests` filter, this can cause an erroneous
failure message that no tests matched the filter.

This change ensures that all of the children/descendents of a `testId`
(`TestState`) are `completed` before the given `testId` is processed.

Addresses:  #4718