### PR TITLE
Deprecate FileCollection.asType()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
@@ -115,9 +115,13 @@ public interface FileCollection extends Iterable<File>, AntBuilderAware, Buildab
      *
      * @param type The type to convert to.
      * @return The converted value.
-     * @throws UnsupportedOperationException When an unsupported type is specified.
+     * @throws org.codehaus.groovy.runtime.typehandling.GroovyCastException When an unsupported type is specified.
+     *
+     * @deprecated This method will be removed in Gradle 5.0. Type conversions with the Groovy {@code as} keyword will keep working
+     * for the collection types. For other conversions use {@link #getSingleFile()} and {@link #getAsFileTree()}.
      */
-    Object asType(Class<?> type) throws UnsupportedOperationException;
+    @Deprecated
+    Object asType(Class<?> type);
 
     /**
      * <p>Adds another collection to this collection. This is an optional operation.</p>

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class FileCollectionIntegrationTest extends AbstractIntegrationSpec {
+    @Unroll
+    def "can use 'as' operator with #type"() {
+        buildFile << """
+            def fileCollection = files("input.txt")
+            def castValue = fileCollection as $type
+            println "Cast value: \$castValue (\${castValue.getClass().name})"
+            assert castValue instanceof $type
+        """
+
+        expect:
+        succeeds "help"
+
+        where:
+        type << ["Object", "Object[]", "Set", "LinkedHashSet", "List", "LinkedList", "Collection", "FileCollection"]
+    }
+
+    def "using 'as' operator with File type produces deprecation warning"() {
+        buildFile << """
+            def fileCollection = files("input.txt")
+            def castValue = fileCollection as File
+            assert castValue instanceof File
+            assert castValue.name == "input.txt"
+        """
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "Do not cast FileCollection to File. This has been deprecated and is scheduled to be removed in Gradle 5.0. Call getSingleFile() instead."
+    }
+
+    def "using 'as' operator with File[] type produces deprecation warning"() {
+        buildFile << """
+            def fileCollection = files("input.txt")
+            def castValue = fileCollection as File[]
+            assert castValue instanceof File[]
+            assert castValue*.name == ["input.txt"]
+        """
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "Do not cast FileCollection to File[]. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0"
+    }
+
+    def "using 'as' operator with FileTree type produces deprecation warning"() {
+        file("input.txt").createFile()
+        buildFile << """
+            def fileCollection = files("input.txt")
+            def castValue = fileCollection as FileTree
+            assert castValue instanceof FileTree
+            castValue.visit { entry ->
+                println "- \$entry"
+            }
+        """
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "input.txt"
+        output.contains "Do not cast FileCollection to FileTree. This has been deprecated and is scheduled to be removed in Gradle 5.0. Call getAsFileTree() instead."
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file;
 
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
@@ -30,6 +31,7 @@ import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.util.CollectionUtils;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
 import java.io.File;
@@ -155,27 +157,29 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
         return this;
     }
 
+    @Deprecated
+    @Override
     public Object asType(Class<?> type) throws UnsupportedOperationException {
-        if (type.isAssignableFrom(Set.class)) {
-            return getFiles();
-        }
-        if (type.isAssignableFrom(List.class)) {
-            return new ArrayList<File>(getFiles());
+        if (type.isAssignableFrom(Object[].class)) {
+            return getFiles().toArray();
         }
         if (type.isAssignableFrom(File[].class)) {
+            DeprecationLogger.nagUserOfDeprecatedBehaviour("Do not cast FileCollection to File[]");
             Set<File> files = getFiles();
             return files.toArray(new File[0]);
         }
         if (type.isAssignableFrom(File.class)) {
+            DeprecationLogger.nagUserOfDeprecatedThing("Do not cast FileCollection to File", "Call getSingleFile() instead");
             return getSingleFile();
         }
         if (type.isAssignableFrom(FileCollection.class)) {
             return this;
         }
         if (type.isAssignableFrom(FileTree.class)) {
+            DeprecationLogger.nagUserOfDeprecatedThing("Do not cast FileCollection to FileTree", "Call getAsFileTree() instead");
             return getAsFileTree();
         }
-        throw new UnsupportedOperationException(String.format("Cannot convert %s to type %s, as this type is not supported.", getDisplayName(), type.getSimpleName()));
+        return DefaultGroovyMethods.asType(this, type);
     }
 
     public TaskDependency getBuildDependencies() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -13,28 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.file;
+package org.gradle.api.internal.file
 
-import org.gradle.api.Task;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
-import org.gradle.api.file.FileVisitorUtil;
-import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.StopExecutionException;
-import org.gradle.api.tasks.TaskDependency;
-import org.gradle.test.fixtures.file.TestFile;
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
-import org.gradle.util.GUtil;
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileVisitorUtil
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.api.tasks.TaskDependency
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.GUtil
 import org.gradle.util.TestUtil
-import org.gradle.util.UsesNativeServices;
-import org.junit.Rule;
-import spock.lang.Specification;
+import org.gradle.util.UsesNativeServices
+import org.junit.Rule
+import spock.lang.Specification
 
-import static org.gradle.api.tasks.AntBuilderAwareUtil.*;
-import static org.gradle.util.Matchers.isEmpty;
-import static org.gradle.util.WrapUtil.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContains
+import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForFileSet
+import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForMatchingTask
+import static org.gradle.util.Matchers.isEmpty
+import static org.gradle.util.WrapUtil.toArray
+import static org.gradle.util.WrapUtil.toLinkedSet
+import static org.gradle.util.WrapUtil.toList
+import static org.gradle.util.WrapUtil.toSet
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.notNullValue
+import static org.hamcrest.Matchers.sameInstance
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.fail;
 
 @UsesNativeServices
 public class AbstractFileCollectionTest extends Specification {
@@ -298,7 +310,7 @@ public class AbstractFileCollectionTest extends Specification {
         TestFileCollection collection = new TestFileCollection(file);
 
         expect:
-        assertThat(collection.asType(Collection.class), equalTo((Object) toLinkedSet(file)));
+        assertThat(collection.asType(Collection.class), equalTo((Object) toList(file)));
         assertThat(collection.asType(Set.class), equalTo((Object) toLinkedSet(file)));
         assertThat(collection.asType(List.class), equalTo((Object) toList(file)));
     }
@@ -331,8 +343,8 @@ public class AbstractFileCollectionTest extends Specification {
         try {
             new TestFileCollection().asType(Integer.class);
             fail();
-        } catch (UnsupportedOperationException e) {
-            assertThat(e.getMessage(), equalTo("Cannot convert collection-display-name to type Integer, as this type is not supported."));
+        } catch (GroovyCastException e) {
+            assertThat(e.getMessage(), equalTo("Cannot cast object 'collection-display-name' with class 'org.gradle.api.internal.file.AbstractFileCollectionTest\$TestFileCollection' to class 'java.lang.Integer'"));
         }
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -86,6 +86,18 @@ The following are the newly deprecated items in this Gradle release. If you have
 With this release of Gradle, the Checkstyle configuration file is discovered in the directory `config/checkstyle` of the root project and automatically applies to all sub projects without having to set a new location for the `configDir` property.
 The Checkstyle configuration file in a sub project takes precedence over the file provided in the root project to support backward compatibility.
 
+### Special casts for `FileCollection` using the Groovy `as` operator
+
+Previously it was possible to cast a `FileCollection` instance to some special types using the Groovy `as` keyword.
+This is now discontinued.
+
+- the `FileCollection.asType(Class)` method is deprecated
+- casting `fileCollection as File` is deprecated, use `FileCollection.getSingleFile()` instead
+- casting `fileCollection as File[]` is deprecated
+- casting `fileCollection as FileTree` is deprecated, use `FileCollection.getAsFileTree()` instead
+
+Using the `as` operator to cast `FileCollection` to `Object[]`, `Collection`, `Set` and `List` is still supported.
+
 ## Potential breaking changes
 
 ### Gradle console output changes


### PR DESCRIPTION
The method was used to add some special conversions for `FileCollection` in Groovy. In an attempt to remove Groovy-specific functionality from public API the method is now deprecated. The type conversions, while not widely used to start with, will mostly keep working because `FileCollection` implements `Iterable<File>` which Groovy know how to convert to other collections.
