### PR TITLE
Change wrapper downloading progress from dots to percentage.

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -84,4 +84,15 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
         failure.assertOutputContains("Could not unzip")
         failure.assertNotOutput("Could not set executable permissions")
     }
+
+    def "wrapper prints progress which contains all tenths of percentages except zero"() {
+        given:
+        prepareWrapper()
+
+        when:
+        def result = wrapperExecuter.run()
+
+        then:
+        result.output.contains("10%... 20%... 30%... 40%... 50%... 60%... 70%... 80%... 90%... 100%...")
+    }
 }


### PR DESCRIPTION
See #2679 for the motivation (damn, it was a long time ago).

Looks something like this in practice:

```
Downloading https://services.gradle.org/distributions/gradle-X-all.zip
10%... 20%... 30%... 40%... 50%... 60%... 70%... 80%... 90%... 100%... 
```

I’ve decided to avoid any real-time numbers change and other fancy console effects to be compatible with non-interactive shells (such as various CI outputs).

This is my first PR, so feel free to guide me to necessary docs and conditions.