### PR TITLE
Use U test to determine performance regressions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -43,6 +43,7 @@ libraries.commons_compress =    [coordinates: 'org.apache.commons:commons-compre
 libraries.commons_httpclient =  [coordinates: 'org.apache.httpcomponents:httpclient', version: '4.5.5']
 libraries.commons_io =          [coordinates: 'commons-io:commons-io', version: '2.4']
 libraries.commons_lang =        [coordinates: 'commons-lang:commons-lang', version: '2.6']
+libraries.commons_math =        [coordinates: 'org.apache.commons:commons-math3', version: '3.6.1']
 libraries.fastutil =            [coordinates: 'it.unimi.dsi:fastutil', version: '7.2.1']
 libraries.gcs =                 [coordinates: 'com.google.apis:google-api-services-storage', version: 'v1-rev116-1.23.0']
 libraries.groovy =              [coordinates: 'org.codehaus.groovy:groovy-all', version: '2.4.12']

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     compile(library("jgit"))
     compile(library("commons_httpclient"))
     compile(library("jsch"))
+    compile(library("commons_math"))
 
     flamegraph("com.github.oehme:jfr-flame-graph:v0.0.10:all")
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -109,7 +109,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
     }
 
     void experiment(String projectName, String displayName, @DelegatesTo(ToolingApiExperimentSpec) Closure<?> spec) {
-        experimentSpec = new ToolingApiExperimentSpec(displayName, projectName, temporaryFolder.testDirectory, 20, 30, null, null)
+        experimentSpec = new ToolingApiExperimentSpec(displayName, projectName, temporaryFolder.testDirectory, 20, 40, null, null)
         performanceTestIdProvider.testSpec = experimentSpec
         def clone = spec.rehydrate(experimentSpec, this, this)
         clone.resolveStrategy = Closure.DELEGATE_FIRST

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BuildExperimentRunner.java
@@ -146,7 +146,7 @@ public class BuildExperimentRunner {
         if (experiment.getInvocationCount() != null) {
             return experiment.getInvocationCount();
         }
-        return 30;
+        return 40;
     }
 
     protected int warmupsForExperiment(BuildExperimentSpec experiment) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/measure/DataSeries.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/measure/DataSeries.java
@@ -33,8 +33,6 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
     private final Amount<Q> min;
     // https://en.wikipedia.org/wiki/Standard_error
     private final Amount<Q> standardError;
-    // https://en.wikipedia.org/wiki/Standard_error#Standard_error_of_the_mean
-    private final Amount<Q> standardErrorOfMean;
 
     public DataSeries(Iterable<? extends Amount<Q>> values) {
         for (Amount<Q> value : values) {
@@ -49,7 +47,6 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
             max = null;
             min = null;
             standardError = null;
-            standardErrorOfMean = null;
             return;
         }
 
@@ -85,7 +82,6 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
         BigDecimal result = BigDecimal.valueOf(Math.sqrt(sumSquares.divide(BigDecimal.valueOf(size()), BigDecimal.ROUND_HALF_UP).doubleValue())).setScale(2, BigDecimal.ROUND_HALF_UP);
 
         standardError = Amount.valueOf(result, baseUnits);
-        standardErrorOfMean = standardError.div(BigDecimal.valueOf(Math.sqrt(size())));
     }
 
     public Amount<Q> getAverage() {
@@ -106,9 +102,5 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
 
     public Amount<Q> getStandardError() {
         return standardError;
-    }
-
-    public Amount<Q> getStandardErrorOfMean() {
-        return standardErrorOfMean;
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceResults.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceResults.groovy
@@ -87,10 +87,12 @@ class CrossVersionPerformanceResults extends PerformanceTestResult {
     }
 
     void assertCurrentVersionHasNotRegressed() {
-        def slower = checkBaselineVersion({ it.fasterThan(current) }, { it.getSpeedStatsAgainst(displayName, current) })
         assertEveryBuildSucceeds()
-        if (slower && whatToCheck().speed()) {
-            throw new AssertionError(Object.cast(slower))
+        if (whatToCheck().speed()) {
+            def slower = checkBaselineVersion({ it.significantlyFasterThan(current) }, { it.getSpeedStatsAgainst(displayName, current) })
+            if (slower) {
+                throw new AssertionError(Object.cast(slower))
+            }
         }
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/GradleVsMavenBuildPerformanceResults.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/GradleVsMavenBuildPerformanceResults.groovy
@@ -31,7 +31,7 @@ class GradleVsMavenBuildPerformanceResults extends CrossBuildPerformanceResults 
 
             println stats
 
-            def mavenIsFaster = baselineVersion.fasterThan(gradle)
+            def mavenIsFaster = baselineVersion.significantlyFasterThan(gradle)
             if (mavenIsFaster && whatToCheck().speed()) {
                 throw new AssertionError(stats as Object)
             }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
@@ -179,7 +179,7 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                     td().text("").end();
                 } else {
                     Amount<T> value = data.getMedian();
-                    Amount<T> stddev = data.getStandardError();
+                    Amount<T> se = data.getStandardError();
                     String classAttr = "numeric";
                     if (value.equals(min)) {
                         classAttr += " min-value";
@@ -189,12 +189,12 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                     }
                     td()
                         .classAttr(classAttr)
-                        .title("median: " + value + ", min: " + data.getMin() + ", max: " + data.getMax() + ", stddev: " + stddev + ", values: " + data)
+                        .title("median: " + value + ", min: " + data.getMin() + ", max: " + data.getMax() + ", se: " + se + ", values: " + data)
                         .text(value.format())
                         .end();
                     td()
                         .classAttr("numeric more-detail")
-                        .text("s: " + stddev.format())
+                        .text("se: " + se.format())
                         .end();
                 }
             }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/MeasuredOperationList.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/MeasuredOperationList.groovy
@@ -34,7 +34,7 @@ public class MeasuredOperationList extends LinkedList<MeasuredOperation> {
     }
 
     private String format(DataSeries<?> measurement) {
-        """  ${name} median: ${measurement.median.format()} min: ${measurement.min.format()}, max: ${measurement.max.format()}, se: ${measurement.standardError.format()}, sem: ${measurement.standardErrorOfMean.format()}
+        """  ${name} median: ${measurement.median.format()} min: ${measurement.min.format()}, max: ${measurement.max.format()}, se: ${measurement.standardError.format()}}
   > ${measurement.collect { it.format() }}
 """
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestExecutionTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestExecutionTest.groovy
@@ -61,14 +61,20 @@ class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
         result.baseline("1.0").results << operation(totalTime: 100)
         result.baseline("1.0").results << operation(totalTime: 100)
         result.baseline("1.0").results << operation(totalTime: 100)
+        result.baseline("1.0").results << operation(totalTime: 100)
+        result.baseline("1.0").results << operation(totalTime: 100)
 
         result.baseline("1.3").results << operation(totalTime: 110)
         result.baseline("1.3").results << operation(totalTime: 110)
+        result.baseline("1.3").results << operation(totalTime: 111)
+        result.baseline("1.3").results << operation(totalTime: 111)
         result.baseline("1.3").results << operation(totalTime: 111)
 
         and:
         result.current << operation(totalTime: 110)
         result.current << operation(totalTime: 110)
+        result.current << operation(totalTime: 111)
+        result.current << operation(totalTime: 111)
         result.current << operation(totalTime: 111)
 
         when:
@@ -76,8 +82,8 @@ class CrossVersionPerformanceTestExecutionTest extends ResultSpecification {
 
         then:
         AssertionError e = thrown()
-        e.message.startsWith("Speed ${result.displayName}: we're slower than 1.0.")
-        e.message.contains('Difference: 10 ms slower (1E+1 ms), 10.00%, max regression: 0.407 ms')
+        e.message.startsWith("Speed ${result.displayName}: we're slower than 1.0 with 99% confidence.")
+        e.message.contains('Difference: 11 ms slower (11 ms), 11.00%')
         !e.message.contains('1.3')
     }
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.performance.ResultSpecification
-import org.gradle.performance.measure.DataAmount
 import org.gradle.performance.measure.Duration
 import org.gradle.performance.results.DataReporter
 import org.gradle.performance.results.MeasuredOperationList
@@ -283,16 +282,66 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
 
         when:
         1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
-            result.add(operation(totalTime: Duration.seconds(10)))
+            10.times {
+                result.add(operation(totalTime: Duration.seconds(6)))
+            }
         }
         1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
-            result.add(operation(totalTime: Duration.seconds(5)))
+            10.times {
+                result.add(operation(totalTime: Duration.seconds(5)))
+            }
         }
         def results = runner.run()
         results.assertCurrentVersionHasNotRegressed()
 
         then: "without overrides, test fails"
         thrown(AssertionError)
+    }
+
+    def "insignificant regressions are ignored"() {
+        given:
+        def runner = runner()
+        runner.targetVersions = ['last']
+
+        when:
+        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
+            result.add(operation(totalTime: Duration.seconds(5.0)))
+            result.add(operation(totalTime: Duration.seconds(5.1)))
+            result.add(operation(totalTime: Duration.seconds(5.2)))
+        }
+        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
+            result.add(operation(totalTime: Duration.seconds(5.0)))
+            result.add(operation(totalTime: Duration.seconds(5.1)))
+            result.add(operation(totalTime: Duration.seconds(5.1)))
+
+        }
+        def results = runner.run()
+
+        then:
+        results.assertCurrentVersionHasNotRegressed()
+    }
+
+    def "outliers are ignored"() {
+        given:
+        def runner = runner()
+        runner.targetVersions = ['last']
+
+        when:
+        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
+            9.times {
+                result.add(operation(totalTime: Duration.seconds(5)))
+            }
+            result.add(operation(totalTime: Duration.seconds(100)))
+        }
+        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
+            10.times {
+                result.add(operation(totalTime: Duration.seconds(5)))
+            }
+        }
+        def results = runner.run()
+
+        then:
+        results.assertCurrentVersionHasNotRegressed()
     }
 
     def "a performance regression is identified in speed but we check for nothing"() {
@@ -304,49 +353,11 @@ class CrossVersionPerformanceTestRunnerTest extends ResultSpecification {
         System.setProperty('org.gradle.performance.execution.checks', 'none')
         1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
             result.add(operation(totalTime: Duration.seconds(10)))
+            result.add(operation(totalTime: Duration.seconds(10)))
         }
         1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
             result.add(operation(totalTime: Duration.seconds(5)))
-        }
-        def results = runner.run()
-        results.assertCurrentVersionHasNotRegressed()
-
-        then: "test passes"
-        noExceptionThrown()
-    }
-
-    def "a performance regression is identified in memory but we only check for speed"() {
-        given:
-        def runner = runner()
-        runner.targetVersions = ['last']
-
-        when:
-        System.setProperty('org.gradle.performance.execution.checks', 'speed')
-        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
-            result.add(operation(totalTime: Duration.seconds(10)))
-        }
-        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
-            result.add(operation(totalTime: Duration.seconds(10), totalMemoryUsed: DataAmount.kbytes(5)))
-        }
-        def results = runner.run()
-        results.assertCurrentVersionHasNotRegressed()
-
-        then: "test passes"
-        noExceptionThrown()
-    }
-
-    def "a performance regression is identified in memory but we only check for nothing"() {
-        given:
-        def runner = runner()
-        runner.targetVersions = ['last']
-
-        when:
-        System.setProperty('org.gradle.performance.execution.checks', 'none')
-        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
-            result.add(operation(totalTime: Duration.seconds(10)))
-        }
-        1 * experimentRunner.run(_, _) >> { BuildExperimentSpec spec, MeasuredOperationList result ->
-            result.add(operation(totalTime: Duration.seconds(10), totalMemoryUsed: DataAmount.kbytes(5)))
+            result.add(operation(totalTime: Duration.seconds(5)))
         }
         def results = runner.run()
         results.assertCurrentVersionHasNotRegressed()

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/measure/DataSeriesTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/measure/DataSeriesTest.groovy
@@ -31,7 +31,6 @@ class DataSeriesTest extends Specification {
         series.min == v1
         series.max == v3
         series.standardError == DataAmount.bytes(8360.92)
-        series.standardErrorOfMean == DataAmount.bytes(4827.179413)
     }
 
     def "ignores null values"() {
@@ -58,6 +57,5 @@ class DataSeriesTest extends Specification {
         series.min == null
         series.max == null
         series.standardError == null
-        series.standardErrorOfMean == null
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -30,7 +30,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         runner.minimumVersion = "4.3.1"
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -31,6 +31,8 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
             action('org.gradle.performance.android.SyncAction') {
                 jvmArguments = customizeJvmOptions(["-Xms4g", "-Xmx4g"])
             }
+            invocationCount = iterations
+            warmUpCount = iterations
         }
 
         when:
@@ -40,7 +42,9 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
         results.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject << ["k9AndroidBuild", "largeAndroidBuild"]
+        testProject         | iterations
+        "k9AndroidBuild"    | 200
+        "largeAndroidBuild" | 40
     }
 
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -27,7 +27,7 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
 
         experiment(testProject) {
             minimumVersion = "4.3.1"
-            targetVersions = ["4.7-20180330212523+0000"]
+            targetVersions = ["4.8-20180405000006+0000"]
             action('org.gradle.performance.android.SyncAction') {
                 jvmArguments = customizeJvmOptions(["-Xms4g", "-Xmx4g"])
             }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -42,7 +42,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 11
         runner.runs = 21
         runner.minimumVersion = "3.5"
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
     }
 
     def "clean #tasks on #testProject with remote http cache"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -39,8 +39,8 @@ import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_
 class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 
     def setup() {
-        runner.warmUpRuns = 5
-        runner.runs = 13
+        runner.warmUpRuns = 11
+        runner.runs = 21
         runner.minimumVersion = "3.5"
         runner.targetVersions = ["4.7-20180330212523+0000"]
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 
 class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
     }
 
     def "visiting zip trees"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -25,7 +25,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
 
     def setup() {
         runner.minimumVersion = '4.0'
-        runner.targetVersions = ["4.7-20180320095059+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
     }
 
     def "merge exclude rules"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
@@ -30,7 +30,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['eclipse']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()
@@ -50,7 +50,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['idea']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -26,7 +26,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
 
     def setup() {
         runner.minimumVersion = '4.0'
-        runner.targetVersions = ["4.7-20180320095059+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
     }
 
     def "resolve large dependency graph from file repo"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -46,7 +46,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
     }
 
     def setup() {
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
         runner.warmUpRuns = 5
         runner.runs = 15
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ProjectCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ProjectCreationPerformanceTest.groovy
@@ -25,7 +25,7 @@ class ProjectCreationPerformanceTest extends AbstractCrossVersionPerformanceTest
         runner.testProject = "bigEmpty"
         runner.tasksToRun = ['help']
         runner.gradleOpts = ['-Xms1500m', '-Xmx1500m']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
@@ -38,7 +38,7 @@ class RichConsolePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms${daemonMemory}", "-Xmx${daemonMemory}"]
         runner.warmUpRuns = 5
         runner.runs = 8
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
@@ -25,7 +25,7 @@ class TaskCreationPerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = "createLotsOfTasks"
         runner.tasksToRun = ['help']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
@@ -28,7 +28,7 @@ class VerboseTestOutputPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.tasksToRun = ['cleanTest', 'test']
         runner.args = ['-q']
         runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -131,7 +131,7 @@ class GradleBuildPerformanceTest extends Specification {
         then:
         def speedStats = baselineResults.getSpeedStatsAgainst(currentResults.name, currentResults)
         println(speedStats)
-        if (baselineResults.fasterThan(currentResults)) {
+        if (baselineResults.significantlyFasterThan(currentResults)) {
             throw new AssertionError(speedStats)
         }
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -36,7 +36,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
         given:
         runner.testProject = "gradleBuildCurrent"
         runner.tasksToRun = tasks.split(' ')
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -32,7 +32,7 @@ class JavaABIChangePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -31,7 +31,7 @@ class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         runner.tasksToRun = ["clean", "assemble"]
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['help']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaDependencyReportPerformanceTest extends AbstractCrossVersionPerformanc
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ["${subProject}dependencyReport"]
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -36,7 +36,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
         runner.useDaemon = false
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
             @Override
             void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
@@ -66,7 +66,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
         runner.useDaemon = false
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -32,7 +32,7 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         given:
         experiment(testProject.projectName) {
             minimumVersion = "2.11"
-            targetVersions = ["4.7-20180330212523+0000"]
+            targetVersions = ["4.8-20180405000006+0000"]
             invocationCount = iterations
             warmUpCount = iterations
             action {
@@ -92,7 +92,7 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         given:
         experiment(testProject.projectName) {
             minimumVersion = "2.11"
-            targetVersions = ["4.7-20180330212523+0000"]
+            targetVersions = ["4.8-20180405000006+0000"]
             invocationCount = iterations
             warmUpCount = iterations
             action {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -33,6 +33,8 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         experiment(testProject.projectName) {
             minimumVersion = "2.11"
             targetVersions = ["4.7-20180330212523+0000"]
+            invocationCount = iterations
+            warmUpCount = iterations
             action {
                 def model = model(tapiClass(EclipseProject)).setJvmArguments("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").get()
                 // we must actually do something to highlight some performance issues
@@ -80,9 +82,9 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         results.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject                   | _
-        LARGE_MONOLITHIC_JAVA_PROJECT | _
-        LARGE_JAVA_MULTI_PROJECT      | _
+        testProject                   | iterations
+        LARGE_MONOLITHIC_JAVA_PROJECT | 200
+        LARGE_JAVA_MULTI_PROJECT      | 40
     }
 
     @Unroll
@@ -91,6 +93,8 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         experiment(testProject.projectName) {
             minimumVersion = "2.11"
             targetVersions = ["4.7-20180330212523+0000"]
+            invocationCount = iterations
+            warmUpCount = iterations
             action {
                 def model = model(tapiClass(IdeaProject)).setJvmArguments("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").get()
                 // we must actually do something to highlight some performance issues
@@ -135,9 +139,9 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         results.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject                   | _
-        LARGE_MONOLITHIC_JAVA_PROJECT | _
-        LARGE_JAVA_MULTI_PROJECT      | _
+        testProject                   | iterations
+        LARGE_MONOLITHIC_JAVA_PROJECT | 200
+        LARGE_JAVA_MULTI_PROJECT      | 40
     }
 
     private static void forEachEclipseProject(def elm, @DelegatesTo(value=EclipseProject) Closure<?> action) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -32,7 +32,7 @@ class JavaNonABIChangePerformanceTest extends AbstractCrossVersionPerformanceTes
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaTasksPerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()
@@ -50,7 +50,7 @@ class JavaTasksPerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks', '--all']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTestChangePerformanceTest.groovy
@@ -33,7 +33,7 @@ class JavaTestChangePerformanceTest extends AbstractCrossVersionPerformanceTest 
         runner.runs = runs
         runner.tasksToRun = ['test']
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['test']))
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -32,7 +32,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/GradleKotlinDslBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/GradleKotlinDslBuildPerformanceTest.groovy
@@ -29,7 +29,7 @@ class GradleKotlinDslBuildPerformanceTest extends AbstractCrossVersionPerformanc
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.gradleOpts = ["-Xms512m", "-Xmx512m"]
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()
@@ -50,7 +50,7 @@ class GradleKotlinDslBuildPerformanceTest extends AbstractCrossVersionPerformanc
         runner.tasksToRun = ['help']
         runner.args = ['--recompile-scripts']
         runner.gradleOpts = ["-Xms512m", "-Xmx512m"]
-        runner.targetVersions = ["4.7-20180330212523+0000"]
+        runner.targetVersions = ["4.8-20180405000006+0000"]
 
         when:
         def result = runner.run()


### PR DESCRIPTION
Instead of an arbitrary threshold we now use the Mann-Whitney U test
to calculate how confident we can be in the results.

For now we'll require a 99% confidence before reporting a regression.
We can tweak that value based on whether we miss too many
regressions or report too many non-regressions.

I'm going to do some experiments on this branch before merging.