### PR TITLE
Remove the verbose flag by default for `swiftc`

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
@@ -119,8 +119,6 @@ class SwiftCompiler extends AbstractCompiler<SwiftCompileSpec> {
                     genericArgs.add(spec.getModuleFile().getAbsolutePath());
                 }
 
-                genericArgs.add("-v");
-
 
                 boolean canSafelyCompileIncrementally = swiftDepsHandler.adjustTimestampsFor(moduleSwiftDeps, spec.getChangedFiles());
                 if (canSafelyCompileIncrementally) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinker.java
@@ -72,7 +72,6 @@ class SwiftLinker extends AbstractCompiler<LinkerSpec> {
             } else {
                 args.add("-emit-executable");
             }
-            args.add("-v");
             args.add("-o");
             args.add(spec.getOutputFile().getAbsolutePath());
             for (File file : spec.getObjectFiles()) {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
@@ -60,7 +60,7 @@ class SwiftLinkerTest extends Specification {
 
         final expectedArgs = [
             "-emit-library",
-            "-v", "-o", outputFile.absolutePath,
+            "-o", outputFile.absolutePath,
             testDir.file("one.o").absolutePath].flatten()
 
         when:
@@ -102,7 +102,7 @@ class SwiftLinkerTest extends Specification {
         final expectedArgs = [
                 "-sys1", "-sys2",
                 "-emit-library",
-                "-v", "-o", outputFile.absolutePath,
+                "-o", outputFile.absolutePath,
                 testDir.file("one.o").absolutePath,
                 testDir.file("two.o").absolutePath,
                 "-arg1", "-arg2"].flatten()
@@ -138,7 +138,7 @@ class SwiftLinkerTest extends Specification {
 
         final expectedArgs = [
             "-emit-library",
-            "-v", "-o", outputFile.absolutePath,
+            "-o", outputFile.absolutePath,
             testDir.file("one.o").absolutePath].flatten()
 
         when:
@@ -162,7 +162,7 @@ class SwiftLinkerTest extends Specification {
 
         final expectedArgs = [
             "-emit-executable",
-            "-v", "-o", outputFile.absolutePath,
+            "-o", outputFile.absolutePath,
             testDir.file("one.o").absolutePath].flatten()
 
         when:
@@ -186,7 +186,7 @@ class SwiftLinkerTest extends Specification {
 
         final expectedArgs = [
             "-Xlinker", "-bundle",
-            "-v", "-o", outputFile.absolutePath,
+            "-o", outputFile.absolutePath,
             testDir.file("one.o").absolutePath].flatten()
 
         when:


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Removing verbose flag passed by default to swift compiler.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fno-verbose-flag-by-default)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
