### PR TITLE
Make worker executor queue-based to minimize the number of threads 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/AbstractConditionalExecution.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/AbstractConditionalExecution.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work;
+
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.resources.ResourceLock;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+public class AbstractConditionalExecution<T> implements ConditionalExecution<T> {
+    private final CountDownLatch finished = new CountDownLatch(1);
+    private final Runnable runnable;
+    private final ResourceLock resourceLock;
+
+    private T result;
+    private Throwable failure;
+
+    public AbstractConditionalExecution(final Callable<T> callable, ResourceLock resourceLock) {
+        this.runnable = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    result = callable.call();
+                } catch (Throwable t) {
+                    registerFailure(t);
+                }
+            }
+        };
+        this.resourceLock = resourceLock;
+    }
+
+    @Override
+    public ResourceLock getResourceLock() {
+        return resourceLock;
+    }
+
+    @Override
+    public Runnable getExecution() {
+        return runnable;
+    }
+
+    @Override
+    public T await() {
+        try {
+            finished.await();
+            if (failure != null) {
+                throw UncheckedException.throwAsUncheckedException(failure);
+            } else {
+                return result;
+            }
+        } catch(InterruptedException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Override
+    public void complete() {
+        finished.countDown();
+    }
+
+    @Override
+    public boolean isComplete() {
+        return finished.getCount() == 0;
+    }
+
+    @Override
+    public void registerFailure(Throwable t) {
+        this.failure = t;
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecution.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.internal.work;
 
-import org.gradle.internal.operations.BuildOperationRef;
+import org.gradle.internal.resources.ResourceLock;
 
-/**
- * A service that executes work in a (potentially) long-lived process or in-process.
- */
-public interface Worker {
-    DefaultWorkResult execute(ActionExecutionSpec spec);
-    DefaultWorkResult execute(ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation);
+public interface ConditionalExecution<T> {
+    ResourceLock getResourceLock();
+
+    Runnable getExecution();
+
+    T await();
+
+    void complete();
+
+    boolean isComplete();
+
+    void registerFailure(Throwable t);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecution.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecution.java
@@ -18,16 +18,37 @@ package org.gradle.internal.work;
 
 import org.gradle.internal.resources.ResourceLock;
 
+/**
+ * Represents an execution that cannot begin until a given resource lock has been acquired.
+ */
 public interface ConditionalExecution<T> {
+    /**
+     * Provides the resource lock that much be acquired before execution can begin.
+     */
     ResourceLock getResourceLock();
 
+    /**
+     * Provides the Runnable that should be executed once the resource lock is acquired.
+     */
     Runnable getExecution();
 
+    /**
+     * Blocks waiting for this execution to complete.  Returns a result provided by the execution.
+     */
     T await();
 
+    /**
+     * This method will be called upon completion of the execution.
+     */
     void complete();
 
+    /**
+     * Whether this execution has been completed or not.
+     */
     boolean isComplete();
 
+    /**
+     * If a failure occurs during execution, this method will be called with the exception.
+     */
     void registerFailure(Throwable t);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.internal.work;
 
-import org.gradle.internal.operations.BuildOperationRef;
+import org.gradle.internal.concurrent.Stoppable;
 
-/**
- * A service that executes work in a (potentially) long-lived process or in-process.
- */
-public interface Worker {
-    DefaultWorkResult execute(ActionExecutionSpec spec);
-    DefaultWorkResult execute(ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation);
+public interface ConditionalExecutionQueue<T> extends Stoppable {
+    void submit(ConditionalExecution<T> execution);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueue.java
@@ -18,6 +18,21 @@ package org.gradle.internal.work;
 
 import org.gradle.internal.concurrent.Stoppable;
 
+/**
+ * Represents a queue of executions that can run when a provided resource lock can be acquired.  The typical use case would
+ * be that a worker lease must be acquired before execution.
+ */
 public interface ConditionalExecutionQueue<T> extends Stoppable {
+    /**
+     * Submit a new conditional execution to the queue.  The execution will occur asynchronously when the provided
+     * resource lock (see {@link ConditionalExecution#getResourceLock()}) can be acquired.  On completion,
+     * {@link ConditionalExecution#complete()} will be called.
+     */
     void submit(ConditionalExecution<T> execution);
+
+    /**
+     * Expand the execution queue worker pool.  This should be called before an execution in the queue is blocked waiting
+     * on another execution (e.g. work that submits and waits on other work).
+     */
+    void expand();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueueFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueueFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.internal.work;
 
-import org.gradle.internal.operations.BuildOperationRef;
-
-/**
- * A service that executes work in a (potentially) long-lived process or in-process.
- */
-public interface Worker {
-    DefaultWorkResult execute(ActionExecutionSpec spec);
-    DefaultWorkResult execute(ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation);
+public interface ConditionalExecutionQueueFactory {
+    <T> ConditionalExecutionQueue<T> create(String displayName, Class<T> resultClass);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueueFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecutionQueueFactory.java
@@ -16,6 +16,13 @@
 
 package org.gradle.internal.work;
 
+/**
+ * Provides new {@link ConditionalExecutionQueue} objects
+ */
 public interface ConditionalExecutionQueueFactory {
+    /**
+     * Provides a {@link ConditionalExecutionQueue} that can process {@link ConditionalExecution} objects that
+     * return the provided result class.
+     */
     <T> ConditionalExecutionQueue<T> create(String displayName, Class<T> resultClass);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.Transformer;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.concurrent.ManagedExecutor;
+import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.resources.ResourceLockState;
+
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock;
+
+/**
+ * A queueing mechanism that only executes items once certain conditions are reached.
+ */
+// TODO This class, DefaultBuildOperationQueue and TaskExecutionPlan have many of the same
+// behavior and concerns - we should look for a way to generalize this pattern.
+public class DefaultConditionalExecutionQueue<T> implements ConditionalExecutionQueue<T> {
+    private enum QueueState {
+        Working, Stopped
+    }
+
+    private final int maxWorkers;
+    private final ResourceLockCoordinationService coordinationService;
+    private final ManagedExecutor executor;
+    private final Deque<ConditionalExecution<T>> queue = Lists.newLinkedList();
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition workAvailable = lock.newCondition();
+    private QueueState queueState = QueueState.Working;
+    private int workerCount;
+
+    public DefaultConditionalExecutionQueue(String displayName, int maxWorkers, ExecutorFactory executorFactory, ResourceLockCoordinationService coordinationService) {
+        this.maxWorkers = maxWorkers;
+        this.executor = executorFactory.create(displayName, maxWorkers);
+        this.coordinationService = coordinationService;
+    }
+
+    public void submit(ConditionalExecution<T> execution) {
+        if (queueState == QueueState.Stopped) {
+            throw new IllegalStateException("DefaultConditionalExecutionQueue cannot be reused once it has been stopped.");
+        }
+
+        lock.lock();
+        try {
+            if (workerCount < maxWorkers) {
+                executor.submit(new ExecutionRunner());
+                workerCount++;
+            }
+
+            queue.add(execution);
+            workAvailable.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void stop() {
+        lock.lock();
+        try {
+            queueState = QueueState.Stopped;
+            workAvailable.signalAll();
+        } finally {
+            lock.unlock();
+        }
+        executor.stop();
+    }
+
+    private class ExecutionRunner implements Runnable {
+        @Override
+        public void run() {
+            ConditionalExecution operation;
+            while ((operation = waitForNextOperation()) != null) {
+                runBatch(operation);
+            }
+            shutDown();
+        }
+
+        private ConditionalExecution waitForNextOperation() {
+            lock.lock();
+            try {
+                while (queueState == QueueState.Working && queue.isEmpty()) {
+                    try {
+                        workAvailable.await();
+                    } catch (InterruptedException e) {
+                        throw new UncheckedException(e);
+                    }
+                }
+
+            } finally {
+                lock.unlock();
+            }
+
+            return getReadyExecution();
+        }
+
+        private void runBatch(final ConditionalExecution firstOperation) {
+            ConditionalExecution operation = firstOperation;
+            while (operation != null) {
+                runExecution(operation);
+                operation = getReadyExecution();
+            }
+        }
+
+        /**
+         * Gets the next ConditionalExecution object that is ready to be executed.
+         */
+        private ConditionalExecution getReadyExecution() {
+            final AtomicReference<ConditionalExecution> execution = new AtomicReference<ConditionalExecution>();
+            coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
+                @Override
+                public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
+                    if (queue.isEmpty()) {
+                        return ResourceLockState.Disposition.FINISHED;
+                    }
+
+                    lock.lock();
+                    try {
+                        Iterator<ConditionalExecution<T>> itr = queue.iterator();
+                        while (itr.hasNext()) {
+                            ConditionalExecution next = itr.next();
+                            if (next.getResourceLock().tryLock()) {
+                                execution.set(next);
+                                itr.remove();
+                                break;
+                            }
+                        }
+                    } finally {
+                        lock.unlock();
+                    }
+
+                    if (execution.get() == null && !queue.isEmpty()) {
+                        return ResourceLockState.Disposition.RETRY;
+                    } else {
+                        return ResourceLockState.Disposition.FINISHED;
+                    }
+                }
+            });
+
+            return execution.get();
+        }
+
+        private void runExecution(ConditionalExecution execution) {
+            try {
+                execution.getExecution().run();
+            } catch (Throwable t) {
+                execution.registerFailure(t);
+            } finally {
+                coordinationService.withStateLock(unlock(execution.getResourceLock()));
+                execution.complete();
+            }
+        }
+
+        private void shutDown() {
+            lock.lock();
+            try {
+                workerCount--;
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueueFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueueFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work;
+
+import org.gradle.concurrent.ParallelismConfiguration;
+import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.resources.ResourceLockCoordinationService;
+
+public class DefaultConditionalExecutionQueueFactory implements ConditionalExecutionQueueFactory {
+    private final ParallelismConfiguration parallelismConfiguration;
+    private final ExecutorFactory executorFactory;
+    private final ResourceLockCoordinationService coordinationService;
+
+    public DefaultConditionalExecutionQueueFactory(ParallelismConfiguration parallelismConfiguration, ExecutorFactory executorFactory, ResourceLockCoordinationService coordinationService) {
+        this.parallelismConfiguration = parallelismConfiguration;
+        this.executorFactory = executorFactory;
+        this.coordinationService = coordinationService;
+    }
+
+    @Override
+    public <T> ConditionalExecutionQueue<T> create(String displayName, Class<T> resultClass) {
+        return new DefaultConditionalExecutionQueue<T>(displayName, parallelismConfiguration.getMaxWorkerCount(), executorFactory, coordinationService);
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultConditionalExecutionQueueTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultConditionalExecutionQueueTest.groovy
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work
+
+import org.gradle.internal.concurrent.DefaultExecutorFactory
+import org.gradle.internal.concurrent.ExecutorFactory
+import org.gradle.internal.concurrent.ManagedExecutor
+import org.gradle.internal.resources.DefaultResourceLockCoordinationService
+import org.gradle.internal.resources.ResourceLock
+import org.gradle.internal.resources.ResourceLockCoordinationService
+import org.gradle.test.fixtures.concurrent.ConcurrentSpec
+import spock.lang.Unroll
+
+import java.util.concurrent.Callable
+
+class DefaultConditionalExecutionQueueTest extends ConcurrentSpec {
+    private static final DISPLAY_NAME = "Test Execution Queue"
+    ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
+    DefaultConditionalExecutionQueue queue = new DefaultConditionalExecutionQueue(DISPLAY_NAME, 4, new DefaultExecutorFactory(), coordinationService)
+
+    def "can conditionally execute a runnable"() {
+        def execution = testExecution({
+            instant.executionStarted
+            println("I'm running!")
+        })
+
+        when:
+        async {
+            start {
+                queue.submit(execution)
+                execution.await()
+            }
+            start {
+                instant.canExecute
+                release(execution)
+            }
+        }
+
+        then:
+        instant.executionStarted > instant.canExecute
+
+        and:
+        execution.resourceLock.released
+    }
+
+    def "can release executions in any order"() {
+        def execution1 = testExecution({
+            instant.execution1Started
+            println("Execution 1 running!")
+        })
+        def execution2 = testExecution({
+            instant.execution2Started
+            println("Execution 2 running!")
+        })
+        def execution3 = testExecution({
+            instant.execution3Started
+            println("Execution 3 running!")
+        })
+
+        when:
+        async {
+            start {
+                queue.submit(execution1)
+                queue.submit(execution2)
+                queue.submit(execution3)
+            }
+            start {
+                release(execution2)
+                execution2.await()
+
+                release(execution1)
+                execution1.await()
+
+                release(execution3)
+                execution3.await()
+            }
+        }
+
+        then:
+        instant.execution2Started < instant.execution1Started
+        instant.execution1Started < instant.execution3Started
+    }
+
+    def "can submit executions from many threads"() {
+        def execution1 = testExecution({
+            instant.execution1Started
+            println("Execution 1 running!")
+        })
+        def execution2 = testExecution({
+            instant.execution2Started
+            println("Execution 2 running!")
+        })
+        def execution3 = testExecution({
+            instant.execution3Started
+            println("Execution 3 running!")
+        })
+
+        expect:
+        async {
+            start {
+                queue.submit(execution1)
+                instant.execution1Submitted
+                execution1.await()
+            }
+            start {
+                queue.submit(execution2)
+                instant.execution2Submitted
+                execution2.await()
+            }
+            start {
+                queue.submit(execution3)
+                instant.execution3Submitted
+                execution3.await()
+            }
+            start {
+                thread.blockUntil.execution1Submitted
+                thread.blockUntil.execution2Submitted
+                thread.blockUntil.execution3Submitted
+                release(execution1)
+                release(execution2)
+                release(execution3)
+            }
+        }
+    }
+
+    def "can submit executions immediately ready to run"() {
+        def execution1 = testExecution({
+            instant.execution1Started
+            println("Execution 1 running!")
+        })
+        def execution2 = testExecution({
+            instant.execution2Started
+            println("Execution 2 running!")
+        })
+        def execution3 = testExecution({
+            instant.execution3Started
+            println("Execution 3 running!")
+        })
+
+        expect:
+        async {
+            start {
+                release(execution1)
+                release(execution2)
+                release(execution3)
+                queue.submit(execution1)
+                queue.submit(execution2)
+                queue.submit(execution3)
+            }
+            start {
+                execution1.await()
+                execution2.await()
+                execution3.await()
+            }
+        }
+    }
+
+    @Unroll
+    def "can process more executions than max workers (maxWorkers = #maxWorkers)"() {
+        def executions = []
+        queue = new DefaultConditionalExecutionQueue(DISPLAY_NAME, maxWorkers, new DefaultExecutorFactory(), coordinationService)
+
+        expect:
+        async {
+            start {
+                int executionCount = maxWorkers * 3
+                executionCount.times { i ->
+                    def execution = testExecution({
+                        println("Execution ${i} running!")
+                    })
+                    executions.add execution
+                    queue.submit(execution)
+                }
+                executions.each { release(it) }
+                executions.each { it.await() }
+            }
+        }
+
+        where:
+        maxWorkers << [1, 2, 4]
+    }
+
+    def "can get a result from an execution"() {
+        def execution = testExecution({
+            instant.executionStarted
+            println("I'm running!")
+            return "foo"
+        })
+        String result = null
+
+        when:
+        async {
+            start {
+                queue.submit(execution)
+                result = execution.await()
+            }
+            start {
+                instant.canExecute
+                release(execution)
+            }
+        }
+
+        then:
+        instant.executionStarted > instant.canExecute
+
+        and:
+        result == "foo"
+    }
+
+    def "stopping the queue stops the underlying executor"() {
+        ExecutorFactory factory = Mock(ExecutorFactory)
+        ManagedExecutor executor = Mock(ManagedExecutor)
+
+        when:
+        queue = new DefaultConditionalExecutionQueue(DISPLAY_NAME, 4, factory, coordinationService)
+
+        then:
+        1 * factory.create(_, 4) >> executor
+
+        when:
+        queue.stop()
+
+        then:
+        1 * executor.stop()
+    }
+
+    void release(TestExecution execution) {
+        execution.setCanExecute(true)
+        coordinationService.notifyStateChange()
+    }
+
+    TestExecution testExecution(Callable<String> callable) {
+        return new TestExecution(callable, new SimpleResourceLock())
+    }
+
+    class TestExecution extends AbstractConditionalExecution {
+        final SimpleResourceLock resourceLock
+
+        TestExecution(Callable callable, SimpleResourceLock resourceLock) {
+            super(callable, resourceLock)
+            this.resourceLock = resourceLock
+        }
+
+        void setCanExecute(boolean canExecute) {
+            this.resourceLock.canExecute = canExecute
+        }
+    }
+
+    class SimpleResourceLock implements ResourceLock {
+        boolean canExecute
+        boolean released
+        boolean locked
+
+        @Override
+        boolean isLocked() {
+            return false
+        }
+
+        @Override
+        boolean isLockedByCurrentThread() {
+            return true
+        }
+
+        @Override
+        boolean tryLock() {
+            if (canExecute) {
+                locked = true
+                return true
+            } else {
+                return false
+            }
+        }
+
+        @Override
+        void unlock() {
+            locked = false
+            released = true
+            canExecute = false
+        }
+
+        @Override
+        String getDisplayName() {
+            return "simple lock"
+        }
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultConditionalExecutionQueueTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultConditionalExecutionQueueTest.groovy
@@ -229,7 +229,7 @@ class DefaultConditionalExecutionQueueTest extends ConcurrentSpec {
         queue = new DefaultConditionalExecutionQueue(DISPLAY_NAME, 4, factory, coordinationService)
 
         then:
-        1 * factory.create(_, 4) >> executor
+        1 * factory.create(_) >> executor
 
         when:
         queue.stop()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -30,13 +30,10 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
         """.stripIndent()
 
         when:
-        def gradle = executer.withTasks("runInWorker").start()
+        succeeds("runInWorker")
 
         then:
-        gradle.waitForFinish()
-
-        and:
-        gradle.standardOutput.contains("Hello World")
+        result.assertOutputContains("Hello World")
 
         where:
         nestedIsolationMode << ISOLATION_MODES
@@ -51,13 +48,47 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
         """.stripIndent()
 
         when:
-        def gradle = executer.withTasks("runInWorker").start()
+        succeeds("runInWorker")
 
         then:
-        gradle.waitForFinish()
+        result.groupedOutput.task(':runInWorker').output.contains("Hello World")
+    }
 
-        and:
-        gradle.standardOutput.contains("Hello World")
+    def "workers with no isolation can spawn more than max workers items of work"() {
+        def maxWorkers = 4
+        buildFile << """
+            ${getRunnableWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
+            task runInWorker(type: NestingWorkerTask) {
+                submissions = ${maxWorkers * 2}
+                childSubmissions = ${maxWorkers}
+            }
+        """.stripIndent()
+
+        when:
+        executer.withArguments("--max-workers=${maxWorkers}")
+        succeeds("runInWorker")
+
+        then:
+        result.groupedOutput.task(':runInWorker').output.contains("Hello World")
+    }
+
+    def "workers with no isolation can spawn and wait for more than max workers items of work"() {
+        def maxWorkers = 4
+        buildFile << """
+            ${getRunnableWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
+            task runInWorker(type: NestingWorkerTask) {
+                waitForChildren = true 
+                submissions = ${maxWorkers * 2}
+                childSubmissions = ${maxWorkers}
+            }
+        """.stripIndent()
+
+        when:
+        executer.withArguments("--max-workers=${maxWorkers}")
+        succeeds("runInWorker")
+
+        then:
+        result.groupedOutput.task(':runInWorker').output.contains("Hello World")
     }
 
     /*
@@ -111,17 +142,21 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
             
                 WorkerExecutor executor
                 String greeting
+                int childSubmissions
                 
                 @Inject
-                public FirstLevelRunnable(WorkerExecutor executor, String greeting) {
+                public FirstLevelRunnable(WorkerExecutor executor, String greeting, int childSubmissions) {
                     this.executor = executor
                     this.greeting = greeting
+                    this.childSubmissions = childSubmissions
                 }
 
                 public void run() {
-                    executor.submit(SecondLevelRunnable) {
-                        isolationMode = $nestedIsolationMode
-                        params = [greeting]
+                    childSubmissions.times {
+                        executor.submit(SecondLevelRunnable) {
+                            isolationMode = $nestedIsolationMode
+                            params = [greeting]
+                        }
                     }
                 }
             }
@@ -144,6 +179,8 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
 
                 WorkerExecutor executor
                 boolean waitForChildren = false
+                int submissions = 1
+                int childSubmissions = 1
 
                 @Inject
                 NestingWorkerTask(WorkerExecutor executor) {
@@ -152,9 +189,11 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
 
                 @TaskAction
                 public void runInWorker() {
-                    executor.submit(FirstLevelRunnable) {
-                        isolationMode = $isolationMode
-                        params = ["Hello World"]
+                    submissions.times {
+                        executor.submit(FirstLevelRunnable) {
+                            isolationMode = $isolationMode
+                            params = ["Hello World", childSubmissions]
+                        }
                     }
                     if (waitForChildren) {
                         executor.await()

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -25,19 +25,16 @@ import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.work.AsyncWorkTracker;
-import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerExecutor;
 
 public class NoIsolationWorkerFactory implements WorkerFactory {
-    private final WorkerLeaseRegistry workerLeaseRegistry;
     private final BuildOperationExecutor buildOperationExecutor;
     private final AsyncWorkTracker workTracker;
     private final InstantiatorFactory instantiatorFactory;
     private Instantiator actionInstantiator;
 
-    public NoIsolationWorkerFactory(WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker workTracker, InstantiatorFactory instantiatorFactory) {
-        this.workerLeaseRegistry = workerLeaseRegistry;
+    public NoIsolationWorkerFactory(BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker workTracker, InstantiatorFactory instantiatorFactory) {
         this.buildOperationExecutor = buildOperationExecutor;
         this.workTracker = workTracker;
         this.instantiatorFactory = instantiatorFactory;
@@ -55,37 +52,31 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
         return new Worker() {
             @Override
             public DefaultWorkResult execute(ActionExecutionSpec spec) {
-                return execute(spec, workerLeaseRegistry.getCurrentWorkerLease(), buildOperationExecutor.getCurrentOperation());
+                return execute(spec, buildOperationExecutor.getCurrentOperation());
             }
 
             @Override
-            public DefaultWorkResult execute(final ActionExecutionSpec spec, WorkerLeaseRegistry.WorkerLease parentWorkerWorkerLease, final BuildOperationRef parentBuildOperation) {
-                WorkerLeaseRegistry.WorkerLeaseCompletion workerLease = parentWorkerWorkerLease.startChild();
-
-                try {
-                    return buildOperationExecutor.call(new CallableBuildOperation<DefaultWorkResult>() {
-                        @Override
-                        public DefaultWorkResult call(BuildOperationContext context) {
-                            DefaultWorkResult result;
-                            try {
-                                WorkerProtocol<ActionExecutionSpec> workerServer = new DefaultWorkerServer(actionInstantiator);
-                                result = workerServer.execute(spec);
-                            } finally {
-                                //TODO the async work tracker should wait for children of an operation to finish first.
-                                //It should not be necessary to call it here.
-                                workTracker.waitForCompletion(buildOperationExecutor.getCurrentOperation(), false);
-                            }
-                            return result;
+            public DefaultWorkResult execute(final ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation) {
+                return buildOperationExecutor.call(new CallableBuildOperation<DefaultWorkResult>() {
+                    @Override
+                    public DefaultWorkResult call(BuildOperationContext context) {
+                        DefaultWorkResult result;
+                        try {
+                            WorkerProtocol<ActionExecutionSpec> workerServer = new DefaultWorkerServer(actionInstantiator);
+                            result = workerServer.execute(spec);
+                        } finally {
+                            //TODO the async work tracker should wait for children of an operation to finish first.
+                            //It should not be necessary to call it here.
+                            workTracker.waitForCompletion(buildOperationExecutor.getCurrentOperation(), false);
                         }
+                        return result;
+                    }
 
-                        @Override
-                        public BuildOperationDescriptor.Builder description() {
-                            return BuildOperationDescriptor.displayName(spec.getDisplayName()).parent(parentBuildOperation);
-                        }
-                    });
-                } finally {
-                    workerLease.leaseFinish();
-                }
+                    @Override
+                    public BuildOperationDescriptor.Builder description() {
+                        return BuildOperationDescriptor.displayName(spec.getDisplayName()).parent(parentBuildOperation);
+                    }
+                });
             }
         };
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -19,7 +19,6 @@ package org.gradle.workers.internal;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.operations.BuildOperationRef;
-import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.process.internal.health.memory.JvmMemoryStatus;
 import org.gradle.process.internal.worker.WorkerProcess;
 
@@ -38,7 +37,7 @@ class WorkerDaemonClient implements Worker, Stoppable {
     }
 
     @Override
-    public DefaultWorkResult execute(final ActionExecutionSpec spec, WorkerLease parentWorkerWorkerLease, final BuildOperationRef parentBuildOperation) {
+    public DefaultWorkResult execute(final ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation) {
         return execute(spec);
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -18,15 +18,19 @@ package org.gradle.workers.internal;
 
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.work.AsyncWorkTracker;
+import org.gradle.internal.work.ConditionalExecutionQueueFactory;
+import org.gradle.internal.work.DefaultConditionalExecutionQueueFactory;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.internal.health.memory.MemoryManager;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
@@ -53,11 +57,11 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     private static class BuildSessionScopeServices {
 
         WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
-            return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor);
+            return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, buildOperationExecutor);
         }
 
         IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(ClassLoaderFactory classLoaderFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
-            return new IsolatedClassloaderWorkerFactory(classLoaderFactory, workerLeaseRegistry, buildOperationExecutor);
+            return new IsolatedClassloaderWorkerFactory(classLoaderFactory, buildOperationExecutor);
         }
 
         WorkerDirectoryProvider createWorkerDirectoryProvider(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
@@ -76,9 +80,13 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
 
     private static class ProjectScopeServices {
 
-        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, FileResolver fileResolver, ExecutorFactory executorFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider) {
-            NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, instantiatorFactory);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorate().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider);
+        ConditionalExecutionQueueFactory createConditionalExecutionQueueFactory(ExecutorFactory executorFactory, ParallelismConfiguration parallelismConfiguration, ResourceLockCoordinationService resourceLockCoordinationService) {
+            return new DefaultConditionalExecutionQueueFactory(parallelismConfiguration, executorFactory, resourceLockCoordinationService);
+        }
+
+        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, FileResolver fileResolver,  WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
+            NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, asyncWorkTracker, instantiatorFactory);
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorate().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, conditionalExecutionQueueFactory);
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -20,11 +20,12 @@ import com.google.common.util.concurrent.ListenableFutureTask
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.Factory
-import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
+import org.gradle.internal.work.ConditionalExecutionQueue
+import org.gradle.internal.work.ConditionalExecutionQueueFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -38,7 +39,6 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def workerDaemonFactory = Mock(WorkerFactory)
     def workerInProcessFactory = Mock(WorkerFactory)
     def workerNoIsolationFactory = Mock(WorkerFactory)
-    def workerExecutorFactory = Mock(ExecutorFactory)
     def buildOperationWorkerRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkerTracker = Mock(AsyncWorkTracker)
@@ -46,21 +46,23 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def stoppableExecutor = Mock(ManagedExecutor)
     def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def instantiatorFactory = Mock(InstantiatorFactory)
+    def executionQueueFactory = Mock(ConditionalExecutionQueueFactory)
+    def executionQueue = Mock(ConditionalExecutionQueue)
     ListenableFutureTask task
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * fileResolver.resolve(_ as File) >> { files -> files[0] }
         _ * fileResolver.resolve(_ as String) >> { files -> new File(files[0]) }
-        _ * workerExecutorFactory.create(_ as String) >> stoppableExecutor
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, workerExecutorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider)
+        _ * executionQueueFactory.create(_, _) >> executionQueue
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory)
     }
 
     @Unroll
     def "work can be submitted concurrently in IsolationMode.#isolationMode"() {
         when:
         async {
-            5.times {
+            6.times {
                 start {
                     thread.blockUntil.allStarted
                     workerExecutor.submit(TestRunnable.class) { config ->
@@ -73,8 +75,8 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         }
 
         then:
-        5 * buildOperationWorkerRegistry.getCurrentWorkerLease()
-        5 * stoppableExecutor.execute(_ as ListenableFutureTask)
+        6 * buildOperationWorkerRegistry.getCurrentWorkerLease()
+        6 * executionQueue.submit(_)
 
         where:
         isolationMode << IsolationMode.values()

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.workers.internal
 
-import com.google.common.util.concurrent.ListenableFutureTask
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.internal.concurrent.ExecutorFactory
-import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
+import org.gradle.internal.work.ConditionalExecution
+import org.gradle.internal.work.ConditionalExecutionQueue
+import org.gradle.internal.work.ConditionalExecutionQueueFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.util.RedirectStdOutAndErr
@@ -40,24 +40,24 @@ class DefaultWorkerExecutorTest extends Specification {
     def workerDaemonFactory = Mock(WorkerFactory)
     def inProcessWorkerFactory = Mock(WorkerFactory)
     def noIsolationWorkerFactory = Mock(WorkerFactory)
-    def executorFactory = Mock(ExecutorFactory)
     def buildOperationWorkerRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkTracker = Mock(AsyncWorkTracker)
     def fileResolver = Mock(FileResolver)
     def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def runnable = Mock(Runnable)
-    def executor = Mock(ManagedExecutor)
     def instantiatorFactory = Mock(InstantiatorFactory)
+    def executionQueueFactory = Mock(ConditionalExecutionQueueFactory)
+    def executionQueue = Mock(ConditionalExecutionQueue)
     def worker = Mock(Worker)
-    ListenableFutureTask task
+    ConditionalExecution task
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * fileResolver.resolve(_ as File) >> { files -> files[0] }
         _ * fileResolver.resolve(_ as String) >> { files -> new File(files[0]) }
-        _ * executorFactory.create(_ as String) >> executor
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, executorFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider)
+        _ * executionQueueFactory.create(_, _) >> executionQueue
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory)
     }
 
     def "worker configuration fork property defaults to AUTO"() {
@@ -139,14 +139,14 @@ class DefaultWorkerExecutorTest extends Specification {
 
         then:
         1 * buildOperationWorkerRegistry.getCurrentWorkerLease()
-        1 * executor.execute(_ as ListenableFutureTask) >> { args -> task = args[0] }
+        1 * executionQueue.submit(_) >> { args -> task = args[0] }
 
         when:
-        task.run()
+        task.getExecution().run()
 
         then:
         1 * workerDaemonFactory.getWorker(_) >> worker
-        1 * worker.execute(_, _, _) >> { spec, workOperation, buildOperation ->
+        1 * worker.execute(_, _) >> { spec, buildOperation ->
             assert spec.implementationClass == TestRunnable
             return new DefaultWorkResult(true, null)
         }
@@ -161,14 +161,14 @@ class DefaultWorkerExecutorTest extends Specification {
 
         then:
         1 * buildOperationWorkerRegistry.getCurrentWorkerLease()
-        1 * executor.execute(_ as ListenableFutureTask) >> { args -> task = args[0] }
+        1 * executionQueue.submit(_) >> { args -> task = args[0] }
 
         when:
-        task.run()
+        task.getExecution().run()
 
         then:
         1 * inProcessWorkerFactory.getWorker(_) >> worker
-        1 * worker.execute(_, _, _) >> { spec, workOperation, buildOperation ->
+        1 * worker.execute(_, _) >> { spec, workOperation, buildOperation ->
             assert spec.implementationClass == TestRunnable
             return new DefaultWorkResult(true, null)
         }
@@ -183,14 +183,14 @@ class DefaultWorkerExecutorTest extends Specification {
 
         then:
         1 * buildOperationWorkerRegistry.getCurrentWorkerLease()
-        1 * executor.execute(_ as ListenableFutureTask) >> { args -> task = args[0] }
+        1 * executionQueue.submit(_) >> { args -> task = args[0] }
 
         when:
-        task.run()
+        task.getExecution().run()
 
         then:
         1 * noIsolationWorkerFactory.getWorker(_) >> worker
-        1 * worker.execute(_, _, _) >> { spec, workOperation, buildOperation ->
+        1 * worker.execute(_, _) >> { spec, workOperation, buildOperation ->
             assert spec.implementationClass == TestRunnable
             return new DefaultWorkResult(true, null)
         }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
@@ -21,20 +21,11 @@ import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationRef
 import spock.lang.Specification
 
-import static org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease
-import static org.gradle.internal.work.WorkerLeaseRegistry.WorkerLeaseCompletion
-
 class WorkerDaemonClientTest extends Specification {
     BuildOperationExecutor buildOperationExecutor = Mock(BuildOperationExecutor)
     BuildOperationRef buildOperation = Mock(BuildOperationRef)
-    WorkerLease workerOperation = Mock(WorkerLease)
-    WorkerLeaseCompletion completion = Mock(WorkerLeaseCompletion)
 
     WorkerDaemonClient client
-
-    def setup() {
-        _ * workerOperation.startChild() >> completion
-    }
 
     def "underlying worker is executed when client is executed"() {
         def workerDaemonProcess = Mock(WorkerDaemonProcess)
@@ -43,7 +34,7 @@ class WorkerDaemonClientTest extends Specification {
         client = client(workerDaemonProcess)
 
         when:
-        client.execute(Stub(ActionExecutionSpec), workerOperation, buildOperation)
+        client.execute(Stub(ActionExecutionSpec), buildOperation)
 
         then:
         1 * workerDaemonProcess.execute(_)
@@ -55,7 +46,7 @@ class WorkerDaemonClientTest extends Specification {
         assert client.uses == 0
 
         when:
-        5.times { client.execute(Stub(ActionExecutionSpec), workerOperation, buildOperation) }
+        5.times { client.execute(Stub(ActionExecutionSpec), buildOperation) }
 
         then:
         client.uses == 5

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
@@ -18,33 +18,25 @@ package org.gradle.workers.internal
 
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationRef
-import org.gradle.internal.work.WorkerLeaseRegistry
-import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease
 import org.gradle.process.internal.health.memory.MemoryManager
 import spock.lang.Specification
 import spock.lang.Subject
-
-import static org.gradle.internal.work.WorkerLeaseRegistry.WorkerLeaseCompletion
 
 class WorkerDaemonFactoryTest extends Specification {
 
     def clientsManager = Mock(WorkerDaemonClientsManager)
     def client = Mock(WorkerDaemonClient)
     def memoryManager = Mock(MemoryManager)
-    def workerLeaseRegistry = Mock(WorkerLeaseRegistry)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
-    def workerOperation = Mock(WorkerLease)
     def buildOperation = Mock(BuildOperationRef)
-    def completion = Mock(WorkerLeaseCompletion)
 
-    @Subject factory = new WorkerDaemonFactory(clientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor)
+    @Subject factory = new WorkerDaemonFactory(clientsManager, memoryManager, buildOperationExecutor)
 
     def workingDir = new File("some-dir")
     def options = Stub(DaemonForkOptions)
     def spec = Stub(ActionExecutionSpec)
 
     def setup() {
-        _ * workerLeaseRegistry.getCurrentWorkerLease() >> workerOperation
         _ * buildOperationExecutor.getCurrentOperation() >> buildOperation
     }
 
@@ -61,7 +53,6 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(options).execute(spec)
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> null
 
         then:
@@ -80,7 +71,6 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(options).execute(spec)
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> client
 
         then:
@@ -96,7 +86,6 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(options).execute(spec)
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> client
 
         then:
@@ -112,7 +101,7 @@ class WorkerDaemonFactoryTest extends Specification {
         WorkerDaemonExpiration workerDaemonExpiration
 
         when:
-        def factory = new WorkerDaemonFactory(clientsManager, memoryManager, workerLeaseRegistry, buildOperationExecutor)
+        def factory = new WorkerDaemonFactory(clientsManager, memoryManager, buildOperationExecutor)
 
         then:
         1 * memoryManager.addMemoryHolder(_) >> { args -> workerDaemonExpiration = args[0] }
@@ -129,10 +118,8 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(options).execute(spec)
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> client
         1 * buildOperationExecutor.call(_)
-        1 * completion.leaseFinish()
     }
 
     def "build worker operation is finished even if worker fails"() {
@@ -140,14 +127,12 @@ class WorkerDaemonFactoryTest extends Specification {
         factory.getWorker(options).execute(spec)
 
         then:
-        1 * workerOperation.startChild() >> completion
         1 * clientsManager.reserveIdleClient(options) >> client
         1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
         1 * client.execute(spec) >> { throw new RuntimeException("Boo!") }
 
         then:
         thrown(RuntimeException)
-        1 * completion.leaseFinish()
     }
 
     def "stops clients"() {


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/4502

This makes the `WorkerExecutor` use a queue-based processor for processing work items.