### PR TITLE
Create marker file to prevent rendering of initial welcome message in integration test

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -31,8 +31,9 @@ class ToolingApiLoggingCrossVersionSpec extends ToolingApiLoggingSpecification {
         toolingApi.requireIsolatedToolingApi()
 
         // Create marker file to prevent creation of "welcome message"
-        def notificationsDir = new File(toolingApi.gradleUserHomeDir, "notifications")
+        def notificationsDir = new File(toolingApi.gradleUserHomeDir, 'notifications')
         def markerDir = new File(notificationsDir, buildContext.version.version)
+        markerDir.mkdirs()
         new File(markerDir, 'release-features.rendered').createNewFile()
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -31,7 +31,8 @@ class ToolingApiLoggingCrossVersionSpec extends ToolingApiLoggingSpecification {
         toolingApi.requireIsolatedToolingApi()
 
         // Create marker file to prevent creation of "welcome message"
-        def markerDir = new File(toolingApi.gradleUserHomeDir, "notifications/$buildContext.version.version")
+        def notificationsDir = new File(toolingApi.gradleUserHomeDir, "notifications")
+        def markerDir = new File(notificationsDir, buildContext.version.version)
         new File(markerDir, 'release-features.rendered').createNewFile()
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -29,6 +29,10 @@ class ToolingApiLoggingCrossVersionSpec extends ToolingApiLoggingSpecification {
 
     def setup() {
         toolingApi.requireIsolatedToolingApi()
+
+        // Create marker file to prevent creation of "welcome message"
+        def markerDir = new File(toolingApi.gradleUserHomeDir, "notifications/$buildContext.version.version")
+        new File(markerDir, 'release-features.rendered').createNewFile()
     }
 
     def cleanup() {


### PR DESCRIPTION
### Context

Fixes flakiness in `ToolingApiLoggingCrossVersionSpec.client receives same standard outpu…tandard error as if running from the command-line`.

https://builds.gradle.org/viewLog.html?buildId=11761736&buildTypeId=Gradle_Check_Quick_Java7_Oracle_Windows_toolingApi