### PR TITLE
 Allow creation of Task with constructor arguments

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -160,6 +160,14 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     String TASK_ACTION = "action";
 
     /**
+     * Constructor arguments for the Task
+     *
+     * @since 4.7
+     */
+    @Incubating
+    String TASK_CONSTRUCTOR_ARGS = "constructorArgs";
+
+    /**
      * <p>Returns the name of this task. The name uniquely identifies the task within its {@link Project}.</p>
      *
      * @return The name of the task. Never returns null.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -150,6 +150,23 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
     <T extends Task> T create(String name, Class<T> type) throws InvalidUserDataException;
 
     /**
+     * <p>Creates a {@link Task} with the given name and type, passing the given arguments to the {@code @Inject}-annotated constructor,
+     * and adds it to this container.</p>
+     *
+     * <p>After the task is added, it is made available as a property of the project, so that you can reference the task
+     * by name in your build file. See <a href="../Project.html#properties">here</a> for more details.</p>
+     *
+     * @param name The name of the task to be created.
+     * @param type The type of task to create.
+     * @param constructorArgs The arguments to pass to the task constructor
+     * @return The newly created task object
+     * @throws InvalidUserDataException If a task with the given name already exists in this project.
+     * @since 4.7
+     */
+    @Incubating
+    <T extends Task> T create(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException;
+
+    /**
      * <p>Creates a {@link Task} with the given name and type, configures it with the given action, and adds it to this container.</p>
      *
      * <p>After the task is added, it is made available as a property of the project, so that you can reference the task

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -51,7 +51,7 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
 
     @Override
     public <S extends TaskInternal> S create(String name, Class<S> type) {
-        return process(create(name, type, (Object[]) null));
+        return create(name, type, (Object[]) null);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -22,8 +22,6 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.reflect.Instantiator;
 
-import java.util.Map;
-
 /**
  * A {@link ITaskFactory} which determines task actions, inputs and outputs based on annotation attached to the task properties. Also provides some validation based on these annotations.
  */
@@ -36,30 +34,22 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
         this.taskFactory = taskFactory;
     }
 
+    @Override
     public ITaskFactory createChild(ProjectInternal project, Instantiator instantiator) {
         return new AnnotationProcessingTaskFactory(taskClassInfoStore, taskFactory.createChild(project, instantiator));
     }
 
-    public TaskInternal createTask(Map<String, ?> args) {
-        return process(taskFactory.createTask(args));
+    @Override
+    public <S extends Task> S create(String name, Class<S> type) {
+        return process(taskFactory.create(name, type));
     }
 
     @Override
-    public TaskInternal createTask(String name, Class<? extends Task> type, Object... args) {
-        return process(taskFactory.createTask(name, type, args));
-    }
-
-    @Override
-    public <S extends TaskInternal> S create(String name, Class<S> type) {
-        return create(name, type, (Object[]) null);
-    }
-
-    @Override
-    public <S extends TaskInternal> S create(String name, Class<S> type, Object... args) {
+    public <S extends Task> S create(String name, Class<S> type, Object... args) {
         return process(taskFactory.create(name, type, args));
     }
 
-    private <S extends TaskInternal> S process(S task) {
+    private <S extends Task> S process(S task) {
         TaskClassInfo taskClassInfo = taskClassInfoStore.getTaskClassInfo(task.getClass());
 
         if (taskClassInfo.isIncremental()) {
@@ -72,7 +62,7 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
         }
 
         for (TaskActionFactory actionFactory : taskClassInfo.getTaskActionFactories()) {
-            task.prependParallelSafeAction(actionFactory.create());
+            ((TaskInternal) task).prependParallelSafeAction(actionFactory.create());
         }
 
         // Enabled caching if task type is annotated with @CacheableTask

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -45,8 +45,18 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
     }
 
     @Override
+    public TaskInternal createTask(String name, Class<? extends Task> type, Object... args) {
+        return process(taskFactory.createTask(name, type, args));
+    }
+
+    @Override
     public <S extends TaskInternal> S create(String name, Class<S> type) {
-        return process(taskFactory.create(name, type));
+        return process(create(name, type, (Object[]) null));
+    }
+
+    @Override
+    public <S extends TaskInternal> S create(String name, Class<S> type, Object... args) {
+        return process(taskFactory.create(name, type, args));
     }
 
     private <S extends TaskInternal> S process(S task) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
+import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.reflect.Instantiator;
@@ -23,7 +24,11 @@ import org.gradle.model.internal.core.NamedEntityInstantiator;
 import java.util.Map;
 
 public interface ITaskFactory extends NamedEntityInstantiator<TaskInternal> {
-    public ITaskFactory createChild(ProjectInternal project, Instantiator instantiator);
+    ITaskFactory createChild(ProjectInternal project, Instantiator instantiator);
 
-    public TaskInternal createTask(Map<String, ?> args);
+    TaskInternal createTask(Map<String, ?> args);
+
+    TaskInternal createTask(String name, Class<? extends Task> type, Object... args);
+
+    <S extends TaskInternal> S create(String name, Class<S> type, Object... args);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
@@ -16,19 +16,12 @@
 package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.Task;
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.core.NamedEntityInstantiator;
 
-import java.util.Map;
-
-public interface ITaskFactory extends NamedEntityInstantiator<TaskInternal> {
+public interface ITaskFactory extends NamedEntityInstantiator<Task> {
     ITaskFactory createChild(ProjectInternal project, Instantiator instantiator);
 
-    TaskInternal createTask(Map<String, ?> args);
-
-    TaskInternal createTask(String name, Class<? extends Task> type, Object... args);
-
-    <S extends TaskInternal> S create(String name, Class<S> type, Object... args);
+    <S extends Task> S create(String name, Class<S> type, Object... args);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -15,36 +15,20 @@
  */
 package org.gradle.api.internal.project.taskfactory;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import groovy.lang.Closure;
-import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.internal.ClassGenerator;
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.api.tasks.TaskInstantiationException;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.util.GUtil;
 import org.gradle.util.NameValidator;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 public class TaskFactory implements ITaskFactory {
-    private static final Set<String> VALID_TASK_ARGUMENTS = ImmutableSet.of(
-        Task.TASK_ACTION, Task.TASK_DEPENDS_ON, Task.TASK_DESCRIPTION, Task.TASK_GROUP, Task.TASK_NAME, Task.TASK_OVERWRITE, Task.TASK_TYPE, Task.TASK_CONSTRUCTOR_ARGS
-    );
-    private static final Set<String> MANDATORY_TASK_ARGUMENTS = ImmutableSet.of(
-        Task.TASK_NAME, Task.TASK_TYPE
-    );
     private final ClassGenerator generator;
     private final ProjectInternal project;
     private final Instantiator instantiator;
@@ -63,62 +47,13 @@ public class TaskFactory implements ITaskFactory {
         return new TaskFactory(generator, project, instantiator);
     }
 
-    public TaskInternal createTask(Map<String, ?> args) {
-        Map<String, ?> actualArgs = checkTaskArgsAndCreateDefaultValues(args);
-
-        String name = actualArgs.get(Task.TASK_NAME).toString();
-        if (!GUtil.isTrue(name)) {
-            throw new InvalidUserDataException("The task name must be provided.");
-        }
-
-        Class<? extends TaskInternal> type = (Class) actualArgs.get(Task.TASK_TYPE);
-        Object[] constructorArgs = getConstructorArgs(actualArgs);
-        TaskInternal task;
-        if (constructorArgs != null) {
-            task = create(name, type, constructorArgs);
-        } else {
-            task = create(name, type);
-        }
-
-        Object dependsOnTasks = actualArgs.get(Task.TASK_DEPENDS_ON);
-        if (dependsOnTasks != null) {
-            task.dependsOn(dependsOnTasks);
-        }
-        Object description = actualArgs.get(Task.TASK_DESCRIPTION);
-        if (description != null) {
-            task.setDescription(description.toString());
-        }
-        Object group = actualArgs.get(Task.TASK_GROUP);
-        if (group != null) {
-            task.setGroup(group.toString());
-        }
-        Object action = actualArgs.get(Task.TASK_ACTION);
-        if (action instanceof Action) {
-            Action<? super Task> taskAction = (Action<? super Task>) action;
-            task.doFirst(taskAction);
-        } else if (action != null) {
-            Closure closure = (Closure) action;
-            task.doFirst(closure);
-        }
-
-        return task;
-    }
-
     @Override
-    public TaskInternal createTask(String name, Class<? extends Task> type, Object... args) {
-        if (type.isAssignableFrom(TaskInternal.class)) {
-            return create(name, TaskInternal.class, args);
-        }
-        return create(name, type.asSubclass(TaskInternal.class), args);
-    }
-
-    @Override
-    public <S extends TaskInternal> S create(String name, final Class<S> type) {
+    public <S extends Task> S create(String name, Class<S> type) {
         return create(name, type, (Object[]) null);
     }
 
     @Override
-    public <S extends TaskInternal> S create(String name, final Class<S> type, final Object... args) {
+    public <S extends Task> S create(String name, final Class<S> type, final Object... args) {
         if (!Task.class.isAssignableFrom(type)) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task of type '%s' as it does not implement the Task interface.",
@@ -148,44 +83,4 @@ public class TaskFactory implements ITaskFactory {
         }));
     }
 
-    private Map<String, ?> checkTaskArgsAndCreateDefaultValues(Map<String, ?> args) {
-        validateArgs(args);
-        if (!args.keySet().containsAll(MANDATORY_TASK_ARGUMENTS)) {
-            Map<String, Object> argsWithDefaults = Maps.newHashMap(args);
-            setIfNull(argsWithDefaults, Task.TASK_NAME, "");
-            setIfNull(argsWithDefaults, Task.TASK_TYPE, DefaultTask.class);
-            return argsWithDefaults;
-        }
-        return args;
-    }
-
-    private void validateArgs(Map<String, ?> args) {
-        if (!VALID_TASK_ARGUMENTS.containsAll(args.keySet())) {
-            Map unknownArguments = new HashMap<String, Object>(args);
-            unknownArguments.keySet().removeAll(VALID_TASK_ARGUMENTS);
-            throw new InvalidUserDataException(String.format("Could not create task '%s': Unknown argument(s) in task definition: %s",
-                args.get(Task.TASK_NAME), unknownArguments.keySet()));
-        }
-    }
-
-    private void setIfNull(Map<String, Object> map, String key, Object defaultValue) {
-        if (map.get(key) == null) {
-            map.put(key, defaultValue);
-        }
-    }
-
-    private Object[] getConstructorArgs(Map<String, ?> args) {
-        Object constructorArgs = args.get(Task.TASK_CONSTRUCTOR_ARGS);
-        if (constructorArgs instanceof List) {
-            List<?> asList = (List<?>) constructorArgs;
-            return asList.toArray(new Object[asList.size()]);
-        }
-        if (constructorArgs instanceof Object[]) {
-            return (Object[]) constructorArgs;
-        }
-        if (constructorArgs != null) {
-            throw new IllegalArgumentException(String.format("%s must be a List or Object[].  Received %s", Task.TASK_CONSTRUCTOR_ARGS, constructorArgs.getClass()));
-        }
-        return null;
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -33,13 +33,14 @@ import org.gradle.util.GUtil;
 import org.gradle.util.NameValidator;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
 public class TaskFactory implements ITaskFactory {
     private static final Set<String> VALID_TASK_ARGUMENTS = ImmutableSet.of(
-        Task.TASK_ACTION, Task.TASK_DEPENDS_ON, Task.TASK_DESCRIPTION, Task.TASK_GROUP, Task.TASK_NAME, Task.TASK_OVERWRITE, Task.TASK_TYPE
+        Task.TASK_ACTION, Task.TASK_DEPENDS_ON, Task.TASK_DESCRIPTION, Task.TASK_GROUP, Task.TASK_NAME, Task.TASK_OVERWRITE, Task.TASK_TYPE, Task.TASK_CONSTRUCTOR_ARGS
     );
     private static final Set<String> MANDATORY_TASK_ARGUMENTS = ImmutableSet.of(
         Task.TASK_NAME, Task.TASK_TYPE
@@ -71,7 +72,13 @@ public class TaskFactory implements ITaskFactory {
         }
 
         Class<? extends TaskInternal> type = (Class) actualArgs.get(Task.TASK_TYPE);
-        TaskInternal task = create(name, type);
+        Object[] constructorArgs = getConstructorArgs(actualArgs);
+        TaskInternal task;
+        if (constructorArgs != null) {
+            task = create(name, type, constructorArgs);
+        } else {
+            task = create(name, type);
+        }
 
         Object dependsOnTasks = actualArgs.get(Task.TASK_DEPENDS_ON);
         if (dependsOnTasks != null) {
@@ -98,7 +105,20 @@ public class TaskFactory implements ITaskFactory {
     }
 
     @Override
+    public TaskInternal createTask(String name, Class<? extends Task> type, Object... args) {
+        if (type.isAssignableFrom(TaskInternal.class)) {
+            return create(name, TaskInternal.class, args);
+        }
+        return create(name, type.asSubclass(TaskInternal.class), args);
+    }
+
+    @Override
     public <S extends TaskInternal> S create(String name, final Class<S> type) {
+        return create(name, type, (Object[]) null);
+    }
+
+    @Override
+    public <S extends TaskInternal> S create(String name, final Class<S> type, final Object... args) {
         if (!Task.class.isAssignableFrom(type)) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task of type '%s' as it does not implement the Task interface.",
@@ -116,6 +136,9 @@ public class TaskFactory implements ITaskFactory {
         return type.cast(AbstractTask.injectIntoNewInstance(project, name, type, new Callable<Task>() {
             public Task call() throws Exception {
                 try {
+                    if (args != null) {
+                        return instantiator.newInstance(generatedType, args);
+                    }
                     return instantiator.newInstance(generatedType);
                 } catch (ObjectInstantiationException e) {
                     throw new TaskInstantiationException(String.format("Could not create task of type '%s'.", type.getSimpleName()),
@@ -149,5 +172,20 @@ public class TaskFactory implements ITaskFactory {
         if (map.get(key) == null) {
             map.put(key, defaultValue);
         }
+    }
+
+    private Object[] getConstructorArgs(Map<String, ?> args) {
+        Object constructorArgs = args.get(Task.TASK_CONSTRUCTOR_ARGS);
+        if (constructorArgs instanceof List) {
+            List<?> asList = (List<?>) constructorArgs;
+            return asList.toArray(new Object[asList.size()]);
+        }
+        if (constructorArgs instanceof Object[]) {
+            return (Object[]) constructorArgs;
+        }
+        if (constructorArgs != null) {
+            throw new IllegalArgumentException(String.format("%s must be a List or Object[].  Received %s", Task.TASK_CONSTRUCTOR_ARGS, constructorArgs.getClass()));
+        }
+        return null;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -101,9 +101,9 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         Object[] constructorArgs = getConstructorArgs(actualArgs);
         TaskInternal task;
         if (constructorArgs != null) {
-            task = create(name, type, constructorArgs);
+            task = createTask(name, type, constructorArgs);
         } else {
-            task = create(name, type);
+            task = createTask(name, type);
         }
 
         Object dependsOnTasks = actualArgs.get(Task.TASK_DEPENDS_ON);
@@ -208,13 +208,17 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public <T extends Task> T create(String name, Class<T> type) {
-        return create(name, type, (Object[]) null);
+        return create(name, type, new Object[0]);
     }
 
     @Override
     public <T extends Task> T create(String name, Class<T> type, @Nullable Object... constructorArgs) throws InvalidUserDataException {
-        T task = taskFactory.create(name, type, constructorArgs);
+        T task = createTask(name, type, constructorArgs);
         return addTask(task, false);
+    }
+
+    private <T extends Task> T createTask(String name, Class<T> type, @Nullable Object... constructorArgs) throws InvalidUserDataException {
+        return taskFactory.create(name, type, constructorArgs);
     }
 
     public Task create(String name) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -115,8 +115,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return create(options).configure(configureClosure);
     }
 
+    @Override
     public <T extends Task> T create(String name, Class<T> type) {
-        T task = instantiator.create(name, type);
+        return create(name, type, (Object[]) null);
+    }
+
+    @Override
+    public <T extends Task> T create(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException {
+        T task = type.cast(taskFactory.createTask(name, type, constructorArgs));
         return addTask(task, false);
     }
 
@@ -298,10 +304,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public <S extends Task> S create(String name, Class<S> type) {
-            if (type.isAssignableFrom(TaskInternal.class)) {
-                return type.cast(taskFactory.create(name, TaskInternal.class));
-            }
-            return type.cast(taskFactory.create(name, type.asSubclass(TaskInternal.class)));
+            return type.cast(taskFactory.createTask(name, type));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -16,6 +16,8 @@
 package org.gradle.api.internal.tasks;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
@@ -23,6 +25,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
@@ -33,6 +36,7 @@ import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.ProjectAccessListener;
+import org.gradle.internal.Cast;
 import org.gradle.internal.Transformers;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.reflect.Instantiator;
@@ -46,26 +50,35 @@ import org.gradle.model.internal.core.UnmanagedModelProjection;
 import org.gradle.model.internal.core.rule.describe.SimpleModelRuleDescriptor;
 import org.gradle.model.internal.type.ModelType;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
+@NonNullApi
 public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements TaskContainerInternal {
+    private static final Set<String> VALID_TASK_ARGUMENTS = ImmutableSet.of(
+        Task.TASK_ACTION, Task.TASK_DEPENDS_ON, Task.TASK_DESCRIPTION, Task.TASK_GROUP, Task.TASK_NAME, Task.TASK_OVERWRITE, Task.TASK_TYPE, Task.TASK_CONSTRUCTOR_ARGS
+    );
+    private static final Set<String> MANDATORY_TASK_ARGUMENTS = ImmutableSet.of(
+        Task.TASK_NAME, Task.TASK_TYPE
+    );
+
     private final MutableModelNode modelNode;
     private final ITaskFactory taskFactory;
     private final ProjectAccessListener projectAccessListener;
     private final Set<String> placeholders = Sets.newHashSet();
-    private final NamedEntityInstantiator<Task> instantiator;
 
     public DefaultTaskContainer(MutableModelNode modelNode, ProjectInternal project, Instantiator instantiator, ITaskFactory taskFactory, ProjectAccessListener projectAccessListener) {
         super(Task.class, instantiator, project);
         this.modelNode = modelNode;
         this.taskFactory = taskFactory;
         this.projectAccessListener = projectAccessListener;
-        this.instantiator = new TaskInstantiator(taskFactory);
     }
 
     public Task create(Map<String, ?> options) {
@@ -77,8 +90,86 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             replace = "true".equals(replaceStr.toString());
         }
 
-        Task task = taskFactory.createTask(factoryOptions);
+        Map<String, ?> actualArgs = checkTaskArgsAndCreateDefaultValues(factoryOptions);
+
+        String name = actualArgs.get(Task.TASK_NAME).toString();
+        if (!GUtil.isTrue(name)) {
+            throw new InvalidUserDataException("The task name must be provided.");
+        }
+
+        Class<? extends TaskInternal> type = Cast.uncheckedCast(actualArgs.get(Task.TASK_TYPE));
+        Object[] constructorArgs = getConstructorArgs(actualArgs);
+        TaskInternal task;
+        if (constructorArgs != null) {
+            task = create(name, type, constructorArgs);
+        } else {
+            task = create(name, type);
+        }
+
+        Object dependsOnTasks = actualArgs.get(Task.TASK_DEPENDS_ON);
+        if (dependsOnTasks != null) {
+            task.dependsOn(dependsOnTasks);
+        }
+        Object description = actualArgs.get(Task.TASK_DESCRIPTION);
+        if (description != null) {
+            task.setDescription(description.toString());
+        }
+        Object group = actualArgs.get(Task.TASK_GROUP);
+        if (group != null) {
+            task.setGroup(group.toString());
+        }
+        Object action = actualArgs.get(Task.TASK_ACTION);
+        if (action instanceof Action) {
+            Action<? super Task> taskAction = Cast.uncheckedCast(action);
+            task.doFirst(taskAction);
+        } else if (action != null) {
+            Closure closure = (Closure) action;
+            task.doFirst(closure);
+        }
+
         return addTask(task, replace);
+    }
+
+    @Nullable
+    private static Object[] getConstructorArgs(Map<String, ?> args) {
+        Object constructorArgs = args.get(Task.TASK_CONSTRUCTOR_ARGS);
+        if (constructorArgs instanceof List) {
+            List<?> asList = (List<?>) constructorArgs;
+            return asList.toArray(new Object[asList.size()]);
+        }
+        if (constructorArgs instanceof Object[]) {
+            return (Object[]) constructorArgs;
+        }
+        if (constructorArgs != null) {
+            throw new IllegalArgumentException(String.format("%s must be a List or Object[].  Received %s", Task.TASK_CONSTRUCTOR_ARGS, constructorArgs.getClass()));
+        }
+        return null;
+    }
+
+    private static Map<String, ?> checkTaskArgsAndCreateDefaultValues(Map<String, ?> args) {
+        validateArgs(args);
+        if (!args.keySet().containsAll(MANDATORY_TASK_ARGUMENTS)) {
+            Map<String, Object> argsWithDefaults = Maps.newHashMap(args);
+            setIfNull(argsWithDefaults, Task.TASK_NAME, "");
+            setIfNull(argsWithDefaults, Task.TASK_TYPE, DefaultTask.class);
+            return argsWithDefaults;
+        }
+        return args;
+    }
+
+    private static void validateArgs(Map<String, ?> args) {
+        if (!VALID_TASK_ARGUMENTS.containsAll(args.keySet())) {
+            Map<String, Object> unknownArguments = new HashMap<String, Object>(args);
+            unknownArguments.keySet().removeAll(VALID_TASK_ARGUMENTS);
+            throw new InvalidUserDataException(String.format("Could not create task '%s': Unknown argument(s) in task definition: %s",
+                args.get(Task.TASK_NAME), unknownArguments.keySet()));
+        }
+    }
+
+    private static void setIfNull(Map<String, Object> map, String key, Object defaultValue) {
+        if (map.get(key) == null) {
+            map.put(key, defaultValue);
+        }
     }
 
     private <T extends Task> T addTask(T task, boolean replaceExisting) {
@@ -121,8 +212,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
-    public <T extends Task> T create(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException {
-        T task = type.cast(taskFactory.createTask(name, type, constructorArgs));
+    public <T extends Task> T create(String name, Class<T> type, @Nullable Object... constructorArgs) throws InvalidUserDataException {
+        T task = taskFactory.create(name, type, constructorArgs);
         return addTask(task, false);
     }
 
@@ -159,7 +250,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     public <T extends Task> T replace(String name, Class<T> type) {
-        T task = instantiator.create(name, type);
+        T task = taskFactory.create(name, type);
         return addTask(task, true);
     }
 
@@ -214,7 +305,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public NamedEntityInstantiator<Task> getEntityInstantiator() {
-        return instantiator;
+        return taskFactory;
     }
 
     public DynamicObject getTasksAsDynamicObject() {
@@ -293,19 +384,6 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     public Set<? extends Class<? extends Task>> getCreateableTypes() {
         return Collections.singleton(getType());
-    }
-
-    private static class TaskInstantiator implements NamedEntityInstantiator<Task> {
-        private final ITaskFactory taskFactory;
-
-        public TaskInstantiator(ITaskFactory taskFactory) {
-            this.taskFactory = taskFactory;
-        }
-
-        @Override
-        public <S extends Task> S create(String name, Class<S> type) {
-            return type.cast(taskFactory.createTask(name, type));
-        }
     }
 
     private static class TaskCreator<T extends TaskInternal> implements Action<MutableModelNode> {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractTaskSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractTaskSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal
 
 import org.gradle.api.Action
-import org.gradle.api.Task
 import org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore
 import org.gradle.api.internal.project.taskfactory.TaskFactory
@@ -25,7 +24,6 @@ import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
-import org.gradle.util.GUtil
 import org.gradle.util.TestUtil
 
 import static org.junit.Assert.assertTrue

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractTaskSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractTaskSpec.groovy
@@ -42,7 +42,7 @@ class AbstractTaskSpec extends AbstractProjectBuilderSpec {
         project = TestUtil.createRootProject(temporaryFolder.testDirectory)
         DefaultServiceRegistry registry = new DefaultServiceRegistry()
         registry.add(Instantiator, DirectInstantiator.INSTANCE)
-        TaskInternal task = rootFactory.createChild(project, instantiator).createTask(GUtil.map(Task.TASK_TYPE, TestTask, Task.TASK_NAME, name))
+        TaskInternal task = rootFactory.createChild(project, instantiator).create(name, TestTask)
         assertTrue(TestTask.isAssignableFrom(task.getClass()))
         return task
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -41,7 +41,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
 
     public void testUsesADefaultTaskTypeWhenNoneSpecified() {
         when:
-        Task task = taskFactory.createTask([name: "task"]);
+        Task task = taskFactory.create("task");
 
         then:
         task instanceof DefaultTask

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -60,7 +60,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "creates by name"() {
         given:
         def task = task("task")
-        taskFactory.createTask("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask, null) >> task
 
         expect:
         container.create("task") == task
@@ -69,7 +69,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "creates by name and type"() {
         given:
         def task = task("task", CustomTask)
-        taskFactory.createTask("task", CustomTask, null) >> task
+        taskFactory.create("task", CustomTask, null) >> task
 
         expect:
         container.create("task", CustomTask.class) == task
@@ -80,7 +80,7 @@ public class DefaultTaskContainerTest extends Specification {
         final Closure action = {}
         def task = task("task")
 
-        taskFactory.createTask("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask, null) >> task
 
         when:
         def added = container.create("task", action)
@@ -95,7 +95,7 @@ public class DefaultTaskContainerTest extends Specification {
         def action = Mock(Action)
         def task = task("task")
 
-        taskFactory.createTask("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask, null) >> task
 
         when:
         def added = container.create("task", action)
@@ -108,7 +108,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "replaces task by name"() {
         given:
         def task = task("task")
-        taskFactory.createTask("task", DefaultTask) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         when:
         def replaced = container.replace("task")
@@ -121,7 +121,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "replaces by name and type"() {
         given:
         def task = task("task", CustomTask)
-        taskFactory.createTask("task", CustomTask) >> task
+        taskFactory.create("task", CustomTask) >> task
 
         expect:
         container.replace("task", CustomTask.class) == task
@@ -132,7 +132,7 @@ public class DefaultTaskContainerTest extends Specification {
         def task = task("task")
 
         container.addRule(rule)
-        taskFactory.createTask("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask, null) >> task
 
         when:
         container.create("task")
@@ -144,7 +144,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "prevents duplicate tasks"() {
         given:
         def task = addTask("task")
-        taskFactory.createTask("task", DefaultTask, null) >> { this.task("task") }
+        taskFactory.create("task", DefaultTask, null) >> { this.task("task") }
 
         when:
         container.create("task")
@@ -159,7 +159,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         addTask("task")
         def newTask = task("task")
-        taskFactory.createTask("task", DefaultTask) >> newTask
+        taskFactory.create("task", DefaultTask) >> newTask
 
         when:
         container.replace("task")
@@ -352,7 +352,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         def task = task("task")
 
-        taskFactory.createTask("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask, null) >> task
 
         when:
         def added = container.maybeCreate("task")
@@ -373,7 +373,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         def task = task("task", CustomTask)
 
-        taskFactory.createTask("task", CustomTask, null) >> task
+        taskFactory.create("task", CustomTask, null) >> task
 
         when:
         def added = container.maybeCreate("task", CustomTask)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -60,7 +60,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "creates by name"() {
         given:
         def task = task("task")
-        taskFactory.create("task", DefaultTask) >> task
+        taskFactory.createTask("task", DefaultTask, null) >> task
 
         expect:
         container.create("task") == task
@@ -69,7 +69,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "creates by name and type"() {
         given:
         def task = task("task", CustomTask)
-        taskFactory.create("task", CustomTask) >> task
+        taskFactory.createTask("task", CustomTask, null) >> task
 
         expect:
         container.create("task", CustomTask.class) == task
@@ -80,7 +80,7 @@ public class DefaultTaskContainerTest extends Specification {
         final Closure action = {}
         def task = task("task")
 
-        taskFactory.create("task", DefaultTask) >> task
+        taskFactory.createTask("task", DefaultTask, null) >> task
 
         when:
         def added = container.create("task", action)
@@ -95,7 +95,7 @@ public class DefaultTaskContainerTest extends Specification {
         def action = Mock(Action)
         def task = task("task")
 
-        taskFactory.create("task", DefaultTask) >> task
+        taskFactory.createTask("task", DefaultTask, null) >> task
 
         when:
         def added = container.create("task", action)
@@ -108,7 +108,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "replaces task by name"() {
         given:
         def task = task("task")
-        taskFactory.create("task", DefaultTask) >> task
+        taskFactory.createTask("task", DefaultTask) >> task
 
         when:
         def replaced = container.replace("task")
@@ -121,7 +121,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "replaces by name and type"() {
         given:
         def task = task("task", CustomTask)
-        taskFactory.create("task", CustomTask) >> task
+        taskFactory.createTask("task", CustomTask) >> task
 
         expect:
         container.replace("task", CustomTask.class) == task
@@ -132,7 +132,7 @@ public class DefaultTaskContainerTest extends Specification {
         def task = task("task")
 
         container.addRule(rule)
-        taskFactory.create("task", DefaultTask) >> task
+        taskFactory.createTask("task", DefaultTask, null) >> task
 
         when:
         container.create("task")
@@ -144,7 +144,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "prevents duplicate tasks"() {
         given:
         def task = addTask("task")
-        taskFactory.create("task", DefaultTask) >> { this.task("task") }
+        taskFactory.createTask("task", DefaultTask, null) >> { this.task("task") }
 
         when:
         container.create("task")
@@ -159,7 +159,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         addTask("task")
         def newTask = task("task")
-        taskFactory.create("task", DefaultTask) >> newTask
+        taskFactory.createTask("task", DefaultTask) >> newTask
 
         when:
         container.replace("task")
@@ -352,7 +352,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         def task = task("task")
 
-        taskFactory.create("task", DefaultTask) >> task
+        taskFactory.createTask("task", DefaultTask, null) >> task
 
         when:
         def added = container.maybeCreate("task")
@@ -373,7 +373,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         def task = task("task", CustomTask)
 
-        taskFactory.create("task", CustomTask) >> task
+        taskFactory.createTask("task", CustomTask, null) >> task
 
         when:
         def added = container.maybeCreate("task", CustomTask)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -45,9 +45,9 @@ public class DefaultTaskContainerTest extends Specification {
     private container = new DefaultTaskContainerFactory(modelRegistry, DirectInstantiator.INSTANCE, taskFactory, project, accessListener).create()
 
     void "creates by Map"() {
-        def options = singletonMap("option", "value")
+        def options = singletonMap("name", "task")
         def task = task("task")
-        taskFactory.createTask(options) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         when:
         def added = container.create(options)
@@ -60,7 +60,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "creates by name"() {
         given:
         def task = task("task")
-        taskFactory.create("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         expect:
         container.create("task") == task
@@ -69,7 +69,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "creates by name and type"() {
         given:
         def task = task("task", CustomTask)
-        taskFactory.create("task", CustomTask, null) >> task
+        taskFactory.create("task", CustomTask) >> task
 
         expect:
         container.create("task", CustomTask.class) == task
@@ -80,7 +80,7 @@ public class DefaultTaskContainerTest extends Specification {
         final Closure action = {}
         def task = task("task")
 
-        taskFactory.create("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         when:
         def added = container.create("task", action)
@@ -95,7 +95,7 @@ public class DefaultTaskContainerTest extends Specification {
         def action = Mock(Action)
         def task = task("task")
 
-        taskFactory.create("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         when:
         def added = container.create("task", action)
@@ -132,7 +132,7 @@ public class DefaultTaskContainerTest extends Specification {
         def task = task("task")
 
         container.addRule(rule)
-        taskFactory.create("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         when:
         container.create("task")
@@ -144,7 +144,7 @@ public class DefaultTaskContainerTest extends Specification {
     void "prevents duplicate tasks"() {
         given:
         def task = addTask("task")
-        taskFactory.create("task", DefaultTask, null) >> { this.task("task") }
+        1 * taskFactory.create("task", DefaultTask) >> { this.task("task") }
 
         when:
         container.create("task")
@@ -352,7 +352,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         def task = task("task")
 
-        taskFactory.create("task", DefaultTask, null) >> task
+        taskFactory.create("task", DefaultTask) >> task
 
         when:
         def added = container.maybeCreate("task")
@@ -373,7 +373,7 @@ public class DefaultTaskContainerTest extends Specification {
         given:
         def task = task("task", CustomTask)
 
-        taskFactory.create("task", CustomTask, null) >> task
+        taskFactory.create("task", CustomTask) >> task
 
         when:
         def added = container.maybeCreate("task", CustomTask)
@@ -422,17 +422,17 @@ public class DefaultTaskContainerTest extends Specification {
     private Task addTask(String name) {
         def task = task(name)
         def options = singletonMap(Task.TASK_NAME, name)
-        taskFactory.createTask(options) >> task
+        1 * taskFactory.create(name, DefaultTask) >> task
         container.create(options)
-        return task;
+        return task
     }
 
     private <U extends Task> U addTask(String name, Class<U> type) {
         def task = task(name, type)
         def options = [name: name, type: type]
-        taskFactory.createTask(options) >> task
+        1 * taskFactory.create(name, type) >> task
         container.create(options)
-        return task;
+        return task
     }
 
     interface CustomTask extends TaskInternal {}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
@@ -34,7 +34,6 @@ import org.gradle.api.specs.Spec
 import org.gradle.internal.Actions
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
-import org.gradle.util.GUtil
 import org.gradle.util.TestUtil
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -58,9 +57,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
     }
 
     def <T extends AbstractTask> T createTask(Class<T> type, Project project, String name) {
-        Task task = taskFactory.createChild(project, DirectInstantiator.INSTANCE).createTask(
-                GUtil.map(Task.TASK_TYPE, type,
-                        Task.TASK_NAME, name))
+        Task task = taskFactory.createChild(project, DirectInstantiator.INSTANCE).create(name, type)
         assert type.isAssignableFrom(task.getClass())
         return type.cast(task)
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
     }
 
     def <T extends AbstractTask> T createTask(Class<T> type, ProjectInternal project, String name) {
-        Task task = project.getServices().get(ITaskFactory.class).createTask(GUtil.map(Task.TASK_TYPE, type, Task.TASK_NAME, name))
+        Task task = project.getServices().get(ITaskFactory.class).create(name, type)
         assertTrue(type.isAssignableFrom(task.getClass()))
         return type.cast(task)
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -29,7 +29,6 @@ import org.gradle.api.specs.Spec
 import org.gradle.internal.Actions
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
-import org.gradle.util.GUtil
 import org.gradle.util.TestUtil
 
 import java.util.concurrent.atomic.AtomicBoolean

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -136,7 +136,7 @@ class TestUtil {
     }
 
     static <T extends Task> T createTask(Class<T> type, ProjectInternal project, String name) {
-        return project.services.get(ITaskFactory).createTask([name: name, type: type])
+        return project.services.get(ITaskFactory).create(name, type)
     }
 
     static ProjectBuilder builder(File rootDir) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.Requires
+import spock.lang.Ignore
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
@@ -53,6 +54,137 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.output.contains('it works!')
+    }
+
+    def 'can run a custom task with constructor arguments via API'() {
+        given:
+        buildFile << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            import javax.inject.Inject
+
+            open class CustomTask @Inject constructor(private val message: String, private val number: Int) : DefaultTask() {
+                @TaskAction fun run() = println("\$message \$number")
+            }
+
+            tasks.create("myTask", CustomTask::class.java, "hello", 42)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains('hello 42')
+    }
+
+    @Ignore
+    def 'can run custom task with constructor arguments via extension'() {
+        given:
+        buildFile << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            import javax.inject.Inject
+
+            open class CustomTask @Inject constructor(private val message: String, private val number: Int) : DefaultTask() {
+                @TaskAction fun run() = println("\$message \$number")
+            }
+
+            task<CustomTask>("myTask", "hello", 42)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains('hello 42')
+    }
+
+    def "fails to build custom task if constructor arguments missing"() {
+        given:
+        buildFile << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            import javax.inject.Inject
+
+            open class CustomTask @Inject constructor(private val message: String, private val number: Int) : DefaultTask() {
+                @TaskAction fun run() = println("\$message \$number")
+            }
+
+            tasks.create("myTask", CustomTask::class.java, "hello")
+        """
+
+        when:
+        fails 'myTask'
+
+        then:
+        result.output.contains("org.gradle.internal.service.UnknownServiceException: No service of type int available")
+    }
+
+    def "can construct a task with @Inject services"() {
+        given:
+        buildFile << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            import org.gradle.workers.WorkerExecutor
+            import javax.inject.Inject
+
+            open class CustomTask @Inject constructor(private val executor: WorkerExecutor) : DefaultTask() {
+                @TaskAction fun run() = println(if (executor != null) "got it" else "NOT IT")
+            }
+
+            task<CustomTask>("myTask")
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it")
+    }
+
+    def "can construct a task with @Inject services and constructor args"() {
+        given:
+        buildFile << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            import org.gradle.workers.WorkerExecutor
+            import javax.inject.Inject
+
+            open class CustomTask @Inject constructor(private val number: Int, private val executor: WorkerExecutor) : DefaultTask() {
+                @TaskAction fun run() = println(if (executor != null) "got it \$number" else "\$number NOT IT")
+            }
+
+            tasks.create("myTask", CustomTask::class.java, 15)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it 15")
+    }
+
+    @Ignore
+    def "can construct a task with @Inject services and constructor args via extension"() {
+        given:
+        buildFile << """
+            import org.gradle.api.*
+            import org.gradle.api.tasks.*
+            import org.gradle.workers.WorkerExecutor
+            import javax.inject.Inject
+
+            open class CustomTask @Inject constructor(private val number: Int, private val executor: WorkerExecutor) : DefaultTask() {
+                @TaskAction fun run() = println(if (executor != null) "got it \$number" else "\$number NOT IT")
+            }
+
+            tasks<CustomTask>("myTask", 15)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it 15")
     }
 
     @LeaksFileHandles

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationSpec.groovy
@@ -47,4 +47,179 @@ class TaskDefinitionIntegrationSpec extends AbstractIntegrationSpec {
         output.contains(message)
         output.contains("The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.")
     }
+
+    def "can construct a custom task without constructor arguments"() {
+        given:
+        buildFile << """
+            class CustomTask extends DefaultTask {
+                @TaskAction
+                void printIt() {
+                    println("hello world")
+                }
+            }
+
+            task myTask(type: CustomTask)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains('hello world')
+    }
+
+    def "can construct a custom task with constructor arguments via Map"() {
+        given:
+        buildFile << """
+            import javax.inject.Inject
+
+            class CustomTask extends DefaultTask {
+                final String message
+                final int number
+
+                @Inject
+                CustomTask(String message, int number) {
+                    this.message = message
+                    this.number = number
+                }
+
+                @TaskAction
+                void printIt() {
+                    println("\$message \$number")
+                }
+            }
+
+            task myTask(type: CustomTask, constructorArgs: ['hello', 42])
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("hello 42")
+    }
+
+    def "can construct a custom task with constructor arguments via API"() {
+        given:
+        buildFile << """
+            import javax.inject.Inject
+
+            class CustomTask extends DefaultTask {
+                final String message
+                final int number
+
+                @Inject
+                CustomTask(String message, int number) {
+                    this.message = message
+                    this.number = number
+                }
+
+                @TaskAction
+                void printIt() {
+                    println("\$message \$number")
+                }
+            }
+
+            tasks.create('myTask', CustomTask, 'hello', 42)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("hello 42")
+    }
+
+    def "fails to build custom task if constructor arguments missing"() {
+        given:
+        buildFile << """
+            import javax.inject.Inject
+
+            class CustomTask extends DefaultTask {
+                final String message
+                final int number
+
+                @Inject
+                CustomTask(String message, int number) {
+                    this.message = message
+                    this.number = number
+                }
+
+                @TaskAction
+                void printIt() {
+                    println("\$message \$number")
+                }
+            }
+
+            task myTask(type: CustomTask, constructorArgs: ['hello'])
+        """
+
+        when:
+        fails 'myTask'
+
+        then:
+        result.output.contains("org.gradle.internal.service.UnknownServiceException: No service of type int available")
+    }
+
+    def "can construct a task with @Inject services"() {
+        given:
+        buildFile << """
+            import org.gradle.workers.WorkerExecutor
+            import javax.inject.Inject
+
+            class CustomTask extends DefaultTask {
+                private final WorkerExecutor executor
+
+                @Inject
+                CustomTask(WorkerExecutor executor) {
+                    this.executor = executor
+                }
+
+                @TaskAction
+                void printIt() {
+                    println(executor != null ? "got it" : "NOT IT")
+                }
+            }
+
+            task myTask(type: CustomTask)
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it")
+    }
+
+    def "can construct a task with @Inject services and constructor args"() {
+        given:
+        buildFile << """
+            import org.gradle.workers.WorkerExecutor
+            import javax.inject.Inject
+
+            class CustomTask extends DefaultTask {
+                private final int number
+                private final WorkerExecutor executor
+
+                @Inject
+                CustomTask(int number, WorkerExecutor executor) {
+                    this.number = number
+                    this.executor = executor
+                }
+
+                @TaskAction
+                void printIt() {
+                    println(executor != null ? "got it \$number" : "\$number NOT IT")
+                }
+            }
+
+            task myTask(type: CustomTask, constructorArgs: [15])
+        """
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it 15")
+    }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationSpec.groovy
@@ -222,4 +222,208 @@ class TaskDefinitionIntegrationSpec extends AbstractIntegrationSpec {
         then:
         result.output.contains("got it 15")
     }
+
+    def "can construct a custom task without constructor arguments from plugin"() {
+        given:
+        file('buildSrc/src/main/java/CustomPlugin.java') << '''
+import org.gradle.api.*;
+import org.gradle.api.tasks.*;
+
+public class CustomPlugin implements Plugin<Project> {
+    public static class CustomTask extends DefaultTask {
+        @TaskAction
+        void printIt() {
+           System.out.println("hello world");
+        }
+    }
+
+    @Override
+    public void apply(Project p) {
+        p.getTasks().create("myTask", CustomTask.class);
+    }
+}
+'''
+
+        file('buildSrc/src/main/resources/META-INF/gradle-plugins/custom.properties') << 'implementation-class=CustomPlugin'
+
+        buildFile << "apply plugin: 'custom'"
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains('hello world')
+    }
+
+    def "can construct a custom task with constructor arguments via API from a plugin"() {
+        given:
+        file('buildSrc/src/main/java/CustomPlugin.java') << '''
+import org.gradle.api.*;
+import org.gradle.api.tasks.*;
+import javax.inject.Inject;
+
+public class CustomPlugin implements Plugin<Project> {
+    public static class CustomTask extends DefaultTask {
+        private final String message;
+        private final int number;
+
+        @Inject
+        public CustomTask(String message, int number) {
+            this.message = message;
+            this.number = number;
+        }
+
+        @TaskAction
+        void printIt() {
+            System.out.println(message + " " + number);
+        }
+    }
+
+    @Override
+    public void apply(Project p) {
+        p.getTasks().create("myTask", CustomTask.class, "hello", 42);
+    }
+}
+'''
+
+        file('buildSrc/src/main/resources/META-INF/gradle-plugins/custom.properties') << 'implementation-class=CustomPlugin'
+
+        buildFile << "apply plugin: 'custom'"
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("hello 42")
+    }
+
+    def "fails to build custom task if constructor arguments missing from a plugin"() {
+        given:
+        file('buildSrc/src/main/java/CustomPlugin.java') << '''
+import org.gradle.api.*;
+import org.gradle.api.tasks.*;
+import javax.inject.Inject;
+
+public class CustomPlugin implements Plugin<Project> {
+    public static class CustomTask extends DefaultTask {
+        private final String message;
+        private final int number;
+
+        @Inject
+        public CustomTask(String message, int number) {
+            this.message = message;
+            this.number = number;
+        }
+
+        @TaskAction
+        void printIt() {
+            System.out.println(message + " " + number);
+        }
+    }
+
+    @Override
+    public void apply(Project p) {
+        p.getTasks().create("myTask", CustomTask.class, "hello");
+    }
+}
+'''
+
+        file('buildSrc/src/main/resources/META-INF/gradle-plugins/custom.properties') << 'implementation-class=CustomPlugin'
+
+        buildFile << "apply plugin: 'custom'"
+
+        when:
+        fails 'myTask'
+
+        then:
+        result.output.contains("org.gradle.internal.service.UnknownServiceException: No service of type int available")
+    }
+
+    def "can construct a task with @Inject services from a plugin"() {
+        given:
+        file('buildSrc/src/main/java/CustomPlugin.java') << '''
+import org.gradle.api.*;
+import org.gradle.api.tasks.*;
+import org.gradle.workers.*;
+import javax.inject.Inject;
+
+public class CustomPlugin implements Plugin<Project> {
+    public static class CustomTask extends DefaultTask {
+        private final WorkerExecutor executor;
+
+        @Inject
+        public CustomTask(WorkerExecutor executor) {
+            this.executor = executor;
+        }
+
+        @TaskAction
+        void printIt() {
+            System.out.println(executor != null ? "got it" : "NOT IT");
+        }
+    }
+
+    @Override
+    public void apply(Project p) {
+        p.getTasks().create("myTask", CustomTask.class);
+    }
+}
+'''
+
+        file('buildSrc/src/main/resources/META-INF/gradle-plugins/custom.properties') << 'implementation-class=CustomPlugin'
+
+        buildFile << "apply plugin: 'custom'"
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it")
+    }
+
+    def "can construct a task with @Inject services and constructor args from a plugin"() {
+        given:
+        file('buildSrc/src/main/java/CustomPlugin.java') << '''
+import org.gradle.api.*;
+import org.gradle.api.tasks.*;
+import org.gradle.workers.*;
+import javax.inject.Inject;
+
+public class CustomPlugin implements Plugin<Project> {
+    public static class CustomTask extends DefaultTask {
+        private final int number;
+        private final WorkerExecutor executor;
+
+        @Inject
+        public CustomTask(int number, WorkerExecutor executor) {
+            this.number = number;
+            this.executor = executor;
+        }
+
+        @TaskAction
+        void printIt() {
+            if (executor != null) {
+                System.out.println("got it " + number);
+            } else {
+                System.out.println(number + " NOT IT");
+            }
+        }
+    }
+
+    @Override
+    public void apply(Project p) {
+        p.getTasks().create("myTask", CustomTask.class, 15);
+    }
+}
+'''
+
+        file('buildSrc/src/main/resources/META-INF/gradle-plugins/custom.properties') << 'implementation-class=CustomPlugin'
+
+        buildFile << "apply plugin: 'custom'"
+
+        when:
+        run 'myTask'
+
+        then:
+        result.output.contains("got it 15")
+    }
 }


### PR DESCRIPTION
Extend the current constructor-injection for tasks to accept arbitrary parameters from DSL methods used to create tasks.

See: https://github.com/gradle/build-cache/issues/1074
Design doc: https://docs.google.com/document/d/1-oC7oUmmNdv4lS22wHL-wJeH_SPtmxOW0MB7foZWKIY/edit#heading=h.kt1y55omntkz