### PR TITLE
Fix 4457. Don't set parallel mode and threadCount for testng if not explicitly defined

### DIFF
--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -101,8 +101,12 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         testNg.setOutputDirectory(testReportDir.getAbsolutePath());
         testNg.setDefaultSuiteName(options.getDefaultSuiteName());
         testNg.setDefaultTestName(options.getDefaultTestName());
-        testNg.setParallel(options.getParallel());
-        testNg.setThreadCount(options.getThreadCount());
+        if (options.getParallel() != null) {
+            testNg.setParallel(options.getParallel());
+        }
+        if (options.getThreadCount() >= 1) {
+            testNg.setThreadCount(options.getThreadCount());
+        }
         invokeVerifiedMethod(testNg, "setConfigFailurePolicy", String.class, options.getConfigFailurePolicy(), TestNGOptions.DEFAULT_CONFIG_FAILURE_POLICY);
         invokeVerifiedMethod(testNg, "setPreserveOrder", boolean.class, options.getPreserveOrder(), false);
         invokeVerifiedMethod(testNg, "setGroupByInstances", boolean.class, options.getGroupByInstances(), false);

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -101,6 +101,7 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         testNg.setOutputDirectory(testReportDir.getAbsolutePath());
         testNg.setDefaultSuiteName(options.getDefaultSuiteName());
         testNg.setDefaultTestName(options.getDefaultTestName());
+
         if (options.getParallel() != null) {
             testNg.setParallel(options.getParallel());
         }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -49,9 +49,9 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     private Set<String> listeners = new LinkedHashSet<String>();
 
-    private String parallel;
+    private String parallel = null;
 
-    private int threadCount = 1;
+    private int threadCount = -1;
 
     private boolean useDefaultListeners;
 


### PR DESCRIPTION
Fix #4457 
Without this fix gradle always overrides values of options `threadCount` and `parallel`, even if they are not explicitly defined in gradle file. As result corresponding values defined in `<suite>` tag inside testng.xml suite are always ignored