### PR TITLE
Ignore scopes in <dependencyManagement> if it is used as BOM

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -100,25 +100,29 @@ public class GradlePomModuleDescriptorBuilder {
     }
 
     public void addDependency(PomDependencyData dep) {
-        doAddDependency(dep, dep.isOptional());
+        doAddDependency(dep, dep.isOptional(), false);
     }
 
     public void addOptionalDependency(PomDependencyMgt dep) {
-        doAddDependency(dep, true);
+        doAddDependency(dep, true, true);
     }
 
-    private void doAddDependency(PomDependencyMgt dep, boolean optional) {
-        String scopeString = dep.getScope();
-        if (scopeString == null || scopeString.length() == 0) {
-            scopeString = getDefaultScope(dep);
-        }
-
+    private void doAddDependency(PomDependencyMgt dep, boolean optional, boolean useCompileScope) {
         MavenScope scope;
-        if (SCOPES.containsKey(scopeString)) {
-            scope = SCOPES.get(scopeString);
-        } else {
-            // unknown scope, defaulting to 'compile'
+        if (useCompileScope) {
             scope = MavenScope.Compile;
+        } else {
+            String scopeString = dep.getScope();
+            if (scopeString == null || scopeString.length() == 0) {
+                scopeString = getDefaultScope(dep);
+            }
+
+            if (SCOPES.containsKey(scopeString)) {
+                scope = SCOPES.get(scopeString);
+            } else {
+                // unknown scope, defaulting to 'compile'
+                scope = MavenScope.Compile;
+            }
         }
 
         String version = determineVersion(dep);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
@@ -379,4 +379,38 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         metadata.dependencies.size() == 3
         metadata.dependencies.each { assert it.optional }
     }
+
+    def "scopes defined in a bom are ignored"() {
+        given:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group-a</groupId>
+    <artifactId>bom</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>group-b</groupId>
+                <artifactId>module-b</artifactId>
+                <version>1.0</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+"""
+
+        when:
+        parsePom()
+
+        then:
+        def dep = single(metadata.dependencies)
+        dep.selector == moduleId('group-b', 'module-b', '1.0')
+        dep.scope == MavenScope.Compile //compile is the 'default' scope
+        hasDefaultDependencyArtifact(dep)
+        dep.optional
+    }
 }


### PR DESCRIPTION
See #4765