### PR TITLE
Fix NPE in capabilities conflict resolution

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -101,7 +101,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('cglib:cglib-nodep:3.2.4', 'cglib:cglib:3.2.5')
-                    .byConflictResolution()
+                    .byReason('latest version of capability cglib:cglib')
                 module('cglib:cglib:3.2.5')
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -375,7 +375,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge('asm:asm:3.0', 'org.ow2.asm:asm:4.0')
-                        .byConflictResolution()
+                        .byReason('latest version of capability asm:asm')
                     module('org.ow2.asm:asm:4.0')
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -322,7 +322,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return state.isSelectable();
     }
 
-    boolean isCandidateForConflictResolution() {
+    public boolean isCandidateForConflictResolution() {
         return state.isCandidateForConflictResolution();
     }
 


### PR DESCRIPTION
It is possible that a large dependency graph resolves capabilities conflicts 2 by 2, at
different "depth" in the transitive graph. In this case, it is possible for a module to
be selected, but then it needs to be considered again when a new module providing the
same capability appears in the graph. If not, we wouldn't choose any version, producing
an NPE when we read the graph back from the binary store.

The error was discovered during dogfooding, so this commit is a pre-requisite to using
capabilities in the Gradle build (will require a wrapper update).

This commit also improves the selection reason in case of capability conflict resolution,
to make it clear it was upgraded to the latest version.
