### PR TITLE
Cleanup wrapper install logging

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -16,17 +16,19 @@
 
 package org.gradle.integtests
 
+import org.gradle.integtests.fixtures.executer.ExecutionFailure
+import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.test.fixtures.file.TestFile
+
 class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
 
     def setup() {
         executer.withWelcomeMessageEnabled()
+        file("build.gradle") << "task emptyTask"
     }
 
     def "wrapper only renders welcome message when executed in quiet mode"() {
         given:
-        file("build.gradle") << """
-task emptyTask
-        """
         prepareWrapper()
 
         when:
@@ -42,5 +44,43 @@ task emptyTask
 
         then:
         result.output.empty
+    }
+
+    def "wrapper logs and continues when there is a problem setting permissions"() {
+        given: "malformed distribution"
+        // Repackage distribution with bin/gradle removed so permissions cannot be set
+        TestFile tempUnzipDir = temporaryFolder.createDir("temp-unzip")
+        distribution.binDistribution.unzipTo(tempUnzipDir)
+        assert tempUnzipDir.file("gradle-${distribution.version.version}", "bin", "gradle").delete()
+        TestFile tempZipDir = temporaryFolder.createDir("temp-zip-foo")
+        TestFile malformedDistZip = new TestFile(tempZipDir, "gradle-${distribution.version.version}-bin.zip")
+        tempUnzipDir.zipTo(malformedDistZip)
+        prepareWrapper(malformedDistZip.toURI())
+
+        when:
+        ExecutionResult result = wrapperExecuter
+            .withTasks("emptyTask")
+            .run()
+
+        then:
+        result.assertOutputContains("Could not set executable permissions")
+        result.assertOutputContains("Please do this manually if you want to use the Gradle UI.")
+    }
+
+    def "wrapper prints error and fails build if downloaded zip is empty"() {
+        given: "empty distribution"
+        TestFile tempUnzipDir = temporaryFolder.createDir("empty-distribution")
+        TestFile malformedDistZip = new TestFile(tempUnzipDir, "gradle-${distribution.version.version}-bin.zip") << ""
+        prepareWrapper(malformedDistZip.toURI())
+
+        when:
+        ExecutionFailure failure = wrapperExecuter
+            .withTasks("emptyTask")
+            .withStackTraceChecksDisabled()
+            .runWithFailure()
+
+        then:
+        failure.assertOutputContains("Could not unzip")
+        failure.assertNotOutput("Could not set executable permissions")
     }
 }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -71,8 +71,13 @@ public class Install {
 
                 verifyDownloadChecksum(configuration.getDistribution().toString(), localZipFile, distributionSha256Sum);
 
-                logger.log("Unzipping " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath());
-                unzip(localZipFile, distDir);
+                try {
+                    unzip(localZipFile, distDir);
+                } catch (IOException e) {
+                    logger.log("Could not unzip " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath() + ".");
+                    logger.log("Reason: " + e.getMessage());
+                    throw e;
+                }
 
                 File root = getAndVerifyDistributionRoot(distDir, safeDistributionUrl.toString());
                 setExecutablePermissions(root);
@@ -84,7 +89,7 @@ public class Install {
     }
 
     private String calculateSha256Sum(File file)
-            throws Exception {
+        throws Exception {
         MessageDigest md = MessageDigest.getInstance("SHA-256");
         InputStream fis = new FileInputStream(file);
         int n = 0;
@@ -98,8 +103,8 @@ public class Install {
         byte byteData[] = md.digest();
 
         StringBuffer hexString = new StringBuffer();
-        for (int i=0; i < byteData.length; i++) {
-            String hex=Integer.toHexString(0xff & byteData[i]);
+        for (int i = 0; i < byteData.length; i++) {
+            String hex = Integer.toHexString(0xff & byteData[i]);
             if (hex.length() == 1) {
                 hexString.append('0');
             }
@@ -110,7 +115,7 @@ public class Install {
     }
 
     private File getAndVerifyDistributionRoot(File distDir, String distributionDescription)
-            throws Exception {
+        throws Exception {
         List<File> dirs = listDirs(distDir);
         if (dirs.isEmpty()) {
             throw new RuntimeException(String.format("Gradle distribution '%s' does not contain any directories. Expected to find exactly 1 directory.", distributionDescription));
@@ -165,9 +170,7 @@ public class Install {
         try {
             ProcessBuilder pb = new ProcessBuilder("chmod", "755", gradleCommand.getCanonicalPath());
             Process p = pb.start();
-            if (p.waitFor() == 0) {
-                logger.log("Set executable permissions for: " + gradleCommand.getAbsolutePath());
-            } else {
+            if (p.waitFor() != 0) {
                 BufferedReader is = new BufferedReader(new InputStreamReader(p.getInputStream()));
                 Formatter stdout = new Formatter();
                 String line;
@@ -213,7 +216,6 @@ public class Install {
     private void unzip(File zip, File dest) throws IOException {
         Enumeration entries;
         ZipFile zipFile = new ZipFile(zip);
-
         try {
             entries = zipFile.entries();
 


### PR DESCRIPTION
Only print anything about ZIP files and file permissions if there was a problem

Supersedes #4706

### Before

```
Downloading https://services.gradle.org/distributions/gradle-4.6-bin.zip
........................................................................
Unzipping /Users/eric/.gradle/wrapper/dists/gradle-4.6-bin/6nscg4yape751pc62922nodvq/gradle-4.6-bin.zip to /Users/eric/.gradle/wrapper/dists/gradle-4.6-bin/6nscg4yape751pc62922nodvq
Set executable permissions for: /Users/eric/.gradle/wrapper/dists/gradle-4.6-bin/6nscg4yape751pc62922nodvq/gradle-4.6/bin/gradle
Starting a Gradle Daemon (subsequent builds will be faster)
Generating JAR file 'gradle-api-4.6.jar'
<other logs>
```

### After

```
Downloading https://services.gradle.org/distributions/gradle-4.7-bin.zip
........................................................................

Starting a Gradle Daemon (subsequent builds will be faster)
Generating JAR file 'gradle-api-4.6.jar'
<other logs>
```

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
