### PR TITLE
Fix 4457. Don't set parallel mode and threadCount for testng if not explicitly defined

### DIFF
--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/testng/TestNGOptionsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/testng/TestNGOptionsTest.groovy
@@ -23,21 +23,21 @@ import org.junit.Test
 import static org.hamcrest.Matchers.hasItems
 import static org.junit.Assert.*
 
-public class TestNGOptionsTest extends AbstractTestFrameworkOptionsTest<TestNGTestFramework> {
+class TestNGOptionsTest extends AbstractTestFrameworkOptionsTest<TestNGTestFramework> {
 
-    TestNGOptions testngOptions;
+    TestNGOptions testngOptions
 
     String[] groups = ['fast', 'unit']
 
-    @Before public void setUp()
-    {
+    @Before
+    void setUp() {
         super.setUp(TestNGTestFramework)
 
         testngOptions = new TestNGOptions(new File("projectDir"))
     }
 
-    @Test public void verifyDefaults()
-    {
+    @Test
+    void verifyDefaults() {
         assertNotNull(testngOptions.includeGroups)
         assertTrue(testngOptions.includeGroups.empty)
 
@@ -49,7 +49,7 @@ public class TestNGOptionsTest extends AbstractTestFrameworkOptionsTest<TestNGTe
 
         assertNull(testngOptions.parallel)
 
-        assertEquals(testngOptions.threadCount, 1)
+        assertEquals(testngOptions.threadCount, -1)
 
         assertEquals('Gradle suite', testngOptions.suiteName)
 
@@ -62,27 +62,27 @@ public class TestNGOptionsTest extends AbstractTestFrameworkOptionsTest<TestNGTe
         assertFalse(testngOptions.groupByInstances)
     }
 
-    @Test public void testIncludeGroups()
-    {
-        assertTrue(testngOptions.excludeGroups.empty);
-        assertTrue(testngOptions.includeGroups.empty);
+    @Test
+    void testIncludeGroups() {
+        assertTrue(testngOptions.excludeGroups.empty)
+        assertTrue(testngOptions.includeGroups.empty)
 
-        testngOptions.includeGroups(groups);
+        testngOptions.includeGroups(groups)
 
         assertFalse(testngOptions.includeGroups.empty)
         assertThat(testngOptions.includeGroups, hasItems(groups))
-        assertTrue(testngOptions.excludeGroups.empty);
+        assertTrue(testngOptions.excludeGroups.empty)
     }
 
-    @Test public void testExcludeGroups()
-    {
-        assertTrue(testngOptions.excludeGroups.empty);
-        assertTrue(testngOptions.includeGroups.empty);
+    @Test
+    void testExcludeGroups() {
+        assertTrue(testngOptions.excludeGroups.empty)
+        assertTrue(testngOptions.includeGroups.empty)
 
         testngOptions.excludeGroups(groups)
 
         assertFalse(testngOptions.excludeGroups.empty)
         assertThat(testngOptions.excludeGroups, hasItems(groups))
-        assertTrue(testngOptions.includeGroups.empty);
+        assertTrue(testngOptions.includeGroups.empty)
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
@@ -22,10 +22,10 @@ import org.gradle.internal.jvm.Jvm
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 
 class TestNGCoverage {
-    final static String NEWEST = Jvm.current().javaVersion.java7Compatible ? '6.9.13.6' : '6.8.7'
+    final static String NEWEST = Jvm.current().javaVersion.java7Compatible ? '6.14.2' : '6.8.7'
     final static String INITIAL_BROKEN_ICLASS_LISTENER = '6.9.10' // introduces initial, buggy IClassListener
     final static String FIXED_ICLASS_LISTENER = '6.9.13.3' // introduces fixed IClassListener
-    final static String[] STANDARD_COVERAGE = ['5.14.10', '6.2', '6.8.7', NEWEST]
+    final static String[] STANDARD_COVERAGE = ['5.14.10', '6.2', '6.8.7', '6.9.13.6', NEWEST]
     final static String[] STANDARD_COVERAGE_WITH_INITIAL_ICLASS_LISTENER =  ObjectArrays.concat(INITIAL_BROKEN_ICLASS_LISTENER, STANDARD_COVERAGE)
     final static String[] PRESERVE_ORDER = Jvm.current().javaVersion.java7Compatible ? ['5.14.6', '6.1.1', '6.9.4', NEWEST] : ['5.14.6', '6.1.1'] // skipped NEWEST (6.8.7) because of cbeust/testng#639
     final static String[] GROUP_BY_INSTANCES = ['6.1', '6.8.7', NEWEST]

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -23,9 +23,9 @@ import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 
-@TargetCoverage({TestNGCoverage.STANDARD_COVERAGE})
+@TargetCoverage({ TestNGCoverage.STANDARD_COVERAGE })
 class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
-    def setup(){
+    def setup() {
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
@@ -77,7 +77,7 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/4457")
-    def "can persist configurations in xml" (){
+    def "can persist configurations in xml"() {
         given:
         createTests(3, 3)
 
@@ -88,7 +88,7 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
         actualThreadIds(output).size() == 3
     }
 
-    private static actualThreadIds(String stdout){
+    private static actualThreadIds(String stdout) {
         String pattern = /.*\d+ - foo \d+ - (\d+)/
         return stdout.readLines().grep(~pattern).collect { (it =~ pattern)[0][1] }.toSet()
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -101,8 +101,12 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         testNg.setOutputDirectory(testReportDir.getAbsolutePath());
         testNg.setDefaultSuiteName(options.getDefaultSuiteName());
         testNg.setDefaultTestName(options.getDefaultTestName());
-        testNg.setParallel(options.getParallel());
-        testNg.setThreadCount(options.getThreadCount());
+        if (options.getParallel() != null) {
+            testNg.setParallel(options.getParallel());
+        }
+        if (options.getThreadCount() >= 1) {
+            testNg.setThreadCount(options.getThreadCount());
+        }
         invokeVerifiedMethod(testNg, "setConfigFailurePolicy", String.class, options.getConfigFailurePolicy(), TestNGOptions.DEFAULT_CONFIG_FAILURE_POLICY);
         invokeVerifiedMethod(testNg, "setPreserveOrder", boolean.class, options.getPreserveOrder(), false);
         invokeVerifiedMethod(testNg, "setGroupByInstances", boolean.class, options.getGroupByInstances(), false);

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
-import org.gradle.api.tasks.testing.testng.TestNGOptions;
 import org.gradle.internal.actor.Actor;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
@@ -42,6 +41,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import static org.gradle.api.tasks.testing.testng.TestNGOptions.*;
 
 public class TestNGTestClassProcessor implements TestClassProcessor {
     private final List<Class<?>> testClasses = new ArrayList<Class<?>>();
@@ -104,10 +105,10 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         if (options.getParallel() != null) {
             testNg.setParallel(options.getParallel());
         }
-        if (options.getThreadCount() >= 1) {
+        if (options.getThreadCount() > 0) {
             testNg.setThreadCount(options.getThreadCount());
         }
-        invokeVerifiedMethod(testNg, "setConfigFailurePolicy", String.class, options.getConfigFailurePolicy(), TestNGOptions.DEFAULT_CONFIG_FAILURE_POLICY);
+        invokeVerifiedMethod(testNg, "setConfigFailurePolicy", String.class, options.getConfigFailurePolicy(), DEFAULT_CONFIG_FAILURE_POLICY);
         invokeVerifiedMethod(testNg, "setPreserveOrder", boolean.class, options.getPreserveOrder(), false);
         invokeVerifiedMethod(testNg, "setGroupByInstances", boolean.class, options.getGroupByInstances(), false);
         testNg.setUseDefaultListeners(options.getUseDefaultListeners());

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -38,6 +38,8 @@ import java.util.Set;
  */
 public class TestNGOptions extends TestFrameworkOptions {
     public static final String DEFAULT_CONFIG_FAILURE_POLICY = "skip";
+    private static final String DEFAULT_PARALLEL_MODE = null;
+    private static final int DEFAULT_THREAD_COUNT = -1;
 
     private File outputDirectory;
 
@@ -49,9 +51,9 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     private Set<String> listeners = new LinkedHashSet<String>();
 
-    private String parallel = null;
+    private String parallel = DEFAULT_PARALLEL_MODE;
 
-    private int threadCount = -1;
+    private int threadCount = DEFAULT_THREAD_COUNT;
 
     private boolean useDefaultListeners;
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -49,9 +49,9 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     private Set<String> listeners = new LinkedHashSet<String>();
 
-    private String parallel;
+    private String parallel = null;
 
-    private int threadCount = 1;
+    private int threadCount = -1;
 
     private boolean useDefaultListeners;
 


### PR DESCRIPTION
Signed-off-by: Oleksandr Kulychok <o.kulychok@astoundcommerce.com>

Fix #4457
Without this fix gradle always overrides values of options threadCount and parallel, even if they are not explicitly defined in gradle file. As result corresponding values defined in <suite> tag inside testng.xml suite are always ignored