### PR TITLE
Improve message for annotation processors on the compile classpath

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
@@ -31,11 +31,12 @@ import java.io.File;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
 public class AnnotationProcessorPathFactory {
-    public static final String COMPILE_CLASSPATH_DEPRECATION_MESSAGE = "Putting annotation processors on the compile classpath";
+    public static final String COMPILE_CLASSPATH_DEPRECATION_MESSAGE = "The following annotation processors were detected on the compile classpath:";
     public static final String PROCESSOR_PATH_DEPRECATION_MESSAGE = "Specifying the processor path in the CompilerOptions compilerArgs property";
 
     private final FileCollectionFactory fileCollectionFactory;
@@ -142,8 +143,15 @@ public class AnnotationProcessorPathFactory {
                     if (hasExplicitProcessor) {
                         return compileClasspath.getFiles();
                     }
-                    if (!annotationProcessorDetector.detectProcessors(compileClasspath).isEmpty()) {
-                        DeprecationLogger.nagUserOfDeprecated(COMPILE_CLASSPATH_DEPRECATION_MESSAGE, "Please add them to the processor path instead. If these processors were unintentionally leaked on the compile classpath, use the -proc:none compiler option to ignore them.");
+                    Map<String, AnnotationProcessorDeclaration> processors = annotationProcessorDetector.detectProcessors(compileClasspath);
+                    if (!processors.isEmpty()) {
+                        DeprecationLogger.nagUserWith(
+                            COMPILE_CLASSPATH_DEPRECATION_MESSAGE +
+                            " '" + Joiner.on("' and '").join(processors.keySet()) + "'. " +
+                            "Detecting annotation processors on the compile classpath is deprecated and Gradle 5.0 will ignore them. " +
+                            "Please add them to the annotation processor path instead. " +
+                            "If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them."
+                        );
                         return compileClasspath.getFiles();
                     }
                     return Collections.emptySet();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
@@ -30,6 +30,7 @@ import org.gradle.util.DeprecationLogger;
 import java.io.File;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 
@@ -55,7 +56,7 @@ public class AnnotationProcessorPathFactory {
      * @return An empty collection when annotation processing should not be performed, non-empty when it should.
      */
     public FileCollection getEffectiveAnnotationProcessorClasspath(final CompileOptions compileOptions, final FileCollection compileClasspath) {
-        if (compileOptions.getCompilerArgs().contains("-proc:none")) {
+        if (compileOptions.getAllCompilerArgs().contains("-proc:none")) {
             return fileCollectionFactory.empty("annotation processor path");
         }
         final FileCollection annotationProcessorPath = compileOptions.getAnnotationProcessorPath();
@@ -74,14 +75,15 @@ public class AnnotationProcessorPathFactory {
 
     private FileCollection getProcessorPathFromCompilerArguments(final CompileOptions compileOptions) {
         final FileCollection annotationProcessorPath = compileOptions.getAnnotationProcessorPath();
-        int pos = compileOptions.getCompilerArgs().indexOf("-processorpath");
+        List<String> compilerArgs = compileOptions.getAllCompilerArgs();
+        int pos = compilerArgs.indexOf("-processorpath");
         if (pos < 0) {
             return null;
         }
-        if (pos == compileOptions.getCompilerArgs().size() - 1) {
-            throw new InvalidUserDataException("No path provided for compiler argument -processorpath in requested compiler args: " + Joiner.on(" ").join(compileOptions.getCompilerArgs()));
+        if (pos == compilerArgs.size() - 1) {
+            throw new InvalidUserDataException("No path provided for compiler argument -processorpath in requested compiler args: " + Joiner.on(" ").join(compilerArgs));
         }
-        final String processorpath = compileOptions.getCompilerArgs().get(pos + 1);
+        final String processorpath = compilerArgs.get(pos + 1);
         if (annotationProcessorPath == null) {
             return fileCollectionFactory.fixed("annotation processor path", extractProcessorPath(processorpath));
         }
@@ -156,10 +158,11 @@ public class AnnotationProcessorPathFactory {
 
     private static boolean checkExplicitProcessorOption(CompileOptions compileOptions) {
         boolean hasExplicitProcessor = false;
-        int pos = compileOptions.getCompilerArgs().indexOf("-processor");
+        List<String> compilerArgs = compileOptions.getAllCompilerArgs();
+        int pos = compilerArgs.indexOf("-processor");
         if (pos >= 0) {
-            if (pos == compileOptions.getCompilerArgs().size() - 1) {
-                throw new InvalidUserDataException("No processor specified for compiler argument -processor in requested compiler args: " + Joiner.on(" ").join(compileOptions.getCompilerArgs()));
+            if (pos == compilerArgs.size() - 1) {
+                throw new InvalidUserDataException("No processor specified for compiler argument -processor in requested compiler args: " + Joiner.on(" ").join(compilerArgs));
             }
             hasExplicitProcessor = true;
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.util.CollectionUtils;
 import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
@@ -350,9 +351,7 @@ public class CompileOptions extends AbstractOptions {
     @Internal
     public List<String> getAllCompilerArgs() {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
-        for (CharSequence arg : getCompilerArgs()) {
-            builder.add(arg.toString());
-        }
+        builder.addAll(CollectionUtils.stringize(getCompilerArgs()));
         for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders()) {
             builder.addAll(compilerArgumentProvider.asArguments());
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -350,7 +350,9 @@ public class CompileOptions extends AbstractOptions {
     @Internal
     public List<String> getAllCompilerArgs() {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
-        builder.addAll(getCompilerArgs());
+        for (CharSequence arg : getCompilerArgs()) {
+            builder.add(arg.toString());
+        }
         for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders()) {
             builder.addAll(compilerArgumentProvider.asArguments());
         }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -213,4 +213,12 @@ class CompileOptionsTest extends Specification {
         then:
         compileOptions.bootClasspath == "lib2.jar"
     }
+
+    def "converts GStrings to Strings when getting all compiler arguments"() {
+        given:
+        compileOptions.compilerArgs << "Foo${23}"
+
+        expect:
+        compileOptions.allCompilerArgs.contains('Foo23')
+    }
 }


### PR DESCRIPTION
Fixes #4730 and gives users more details on what is deprecated and how to work around it.