### PR TITLE
Exclude anonymous class in JUnit Platform

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -42,7 +42,6 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.isNestedClassInsideEnclosedRunner;
@@ -53,7 +52,6 @@ import static org.junit.platform.launcher.TagFilter.excludeTags;
 import static org.junit.platform.launcher.TagFilter.includeTags;
 
 public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProcessor<JUnitPlatformSpec> {
-    private static final Pattern ANONYMOUS_CLASS_NAME = Pattern.compile(".*\\$\\d+");
     private TestResultProcessor resultProcessor;
     private TestClassExecutionListener executionListener;
     private CollectAllTestClassesExecutor testClassExecutor;
@@ -76,15 +74,16 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         super.stop();
     }
 
-
     private class CollectAllTestClassesExecutor implements Action<String> {
-        private final List<String> testClasses = new ArrayList<>();
+        private final List<Class<?>> testClasses = new ArrayList<>();
 
         @Override
         public void execute(String testClassName) {
-            if (shouldIncludeClass(testClassName)) {
-                testClasses.add(testClassName);
+            Class<?> klass = loadClass(testClassName);
+            if (isInnerClass(klass) || isNestedClassInsideEnclosedRunner(klass)) {
+                return;
             }
+            testClasses.add(klass);
         }
 
         private void processAllTestClasses() {
@@ -92,18 +91,6 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
             launcher.registerTestExecutionListeners(new JUnitPlatformTestExecutionListener(resultProcessor, clock, idGenerator, executionListener));
             launcher.execute(createLauncherDiscoveryRequest(testClasses));
         }
-    }
-
-    private boolean shouldIncludeClass(String testClassName) {
-        if (isAnonymousClass(testClassName)) {
-            return false;
-        }
-        Class<?> klass = loadClass(testClassName);
-        return !isInnerClass(klass) && !isNestedClassInsideEnclosedRunner(klass);
-    }
-
-    private boolean isAnonymousClass(String testClassName) {
-        return ANONYMOUS_CLASS_NAME.matcher(testClassName).matches();
     }
 
     private boolean isInnerClass(Class<?> klass) {
@@ -119,7 +106,7 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         }
     }
 
-    private LauncherDiscoveryRequest createLauncherDiscoveryRequest(List<String> testClasses) {
+    private LauncherDiscoveryRequest createLauncherDiscoveryRequest(List<Class<?>> testClasses) {
         List<DiscoverySelector> classSelectors = testClasses.stream()
             .map(DiscoverySelectors::selectClass)
             .collect(Collectors.toList());

--- a/subprojects/testing-junit-platform/src/test/groovy/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorTest.groovy
+++ b/subprojects/testing-junit-platform/src/test/groovy/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorTest.groovy
@@ -37,18 +37,6 @@ class JUnitPlatformTestClassProcessorTest extends Specification {
     @Subject
     JUnitPlatformTestClassProcessor processor = new JUnitPlatformTestClassProcessor(spec, idGenerator, actorFactory, clock)
 
-    def 'can exclude anonymous class'() {
-        given:
-        def anonymousInstance = new Object() {}
-        def executor = processor.createTestExecutor(resultProcessor, listener)
-
-        when:
-        executor.execute(anonymousInstance.class.name)
-
-        then:
-        executor.testClasses.isEmpty()
-    }
-
     class InnerClass {}
 
     static class NestedClass {}

--- a/subprojects/testing-junit-platform/src/test/groovy/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorTest.groovy
+++ b/subprojects/testing-junit-platform/src/test/groovy/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.testing.junit.TestClassExecutionListener
 import org.gradle.internal.actor.ActorFactory
 import org.gradle.internal.id.IdGenerator
 import org.gradle.internal.time.Clock
+import org.junit.Ignore
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import spock.lang.Specification
@@ -50,7 +51,7 @@ class JUnitPlatformTestClassProcessorTest extends Specification {
         executor.execute(NestedClass.name)
 
         then:
-        executor.testClasses == [NestedClass.name]
+        executor.testClasses == [NestedClass]
     }
 
     def 'can exclude nested class in Enclosed runner'() {
@@ -66,6 +67,7 @@ class JUnitPlatformTestClassProcessorTest extends Specification {
 }
 
 @RunWith(Enclosed.class)
+@Ignore
 class EnclosedTest {
     static class NestedClass {
     }

--- a/subprojects/testing-junit-platform/src/test/groovy/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorTest.groovy
+++ b/subprojects/testing-junit-platform/src/test/groovy/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junitplatform
+
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import org.gradle.api.internal.tasks.testing.junit.TestClassExecutionListener
+import org.gradle.internal.actor.ActorFactory
+import org.gradle.internal.id.IdGenerator
+import org.gradle.internal.time.Clock
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import spock.lang.Specification
+import spock.lang.Subject
+
+class JUnitPlatformTestClassProcessorTest extends Specification {
+    JUnitPlatformSpec spec = Mock()
+    IdGenerator idGenerator = Mock()
+    ActorFactory actorFactory = Mock()
+    Clock clock = Mock()
+    TestResultProcessor resultProcessor = Mock()
+    TestClassExecutionListener listener = Mock()
+
+    @Subject
+    JUnitPlatformTestClassProcessor processor = new JUnitPlatformTestClassProcessor(spec, idGenerator, actorFactory, clock)
+
+    def 'can exclude anonymous class'() {
+        given:
+        def anonymousInstance = new Object() {}
+        def executor = processor.createTestExecutor(resultProcessor, listener)
+
+        when:
+        executor.execute(anonymousInstance.class.name)
+
+        then:
+        executor.testClasses.isEmpty()
+    }
+
+    class InnerClass {}
+
+    static class NestedClass {}
+
+    def 'can exclude inner class but include nested class'() {
+        given:
+        def executor = processor.createTestExecutor(resultProcessor, listener)
+
+        when:
+        executor.execute(InnerClass.name)
+        executor.execute(NestedClass.name)
+
+        then:
+        executor.testClasses == [NestedClass.name]
+    }
+
+    def 'can exclude nested class in Enclosed runner'() {
+        given:
+        def executor = processor.createTestExecutor(resultProcessor, listener)
+
+        when:
+        executor.execute(EnclosedTest.NestedClass.name)
+
+        then:
+        executor.testClasses.isEmpty()
+    }
+}
+
+@RunWith(Enclosed.class)
+class EnclosedTest {
+    static class NestedClass {
+    }
+}

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/DefaultTestClassScannerTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/DefaultTestClassScannerTest.groovy
@@ -26,13 +26,13 @@ import org.gradle.api.internal.tasks.testing.TestClassProcessor
 import org.junit.Test
 import spock.lang.Specification
 
-public class DefaultTestClassScannerTest extends Specification {
+class DefaultTestClassScannerTest extends Specification {
     private final TestFrameworkDetector detector = Mock()
     private final TestClassProcessor processor = Mock()
     private final FileTree files = Mock()
 
     @Test
-    public void passesEachClassFileToTestClassDetector() {
+    void passesEachClassFileToTestClassDetector() {
         DefaultTestClassScanner scanner = new DefaultTestClassScanner(files, detector, processor)
 
         when:
@@ -50,6 +50,26 @@ public class DefaultTestClassScannerTest extends Specification {
             assert visitor
             visitor.visitFile(mockFileVisitDetails('class1'))
             visitor.visitFile(mockFileVisitDetails('class2'))
+        }
+
+        0 * _._
+    }
+
+    @Test
+    void skipAnonymousClass() {
+        DefaultTestClassScanner scanner = new DefaultTestClassScanner(files, detector, processor)
+
+        when:
+        scanner.run()
+
+        then:
+        1 * detector.startDetection(processor)
+        then:
+        1 * files.visit(_) >> { args ->
+            FileVisitor visitor = args[0]
+            assert visitor
+            visitor.visitFile(mockFileVisitDetails('AnonymousClass$1'))
+            visitor.visitFile(mockFileVisitDetails('AnonymousClass$1$22'))
         }
 
         0 * _._


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4544 https://github.com/gradle/gradle/issues/4618

Previously we send anonymous class to JUnit Platform test worker, which caused some issues.
Now they're excluded by name pattern `.*\$\d+`