### PR TITLE
Fix buildSrc import into IDEA

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,6 +16,7 @@
 
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
+import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import java.util.Properties
@@ -80,6 +81,10 @@ subprojects {
     apply {
         plugin("idea")
         plugin("eclipse")
+    }
+
+    the<IdeaModel>().apply {
+        module.name = "buildSrc-${this@subprojects.name}"
     }
 
     dependencies {


### PR DESCRIPTION
With this change it is again possible to have buildSrc in IDEA when
using `gradlew idea` and not the project import.

This broke when `buildSrc` became a multi-project build.

We prefix the IDEA-module name of buildSrc projects with `buildSrc-` to
avoid conflicts with already existing projects.
