### PR TITLE
Improve task grouping in console

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -48,7 +48,6 @@ To see more detail about a task, run gradle help --task <task>
 
 For troubleshooting, visit https://help.gradle.org
 
-
 BUILD SUCCESSFUL"""
     }
 
@@ -73,7 +72,6 @@ Description
 Group
      help
 
-
 BUILD SUCCESSFUL"""
     }
 
@@ -97,7 +95,6 @@ Description
 
 Group
      help
-
 
 BUILD SUCCESSFUL"""
     }
@@ -135,7 +132,6 @@ Descriptions
 
 Group
      -
-
 
 BUILD SUCCESSFUL"""
     }
@@ -182,7 +178,6 @@ Groups
      (:someproj1:hello) group of subproject task
      (:someproj2:hello) group of subproject task
 
-
 BUILD SUCCESSFUL"""
     }
 
@@ -207,7 +202,6 @@ Description
 Group
      build
 
-
 BUILD SUCCESSFUL"""
 
         when:
@@ -227,7 +221,6 @@ Description
 
 Group
      build
-
 
 BUILD SUCCESSFUL"""
 
@@ -279,7 +272,6 @@ Group
 
 ----------------------
 
-
 BUILD SUCCESSFUL"""
     }
 
@@ -314,7 +306,6 @@ Description
 
 Group
      -
-
 
 BUILD SUCCESSFUL"""
 
@@ -359,7 +350,6 @@ Description
 Group
      -
 
-
 BUILD SUCCESSFUL"""
     }
 
@@ -388,7 +378,6 @@ Description
 
 Group
      -
-
 
 BUILD SUCCESSFUL"""
     }

--- a/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/model/ModelReportParser.groovy
+++ b/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/model/ModelReportParser.groovy
@@ -148,6 +148,6 @@ class ModelReportParser {
         if (successMarker == 0) {
             return []
         }
-        nodeLines.subList(0, successMarker - 2)
+        nodeLines.subList(0, successMarker - 1)
     }
 }

--- a/subprojects/docs/src/samples/userguideOutput/abbreviateCamelCaseTaskName.out
+++ b/subprojects/docs/src/samples/userguideOutput/abbreviateCamelCaseTaskName.out
@@ -5,6 +5,5 @@ compiling source
 > Task :compileTest
 compiling unit tests
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/addBehaviourToAntTarget.out
+++ b/subprojects/docs/src/samples/userguideOutput/addBehaviourToAntTarget.out
@@ -3,6 +3,5 @@
 [ant:echo] Hello, from Ant
 Hello, from Gradle
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/antHello.out
+++ b/subprojects/docs/src/samples/userguideOutput/antHello.out
@@ -2,6 +2,5 @@
 > Task :hello
 [ant:echo] Hello, from Ant
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/antLogging.out
+++ b/subprojects/docs/src/samples/userguideOutput/antLogging.out
@@ -2,6 +2,5 @@
 > Task :hello
 [ant:echo] hello from info priority!
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/basicRuleSourcePlugin-all.out
+++ b/subprojects/docs/src/samples/userguideOutput/basicRuleSourcePlugin-all.out
@@ -2,6 +2,5 @@
 > Task :hello
 Hello John Smith!
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/buildlifecycle.out
+++ b/subprojects/docs/src/samples/userguideOutput/buildlifecycle.out
@@ -12,6 +12,5 @@ This is executed during the execution phase.
 This is executed first during the execution phase.
 This is executed last during the execution phase.
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/compileSourceSet.out
+++ b/subprojects/docs/src/samples/userguideOutput/compileSourceSet.out
@@ -2,6 +2,5 @@
 > Task :processIntTestResources
 > Task :intTestClasses
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/custom_logging_ui.out
+++ b/subprojects/docs/src/samples/userguideOutput/custom_logging_ui.out
@@ -17,6 +17,5 @@ running unit tests
 > Task :build
 [build]
 
-
 build completed
 3 actionable tasks: 3 executed

--- a/subprojects/docs/src/samples/userguideOutput/dependentTaskForApplicationDistributionOutput.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependentTaskForApplicationDistributionOutput.out
@@ -6,6 +6,5 @@
 > Task :startScripts
 > Task :distZip
 
-
 BUILD SUCCESSFUL in 0s
 5 actionable tasks: 5 executed

--- a/subprojects/docs/src/samples/userguideOutput/dependsOnAntTarget.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependsOnAntTarget.out
@@ -5,6 +5,5 @@
 > Task :intro
 Hello, from Gradle
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/dependsOnTask.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependsOnTask.out
@@ -5,6 +5,5 @@ Hello, from Gradle
 > Task :hello
 [ant:echo] Hello, from Ant
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/disableTask.out
+++ b/subprojects/docs/src/samples/userguideOutput/disableTask.out
@@ -1,4 +1,3 @@
 > Task :disableMe SKIPPED
 
-
 BUILD SUCCESSFUL in 0s

--- a/subprojects/docs/src/samples/userguideOutput/excludeTask.out
+++ b/subprojects/docs/src/samples/userguideOutput/excludeTask.out
@@ -5,6 +5,5 @@ compiling source
 > Task :dist
 building the distribution
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/implicitTaskDependency.out
+++ b/subprojects/docs/src/samples/userguideOutput/implicitTaskDependency.out
@@ -5,6 +5,5 @@ Wrote 'Hello, World!' to /home/user/gradle/samples/providers/implicitTaskDepende
 > Task :consumer
 Read 'Hello, World!' from /home/user/gradle/samples/providers/implicitTaskDependency/output/file.txt
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/javaQuickstart.out
+++ b/subprojects/docs/src/samples/userguideOutput/javaQuickstart.out
@@ -10,6 +10,5 @@
 > Task :check
 > Task :build
 
-
 BUILD SUCCESSFUL in 0s
 6 actionable tasks: 6 executed

--- a/subprojects/docs/src/samples/userguideOutput/listProperty.out
+++ b/subprojects/docs/src/samples/userguideOutput/listProperty.out
@@ -5,6 +5,5 @@ The list contains: [element-1, element-2]
 The list contains: [element-3, element-4]
 The list contains: [element-3, element-4, element-5, element-6]
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/modelDslConfigureRuleNotRunWhenNotRequired.out
+++ b/subprojects/docs/src/samples/userguideOutput/modelDslConfigureRuleNotRunWhenNotRequired.out
@@ -2,6 +2,5 @@
 > Task :somethingElse
 Not using person
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/modelDslConfigureRuleRunWhenRequired.out
+++ b/subprojects/docs/src/samples/userguideOutput/modelDslConfigureRuleRunWhenRequired.out
@@ -3,6 +3,5 @@ configuring person
 > Task :showPerson
 Hello John Smith!
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/modelDslInitializationRuleRunsBeforeConfigurationRule.out
+++ b/subprojects/docs/src/samples/userguideOutput/modelDslInitializationRuleRunsBeforeConfigurationRule.out
@@ -5,6 +5,5 @@ last name is Smith, should be Smythe
 > Task :showPerson
 Hello John Smythe!
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/modelDslModelMapNestedAll.out
+++ b/subprojects/docs/src/samples/userguideOutput/modelDslModelMapNestedAll.out
@@ -7,6 +7,5 @@ configuring Person 'people.john'
 Hello Barry Barry!
 Hello John Smith!
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/multiprojectPartialTasksNotQuiet.out
+++ b/subprojects/docs/src/samples/userguideOutput/multiprojectPartialTasksNotQuiet.out
@@ -5,6 +5,5 @@
 > Task :krill:distanceToIceberg
 5 nautical miles
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/multitestingBuild.out
+++ b/subprojects/docs/src/samples/userguideOutput/multitestingBuild.out
@@ -14,6 +14,5 @@
 > Task :api:check
 > Task :api:build
 
-
 BUILD SUCCESSFUL in 0s
 9 actionable tasks: 9 executed

--- a/subprojects/docs/src/samples/userguideOutput/multitestingBuildDashA.out
+++ b/subprojects/docs/src/samples/userguideOutput/multitestingBuildDashA.out
@@ -10,6 +10,5 @@
 > Task :api:check
 > Task :api:build
 
-
 BUILD SUCCESSFUL in 0s
 6 actionable tasks: 6 executed

--- a/subprojects/docs/src/samples/userguideOutput/multitestingBuildDependents.out
+++ b/subprojects/docs/src/samples/userguideOutput/multitestingBuildDependents.out
@@ -27,6 +27,5 @@
 > Task :services:personService:buildDependents
 > Task :api:buildDependents
 
-
 BUILD SUCCESSFUL in 0s
 17 actionable tasks: 17 executed

--- a/subprojects/docs/src/samples/userguideOutput/multitestingBuildNeeded.out
+++ b/subprojects/docs/src/samples/userguideOutput/multitestingBuildNeeded.out
@@ -23,6 +23,5 @@
 > Task :shared:buildNeeded
 > Task :api:buildNeeded
 
-
 BUILD SUCCESSFUL in 0s
 12 actionable tasks: 12 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeAssembleDependentComponents.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeAssembleDependentComponents.out
@@ -10,6 +10,5 @@
 > Task :operatorsPassingStaticLibrary
 > Task :assembleDependentsOperatorsPassingStaticLibrary
 
-
 BUILD SUCCESSFUL in 0s
 7 actionable tasks: 7 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeAssembleDependentComponentsReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeAssembleDependentComponentsReport.out
@@ -13,6 +13,5 @@ operators - Components that depend on native library 'operators'
 
 Some test suites were not shown, use --test-suites or --all to show them.
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeBuildDependentComponents.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeBuildDependentComponents.out
@@ -13,6 +13,5 @@
 > Task :operatorsPassingStaticLibrary
 > Task :buildDependentsOperatorsPassingStaticLibrary
 
-
 BUILD SUCCESSFUL in 0s
 9 actionable tasks: 9 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeBuildDependentComponentsReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeBuildDependentComponentsReport.out
@@ -15,6 +15,5 @@ operators - Components that depend on native library 'operators'
 
 (t) - Test suite binary
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeComponentCustomCheckOutput.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeComponentCustomCheckOutput.out
@@ -4,6 +4,5 @@ Executing my custom check
 
 > Task :checkHelloSharedLibrary
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeComponentReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeComponentReport.out
@@ -47,6 +47,5 @@ Binaries
 
 Note: currently not all plugins register their components, so some components may not be visible here.
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeDependentComponentsReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeDependentComponentsReport.out
@@ -13,6 +13,5 @@ operators - Components that depend on native library 'operators'
 
 Some test suites were not shown, use --test-suites or --all to show them.
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/nativeDependentComponentsReportAll.out
+++ b/subprojects/docs/src/samples/userguideOutput/nativeDependentComponentsReportAll.out
@@ -19,6 +19,5 @@ operatorsTest - Components that depend on Cunit test suite 'operatorsTest'
 
 (t) - Test suite binary
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/playComponentReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/playComponentReport.out
@@ -38,6 +38,5 @@ Binaries
 
 Note: currently not all plugins register their components, so some components may not be visible here.
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/publishingIvyGenerateDescriptor.out
+++ b/subprojects/docs/src/samples/userguideOutput/publishingIvyGenerateDescriptor.out
@@ -1,5 +1,4 @@
 > Task :generateDescriptorFileForIvyCustomPublication
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/publishingIvyPublishLifecycle.out
+++ b/subprojects/docs/src/samples/userguideOutput/publishingIvyPublishLifecycle.out
@@ -6,6 +6,5 @@
 > Task :publishIvyJavaPublicationToIvyRepository
 > Task :publish
 
-
 BUILD SUCCESSFUL in 0s
 3 actionable tasks: 3 executed

--- a/subprojects/docs/src/samples/userguideOutput/publishingIvyPublishSingle.out
+++ b/subprojects/docs/src/samples/userguideOutput/publishingIvyPublishSingle.out
@@ -5,6 +5,5 @@
 > Task :jar
 > Task :publishIvyJavaPublicationToIvyRepository
 
-
 BUILD SUCCESSFUL in 0s
 3 actionable tasks: 3 executed

--- a/subprojects/docs/src/samples/userguideOutput/publishingMavenGeneratePom.out
+++ b/subprojects/docs/src/samples/userguideOutput/publishingMavenGeneratePom.out
@@ -1,5 +1,4 @@
 > Task :generatePomFileForMavenCustomPublication
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/publishingMavenPublishLocal.out
+++ b/subprojects/docs/src/samples/userguideOutput/publishingMavenPublishLocal.out
@@ -6,6 +6,5 @@
 > Task :publishMavenJavaPublicationToMavenLocal
 > Task :publishToMavenLocal
 
-
 BUILD SUCCESSFUL in 0s
 4 actionable tasks: 4 executed

--- a/subprojects/docs/src/samples/userguideOutput/publishingMavenPublishMinimal.out
+++ b/subprojects/docs/src/samples/userguideOutput/publishingMavenPublishMinimal.out
@@ -6,6 +6,5 @@
 > Task :publishMavenJavaPublicationToMavenRepository
 > Task :publish
 
-
 BUILD SUCCESSFUL in 0s
 4 actionable tasks: 4 executed

--- a/subprojects/docs/src/samples/userguideOutput/renameAntDelegate.out
+++ b/subprojects/docs/src/samples/userguideOutput/renameAntDelegate.out
@@ -2,6 +2,5 @@
 > Task :a-hello
 [ant:echo] Hello, from Ant
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/signingArchivesOutput.out
+++ b/subprojects/docs/src/samples/userguideOutput/signingArchivesOutput.out
@@ -4,6 +4,5 @@
 > Task :jar
 > Task :signArchives
 
-
 BUILD SUCCESSFUL in 0s
 4 actionable tasks: 4 executed

--- a/subprojects/docs/src/samples/userguideOutput/signingTaskOutput.out
+++ b/subprojects/docs/src/samples/userguideOutput/signingTaskOutput.out
@@ -1,6 +1,5 @@
 > Task :stuffZip
 > Task :signStuffZip
 
-
 BUILD SUCCESSFUL in 0s
 2 actionable tasks: 2 executed

--- a/subprojects/docs/src/samples/userguideOutput/taskOnlyIf.out
+++ b/subprojects/docs/src/samples/userguideOutput/taskOnlyIf.out
@@ -1,4 +1,3 @@
 > Task :hello SKIPPED
 
-
 BUILD SUCCESSFUL in 0s

--- a/subprojects/docs/src/samples/userguideOutput/taskWithNestedText.out
+++ b/subprojects/docs/src/samples/userguideOutput/taskWithNestedText.out
@@ -2,6 +2,5 @@
 > Task :hello
 [ant:echo] hello from Ant
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/useAntTask.out
+++ b/subprojects/docs/src/samples/userguideOutput/useAntTask.out
@@ -2,6 +2,5 @@
 > Task :hello
 [ant:echo] hello from Ant
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/usePropertyAndProvider.out
+++ b/subprojects/docs/src/samples/userguideOutput/usePropertyAndProvider.out
@@ -2,6 +2,5 @@
 > Task :greeting
 Hi from Gradle
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/workingWithFiles.out
+++ b/subprojects/docs/src/samples/userguideOutput/workingWithFiles.out
@@ -5,6 +5,5 @@ foo.someFiles contains someDirectory? true
 foo.someFile = /home/user/gradle/samples/providers/fileAndDirectoryProperty/build/some-file
 foo.someFiles contains someFile? true
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguideOutput/wrapperCommandLine.out
+++ b/subprojects/docs/src/samples/userguideOutput/wrapperCommandLine.out
@@ -1,5 +1,4 @@
 > Task :wrapper
 
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -108,7 +108,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
 
     def "long running task output correctly interleave with other tasks in parallel"() {
         given:
-        def sleepTime = GroupingProgressLogEventGenerator.LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT / 2 * 3
+        def sleepTime = GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT / 2 * 3
         buildFile << """import java.util.concurrent.Semaphore
             project(":a") {
                 ext.lock = new Semaphore(0)
@@ -193,7 +193,7 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
     }
 
     private static void assertOutputContains(GradleHandle gradle, String str) {
-        ConcurrentTestUtil.poll(GroupingProgressLogEventGenerator.LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT/2 * 3 as long) {
+        ConcurrentTestUtil.poll(GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT/2 * 3 as long) {
             assert gradle.standardOutput =~ /(?ms)$str/
         }
     }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -192,8 +192,8 @@ abstract class AbstractBasicGroupedTaskLoggingFunctionalTest extends AbstractCon
         gradle?.waitForFinish()
     }
 
-    private void assertOutputContains(GradleHandle gradle, String str) {
-        ConcurrentTestUtil.poll {
+    private static void assertOutputContains(GradleHandle gradle, String str) {
+        ConcurrentTestUtil.poll(GroupingProgressLogEventGenerator.LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT/2 * 3 as long) {
             assert gradle.standardOutput =~ /(?ms)$str/
         }
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class GroupingProgressLogEventGenerator implements OutputEventListener {
 
-    private static final long LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT = TimeUnit.SECONDS.toMillis(2);
+    private static final long LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT = Long.getLong("org.gradle.console.flush-timeout", TimeUnit.SECONDS.toMillis(30));
     private final OutputEventListener listener;
     private final Clock clock;
     private final LogHeaderFormatter headerFormatter;

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
@@ -338,7 +338,7 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
 
     def "forwards a batched group of events after receiving update now event after flush period"() {
         given:
-        def olderTimestamp = timeProvider.currentTime - GroupingProgressLogEventGenerator.LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT
+        def olderTimestamp = timeProvider.currentTime - GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT
         def taskAStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), olderTimestamp, CATEGORY, "Execute :a", ":a", null, null, 0, true, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)
         def taskAOutput = event(olderTimestamp, 'message for task a', LogLevel.WARN, taskAStartEvent.buildOperationId)
         def updateNowEvent = new UpdateNowEvent(timeProvider.currentTime)
@@ -361,7 +361,7 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
 
     def "forwards multiple batched groups of events after receiving update now event after flush period"() {
         given:
-        def olderTimestamp = timeProvider.currentTime - GroupingProgressLogEventGenerator.LONG_RUNNING_TASK_OUTPUT_FLUSH_TIMEOUT
+        def olderTimestamp = timeProvider.currentTime - GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT
         def taskAStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), olderTimestamp, CATEGORY, "Execute :a", ":a", null, null, 0, true, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)
         def taskAOutput = event(olderTimestamp, 'message for task a', LogLevel.WARN, taskAStartEvent.buildOperationId)
         def taskBStartEvent = new ProgressStartEvent(new OperationIdentifier(-13L), new OperationIdentifier(-14L), olderTimestamp, CATEGORY, "Execute :b", ":b", null, null, 0, true, new OperationIdentifier(12L), null, BuildOperationCategory.TASK)

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
@@ -328,7 +328,6 @@ SampleBinary 'sampleBinary'
 
 Note: currently not all plugins register their components, so some components may not be visible here.
 
-
 BUILD SUCCESSFUL"""
     }
 

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
@@ -164,7 +164,6 @@ SampleComponent 'sampleLib'
 
 Note: currently not all plugins register their components, so some components may not be visible here.
 
-
 BUILD SUCCESSFUL"""
     }
 

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
@@ -115,7 +115,6 @@ SampleBinary 'sampleBinary'
 
 Note: currently not all plugins register their components, so some components may not be visible here.
 
-
 BUILD SUCCESSFUL"""
     }
 

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -560,7 +560,6 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
 
             No components.
 
-
             BUILD SUCCESSFUL
         """.stripIndent().trim()
     }


### PR DESCRIPTION
See https://github.com/gradle/gradle-native/issues/584.

This improves the task grouping in the console for longer running tasks so that output tends to be grouped a little better.  It implements an approach where once a "foreground" task starts writing to the console, we attempt to avoid switching the output to another task until either the foreground task completes, or a much longer "high watermark" timeout expires (at which point, other long-running tasks will flush any buffered output).