### PR TITLE
Make ClassMethodNameStackTraceSpec support anonymous class matching

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpec.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpec.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 import java.util.regex.Pattern;
 
 public class ClassMethodNameStackTraceSpec implements Spec<StackTraceElement> {
-    private static final Pattern ANONYMOUS_CLASS_NAME_SUFFIX = Pattern.compile("[\\d$]+");
+    private static final Pattern ANONYMOUS_CLASS_NAME_SUFFIX = Pattern.compile("\\$[\\d$]+");
     private final String className;
     private final String methodName;
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpec.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpec.java
@@ -19,19 +19,34 @@ package org.gradle.api.internal.tasks.testing.logging;
 import org.gradle.api.specs.Spec;
 
 import javax.annotation.Nullable;
+import java.util.regex.Pattern;
 
 public class ClassMethodNameStackTraceSpec implements Spec<StackTraceElement> {
+    private static final Pattern ANONYMOUS_CLASS_NAME_SUFFIX = Pattern.compile("[\\d$]+");
     private final String className;
     private final String methodName;
 
-    ClassMethodNameStackTraceSpec(@Nullable String className, @Nullable String methodName) {
+    ClassMethodNameStackTraceSpec(String className, @Nullable String methodName) {
         this.className = className;
         this.methodName = methodName;
     }
 
     @Override
     public boolean isSatisfiedBy(StackTraceElement element) {
-        return (className == null || className.equals(element.getClassName()))
-                && (methodName == null || methodName.equals(element.getMethodName()));
+        return classNameMatch(element.getClassName()) && methodNameMatch(element.getMethodName());
+    }
+
+    private boolean methodNameMatch(String methodName) {
+        return this.methodName == null || this.methodName.equals(methodName);
+    }
+
+    private boolean classNameMatch(String targetClassName) {
+        if (!targetClassName.startsWith(className)) {
+            return false;
+        }
+
+        String suffix = targetClassName.substring(className.length());
+
+        return suffix.isEmpty() || ANONYMOUS_CLASS_NAME_SUFFIX.matcher(suffix).matches();
     }
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpecTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpecTest.groovy
@@ -45,6 +45,7 @@ class ClassMethodNameStackTraceSpecTest extends Specification {
         spec.isSatisfiedBy(new StackTraceElement("ClassName", "methodName", "SomeFile.java", 42))
         spec.isSatisfiedBy(new StackTraceElement('ClassName$1$1$1', "methodName", "SomeFile.kt", 42))
         spec.isSatisfiedBy(new StackTraceElement("ClassName", "otherMethodName", "SomeFile.java", 42))
+        !spec.isSatisfiedBy(new StackTraceElement('ClassName1$1', "otherMethodName", "SomeFile.java", 42))
         !spec.isSatisfiedBy(new StackTraceElement("OtherClassName", "methodName", "OtherFile.java", 21))
         !spec.isSatisfiedBy(new StackTraceElement('ClassName$Inner$1', "methodName", "OtherFile.kt", 21))
     }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpecTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpecTest.groovy
@@ -25,6 +25,8 @@ class ClassMethodNameStackTraceSpecTest extends Specification {
         expect:
         spec.isSatisfiedBy(new StackTraceElement("ClassName", "methodName", "SomeFile.java", 42))
         spec.isSatisfiedBy(new StackTraceElement("ClassName", "methodName", "OtherFile.java", 21))
+        spec.isSatisfiedBy(new StackTraceElement('ClassName$1', "methodName", "ClassName.java", 21))
+        spec.isSatisfiedBy(new StackTraceElement('ClassName$1$22', "methodName", "ClassName.kt", 21))
     }
 
     def "rejects elements whose class or method name does not match"() {
@@ -33,6 +35,7 @@ class ClassMethodNameStackTraceSpecTest extends Specification {
         expect:
         !spec.isSatisfiedBy(new StackTraceElement("ClassName", "otherMethodName", "SomeFile.java", 42))
         !spec.isSatisfiedBy(new StackTraceElement("OtherClassName", "methodName", "OtherFile.java", 21))
+        !spec.isSatisfiedBy(new StackTraceElement('ClassName$Inner', "otherMethodName", "SomeFile.kt", 42))
     }
 
     def "allows to only match class name (by setting method name to null)"() {
@@ -40,16 +43,9 @@ class ClassMethodNameStackTraceSpecTest extends Specification {
 
         expect:
         spec.isSatisfiedBy(new StackTraceElement("ClassName", "methodName", "SomeFile.java", 42))
+        spec.isSatisfiedBy(new StackTraceElement('ClassName$1$1$1', "methodName", "SomeFile.kt", 42))
         spec.isSatisfiedBy(new StackTraceElement("ClassName", "otherMethodName", "SomeFile.java", 42))
         !spec.isSatisfiedBy(new StackTraceElement("OtherClassName", "methodName", "OtherFile.java", 21))
-    }
-
-    def "allows to only match method name (by setting class name to null)"() {
-        def spec = new ClassMethodNameStackTraceSpec(null, "methodName")
-
-        expect:
-        spec.isSatisfiedBy(new StackTraceElement("ClassName", "methodName", "SomeFile.java", 42))
-        spec.isSatisfiedBy(new StackTraceElement("OtherClassName", "methodName", "SomeFile.java", 42))
-        !spec.isSatisfiedBy(new StackTraceElement("ClassName", "otherMethodName", "OtherFile.java", 21))
+        !spec.isSatisfiedBy(new StackTraceElement('ClassName$Inner$1', "methodName", "OtherFile.kt", 21))
     }
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/FullExceptionFormatterTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/FullExceptionFormatterTest.groovy
@@ -177,6 +177,25 @@ class FullExceptionFormatterTest extends Specification {
 """
     }
 
+    def "treat anonymous class and its enclosing class equally"() {
+        testLogging.getShowCauses() >> true
+        testLogging.getShowStackTraces() >> true
+        testLogging.getStackTraceFilters() >> EnumSet.of(TestStackTraceFilter.TRUNCATE, TestStackTraceFilter.GROOVY)
+
+        def exception = new PlaceholderException(Exception.name, "ouch", null, "java.lang.Exception: ouch", null, null)
+        def stacktrace = createGroovyTrace()
+        stacktrace[3] = new StackTraceElement('ClassName$1$1', "whatever", "MyTest.java", 22)
+        exception.stackTrace = stacktrace
+
+        expect:
+        formatter.format(testDescriptor, [exception]) == '''\
+    java.lang.Exception: ouch
+        at org.ClassName1.methodName1(FileName1.java:11)
+        at org.ClassName2.methodName2(FileName2.java:22)
+        at ClassName$1$1.whatever(MyTest.java:22)
+'''
+    }
+
     def "also filters stack traces of causes"() {
         testLogging.getShowCauses() >> true
         testLogging.getShowStackTraces() >> true


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/4681

Previously, when `TestExceptionFormatter` formats test stacktraces, it tries to
find the exactly matched class/method name as stacktrace truncation point.
However, some kotlin-based tests have only anonymous classes in their stacktraces,
which makes it impossible to find the exact truncation point. This PR treats
`SomeClass$1$1$1` and `SomeClass` equally when performing class name matching.
