### PR TITLE
Cleanup tests and docs for plain console task grouping

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/AbstractBuildResultLoggerFunctionalTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/AbstractBuildResultLoggerFunctionalTest.groovy
@@ -16,15 +16,11 @@
 
 package org.gradle.api.internal.buildevents
 
-import org.fusesource.jansi.Ansi
 import org.gradle.api.logging.configuration.ConsoleOutput
-import org.gradle.integtests.fixtures.RichConsoleStyling
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-class BuildResultLoggerFunctionalSpec extends AbstractIntegrationSpec implements RichConsoleStyling {
-
+abstract class AbstractBuildResultLoggerFunctionalTest extends AbstractIntegrationSpec {
     def setup() {
-        executer.withConsole(ConsoleOutput.Rich)
         executer.withStackTraceChecksDisabled()
     }
 
@@ -33,32 +29,41 @@ class BuildResultLoggerFunctionalSpec extends AbstractIntegrationSpec implements
         buildFile << "task fail { doFirst { assert false } }"
 
         when:
+        executer.withConsole(consoleType)
         executer.withQuietLogging()
         fails('fail')
 
         then:
-        result.output.contains("BUILD FAILED")
+        result.output.contains(failureMessage)
     }
 
-    def "Failure message is logged bold and red"() {
+    def "Failure message is logged with appropriate styling"() {
         given:
         buildFile << "task fail { doFirst { assert false } }"
 
         when:
+        executer.withConsole(consoleType)
         fails('fail')
 
         then:
-        result.output.contains(styled("BUILD FAILED", Ansi.Color.RED, Ansi.Attribute.INTENSITY_BOLD))
+        result.output.contains(failureMessage)
     }
 
-    def "Success message is logged bold and green in the rich console"() {
+    def "Success message is logged with appropriate styling"() {
         given:
         buildFile << "task success"
 
         when:
+        executer.withConsole(consoleType)
         succeeds('success')
 
         then:
-        result.output.contains(styled('BUILD SUCCESSFUL', Ansi.Color.GREEN, Ansi.Attribute.INTENSITY_BOLD))
+        result.output.contains(successMessage)
     }
+
+    abstract ConsoleOutput getConsoleType()
+
+    abstract String getFailureMessage()
+
+    abstract String getSuccessMessage()
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/PlainConsoleBuildResultLoggerFunctionalTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/PlainConsoleBuildResultLoggerFunctionalTest.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.buildevents
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class PlainConsoleBuildResultLoggerFunctionalTest extends AbstractBuildResultLoggerFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Plain
+    String failureMessage = "BUILD FAILED"
+    String successMessage = "BUILD SUCCESSFUL"
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/RichConsoleBuildResultLoggerFunctionalTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/RichConsoleBuildResultLoggerFunctionalTest.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.buildevents
+
+import org.fusesource.jansi.Ansi
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.integtests.fixtures.RichConsoleStyling
+
+class RichConsoleBuildResultLoggerFunctionalTest extends AbstractBuildResultLoggerFunctionalTest implements RichConsoleStyling {
+    ConsoleOutput consoleType = ConsoleOutput.Rich
+    String failureMessage = styled("BUILD FAILED", Ansi.Color.RED, Ansi.Attribute.INTENSITY_BOLD)
+    String successMessage = styled('BUILD SUCCESSFUL', Ansi.Color.GREEN, Ansi.Attribute.INTENSITY_BOLD)
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/VerboseConsoleBuildResultLoggerFunctionalTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/buildevents/VerboseConsoleBuildResultLoggerFunctionalTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.buildevents
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class VerboseConsoleBuildResultLoggerFunctionalTest extends RichConsoleBuildResultLoggerFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractExecOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractExecOutputIntegrationTest.groovy
@@ -19,19 +19,16 @@ package org.gradle.api.tasks
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
-import spock.lang.Unroll
 import spock.util.environment.OperatingSystem
 
-import static org.gradle.api.logging.configuration.ConsoleOutput.*
-
 @Issue("https://github.com/gradle/gradle/issues/2009")
-class ExecOutputIntegrationTest extends AbstractIntegrationSpec {
-    private static final List<ConsoleOutput> CONSOLE_TYPES = [Rich, Plain]
+abstract class AbstractExecOutputIntegrationTest extends AbstractIntegrationSpec {
     private static final String EXPECTED_OUTPUT = "Hello, World!"
     private static final String EXPECTED_ERROR = "Goodbye, World!"
 
-    @Unroll
-    def "Project#javaexec output is grouped with its task output (#consoleType console)"() {
+    abstract ConsoleOutput getConsoleType()
+
+    def "Project.javaexec output is grouped with its task output"() {
         given:
         generateMainJavaFileEchoing(EXPECTED_OUTPUT, EXPECTED_ERROR)
         buildFile << """
@@ -56,13 +53,9 @@ class ExecOutputIntegrationTest extends AbstractIntegrationSpec {
         def output = result.groupedOutput.task(':run').output
         output.contains(EXPECTED_OUTPUT)
         output.contains(EXPECTED_ERROR)
-
-        where:
-        consoleType << CONSOLE_TYPES
     }
 
-    @Unroll
-    def "JavaExec task output is grouped with its task output (#consoleType console)"() {
+    def "JavaExec task output is grouped with its task output"() {
         given:
         generateMainJavaFileEchoing(EXPECTED_OUTPUT, EXPECTED_ERROR)
         buildFile << """
@@ -83,13 +76,9 @@ class ExecOutputIntegrationTest extends AbstractIntegrationSpec {
         def output = result.groupedOutput.task(':run').output
         output.contains(EXPECTED_OUTPUT)
         output.contains(EXPECTED_ERROR)
-
-        where:
-        consoleType << CONSOLE_TYPES
     }
 
-    @Unroll
-    def "Project#exec output is grouped with its task output (#consoleType console)"() {
+    def "Project.exec output is grouped with its task output"() {
         given:
         buildFile << """
             task run {
@@ -107,12 +96,9 @@ class ExecOutputIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.groupedOutput.task(':run').output == EXPECTED_OUTPUT
-
-        where:
-        consoleType << CONSOLE_TYPES
     }
 
-    def "Exec task output is grouped with its task output (#consoleType console)"() {
+    def "Exec task output is grouped with its task output"() {
         given:
         buildFile << """
             task run(type: Exec) {
@@ -126,9 +112,6 @@ class ExecOutputIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.groupedOutput.task(':run').output == EXPECTED_OUTPUT
-
-        where:
-        consoleType << CONSOLE_TYPES
     }
 
     private static String echo(String s) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/PlainConsoleExecOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/PlainConsoleExecOutputIntegrationTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class PlainConsoleExecOutputIntegrationTest extends AbstractExecOutputIntegrationTest {
+    ConsoleOutput consoleType = ConsoleOutput.Plain
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/RichConsoleExecOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/RichConsoleExecOutputIntegrationTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class RichConsoleExecOutputIntegrationTest extends AbstractExecOutputIntegrationTest {
+    ConsoleOutput consoleType = ConsoleOutput.Rich
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/VerboseConsoleExecOutputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/VerboseConsoleExecOutputIntegrationTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class VerboseConsoleExecOutputIntegrationTest extends AbstractExecOutputIntegrationTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
+++ b/subprojects/docs/src/docs/userguide/commandLineInterface.adoc
@@ -446,9 +446,9 @@ image::img/rich-cli.png[alt="Gradle Rich Console"]
 
 Features:
 
- * Logs above grouped by task that generated them
  * Progress bar and timer visually describe overall status
  * Parallel work-in-progress lines below describe what is happening now
+ * Colors and fonts are used to highlight important output and errors
 
 [[sec:command_line_execution_options]]
 === Execution options

--- a/subprojects/docs/src/docs/userguide/console.adoc
+++ b/subprojects/docs/src/docs/userguide/console.adoc
@@ -163,26 +163,27 @@ BUILD SUCCESSFUL in 2m 10s
 [[sec:console_non_interactive_environments]]
 === Look & feel in non-interactive environments
 
-By default, Gradle tries to enable rich console output by detecting the type of console the build is running from. This enables color and additional console output formatting. Non-interactive environments fall back to using plain console output. The plain output format _does not_ support grouping of output. Tasks and outcomes are always printed to be consistent with Gradle 3.x versions.
+By default, Gradle tries to enable rich console output by detecting the type of console the build is running from. This enables color and additional console output formatting. Non-interactive environments fall back to using plain console output, which presents the status and output of tasks as they execute, but does not display the build progress bar or the work-in-progress display.
 
 NOTE: Gradle builds executed from an IDE (e.g. Buildship and IntelliJ) or Continuous Integration products (e.g. Jenkins and TeamCity) use plain console output by default.
 
 The following output demonstrates the use of a plain console:
 
 ----
-:compileJava
+> Task :compileJava
 Note: Some input files use unchecked or unsafe operations.
 Note: Recompile with -Xlint:unchecked for details.
-:processResources
-:classes
-:jar
-:assemble
-:compileTestJava NO-SOURCE
-:processTestResources NO-SOURCE
-:testClasses UP-TO-DATE
-:test NO-SOURCE
-:check UP-TO-DATE
-:build
+
+> Task :processResources
+> Task :classes
+> Task :jar
+> Task :assemble
+> Task :compileTestJava
+> Task :processTestResources
+> Task :testClasses
+> Task :test
+> Task :check
+> Task :build
 
 BUILD SUCCESSFUL in 6s
 11 actionable tasks: 6 executed, 5 up-to-date

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/PlainConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/PlainConsoleJvmTestLoggingFunctionalTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.jvm
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class PlainConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleJvmTestLoggingFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Plain
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/RichConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/RichConsoleJvmTestLoggingFunctionalTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.jvm
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class RichConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleJvmTestLoggingFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Rich
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/VerboseConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/VerboseConsoleJvmTestLoggingFunctionalTest.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.jvm
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class VerboseConsoleJvmTestLoggingFunctionalTest extends AbstractConsoleJvmTestLoggingFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.sink.GroupingProgressLogEventGenerator
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
+import spock.lang.IgnoreIf
 
 abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractConsoleGroupedTaskFunctionalTest {
     @Rule
@@ -106,6 +108,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
         result.groupedOutput.task(':log').output =~ /First line of text\n{3,}Last line of text/
     }
 
+    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "long running task output correctly interleave with other tasks in parallel"() {
         given:
         def sleepTime = GroupingProgressLogEventGenerator.LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT / 2 * 3
@@ -153,6 +156,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
         """
 
         when:
+        executer.withArguments("--parallel")
         fails('run')
 
         then:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleGroupedTaskFunctionalTest.groovy
@@ -19,18 +19,14 @@ package org.gradle.internal.logging.console.taskgrouping
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RichConsoleStyling
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
 
 /**
  * A base class for testing task grouping in the console. Executes with a Gradle distribution and {@code "--parallel"} command line option.
  */
-@IgnoreIf({ GradleContextualExecuter.parallel })
 abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
     def setup() {
         executer.beforeExecute {
             it.withConsole(consoleType)
-            it.withArgument('--parallel')
         }
     }
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
+
 abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractConsoleVerboseBasicFunctionalTest {
     def 'failed task result can be rendered (#consoleType console)'() {
         given:
@@ -56,6 +59,7 @@ abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractCon
         result.groupedOutput.task(':upToDate').outcome == 'UP-TO-DATE'
     }
 
+    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "task headers for long running tasks are printed only once when there is no output"() {
         given:
         settingsFile << """
@@ -80,6 +84,7 @@ abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractCon
         """
 
         when:
+        executer.withArguments("--parallel")
         succeeds "allTasks"
 
         then:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping.verbose
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.internal.logging.console.taskgrouping.AbstractBasicGroupedTaskLoggingFunctionalTest
+
+class VerboseConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGroupedTaskLoggingFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleBuildSrcGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleBuildSrcGroupedTaskFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping.verbose
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleBuildSrcGroupedTaskFunctionalTest
+
+class VerboseConsoleBuildSrcGroupedTaskFunctionalTest extends AbstractConsoleBuildSrcGroupedTaskFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleCompositeBuildGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleCompositeBuildGroupedTaskFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping.verbose
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleCompositeBuildGroupedTaskFunctionalTest
+
+class VerboseConsoleCompositeBuildGroupedTaskFunctionalTest extends AbstractConsoleCompositeBuildGroupedTaskFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleDeprecationMessageGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleDeprecationMessageGroupedTaskFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping.verbose
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleDeprecationMessageGroupedTaskFunctionalTest
+
+class VerboseConsoleDeprecationMessageGroupedTaskFunctionalTest extends AbstractConsoleDeprecationMessageGroupedTaskFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleGradleBuildGroupedTaskFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleGradleBuildGroupedTaskFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping.verbose
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.internal.logging.console.taskgrouping.AbstractConsoleGradleBuildGroupedTaskFunctionalTest
+
+class VerboseConsoleGradleBuildGroupedTaskFunctionalTest extends AbstractConsoleGradleBuildGroupedTaskFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}


### PR DESCRIPTION
This is follow-up work from https://github.com/gradle/gradle/pull/4756.  There are three main pieces of work here:

- Refactor tests to ensure that all console tests run for the plain, rich and verbose consoles, as well as some restructuring to handle different console types consistently.
- Updates to the userguide to remove verbiage about the plain console not showing grouped task output.
- Change the console tests to run for both parallel and non-parallel except for certain tests that specifically test parallel functionality.