### PR TITLE
Exclude anonymous class in JUnit Platform (#4774)

### DIFF
--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/DefaultTestClassScannerTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/DefaultTestClassScannerTest.groovy
@@ -26,13 +26,13 @@ import org.gradle.api.internal.tasks.testing.TestClassProcessor
 import org.junit.Test
 import spock.lang.Specification
 
-public class DefaultTestClassScannerTest extends Specification {
+class DefaultTestClassScannerTest extends Specification {
     private final TestFrameworkDetector detector = Mock()
     private final TestClassProcessor processor = Mock()
     private final FileTree files = Mock()
 
     @Test
-    public void passesEachClassFileToTestClassDetector() {
+    void passesEachClassFileToTestClassDetector() {
         DefaultTestClassScanner scanner = new DefaultTestClassScanner(files, detector, processor)
 
         when:
@@ -50,6 +50,26 @@ public class DefaultTestClassScannerTest extends Specification {
             assert visitor
             visitor.visitFile(mockFileVisitDetails('class1'))
             visitor.visitFile(mockFileVisitDetails('class2'))
+        }
+
+        0 * _._
+    }
+
+    @Test
+    void skipAnonymousClass() {
+        DefaultTestClassScanner scanner = new DefaultTestClassScanner(files, detector, processor)
+
+        when:
+        scanner.run()
+
+        then:
+        1 * detector.startDetection(processor)
+        then:
+        1 * files.visit(_) >> { args ->
+            FileVisitor visitor = args[0]
+            assert visitor
+            visitor.visitFile(mockFileVisitDetails('AnonymousClass$1'))
+            visitor.visitFile(mockFileVisitDetails('AnonymousClass$1$22'))
         }
 
         0 * _._


### PR DESCRIPTION
Some tests in #4774 cause some IDEA issues: `The following modules must have the same language level assigned because of cyclic dependencies between them`. This PR removes those tests.