### PR TITLE
Fix for Batch scripts not properly signalling a failure in a pipeline

### DIFF
--- a/buildSrc/gradlew.bat
+++ b/buildSrc/gradlew.bat
@@ -70,15 +70,17 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if not "%ERRORLEVEL%"=="0" goto fail
+
+if "%OS%"=="Windows_NT" endlocal
+exit /b 0
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+if not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
 
-:mainEnd
-if "%OS%"=="Windows_NT" endlocal
+@rem exit /b will not properly signal a failure, instead cause a real failure to signal a failure of this script
+@%COMSPEC% /C exit 1 >nul
 
 :omega

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,15 +70,17 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if not "%ERRORLEVEL%"=="0" goto fail
+
+if "%OS%"=="Windows_NT" endlocal
+exit /b 0
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+if not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
 
-:mainEnd
-if "%OS%"=="Windows_NT" endlocal
+@rem exit /b will not properly signal a failure, instead cause a real failure to signal a failure of this script
+@%COMSPEC% /C exit 1 >nul
 
 :omega

--- a/subprojects/docs/src/samples/userguide/wrapper/sha256-verification/gradlew.bat
+++ b/subprojects/docs/src/samples/userguide/wrapper/sha256-verification/gradlew.bat
@@ -70,15 +70,17 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if not "%ERRORLEVEL%"=="0" goto fail
+
+if "%OS%"=="Windows_NT" endlocal
+exit /b 0
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+if not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
 
-:mainEnd
-if "%OS%"=="Windows_NT" endlocal
+@rem exit /b will not properly signal a failure, instead cause a real failure to signal a failure of this script
+@%COMSPEC% /C exit 1 >nul
 
 :omega

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -71,15 +71,17 @@ set CLASSPATH=$classpath
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if not "%ERRORLEVEL%"=="0" goto fail
+
+if "%OS%"=="Windows_NT" endlocal
+exit /b 0
 
 :fail
 rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%${exitEnvironmentVar}%" exit 1
-exit /b 1
+if not "" == "%${exitEnvironmentVar}%" exit 1
 
-:mainEnd
-if "%OS%"=="Windows_NT" endlocal
+@rem exit /b will not properly signal a failure, instead cause a real failure to signal a failure of this script
+@%COMSPEC% /C exit 1 >nul
 
 :omega

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.plugins
 
 import org.gradle.jvm.application.scripts.JavaAppStartScriptGenerationDetails
-import org.gradle.util.TextUtil
 import org.gradle.util.WrapUtil
 import spock.lang.Specification
 
@@ -46,7 +45,7 @@ class WindowsStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.windowsLineSeparator).length == 84
+        (destination.toString() ==~ /(?<!\r)\n/) == false
     }
 
     def "defaultJvmOpts is expanded properly in windows script"() {


### PR DESCRIPTION
The Windows shell pipeline will not detect a failure when using 'exit /b 1'.  Instead generate a real failure that will cause the pipeline to behave correctly.

Signed-off-by: Jason Archer <jasonmarcher@gmail.com>

### Context
One of our developers noticed that `gradlew someTaskThatDoesNotExist && echo Success` does not behave correctly on Windows.  The echo will happen even though the Gradle invocation failed.

Here is a StackOverflow thread about the issue and the source of the solution used here.  https://stackoverflow.com/questions/4632891/exiting-batch-with-exit-b-x-where-x-1-acts-as-if-command-completed-successfu

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
