### PR TITLE
Pay down some logging and test fixture related debt

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -263,7 +263,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         and:
         succeeds "checkstyleMain"
         then:
-        result.executedTasks.contains(":checkstyleMain")
+        result.assertTaskExecuted(":checkstyleMain")
     }
 
     def "can change built-in config_loc"() {
@@ -282,7 +282,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         succeeds "checkstyleMain"
         then:
         suppressionsXml.assertDoesNotExist()
-        result.executedTasks.contains(":checkstyleMain")
+        result.assertTaskExecuted(":checkstyleMain")
 
         when:
         file("config/checkstyle/newFile.xml") << "<!-- This is a new file -->"
@@ -311,7 +311,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         succeeds "checkstyleMain"
         then:
         result.assertOutputContains("Adding 'config_loc' to checkstyle.configProperties has been deprecated and is scheduled to be removed in Gradle 5.0. Use checkstyle.configDir instead as this will behave better with up-to-date checks.")
-        result.executedTasks.contains(":checkstyleMain")
+        result.assertTaskExecuted(":checkstyleMain")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2326")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -98,15 +98,9 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
     }
 
     protected void executed(String... tasks) {
-        def executedTasks = result.executedTasks
         for (String task : tasks) {
-            containsOnce(executedTasks, task)
+            result.assertTaskExecuted(task)
         }
-    }
-
-    protected static void containsOnce(List<String> tasks, String task) {
-        assert tasks.contains(task)
-        assert tasks.findAll({ it == task }).size() == 1
     }
 
     void assertTaskExecuted(String build, String taskPath) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
@@ -182,7 +182,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         def executedTasks = result.executedTasks
         def beforeTask
         for (String task : tasks) {
-            containsOnce(executedTasks, task)
+            result.assertTaskExecuted(task)
 
             if (beforeTask != null) {
                 assert executedTasks.indexOf(beforeTask) < executedTasks.indexOf(task) : "task ${beforeTask} must be executed before ${task}"

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
@@ -696,7 +696,7 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         def executedTasks = result.executedTasks
         def beforeTask
         for (String task : tasks) {
-            containsOnce(executedTasks, task)
+            result.assertTaskExecuted(task)
 
             if (beforeTask != null) {
                 assert executedTasks.indexOf(beforeTask) < executedTasks.indexOf(task) : "task ${beforeTask} must be executed before ${task}"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -356,7 +356,7 @@ project(':api') {
         run(":b:buildNeeded")
 
         then:
-        result.executedTasks.containsAll ':b:buildNeeded', ':a:buildNeeded'
+        executed ':b:buildNeeded', ':a:buildNeeded'
         fixture.assertProjectsConfigured(":", ":b", ":a")
     }
 
@@ -374,7 +374,7 @@ project(':api') {
         run(":a:buildDependents")
 
         then:
-        result.executedTasks.containsAll ':b:buildDependents', ':a:buildDependents'
+        executed ':b:buildDependents', ':a:buildDependents'
         //unfortunately buildDependents requires all projects to be configured
         fixture.assertProjectsConfigured(":", ":a", ":b", ":c")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -685,7 +685,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         cleanBuildDir()
         withBuildCache().run "consumer"
         then:
-        skippedTasks.sort() == [":consumer", ":producer"]
+        result.assertTasksSkipped(":consumer", ":producer")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3043")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -132,7 +132,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         when:
         TestFile.Snapshot aSnapshot = outputFileA.snapshot()
@@ -147,7 +147,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         outputFileA.assertHasNotChangedSince(aSnapshot)
         outputFileB.assertHasNotChangedSince(bSnapshot)
@@ -158,7 +158,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         outputFileA.assertHasNotChangedSince(aSnapshot)
         outputFileB.assertHasNotChangedSince(bSnapshot)
@@ -169,7 +169,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         outputFileA.assertHasChangedSince(aSnapshot)
         outputFileB.assertHasChangedSince(bSnapshot)
@@ -180,7 +180,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change input content, different length
         when:
@@ -188,7 +188,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         outputFileA.assertHasChangedSince(aSnapshot)
         outputFileB.assertHasChangedSince(bSnapshot)
@@ -199,7 +199,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Delete intermediate output file
         when:
@@ -207,8 +207,8 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
 
         outputFileA.text == '[new content]'
         outputFileB.text == '[[new content]]'
@@ -219,8 +219,8 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":b"]
-        skippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":b")
+        result.assertTasksSkipped(":a")
 
         outputFileA.text == '[new content]'
         outputFileB.text == '[[new content]]'
@@ -229,7 +229,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change intermediate output file, different length
         when:
@@ -237,8 +237,8 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
 
         outputFileA.text == '[new content]'
         outputFileB.text == '[[new content]]'
@@ -247,7 +247,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change intermediate output file timestamp, same content
         when:
@@ -255,7 +255,7 @@ apply from: 'changes.gradle'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change input file location
         when:
@@ -266,15 +266,15 @@ a.inputFile = file('new-a-input.txt')
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
         outputFileA.text == '[new content]'
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change final output file destination
         when:
@@ -285,8 +285,8 @@ b.outputFile = file('new-output.txt')
         outputFileB = file('new-output.txt')
 
         then:
-        skippedTasks.sort() == [":a"]
-        nonSkippedTasks.sort() == [":b"]
+        result.assertTasksSkipped(":a")
+        result.assertTasksNotSkipped(":b")
 
         outputFileB.text == '[[new content]]'
 
@@ -294,7 +294,7 @@ b.outputFile = file('new-output.txt')
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change intermediate output file destination
         when:
@@ -306,14 +306,14 @@ b.inputFile = a.outputFile
         outputFileA = file('new-a-output.txt')
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
         outputFileA.text == '[new content]'
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change an input property of the first task (the content format)
         when:
@@ -323,7 +323,7 @@ a.format = '- %s -'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         outputFileA.text == '- new content -'
         outputFileB.text == '[- new content -]'
@@ -332,14 +332,14 @@ a.format = '- %s -'
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Run with --rerun-tasks command-line options
         when:
         succeeds "b", "--rerun-tasks"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         // Output files already exist before using this version of Gradle
         // delete .gradle dir to simulate this
@@ -350,21 +350,21 @@ a.format = '- %s -'
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         when:
         outputFileB.delete()
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":b"]
-        skippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":b")
+        result.assertTasksSkipped(":a")
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
     }
 
     def "skips task when output dir contents are up-to-date"() {
@@ -387,7 +387,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         when:
         TestFile outputAFile = file('build/a/file1.txt')
@@ -404,7 +404,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
         outputAFile.assertHasNotChangedSince(aSnapshot)
         outputBFile.assertHasNotChangedSince(bSnapshot)
 
@@ -414,7 +414,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         outputAFile.assertHasChangedSince(aSnapshot)
         outputBFile.assertHasChangedSince(bSnapshot)
@@ -425,7 +425,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change input content, different length
         when:
@@ -433,7 +433,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         outputAFile.assertHasChangedSince(aSnapshot)
         outputBFile.assertHasChangedSince(bSnapshot)
@@ -444,7 +444,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Add input file
         when:
@@ -452,7 +452,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         file('build/a/file2.txt').text == '[content2]'
         file('build/b/file2.txt').text == '[[content2]]'
@@ -461,7 +461,7 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Remove input file
         when:
@@ -469,14 +469,14 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Change intermediate output file, different length
         when:
@@ -484,15 +484,15 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
         outputAFile.text == '[new content]'
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Remove intermediate output file
         when:
@@ -500,15 +500,15 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
         outputAFile.text == '[new content]'
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Output files already exist before using this version of Gradle
         // delete .gradle dir to simulate this
@@ -519,21 +519,21 @@ task b(type: DirTransformerTask, dependsOn: a) {
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         when:
         file('build/b').deleteDir()
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":b"]
-        skippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":b")
+        result.assertTasksSkipped(":a")
 
         when:
         succeeds "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
     }
 
     def "notices changes to input files where the file length does not change"() {
@@ -606,19 +606,19 @@ task a(type: GeneratorTask) {
         succeeds "a", "-Ptext=text"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":a")
 
         when:
         succeeds "a", "-Ptext=text"
 
         then:
-        skippedTasks.sort() == [":a"]
+        result.assertTasksSkipped(":a")
 
         when:
         succeeds "a", "-Ptext=newtext"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":a")
     }
 
     def "multiple tasks can generate into overlapping output directories"() {
@@ -642,14 +642,14 @@ task b(type: DirTransformerTask) {
         succeeds "a", "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         // No changes
         when:
         succeeds "a", "b"
 
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
 
         // Delete an output file
         when:
@@ -657,8 +657,8 @@ task b(type: DirTransformerTask) {
         succeeds "a", "b"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
-        skippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksSkipped(":b")
 
         // Change an output file
         when:
@@ -666,8 +666,8 @@ task b(type: DirTransformerTask) {
         succeeds "a", "b"
 
         then:
-        nonSkippedTasks.sort() == [":b"]
-        skippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":b")
+        result.assertTasksSkipped(":a")
 
         // Output files already exist before using this version of Gradle
         // Simulate this by removing the .gradle dir
@@ -678,20 +678,20 @@ task b(type: DirTransformerTask) {
         succeeds "a", "b"
 
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         when:
         file('build').deleteDir()
         succeeds "a"
 
         then:
-        nonSkippedTasks.sort() == [":a"]
+        result.assertTasksNotSkipped(":a")
 
         when:
         succeeds "b"
 
         then:
-        nonSkippedTasks.sort() == [":b"]
+        result.assertTasksNotSkipped(":b")
     }
 
     def "can use up-to-date predicate to force task to execute"() {
@@ -725,7 +725,7 @@ task nothing {
         succeeds "inputsAndOutputs"
 
         then:
-        nonSkippedTasks.sort() == [":inputsAndOutputs"]
+        result.assertTasksNotSkipped(":inputsAndOutputs")
 
         // Is up to date
 
@@ -733,7 +733,7 @@ task nothing {
         succeeds "inputsAndOutputs", '-Puptodate'
 
         then:
-        skippedTasks.sort() == [":inputsAndOutputs"]
+        result.assertTasksSkipped(":inputsAndOutputs")
 
         // Changed input file
         when:
@@ -741,28 +741,28 @@ task nothing {
         succeeds "inputsAndOutputs", '-Puptodate'
 
         then:
-        nonSkippedTasks.sort() == [":inputsAndOutputs"]
+        result.assertTasksNotSkipped(":inputsAndOutputs")
 
         // Predicate is false
         when:
         succeeds "inputsAndOutputs"
 
         then:
-        nonSkippedTasks.sort() == [":inputsAndOutputs"]
+        result.assertTasksNotSkipped(":inputsAndOutputs")
 
         // Task with input files and a predicate
         when:
         succeeds "noOutputs"
 
         then:
-        nonSkippedTasks.sort() == [":noOutputs"]
+        result.assertTasksNotSkipped(":noOutputs")
 
         // Is up to date
         when:
         succeeds "noOutputs", "-Puptodate"
 
         then:
-        skippedTasks.sort() == [":noOutputs"]
+        result.assertTasksSkipped(":noOutputs")
 
         // Changed input file
         when:
@@ -770,35 +770,35 @@ task nothing {
         succeeds "noOutputs", "-Puptodate"
 
         then:
-        nonSkippedTasks.sort() == [":noOutputs"]
+        result.assertTasksNotSkipped(":noOutputs")
 
         // Predicate is false
         when:
         succeeds "noOutputs"
 
         then:
-        nonSkippedTasks.sort() == [":noOutputs"]
+        result.assertTasksNotSkipped(":noOutputs")
 
         // Task a predicate only
         when:
         succeeds "nothing"
 
         then:
-        nonSkippedTasks.sort() == [":nothing"]
+        result.assertTasksNotSkipped(":nothing")
 
         // Is up to date
         when:
         succeeds "nothing", "-Puptodate"
 
         then:
-        skippedTasks.sort() == [":nothing"]
+        result.assertTasksSkipped(":nothing")
 
         // Predicate is false
         when:
         succeeds "nothing"
 
         then:
-        nonSkippedTasks.sort() == [":nothing"]
+        result.assertTasksNotSkipped(":nothing")
     }
 
     def "lifecycle task is up-to-date when all dependencies are skipped"() {
@@ -817,12 +817,12 @@ task b(dependsOn: a)
         when:
         succeeds "b"
         then:
-        nonSkippedTasks.sort() == [":a", ":b"]
+        result.assertTasksNotSkipped(":a", ":b")
 
         when:
         succeeds "b"
         then:
-        skippedTasks.sort() == [":a", ":b"]
+        result.assertTasksSkipped(":a", ":b")
     }
 
     def "can share artifacts between builds"() {
@@ -850,13 +850,13 @@ task generate(type: TransformerTask) {
         when:
         succeeds "transform"
         then:
-        nonSkippedTasks.sort() == [":build:generate", ":otherBuild", ':transform']
+        result.assertTasksNotSkipped(":build:generate", ":otherBuild", ':transform')
 
         when:
         succeeds "transform"
         then:
-        nonSkippedTasks.sort() == [":otherBuild"]
-        skippedTasks.sort() == [":build:generate", ":transform"]
+        result.assertTasksNotSkipped(":otherBuild")
+        result.assertTasksSkipped(":build:generate", ":transform")
     }
 
     def "task can have outputs and no inputs"() {
@@ -879,7 +879,7 @@ task generate(type: TransformerTask) {
         succeeds "a"
 
         then:
-        nonSkippedTasks.sort() == [':a']
+        result.assertTasksNotSkipped(':a')
         def outputFile = file('output.txt')
         outputFile.text == 'output-file'
 
@@ -888,7 +888,7 @@ task generate(type: TransformerTask) {
         succeeds "a"
 
         then:
-        skippedTasks.sort() == [':a']
+        result.assertTasksSkipped(':a')
 
         // Remove output file
         when:
@@ -896,14 +896,14 @@ task generate(type: TransformerTask) {
         succeeds "a"
 
         then:
-        nonSkippedTasks.sort() == [':a']
+        result.assertTasksNotSkipped(':a')
         outputFile.text == 'output-file'
 
         when:
         succeeds "a"
 
         then:
-        skippedTasks.sort() == [':a']
+        result.assertTasksSkipped(':a')
 
         // Change output file
         when:
@@ -911,14 +911,14 @@ task generate(type: TransformerTask) {
         succeeds "a"
 
         then:
-        nonSkippedTasks.sort() == [':a']
+        result.assertTasksNotSkipped(':a')
         outputFile.text == 'output-file'
 
         when:
         succeeds "a"
 
         then:
-        skippedTasks.sort() == [':a']
+        result.assertTasksSkipped(':a')
     }
 
     def "task can have inputs and no outputs"() {
@@ -942,7 +942,7 @@ task generate(type: TransformerTask) {
         succeeds "a"
 
         then:
-        nonSkippedTasks.sort() == [':a']
+        result.assertTasksNotSkipped(':a')
         outputContains("file name: input.txt content: 'input-file'")
 
         // No changes
@@ -950,7 +950,7 @@ task generate(type: TransformerTask) {
         succeeds "a"
 
         then:
-        nonSkippedTasks.sort() == [':a']
+        result.assertTasksNotSkipped(':a')
         outputContains("file name: input.txt content: 'input-file'")
     }
 
@@ -1054,7 +1054,7 @@ task generate(type: TransformerTask) {
         succeeds "b", "b2"
 
         then:
-        nonSkippedTasks.sort() == [':a', ':b', ':b2']
+        result.assertTasksNotSkipped(':a', ':b', ':b2')
         output.contains "Task 'b' file 'output.txt' with 'output-file'"
         output.contains "Task 'b2' file 'output.txt' with 'output-file'"
 
@@ -1062,8 +1062,8 @@ task generate(type: TransformerTask) {
         succeeds "b", "b2"
 
         then:
-        skippedTasks.sort() == [':a']
-        nonSkippedTasks.sort() == [':b', ':b2']
+        result.assertTasksSkipped(':a')
+        result.assertTasksNotSkipped(':b', ':b2')
         output.contains "Task 'b' file 'output.txt' with 'output-file'"
         output.contains "Task 'b2' file 'output.txt' with 'output-file'"
     }

--- a/subprojects/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuterIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuterIntegrationTest.groovy
@@ -23,6 +23,8 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static org.gradle.util.TextUtil.normaliseLineSeparators
+
 class InProcessGradleExecuterIntegrationTest extends Specification {
     @Rule
     RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
@@ -71,14 +73,14 @@ class InProcessGradleExecuterIntegrationTest extends Specification {
 
         and:
         outputs.stdOut.contains("BEFORE OUT")
-        outputs.stdOut.contains(result1.output)
-        outputs.stdOut.contains(result2.output)
+        normaliseLineSeparators(outputs.stdOut).contains(result1.output)
+        normaliseLineSeparators(outputs.stdOut).contains(result2.output)
         outputs.stdOut.contains("AFTER OUT")
 
         and:
         outputs.stdErr.contains("BEFORE ERR")
-        outputs.stdOut.contains(result1.error)
-        outputs.stdOut.contains(result2.error)
+        normaliseLineSeparators(outputs.stdOut).contains(result1.error)
+        normaliseLineSeparators(outputs.stdOut).contains(result2.error)
         outputs.stdErr.contains("AFTER ERR")
 
         where:

--- a/subprojects/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuterIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuterIntegrationTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.RedirectStdOutAndErr
+import org.junit.Rule
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class InProcessGradleExecuterIntegrationTest extends Specification {
+    @Rule
+    RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
+    @Rule
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    def distribution = new UnderDevelopmentGradleDistribution(IntegrationTestBuildContext.INSTANCE)
+    def executer = new GradleContextualExecuter(distribution, temporaryFolder, IntegrationTestBuildContext.INSTANCE)
+
+    @Unroll
+    def "can write to System.out and System.err around build invocation with #console console"() {
+        given:
+        temporaryFolder.file("settings.gradle") << '''
+            // Use System.out and System.err in the build
+            println("settings out 1")
+            System.out.println("settings out 2")
+            System.err.println("settings err 1")
+        '''
+
+        when:
+        System.out.println("BEFORE OUT")
+        System.err.println("BEFORE ERR")
+
+        def result1 = executer
+            .inDirectory(temporaryFolder.testDirectory)
+            .withTasks("help")
+            .withConsole(console)
+            .run()
+
+        System.out.println("AFTER OUT")
+        System.err.println("AFTER ERR")
+
+        def result2 = executer
+            .inDirectory(temporaryFolder.testDirectory)
+            .withTasks("help")
+            .withConsole(console)
+            .run()
+
+        then:
+        [result1, result2].each {
+            it.assertNotOutput("BEFORE")
+            it.assertNotOutput("AFTER")
+            it.assertOutputContains("settings out 1")
+            it.assertOutputContains("settings out 2")
+            it.assertHasErrorOutput("settings err 1")
+        }
+
+        and:
+        outputs.stdOut.contains("BEFORE OUT")
+        outputs.stdOut.contains(result1.output)
+        outputs.stdOut.contains(result2.output)
+        outputs.stdOut.contains("AFTER OUT")
+
+        and:
+        outputs.stdErr.contains("BEFORE ERR")
+        outputs.stdOut.contains(result1.error)
+        outputs.stdOut.contains(result2.error)
+        outputs.stdErr.contains("AFTER ERR")
+
+        where:
+        console << [ConsoleOutput.Plain, ConsoleOutput.Rich, ConsoleOutput.Verbose]
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -206,33 +206,26 @@ class AbstractIntegrationSpec extends Specification {
 
     protected void executedAndNotSkipped(String... tasks) {
         tasks.each {
-            assert it in executedTasks
-            assert !skippedTasks.contains(it)
+            result.assertTaskNotSkipped(it)
         }
     }
 
     protected void skipped(String... tasks) {
         tasks.each {
-            assert it in executedTasks
-            assert skippedTasks.contains(it)
+            result.assertTaskSkipped(it)
         }
     }
 
     protected void notExecuted(String... tasks) {
         tasks.each {
-            assert !(it in executedTasks)
+            result.assertTaskNotExecuted(it)
         }
     }
 
     protected void executed(String... tasks) {
         tasks.each {
-            assert (it in executedTasks)
+            result.assertTaskExecuted(it)
         }
-    }
-
-    protected void assertTaskOrder(Object... tasks) {
-        assertHasResult()
-        result.assertTaskOrder(tasks)
     }
 
     protected void failureHasCause(String cause) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -44,13 +44,10 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.DefaultLoggingManagerFactory;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.logging.sink.ConsoleStateUtil;
-import org.gradle.internal.logging.sink.OutputEventRenderer;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
-import org.gradle.internal.time.Clock;
-import org.gradle.internal.time.Time;
 import org.gradle.launcher.daemon.configuration.DaemonBuildOptions;
 import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
@@ -63,7 +60,6 @@ import org.gradle.util.GradleVersion;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.Charset;
@@ -78,7 +74,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.*;
+import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.DAEMON;
+import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.FOREGROUND;
+import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NOT_DEFINED;
+import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NO_DAEMON;
 import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.STACK_TRACE_ELEMENT;
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES;
 import static org.gradle.util.CollectionUtils.collect;
@@ -1356,49 +1355,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     }
 
     private static LoggingServiceRegistry newCommandLineProcessLogging() {
-        LoggingServiceRegistry loggingServices = new LoggingServiceRegistry() {
-            @Override
-            protected OutputEventRenderer makeOutputEventRenderer() {
-                return new VerboseAwareOutputEventRenderer(Time.clock());
-            }
-        };
+        LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newEmbeddableLogging();
         LoggingManagerInternal rootLoggingManager = loggingServices.get(DefaultLoggingManagerFactory.class).getRoot();
         rootLoggingManager.captureSystemSources();
         rootLoggingManager.attachSystemOutAndErr();
         return loggingServices;
-    }
-
-    private static class VerboseAwareOutputEventRenderer extends OutputEventRenderer {
-        VerboseAwareOutputEventRenderer(Clock clock) {
-            super(clock);
-        }
-
-        @Override
-        public void attachAnsiConsole(OutputStream outputStream) {
-            if (outputStream instanceof VerboseAwareAnsiOutputStream) {
-                attachAnsiConsole(outputStream, VerboseAwareAnsiOutputStream.class.cast(outputStream).isVerbose());
-            } else {
-                super.attachAnsiConsole(outputStream);
-            }
-        }
-    }
-
-    protected static class VerboseAwareAnsiOutputStream extends OutputStream {
-        private final OutputStream delegate;
-        private boolean verbose;
-
-        VerboseAwareAnsiOutputStream(OutputStream delegate, boolean verbose) {
-            this.delegate = delegate;
-            this.verbose = verbose;
-        }
-
-        public boolean isVerbose() {
-            return verbose;
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            delegate.write(b);
-        }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1357,7 +1357,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private static LoggingServiceRegistry newCommandLineProcessLogging() {
         LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newEmbeddableLogging();
         LoggingManagerInternal rootLoggingManager = loggingServices.get(DefaultLoggingManagerFactory.class).getRoot();
-        rootLoggingManager.captureSystemSources();
+//        rootLoggingManager.captureSystemSources();
         rootLoggingManager.attachSystemOutAndErr();
         return loggingServices;
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -37,6 +37,8 @@ public interface ExecutionResult {
      *     <li>Removes notice about starting the daemon.</li>
      *     <li>Normalizes build time to 1 second.
      * </ul>
+     *
+     * <p>You should avoid using this method as it couples the tests to a particular layout for the console. Instead use the more descriptive assertion methods.</p>
      */
     String getNormalizedOutput();
 
@@ -90,7 +92,9 @@ public interface ExecutionResult {
     ExecutionResult assertHasPostBuildOutput(String expectedOutput);
 
     /**
-     * Returns the tasks have been executed in order (includes tasks that were skipped). Note: ignores buildSrc tasks.
+     * Returns the tasks have been executed in order started (includes tasks that were skipped). Note: ignores buildSrc tasks.
+     *
+     * <p>You should avoid using this method, as as doing so not provide useful context on assertion failure. Instead, use the more descriptive assertion methods
      */
     List<String> getExecutedTasks();
 
@@ -115,6 +119,8 @@ public interface ExecutionResult {
 
     /**
      * Returns the tasks that were skipped, in an undefined order. Note: ignores buildSrc tasks.
+     *
+     * <p>You should avoid using this method, as as doing so not provide useful context on assertion failure. Instead, use the more descriptive assertion methods
      */
     Set<String> getSkippedTasks();
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -92,7 +92,7 @@ public interface ExecutionResult {
     ExecutionResult assertHasPostBuildOutput(String expectedOutput);
 
     /**
-     * Returns the tasks have been executed in order started (includes tasks that were skipped). Note: ignores buildSrc tasks.
+     * Returns the tasks have been executed in order started (includes tasks that were skipped). Asserts that each task appears once only. Note: ignores buildSrc tasks.
      *
      * <p>You should avoid using this method, as as doing so not provide useful context on assertion failure. Instead, use the more descriptive assertion methods
      */
@@ -109,6 +109,16 @@ public interface ExecutionResult {
      * Asserts that exactly the given set of tasks have been executed in any order. Note: ignores buildSrc tasks.
      */
     ExecutionResult assertTasksExecuted(Object... taskPaths);
+
+    /**
+     * Asserts that the given task has been executed. Note: ignores buildSrc tasks.
+     */
+    ExecutionResult assertTaskExecuted(String taskPath);
+
+    /**
+     * Asserts that the given task has not been executed. Note: ignores buildSrc tasks.
+     */
+    ExecutionResult assertTaskNotExecuted(String taskPath);
 
     /**
      * Asserts that the provided tasks were executed in the given order.  Each task path can be either a String

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -555,9 +555,6 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         @Override
         public ExecutionResult assertTasksSkipped(Object... taskPaths) {
-            if (GradleContextualExecuter.isParallel()) {
-                return this;
-            }
             Set<String> expected = new HashSet<String>(flattenTaskPaths(taskPaths));
             assertThat(skippedTasks, equalTo(expected));
             outputResult.assertTasksSkipped(expected);
@@ -565,9 +562,6 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         }
 
         public ExecutionResult assertTaskSkipped(String taskPath) {
-            if (GradleContextualExecuter.isParallel()) {
-                return this;
-            }
             assertThat(skippedTasks, hasItem(taskPath));
             outputResult.assertTaskSkipped(taskPath);
             return this;
@@ -575,9 +569,6 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
 
         @Override
         public ExecutionResult assertTasksNotSkipped(Object... taskPaths) {
-            if (GradleContextualExecuter.isParallel()) {
-                return this;
-            }
             Set<String> expected = new HashSet<String>(flattenTaskPaths(taskPaths));
             Set<String> notSkipped = getNotSkippedTasks();
             assertThat(notSkipped, equalTo(expected));
@@ -586,9 +577,6 @@ public class InProcessGradleExecuter extends AbstractGradleExecuter {
         }
 
         public ExecutionResult assertTaskNotSkipped(String taskPath) {
-            if (GradleContextualExecuter.isParallel()) {
-                return this;
-            }
             assertThat(getNotSkippedTasks(), hasItem(taskPath));
             outputResult.assertTaskNotSkipped(taskPath);
             return this;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -64,10 +64,20 @@ public class LogContent {
         return new LogContent(ImmutableList.copyOf(lines), false);
     }
 
+    /**
+     * Creates a new instance from a sequence of lines (without the line separators).
+     */
+    public static LogContent of(List<String> lines) {
+        return new LogContent(ImmutableList.copyOf(lines), false);
+    }
+
     public static LogContent empty() {
         return new LogContent(ImmutableList.<String>of(), true);
     }
 
+    /**
+     * Does not return the text of this content.
+     */
     @Override
     public String toString() {
         // Intentionally not the text
@@ -75,13 +85,20 @@ public class LogContent {
     }
 
     /**
-     * Returns this content formatted with new line chars to separate lines.
+     * Returns this content formatted using a new line char to separate lines.
      */
     public String withNormalizedEol() {
         if (lines.isEmpty()) {
             return "";
         }
         return Joiner.on('\n').join(lines);
+    }
+
+    /**
+     * Returns this content separated into lines. The line does not include the line separator.
+     */
+    public ImmutableList<String> getLines() {
+        return lines;
     }
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -113,7 +113,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         return groupedOutputFixture;
     }
 
-    public static String normalize(LogContent output) {
+    private String normalize(LogContent output) {
         List<String> result = new ArrayList<String>();
         List<String> lines = output.getLines();
         int i = 0;
@@ -222,6 +222,24 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         Set<String> actualTasks = findExecutedTasksInOrderStarted();
         if (!expectedTasks.equals(actualTasks)) {
             failOnDifferentSets("Build output does not contain the expected tasks.", expectedTasks, actualTasks);
+        }
+        return this;
+    }
+
+    @Override
+    public ExecutionResult assertTaskExecuted(String taskPath) {
+        Set<String> actualTasks = findExecutedTasksInOrderStarted();
+        if (!actualTasks.contains(taskPath)) {
+            failOnMissingElement("Build output does not contain the expected task.", taskPath, actualTasks);
+        }
+        return this;
+    }
+
+    @Override
+    public ExecutionResult assertTaskNotExecuted(String taskPath) {
+        Set<String> actualTasks = findExecutedTasksInOrderStarted();
+        if (actualTasks.contains(taskPath)) {
+            failOnMissingElement("Build output does contains unexpected task.", taskPath, actualTasks);
         }
         return this;
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -17,10 +17,7 @@ package org.gradle.integtests.fixtures.executer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.io.CharSource;
-import org.apache.commons.collections.CollectionUtils;
 import org.gradle.api.Action;
-import org.gradle.api.UncheckedIOException;
 import org.gradle.integtests.fixtures.logging.GroupedOutputFixture;
 import org.gradle.internal.Pair;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
@@ -29,9 +26,8 @@ import org.gradle.launcher.daemon.client.DaemonStartupMessage;
 import org.gradle.launcher.daemon.server.DaemonStateCoordinator;
 import org.gradle.launcher.daemon.server.health.LowTenuredSpaceDaemonExpirationStrategy;
 import org.gradle.util.GUtil;
-import org.hamcrest.core.StringContains;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,28 +35,24 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
-import static org.gradle.util.TextUtil.normaliseLineSeparators;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 public class OutputScrapingExecutionResult implements ExecutionResult {
     static final Pattern STACK_TRACE_ELEMENT = Pattern.compile("\\s+(at\\s+)?([\\w.$_]+/)?[\\w.$_]+\\.[\\w$_ =\\+\'-<>]+\\(.+?\\)(\\x1B\\[0K)?");
     private static final String TASK_PREFIX = "> Task ";
+
+    //for example: ':a SKIPPED' or ':foo:bar:baz UP-TO-DATE' but not ':a'
+    private static final Pattern SKIPPED_TASK_PATTERN = Pattern.compile("(> Task )?(:\\S+?(:\\S+?)*)\\s+((SKIPPED)|(UP-TO-DATE)|(NO-SOURCE)|(FROM-CACHE))");
+
+    //for example: ':hey' or ':a SKIPPED' or ':foo:bar:baz UP-TO-DATE' but not ':a FOO'
+    private static final Pattern TASK_PATTERN = Pattern.compile("(> Task )?(:\\S+?(:\\S+?)*)((\\s+SKIPPED)|(\\s+UP-TO-DATE)|(\\s+FROM-CACHE)|(\\s+NO-SOURCE)|(\\s+FAILED)|(\\s*))");
+
+    private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("BUILD (SUCCESSFUL|FAILED) in( \\d+[smh])+");
+
     private final LogContent output;
     private final LogContent error;
     private final LogContent mainContent;
     private final LogContent postBuild;
     private GroupedOutputFixture groupedOutputFixture;
     private Set<String> tasks;
-
-    //for example: ':a SKIPPED' or ':foo:bar:baz UP-TO-DATE' but not ':a'
-    private final Pattern skippedTaskPattern = Pattern.compile("(> Task )?(:\\S+?(:\\S+?)*)\\s+((SKIPPED)|(UP-TO-DATE)|(NO-SOURCE)|(FROM-CACHE))");
-
-    //for example: ':hey' or ':a SKIPPED' or ':foo:bar:baz UP-TO-DATE' but not ':a FOO'
-    private final Pattern taskPattern = Pattern.compile("(" + TASK_PREFIX + ")?(:\\S+?(:\\S+?)*)((\\s+SKIPPED)|(\\s+UP-TO-DATE)|(\\s+FROM-CACHE)|(\\s+NO-SOURCE)|(\\s+FAILED)|(\\s*))");
-
-    private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("BUILD (SUCCESSFUL|FAILED) in( \\d+[smh])+");
 
     public static List<String> flattenTaskPaths(Object[] taskPaths) {
         return org.gradle.util.CollectionUtils.toStringList(GUtil.flatten(taskPaths, Lists.newArrayList()));
@@ -88,6 +80,8 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     protected OutputScrapingExecutionResult(LogContent output, LogContent error) {
         this.output = output;
         this.error = error;
+
+        // Split out up the output into main content and post build content
         Pair<LogContent, LogContent> match = this.output.splitOnFirstMatchingLine(BUILD_RESULT_PATTERN);
         if (match == null) {
             this.mainContent = this.output;
@@ -108,7 +102,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     @Override
     public String getNormalizedOutput() {
-        return normalize(output.withNormalizedEol());
+        return normalize(output);
     }
 
     @Override
@@ -119,14 +113,9 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         return groupedOutputFixture;
     }
 
-    public static String normalize(String output) {
-        StringBuilder result = new StringBuilder();
-        List<String> lines;
-        try {
-            lines = CharSource.wrap(output).readLines();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    public static String normalize(LogContent output) {
+        List<String> result = new ArrayList<String>();
+        List<String> lines = output.getLines();
         int i = 0;
         while (i < lines.size()) {
             String line = lines.get(i);
@@ -149,17 +138,15 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
                     i++;
                 }
             } else if (BUILD_RESULT_PATTERN.matcher(line).matches()) {
-                result.append(BUILD_RESULT_PATTERN.matcher(line).replaceFirst("BUILD $1 in 0s"));
-                result.append('\n');
+                result.add(BUILD_RESULT_PATTERN.matcher(line).replaceFirst("BUILD $1 in 0s"));
                 i++;
             } else {
-                result.append(line);
-                result.append('\n');
+                result.add(line);
                 i++;
             }
         }
 
-        return result.toString();
+        return LogContent.of(result).withNormalizedEol();
     }
 
     public ExecutionResult assertOutputEquals(String expectedOutput, boolean ignoreExtraLines, boolean ignoreLineOrder) {
@@ -170,20 +157,30 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     @Override
     public ExecutionResult assertHasPostBuildOutput(String expectedOutput) {
-        assertTrue("Substring not found in build output", postBuild.withNormalizedEol().contains(expectedOutput));
+        String expectedText = LogContent.of(expectedOutput).withNormalizedEol();
+        String actualText = postBuild.withNormalizedEol();
+        if (!actualText.contains(expectedText)) {
+            failOnMissingOutput("Did not find expected text in post-build output.", "Post-build output", expectedText, actualText);
+        }
         return this;
     }
 
     @Override
     public ExecutionResult assertNotOutput(String expectedOutput) {
-        assertFalse("Substring found in build output", getOutput().contains(expectedOutput));
-        assertFalse("Substring found in build output", getError().contains(expectedOutput));
+        String expectedText = LogContent.of(expectedOutput).withNormalizedEol();
+        if (getOutput().contains(expectedText)|| getError().contains(expectedText)) {
+            throw new AssertionError(String.format("Found unexpected text in build output.%nExpected not present: %s%n%nOutput:%n=======%n%s%nError:%n======%n%s", expectedText, getOutput(), getError()));
+        }
         return this;
     }
 
     @Override
     public ExecutionResult assertOutputContains(String expectedOutput) {
-        assertThat("Substring not found in build output", getMainContent().withNormalizedEol(), StringContains.containsString(normaliseLineSeparators(expectedOutput)));
+        String expectedText = LogContent.of(expectedOutput).withNormalizedEol();
+        String actualText = getMainContent().withNormalizedEol();
+        if (!actualText.contains(expectedText)) {
+            failOnMissingOutput("Did not find expected text in build output.", "Build output", expectedOutput, actualText);
+        }
         return this;
     }
 
@@ -207,7 +204,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     private Set<String> findExecutedTasksInOrderStarted() {
         if (tasks == null) {
-            tasks = new LinkedHashSet<String>(grepTasks(taskPattern));
+            tasks = new LinkedHashSet<String>(grepTasks(TASK_PATTERN));
         }
         return tasks;
     }
@@ -236,7 +233,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     }
 
     public Set<String> getSkippedTasks() {
-        return new TreeSet<String>(grepTasks(skippedTaskPattern));
+        return new TreeSet<String>(grepTasks(SKIPPED_TASK_PATTERN));
     }
 
     @Override
@@ -258,9 +255,10 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     }
 
     private Collection<String> getNotSkippedTasks() {
-        List all = getExecutedTasks();
-        Set skipped = getSkippedTasks();
-        return CollectionUtils.subtract(all, skipped);
+        Set<String> all = new TreeSet<String>(getExecutedTasks());
+        Set<String> skipped = getSkippedTasks();
+        all.removeAll(skipped);
+        return all;
     }
 
     @Override
@@ -282,11 +280,15 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     }
 
     private void failOnDifferentSets(String message, Set<String> expected, Set<String> actual) {
-        throw new AssertionError(String.format("%s%nExpected: %s%nActual: %s%nOutput:%n%s%nError%n%s", message, expected, actual, getOutput(), getError()));
+        throw new AssertionError(String.format("%s%nExpected: %s%nActual: %s%nOutput:%n=======%n%s%nError:%n======%n%s", message, expected, actual, getOutput(), getError()));
     }
 
     private void failOnMissingElement(String message, String expected, Set<String> actual) {
-        throw new AssertionError(String.format("%s%nExpected: %s%nActual: %s%nOutput:%n%s%nError%n%s", message, expected, actual, getOutput(), getError()));
+        throw new AssertionError(String.format("%s%nExpected: %s%nActual: %s%nOutput:%n=======%n%s%nError:%n======%n%s", message, expected, actual, getOutput(), getError()));
+    }
+
+    private void failOnMissingOutput(String message, String type, String expected, String actual) {
+        throw new AssertionError(String.format("%s%nExpected: %s%n%n%s:%n=======%n%s%nOutput:%n=======%n%s%nError:%n======%n%s", message, expected, type, actual, getOutput(), getError()));
     }
 
     private List<String> grepTasks(final Pattern pattern) {
@@ -294,8 +296,8 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         final List<String> taskStatusLines = Lists.newArrayList();
 
         getMainContent().removeDebugPrefix().eachLine(new Action<String>() {
-            public void execute(String s) {
-                java.util.regex.Matcher matcher = pattern.matcher(s);
+            public void execute(String line) {
+                java.util.regex.Matcher matcher = pattern.matcher(line);
                 if (matcher.matches()) {
                     String taskStatusLine = matcher.group().replace(TASK_PREFIX, "");
                     String taskName = matcher.group(2);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
@@ -22,12 +22,8 @@ import org.gradle.process.internal.AbstractExecHandleBuilder;
 import org.gradle.util.SingleMessageLogger;
 
 import java.io.PipedOutputStream;
-import java.util.HashSet;
-import java.util.Set;
 
 import static java.lang.String.format;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class ParallelForkingGradleHandle extends ForkingGradleHandle {
 
@@ -51,13 +47,6 @@ public class ParallelForkingGradleHandle extends ForkingGradleHandle {
     private static class ParallelExecutionResult extends OutputScrapingExecutionFailure {
         public ParallelExecutionResult(String output, String error) {
             super(output, error);
-        }
-
-        @Override
-        public ExecutionResult assertTasksExecuted(Object... taskPaths) {
-            Set<String> expectedTasks = new HashSet<String>(flattenTaskPaths(taskPaths));
-            assertThat(String.format("Expected tasks %s not found in process output:%n%s", expectedTasks, getOutput()), new HashSet<String>(getExecutedTasks()), equalTo(expectedTasks));
-            return this;
         }
 
         @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -133,7 +133,7 @@ public class GroupedOutputFixture {
         boolean foundTask = hasTask(taskName);
 
         if (!foundTask) {
-            throw new AssertionError(String.format("The grouped output for task '%s' could not be found", taskName));
+            throw new AssertionError(String.format("The grouped output for task '%s' could not be found.%nOutput:%n%s", taskName, originalOutput));
         }
 
         return tasks.get(taskName);

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractExecutionResultTest.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import org.gradle.util.TextUtil
+import spock.lang.Specification
+
+
+abstract class AbstractExecutionResultTest extends Specification {
+    String error(String text) {
+        return TextUtil.normaliseLineSeparators(text.stripIndent().trim())
+    }
+
+    String error(Throwable failure) {
+        return TextUtil.normaliseLineSeparators(failure.message)
+    }
+}

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -20,7 +20,7 @@ import spock.lang.Specification
 
 
 class OutputScrapingExecutionResultTest extends Specification {
-    def "normalizes line ending"() {
+    def "normalizes line ending in output"() {
         def output = "\n\r\nabc\r\n\n"
         def error = "\r\n\nerror\n\r\n"
         def result = OutputScrapingExecutionResult.from(output, error)
@@ -30,7 +30,7 @@ class OutputScrapingExecutionResultTest extends Specification {
         result.error == "\n\nerror\n\n"
     }
 
-    def "retains trailing line ending"() {
+    def "retains trailing line ending in output"() {
         def output = "\n\nabc\n"
         def error = "\nerror\n"
         def result = OutputScrapingExecutionResult.from(output, error)
@@ -40,7 +40,7 @@ class OutputScrapingExecutionResultTest extends Specification {
         result.error == error
     }
 
-    def "can assert build output is present"() {
+    def "can assert build output is present in main content"() {
         def output = """
 message
 
@@ -110,6 +110,200 @@ post build
         then:
         def e3 = thrown(AssertionError)
         e3.message.startsWith('Substring not found in build output')
+    }
+
+    def "can assert task is present when task output is split into several groups"() {
+        def output = """
+before
+
+> Task :a
+> Task :b
+
+> Task :a
+some content
+
+> Task :b
+other content
+
+> Task :a
+all good
+
+> Task :b SKIPPED
+
+after
+
+BUILD SUCCESSFUL in 12s
+
+post build
+"""
+        when:
+        def result = OutputScrapingExecutionResult.from(output, "")
+
+        then:
+        result.assertTasksExecuted(":a", ":b")
+        result.assertTasksExecuted([":a", ":b"])
+        result.assertTasksExecuted(":a", ":b", ":a", [":a", ":b"], ":b")
+
+        and:
+        result.assertTasksExecutedInOrder(":a", ":b")
+        result.assertTasksExecutedInOrder([":a", ":b"])
+
+        and:
+        result.executedTasks == [":a", ":b"]
+        result.skippedTasks == [":b"] as Set
+
+        and:
+        result.assertTasksNotSkipped(":a")
+        result.assertTasksNotSkipped(":a", ":a", [":a"])
+
+        and:
+        result.assertTaskNotSkipped(":a")
+
+        and:
+        result.assertTasksSkipped(":b")
+        result.assertTasksSkipped(":b", ":b", [":b"])
+
+        and:
+        result.assertTaskSkipped(":b")
+
+        when:
+        result.assertTasksExecuted(":a")
+
+        then:
+        def e = thrown(AssertionError)
+        e.message.startsWith('''
+            Build output does not contain the expected tasks.
+            Expected: [:a]
+            Actual: [:a, :b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksExecuted(":a", ":b", ":c")
+
+        then:
+        def e2 = thrown(AssertionError)
+        e2.message.startsWith('''
+            Build output does not contain the expected tasks.
+            Expected: [:a, :b, :c]
+            Actual: [:a, :b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksExecutedInOrder(":b", ":a")
+
+        then:
+        def e3 = thrown(AssertionError)
+        e3.message.startsWith(":a does not occur in expected order (expected: exact([:b, :a]), actual [:a, :b])")
+
+        when:
+        result.assertTasksExecutedInOrder(":a")
+
+        then:
+        def e4 = thrown(AssertionError)
+        e4.message.startsWith('''
+            Build output does not contain the expected tasks.
+            Expected: [:a]
+            Actual: [:a, :b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksExecutedInOrder(":a", ":b", ":c")
+
+        then:
+        def e5 = thrown(AssertionError)
+        e5.message.startsWith('''
+            Build output does not contain the expected tasks.
+            Expected: [:a, :b, :c]
+            Actual: [:a, :b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksSkipped()
+
+        then:
+        def e6 = thrown(AssertionError)
+        e6.message.startsWith('''
+            Build output does not contain the expected skipped tasks.
+            Expected: []
+            Actual: [:b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksSkipped(":a")
+
+        then:
+        def e7 = thrown(AssertionError)
+        e7.message.startsWith('''
+            Build output does not contain the expected skipped tasks.
+            Expected: [:a]
+            Actual: [:b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksSkipped(":b", ":c")
+
+        then:
+        def e8 = thrown(AssertionError)
+        e8.message.startsWith('''
+            Build output does not contain the expected skipped tasks.
+            Expected: [:b, :c]
+            Actual: [:b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTaskSkipped(":a")
+
+        then:
+        def e9 = thrown(AssertionError)
+        e9.message.startsWith('''
+            Build output does not contain the expected skipped task.
+            Expected: :a
+            Actual: [:b]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksNotSkipped()
+
+        then:
+        def e10 = thrown(AssertionError)
+        e10.message.startsWith('''
+            Build output does not contain the expected non skipped tasks.
+            Expected: []
+            Actual: [:a]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksNotSkipped(":b")
+
+        then:
+        def e11 = thrown(AssertionError)
+        e11.message.startsWith('''
+            Build output does not contain the expected non skipped tasks.
+            Expected: [:b]
+            Actual: [:a]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTasksNotSkipped(":a", ":c")
+
+        then:
+        def e12 = thrown(AssertionError)
+        e12.message.startsWith('''
+            Build output does not contain the expected non skipped tasks.
+            Expected: [:a, :c]
+            Actual: [:a]
+        '''.stripIndent().trim())
+
+        when:
+        result.assertTaskNotSkipped(":b")
+
+        then:
+        def e13 = thrown(AssertionError)
+        e13.message.startsWith('''
+            Build output does not contain the expected non skipped task.
+            Expected: :b
+            Actual: [:a]
+        '''.stripIndent().trim())
     }
 
     def "creates failure result"() {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -346,4 +346,8 @@ BUILD FAILED in 13s
         then:
         result.assertTasksExecutedInOrder(":compileMyTestBinaryMyTestJava", ":myTestBinaryTest")
     }
+
+    def error(String text) {
+        return TextUtil.normaliseLineSeparators(text.stripIndent().trim())
+    }
 }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -16,10 +16,18 @@
 
 package org.gradle.integtests.fixtures.executer
 
-import spock.lang.Specification
+import spock.lang.Unroll
 
+class OutputScrapingExecutionResultTest extends AbstractExecutionResultTest {
+    def "can have empty output"() {
+        def result = OutputScrapingExecutionResult.from("", "")
 
-class OutputScrapingExecutionResultTest extends Specification {
+        expect:
+        result.output.empty
+        result.normalizedOutput.empty
+        result.error.empty
+    }
+
     def "normalizes line ending in output"() {
         def output = "\n\r\nabc\r\n\n"
         def error = "\r\n\nerror\n\r\n"
@@ -27,6 +35,7 @@ class OutputScrapingExecutionResultTest extends Specification {
 
         expect:
         result.output == "\n\nabc\n\n"
+        result.normalizedOutput == "\n\nabc\n\n"
         result.error == "\n\nerror\n\n"
     }
 
@@ -37,12 +46,14 @@ class OutputScrapingExecutionResultTest extends Specification {
 
         expect:
         result.output == output
+        result.normalizedOutput == output
         result.error == error
     }
 
     def "can assert build output is present in main content"() {
         def output = """
 message
+message 2
 
 BUILD SUCCESSFUL in 12s
 
@@ -53,27 +64,103 @@ post build
 
         then:
         result.assertOutputContains("message")
+        result.assertOutputContains("\nmessage\nmessage 2")
+        result.assertOutputContains("\nmessage\nmessage 2\n")
+        result.assertOutputContains("\r\nmessage\r\nmessage 2")
 
         when:
         result.assertOutputContains("missing")
 
         then:
         def e = thrown(AssertionError)
-        e.message.startsWith('Substring not found in build output')
+        error(e).startsWith(error('''
+            Did not find expected text in build output.
+            Expected: missing
+             
+            Build output:
+            =======
+             
+            message
+            message 2
+             
+            Output:
+        '''))
 
         when:
         result.assertOutputContains("post build")
 
         then:
         def e2 = thrown(AssertionError)
-        e2.message.startsWith('Substring not found in build output')
+        error(e2).startsWith(error('''
+            Did not find expected text in build output.
+            Expected: post build
+             
+            Build output:
+            =======
+             
+            message
+            message 2
+             
+            Output:
+        '''))
 
         when:
         result.assertOutputContains("BUILD")
 
         then:
         def e3 = thrown(AssertionError)
-        e3.message.startsWith('Substring not found in build output')
+        error(e3).startsWith(error('''
+            Did not find expected text in build output.
+            Expected: BUILD
+             
+            Build output:
+            =======
+             
+            message
+            message 2
+             
+            Output:
+        '''))
+
+        when:
+        result.assertOutputContains("message extra")
+
+        then:
+        def e4 = thrown(AssertionError)
+        error(e4).startsWith(error('''
+            Did not find expected text in build output.
+            Expected: message extra
+             
+            Build output:
+            =======
+             
+            message
+            message 2
+             
+            Output:
+        '''))
+
+        when:
+        result.assertOutputContains("\n\nmessage\n\n")
+
+        then:
+        def e6 = thrown(AssertionError)
+        error(e6).startsWith(error('''
+            Did not find expected text in build output.
+            Expected: 
+
+            message
+            
+            
+            
+            Build output:
+            =======
+             
+            message
+            message 2
+             
+            Output:
+        '''))
     }
 
     def "can assert post build output is present"() {
@@ -83,33 +170,153 @@ message
 BUILD SUCCESSFUL in 12s
 
 post build
+more post build
 """
         when:
         def result = OutputScrapingExecutionResult.from(output, "")
 
         then:
         result.assertHasPostBuildOutput("post build")
+        result.assertHasPostBuildOutput("post build\nmore post build\n")
+        result.assertHasPostBuildOutput("post build\r\nmore post build\r\n")
+        result.assertHasPostBuildOutput("\npost build\n")
+        result.assertHasPostBuildOutput("\r\npost build\r\nmore")
 
         when:
         result.assertHasPostBuildOutput("missing")
 
         then:
         def e = thrown(AssertionError)
-        e.message.startsWith('Substring not found in build output')
+        error(e).startsWith(error('''
+            Did not find expected text in post-build output.
+            Expected: missing
+            
+            Post-build output:
+            =======
+             
+            post build
+            more post build
+             
+            Output:
+        '''))
 
         when:
         result.assertHasPostBuildOutput("message")
 
         then:
         def e2 = thrown(AssertionError)
-        e2.message.startsWith('Substring not found in build output')
+        error(e2).startsWith(error('''
+            Did not find expected text in post-build output.
+            Expected: message
+            
+            Post-build output:
+            =======
+             
+            post build
+            more post build
+             
+            Output:
+        '''))
 
         when:
         result.assertHasPostBuildOutput("BUILD")
 
         then:
         def e3 = thrown(AssertionError)
-        e3.message.startsWith('Substring not found in build output')
+        error(e3).startsWith(error('''
+            Did not find expected text in post-build output.
+            Expected: BUILD
+            
+            Post-build output:
+            =======
+             
+            post build
+            more post build
+             
+            Output:
+        '''))
+
+        when:
+        result.assertHasPostBuildOutput("post build extra")
+
+        then:
+        def e4 = thrown(AssertionError)
+        error(e4).startsWith(error('''
+            Did not find expected text in post-build output.
+            Expected: post build extra
+            
+            Post-build output:
+            =======
+             
+            post build
+            more post build
+             
+            Output:
+        '''))
+
+        when:
+        result.assertHasPostBuildOutput("post build\n\n")
+
+        then:
+        def e5 = thrown(AssertionError)
+        error(e5).startsWith(error('''
+            Did not find expected text in post-build output.
+            Expected: post build
+
+
+            
+            Post-build output:
+            =======
+             
+            post build
+            more post build
+             
+            Output:
+        '''))
+    }
+
+    @Unroll
+    def "can assert output is not present = #text"() {
+        def output = """
+message
+
+BUILD SUCCESSFUL in 12s
+
+post build
+more post build
+"""
+        def errorOut = """
+broken
+"""
+        when:
+        def result = OutputScrapingExecutionResult.from(output, errorOut)
+
+        then:
+        result.assertNotOutput("missing")
+        result.assertNotOutput("missing extra")
+        result.assertNotOutput("missing\n\nBUILD FAILED")
+        result.assertNotOutput("missing\n\n\nBUILD")
+
+        when:
+        result.assertNotOutput(text)
+
+        then:
+        def e = thrown(AssertionError)
+        error(e).startsWith(error("""
+Found unexpected text in build output.
+Expected not present: ${text}
+
+Output:
+"""))
+
+        where:
+        text               | _
+        "message"          | _
+        "message\n\nBUILD" | _
+        "BUILD"            | _
+        "post"             | _
+        "broken"           | _
+        "broken\n"         | _
     }
 
     def "can assert task is present when task output is split into several groups"() {
@@ -171,22 +378,22 @@ post build
 
         then:
         def e = thrown(AssertionError)
-        e.message.startsWith('''
+        error(e).startsWith(error('''
             Build output does not contain the expected tasks.
             Expected: [:a]
             Actual: [:a, :b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksExecuted(":a", ":b", ":c")
 
         then:
         def e2 = thrown(AssertionError)
-        e2.message.startsWith('''
+        error(e2).startsWith(error('''
             Build output does not contain the expected tasks.
             Expected: [:a, :b, :c]
             Actual: [:a, :b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksExecutedInOrder(":b", ":a")
@@ -200,110 +407,110 @@ post build
 
         then:
         def e4 = thrown(AssertionError)
-        e4.message.startsWith('''
+        error(e4).startsWith(error('''
             Build output does not contain the expected tasks.
             Expected: [:a]
             Actual: [:a, :b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksExecutedInOrder(":a", ":b", ":c")
 
         then:
         def e5 = thrown(AssertionError)
-        e5.message.startsWith('''
+        error(e5).startsWith(error('''
             Build output does not contain the expected tasks.
             Expected: [:a, :b, :c]
             Actual: [:a, :b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksSkipped()
 
         then:
         def e6 = thrown(AssertionError)
-        e6.message.startsWith('''
+        error(e6).startsWith(error('''
             Build output does not contain the expected skipped tasks.
             Expected: []
             Actual: [:b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksSkipped(":a")
 
         then:
         def e7 = thrown(AssertionError)
-        e7.message.startsWith('''
+        error(e7).startsWith(error('''
             Build output does not contain the expected skipped tasks.
             Expected: [:a]
             Actual: [:b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksSkipped(":b", ":c")
 
         then:
         def e8 = thrown(AssertionError)
-        e8.message.startsWith('''
+        error(e8).startsWith(error('''
             Build output does not contain the expected skipped tasks.
             Expected: [:b, :c]
             Actual: [:b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTaskSkipped(":a")
 
         then:
         def e9 = thrown(AssertionError)
-        e9.message.startsWith('''
+        error(e9).startsWith(error('''
             Build output does not contain the expected skipped task.
             Expected: :a
             Actual: [:b]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksNotSkipped()
 
         then:
         def e10 = thrown(AssertionError)
-        e10.message.startsWith('''
+        error(e10).startsWith(error('''
             Build output does not contain the expected non skipped tasks.
             Expected: []
             Actual: [:a]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksNotSkipped(":b")
 
         then:
         def e11 = thrown(AssertionError)
-        e11.message.startsWith('''
+        error(e11).startsWith(error('''
             Build output does not contain the expected non skipped tasks.
             Expected: [:b]
             Actual: [:a]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTasksNotSkipped(":a", ":c")
 
         then:
         def e12 = thrown(AssertionError)
-        e12.message.startsWith('''
+        error(e12).startsWith(error('''
             Build output does not contain the expected non skipped tasks.
             Expected: [:a, :c]
             Actual: [:a]
-        '''.stripIndent().trim())
+        '''))
 
         when:
         result.assertTaskNotSkipped(":b")
 
         then:
         def e13 = thrown(AssertionError)
-        e13.message.startsWith('''
+        error(e13).startsWith(error('''
             Build output does not contain the expected non skipped task.
             Expected: :b
             Actual: [:a]
-        '''.stripIndent().trim())
+        '''))
     }
 
     def "creates failure result"() {
@@ -345,9 +552,5 @@ BUILD FAILED in 13s
 
         then:
         result.assertTasksExecutedInOrder(":compileMyTestBinaryMyTestJava", ":myTestBinaryTest")
-    }
-
-    def error(String text) {
-        return TextUtil.normaliseLineSeparators(text.stripIndent().trim())
     }
 }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -557,7 +557,7 @@ post build
         result instanceof OutputScrapingExecutionFailure
     }
 
-    def "can capture tasks with multiple headers"() {
+    def "can assert task is present when task failure output is split into several groups"() {
         def output = """
 > Task :compileMyTestBinaryMyTestJava
 > Task :myTestBinaryTest
@@ -581,5 +581,7 @@ BUILD FAILED in 13s
 
         then:
         result.assertTasksExecutedInOrder(":compileMyTestBinaryMyTestJava", ":myTestBinaryTest")
+        result.assertTasksExecuted(":myTestBinaryTest", ":compileMyTestBinaryMyTestJava")
+        result.assertTasksNotSkipped(":myTestBinaryTest", ":compileMyTestBinaryMyTestJava")
     }
 }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -356,6 +356,11 @@ post build
         result.assertTasksExecutedInOrder([":a", ":b"])
 
         and:
+        result.assertTaskExecuted(':a')
+        result.assertTaskExecuted(':b')
+        result.assertTaskNotExecuted(':c')
+
+        and:
         result.executedTasks == [":a", ":b"]
         result.skippedTasks == [":b"] as Set
 
@@ -425,11 +430,35 @@ post build
         '''))
 
         when:
-        result.assertTasksSkipped()
+        result.assertTaskExecuted(':c')
 
         then:
         def e6 = thrown(AssertionError)
         error(e6).startsWith(error('''
+            Build output does not contain the expected task.
+            Expected: :c
+            Actual: [:a, :b]
+            Output:
+        '''))
+
+        when:
+        result.assertTaskNotExecuted(':b')
+
+        then:
+        def e7 = thrown(AssertionError)
+        error(e7).startsWith(error('''
+            Build output does contains unexpected task.
+            Expected: :b
+            Actual: [:a, :b]
+            Output:
+        '''))
+
+        when:
+        result.assertTasksSkipped()
+
+        then:
+        def e8 = thrown(AssertionError)
+        error(e8).startsWith(error('''
             Build output does not contain the expected skipped tasks.
             Expected: []
             Actual: [:b]
@@ -439,8 +468,8 @@ post build
         result.assertTasksSkipped(":a")
 
         then:
-        def e7 = thrown(AssertionError)
-        error(e7).startsWith(error('''
+        def e9 = thrown(AssertionError)
+        error(e9).startsWith(error('''
             Build output does not contain the expected skipped tasks.
             Expected: [:a]
             Actual: [:b]
@@ -450,8 +479,8 @@ post build
         result.assertTasksSkipped(":b", ":c")
 
         then:
-        def e8 = thrown(AssertionError)
-        error(e8).startsWith(error('''
+        def e10 = thrown(AssertionError)
+        error(e10).startsWith(error('''
             Build output does not contain the expected skipped tasks.
             Expected: [:b, :c]
             Actual: [:b]
@@ -461,8 +490,8 @@ post build
         result.assertTaskSkipped(":a")
 
         then:
-        def e9 = thrown(AssertionError)
-        error(e9).startsWith(error('''
+        def e11 = thrown(AssertionError)
+        error(e11).startsWith(error('''
             Build output does not contain the expected skipped task.
             Expected: :a
             Actual: [:b]
@@ -472,8 +501,8 @@ post build
         result.assertTasksNotSkipped()
 
         then:
-        def e10 = thrown(AssertionError)
-        error(e10).startsWith(error('''
+        def e12 = thrown(AssertionError)
+        error(e12).startsWith(error('''
             Build output does not contain the expected non skipped tasks.
             Expected: []
             Actual: [:a]
@@ -483,8 +512,8 @@ post build
         result.assertTasksNotSkipped(":b")
 
         then:
-        def e11 = thrown(AssertionError)
-        error(e11).startsWith(error('''
+        def e13 = thrown(AssertionError)
+        error(e13).startsWith(error('''
             Build output does not contain the expected non skipped tasks.
             Expected: [:b]
             Actual: [:a]
@@ -494,8 +523,8 @@ post build
         result.assertTasksNotSkipped(":a", ":c")
 
         then:
-        def e12 = thrown(AssertionError)
-        error(e12).startsWith(error('''
+        def e14 = thrown(AssertionError)
+        error(e14).startsWith(error('''
             Build output does not contain the expected non skipped tasks.
             Expected: [:a, :c]
             Actual: [:a]
@@ -505,8 +534,8 @@ post build
         result.assertTaskNotSkipped(":b")
 
         then:
-        def e13 = thrown(AssertionError)
-        error(e13).startsWith(error('''
+        def e15 = thrown(AssertionError)
+        error(e15).startsWith(error('''
             Build output does not contain the expected non skipped task.
             Expected: :b
             Actual: [:a]

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -215,7 +215,7 @@ Output from 2
 
         then:
         def t = thrown(AssertionError)
-        t.message == "The grouped output for task ':doesNotExist' could not be found"
+        t.message.startsWith("The grouped output for task ':doesNotExist' could not be found.")
     }
 
     def "handles output right before end of failed build"() {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuter.java
@@ -16,6 +16,7 @@
 package org.gradle.tooling.internal.provider;
 
 import org.gradle.api.logging.StandardOutputListener;
+import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.logging.LoggingManagerInternal;
@@ -23,7 +24,6 @@ import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.events.ProgressCompleteEvent;
 import org.gradle.internal.logging.events.ProgressStartEvent;
-import org.gradle.internal.logging.text.StreamBackedStandardOutputListener;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.tooling.internal.protocol.ProgressListenerVersion1;
@@ -44,21 +44,9 @@ public class LoggingBridgingBuildActionExecuter implements BuildActionExecuter<P
 
     public Object execute(BuildAction action, BuildRequestContext buildRequestContext, ProviderOperationParameters actionParameters, ServiceRegistry contextServices) {
         if (Boolean.TRUE.equals(actionParameters.isColorOutput(null)) && actionParameters.getStandardOutput() != null) {
-            loggingManager.attachAnsiConsole(actionParameters.getStandardOutput());
+            loggingManager.attachConsole(actionParameters.getStandardOutput(), ConsoleOutput.Rich);
         } else if (actionParameters.getStandardOutput() != null || actionParameters.getStandardError() != null){
-            StandardOutputListener outputListener;
-            if (actionParameters.getStandardOutput() != null) {
-                outputListener = new StreamBackedStandardOutputListener(actionParameters.getStandardOutput());
-            } else {
-                outputListener = new IgnoreOutput();
-            }
-            StandardOutputListener errorListener;
-            if (actionParameters.getStandardError() != null) {
-                errorListener = new StreamBackedStandardOutputListener(actionParameters.getStandardError());
-            } else {
-                errorListener = new IgnoreOutput();
-            }
-            loggingManager.attachPlainConsole(outputListener, errorListener);
+            loggingManager.attachConsole(actionParameters.getStandardOutput(), ConsoleOutput.Plain);
         }
         ProgressListenerVersion1 progressListener = actionParameters.getProgressListener();
         OutputEventListenerAdapter listener = new OutputEventListenerAdapter(progressListener);

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleGroupedTaskFunctionalTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.internal.logging.console.taskgrouping
 
 import org.gradle.api.logging.configuration.ConsoleOutput
-import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
@@ -28,8 +28,10 @@ import spock.lang.IgnoreIf
 @IgnoreIf({ GradleContextualExecuter.parallel })
 abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
     def setup() {
-        executer.withConsole(consoleType)
-        executer.withArgument('--parallel')
+        executer.beforeExecute {
+            it.withConsole(consoleType)
+            it.withArgument('--parallel')
+        }
     }
 
     abstract ConsoleOutput getConsoleType()

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
@@ -28,7 +28,6 @@ abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractCon
         '''
 
         when:
-        executer.withConsole(consoleType)
         fails('myFailure')
 
         then:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleVerboseRenderingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleVerboseRenderingFunctionalTest.groovy
@@ -36,7 +36,6 @@ task upToDate{
 
         when:
         succeeds('upToDate')
-        executer.withConsole(Verbose)
         succeeds('upToDate')
 
         then:

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.logging;
 
 import org.gradle.api.logging.LoggingOutput;
-import org.gradle.api.logging.StandardOutputListener;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -42,19 +41,13 @@ public interface LoggingOutputInternal extends LoggingOutput {
     void attachProcessConsole(ConsoleOutput consoleOutput);
 
     /**
-     * Adds the given {@link java.io.OutputStream} as a logging destination. The stream receives stdout and stderr logging formatted according to the current logging settings
-     * and encoded using the system character encoding. The output also includes color and dynamic text encoded using ANSI control sequences.
+     * Adds the given {@link java.io.OutputStream} as a logging destination. The stream receives stdout and stderr logging formatted according to the current logging settings and encoded using the system character encoding. The output also includes color and dynamic text encoded using ANSI control sequences, depending on the requested output format.
      *
      * <p>Removes standard output and/or error as a side-effect.
-     */
-    void attachAnsiConsole(OutputStream outputStream);
-
-    /**
-     * Adds the given {@link StandardOutputListener} objects as logging destinations.  The output will include plain text only, with no color or dynamic text.
      *
-     * <p>Removes standard output and/or error as a side-effect.
+     * @param consoleOutput The output format.
      */
-    void attachPlainConsole(StandardOutputListener outputListener, StandardOutputListener errorListener);
+    void attachConsole(OutputStream outputStream, ConsoleOutput consoleOutput);
 
     /**
      * Adds the given {@link java.io.OutputStream} as a logging destination. The stream receives stdout logging formatted according to the current logging settings and

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/compatbridge/LoggingManagerInternalCompatibilityBridge.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/compatbridge/LoggingManagerInternalCompatibilityBridge.java
@@ -18,6 +18,7 @@ package org.gradle.internal.logging.compatbridge;
 
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.StandardOutputListener;
+import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.internal.logging.LoggingManagerInternal;
 
 import java.io.OutputStream;
@@ -112,7 +113,7 @@ public class LoggingManagerInternalCompatibilityBridge implements org.gradle.log
 
     @Override
     public void attachAnsiConsole(OutputStream outputStream) {
-        delegate.attachAnsiConsole(outputStream);
+        delegate.attachConsole(outputStream, ConsoleOutput.Rich);
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -150,22 +150,16 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     }
 
     @Override
-    public void attachAnsiConsole(OutputStream outputStream) {
-        attachAnsiConsole(outputStream, false);
-    }
-
-    @Override
-    public void attachPlainConsole(StandardOutputListener outputListener, StandardOutputListener errorListener) {
-        // Currently does not write any console content to the error stream
-        addPlainConsole(outputListener);
-    }
-
-    protected void attachAnsiConsole(OutputStream outputStream, boolean verbose) {
+    public void attachConsole(OutputStream outputStream, ConsoleOutput consoleOutput) {
         synchronized (lock) {
-            ConsoleMetaData consoleMetaData = FallbackConsoleMetaData.INSTANCE;
-            OutputStreamWriter writer = new OutputStreamWriter(outputStream);
-            Console console = new AnsiConsole(writer, writer, getColourMap(), consoleMetaData, true);
-            addRichConsole(console, true, true, consoleMetaData, verbose);
+            if (consoleOutput == ConsoleOutput.Plain) {
+                addPlainConsole(new StreamBackedStandardOutputListener(outputStream));
+            } else {
+                ConsoleMetaData consoleMetaData = FallbackConsoleMetaData.INSTANCE;
+                OutputStreamWriter writer = new OutputStreamWriter(outputStream);
+                Console console = new AnsiConsole(writer, writer, getColourMap(), consoleMetaData, true);
+                addRichConsole(console, true, true, consoleMetaData, consoleOutput == ConsoleOutput.Verbose);
+            }
         }
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/source/PrintStreamLoggingSystem.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/source/PrintStreamLoggingSystem.java
@@ -110,6 +110,7 @@ abstract class PrintStreamLoggingSystem implements LoggingSourceSystem {
             outstr.flush();
             destination.set(original);
             set(original.originalStream);
+            original = null;
         }
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/services/DefaultLoggingManagerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/services/DefaultLoggingManagerTest.groovy
@@ -481,14 +481,14 @@ public class DefaultLoggingManagerTest extends Specification {
         def snapshot = Stub(LoggingSystem.Snapshot)
         def output = Stub(OutputStream)
 
-        loggingManager.attachAnsiConsole(output)
+        loggingManager.attachConsole(output, ConsoleOutput.Verbose)
 
         when:
         loggingManager.start()
 
         then:
         1 * loggingRouter.snapshot() >> snapshot
-        1 * loggingRouter.attachAnsiConsole(output)
+        1 * loggingRouter.attachConsole(output, ConsoleOutput.Verbose)
         0 * loggingRouter._
 
         when:
@@ -511,10 +511,10 @@ public class DefaultLoggingManagerTest extends Specification {
         0 * loggingRouter._
 
         when:
-        loggingManager.attachAnsiConsole(output)
+        loggingManager.attachConsole(output, ConsoleOutput.Verbose)
 
         then:
-        1 * loggingRouter.attachAnsiConsole(output)
+        1 * loggingRouter.attachConsole(output, ConsoleOutput.Verbose)
         0 * loggingRouter._
 
         when:

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/source/PrintStreamLoggingSystemTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/source/PrintStreamLoggingSystemTest.groovy
@@ -60,6 +60,26 @@ class PrintStreamLoggingSystemTest extends Specification {
         stream == originalStream
     }
 
+    def originalStreamCanBeReplacedBetweenCapture() {
+        def stream2 = new PrintStream(new ByteArrayOutputStream())
+
+        given:
+        loggingSystem.restore(loggingSystem.startCapture())
+        stream = stream2
+
+        when:
+        def snapshot = loggingSystem.startCapture()
+
+        then:
+        stream != stream2
+
+        when:
+        loggingSystem.restore(snapshot)
+
+        then:
+        stream == stream2
+    }
+
     def onStartsCapturingWhenNotAlreadyCapturing() {
         when:
         loggingSystem.setLevel(LogLevel.INFO)

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCaptureOutputIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCaptureOutputIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testkit.runner
 
+import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.launcher.daemon.client.DaemonDisappearedException
 import org.gradle.test.fixtures.server.http.CyclicBarrierHttpServer
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
@@ -23,8 +24,6 @@ import org.gradle.testkit.runner.fixtures.NoDebug
 import org.gradle.tooling.GradleConnectionException
 import org.gradle.util.RedirectStdOutAndErr
 import org.junit.Rule
-
-import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.normalize
 
 @InspectsBuildOutput
 class GradleRunnerCaptureOutputIntegrationTest extends BaseGradleRunnerIntegrationTest {
@@ -66,8 +65,9 @@ class GradleRunnerCaptureOutputIntegrationTest extends BaseGradleRunnerIntegrati
 
         // isn't empty if version < 2.8 or potentially contains Gradle dist download progress output
         if (isCompatibleVersion('2.8') && !crossVersion) {
-            assert normalize(stdStreams.stdOut).empty
-            assert normalize(stdStreams.stdErr).empty
+            def output = OutputScrapingExecutionResult.from(stdStreams.stdOut, stdStreams.stdErr)
+            output.normalizedOutput.empty
+            output.error.empty
         }
     }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -166,7 +166,8 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
         t.cause.cause.class.name == DaemonDisappearedException.name // not the same class because it's coming from the tooling client
 
         and:
-        OutputScrapingExecutionResult.normalize(t.message) == """An error occurred executing build with args '${runner.arguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
+        def output = OutputScrapingExecutionResult.from(t.message, "")
+        output.normalizedOutput == """An error occurred executing build with args '${runner.arguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
 
 > Task :helloWorld
 Hello world!


### PR DESCRIPTION
### Context

Some simplifications for logging setup and test fixtures, some improvements to the diagnostics from test fixtures, and fixes to properly restore `System.out` and `System.err` after running a Gradle build from a test using in-process execution.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
