### PR TITLE
Use JaCoCo 0.8.1 by default

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.8.0</literal></td>
+                <td><literal>0.8.1</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -47,6 +47,10 @@ In previous releases, the rich console had some features that the plain console 
 
 TBD - build scan task output grouping
     
+### Default JaCoCo version upgraded to 0.8.1
+
+[The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.1](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
@@ -23,7 +23,7 @@ apply plugin: "jacoco"
 
 // START SNIPPET jacoco-configuration
 jacoco {
-    toolVersion = "0.8.0"
+    toolVersion = "0.8.1"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // END SNIPPET jacoco-configuration

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -52,7 +52,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * The jacoco version used if none is explicitly specified.
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.8.0";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.1";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -44,6 +44,7 @@ class JacocoAgentJarTest extends Specification {
         '0.7.8'               | true
         '0.7.9'               | true
         '0.8.0'               | true
+        '0.8.1'               | true
     }
 
     @Unroll
@@ -65,5 +66,6 @@ class JacocoAgentJarTest extends Specification {
         '0.7.8'               | true
         '0.7.9'               | true
         '0.8.0'               | true
+        '0.8.1'               | true
     }
 }


### PR DESCRIPTION
This JaCoCo release is mainly about **Java 10 support**.
Full changelog - http://www.jacoco.org/jacoco/trunk/doc/changes.html