### PR TITLE
DefaultClassLoaderScope exposes its ID in exception messages

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -115,7 +115,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
                 }
             } else { // creating before locking, have to create the most flexible setup
                 if (Boolean.getBoolean(STRICT_MODE_PROPERTY)) {
-                    throw new IllegalStateException("Attempt to define scope class loader before scope is locked");
+                    throw new IllegalStateException("Attempt to define scope class loader before scope is locked " + id);
                 }
 
                 exportingClassLoader = buildMultiLoader(id.exportId(), export, exportLoaders);
@@ -219,7 +219,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
 
     private void assertNotLocked() {
         if (locked) {
-            throw new IllegalStateException("class loader scope is locked");
+            throw new IllegalStateException("class loader scope is locked " + id);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -115,7 +115,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
                 }
             } else { // creating before locking, have to create the most flexible setup
                 if (Boolean.getBoolean(STRICT_MODE_PROPERTY)) {
-                    throw new IllegalStateException("Attempt to define scope class loader before scope is locked " + id);
+                    throw new IllegalStateException("Attempt to define scope class loader before scope is locked, scope identifier is " + id);
                 }
 
                 exportingClassLoader = buildMultiLoader(id.exportId(), export, exportLoaders);
@@ -219,7 +219,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
 
     private void assertNotLocked() {
         if (locked) {
-            throw new IllegalStateException("class loader scope is locked " + id);
+            throw new IllegalStateException("class loader scope is locked, scope identifier is " + id);
         }
     }
 


### PR DESCRIPTION
in order to make it easier to troubleshoot related issues (e.g. #4799)
