### PR TITLE
Reinstate BuildIdentifier.isCurrentBuild()

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -86,9 +86,11 @@ Required by:
                 assert components.size() == 2
                 // TODO - should encode 'buildB' somewhere
                 assert components[0].build.name == 'buildSrc'
+                assert components[0].build.currentBuild
                 assert components[0].projectPath == ':'
                 assert components[0].projectName == 'buildSrc'
                 assert components[1].build.name == 'buildSrc'
+                assert components[1].build.currentBuild
                 assert components[1].projectPath == ':a'
                 assert components[1].projectName == 'a'
             }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -75,10 +75,12 @@ Required by:
                 def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
                 assert components.size() == 2
                 assert components[0].build.name == ':'
+                assert components[0].build.currentBuild
                 assert components[0].projectPath == ':'
                 // TODO - should be 'buildA'
                 assert components[0].projectName == ':'
                 assert components[1].build.name == 'buildB'
+                assert !components[1].build.currentBuild
                 assert components[1].projectPath == ':'
                 assert components[1].projectName == 'buildB'
             }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -28,6 +28,7 @@ import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.ForeignBuildIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
@@ -36,6 +37,7 @@ import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.Pair;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
+import org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
@@ -124,10 +126,15 @@ public class DefaultIncludedBuild implements IncludedBuildInternal, Configurable
         LocalComponentRegistry localComponentRegistry = project.getServices().get(LocalComponentRegistry.class);
         ProjectComponentIdentifier originalIdentifier = newProjectId(project);
         DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(originalIdentifier);
-        ProjectComponentIdentifier componentIdentifier = newProjectId(this, project.getPath());
+        ProjectComponentIdentifier componentIdentifier = idForProjectInThisBuild(project.getPath());
         ModuleVersionIdentifier moduleId = originalComponent.getModuleVersionId();
         LOGGER.info("Registering " + project + " in composite build. Will substitute for module '" + moduleId.getModule() + "'.");
         availableModules.add(Pair.of(moduleId, componentIdentifier));
+    }
+
+    public ProjectComponentIdentifier idForProjectInThisBuild(String projectPath) {
+        // Need to use a 'foreign' build id to make BuildIdentifier.isCurrentBuild work in the root build
+        return new DefaultProjectComponentIdentifier(new ForeignBuildIdentifier(getName()), projectPath);
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -147,7 +147,7 @@ public class DefaultIncludedBuildRegistry implements IncludedBuildRegistry, Stop
 
     private void registerRootBuildProjects(SettingsInternal settings) {
         ProjectRegistry<DefaultProjectDescriptor> settingsProjectRegistry = settings.getProjectRegistry();
-        DefaultBuildIdentifier buildIdentifier = new DefaultBuildIdentifier(":");
+        BuildIdentifier buildIdentifier = DefaultBuildIdentifier.ROOT;
         registerProjects(Path.ROOT, buildIdentifier, settingsProjectRegistry.getAllProjects(), false);
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
@@ -45,18 +45,18 @@ public class IncludedBuildDependencyMetadataBuilder {
         Map<ProjectComponentIdentifier, RegisteredProject> registeredProjects = Maps.newHashMap();
         Gradle gradle = build.getConfiguredBuild();
         for (Project project : gradle.getRootProject().getAllprojects()) {
-            registerProject(registeredProjects, build.getModel(), (ProjectInternal) project);
+            registerProject(registeredProjects, build, (ProjectInternal) project);
         }
         return registeredProjects;
     }
 
-    private void registerProject(Map<ProjectComponentIdentifier, RegisteredProject> registeredProjects, IncludedBuild build, ProjectInternal project) {
+    private void registerProject(Map<ProjectComponentIdentifier, RegisteredProject> registeredProjects, IncludedBuildInternal build, ProjectInternal project) {
         LocalComponentRegistry localComponentRegistry = project.getServices().get(LocalComponentRegistry.class);
         ProjectComponentIdentifier originalIdentifier = newProjectId(project);
         DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(originalIdentifier);
 
-        ProjectComponentIdentifier componentIdentifier = newProjectId(build, project.getPath());
-        LocalComponentMetadata compositeComponent = createCompositeCopy(build, componentIdentifier, originalComponent);
+        ProjectComponentIdentifier componentIdentifier = build.idForProjectInThisBuild(project.getPath());
+        LocalComponentMetadata compositeComponent = createCompositeCopy(build.getModel(), componentIdentifier, originalComponent);
         registeredProjects.put(componentIdentifier, new RegisteredProject(compositeComponent));
     }
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal
+
+import org.gradle.api.internal.BuildDefinition
+import org.gradle.api.internal.artifacts.ForeignBuildIdentifier
+import org.gradle.initialization.NestedBuildFactory
+import org.gradle.internal.work.WorkerLeaseRegistry
+import spock.lang.Specification
+
+class DefaultIncludedBuildTest extends Specification {
+    def "creates a foreign id for projects"() {
+        def build = new DefaultIncludedBuild(Stub(BuildDefinition), Stub(NestedBuildFactory), Stub(WorkerLeaseRegistry.WorkerLease))
+
+        expect:
+        def id = build.idForProjectInThisBuild(":a:b:c")
+        id.build instanceof ForeignBuildIdentifier
+        id.projectPath == ":a:b:c"
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/BuildIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/BuildIdentifier.java
@@ -19,7 +19,7 @@ package org.gradle.api.artifacts.component;
 import org.gradle.api.Incubating;
 
 /**
- * Identifies a Gradle build.
+ * Identifies a Gradle build. The identifier is unique within a Gradle invocation, so for example, each included build will have a different identifier.
  */
 @Incubating
 public interface BuildIdentifier {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentIdentifier.java
@@ -27,21 +27,22 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 @UsedByScanPlugin
 public interface ProjectComponentIdentifier extends ComponentIdentifier {
     /**
-     * Identifies the build that contains the project component.
+     * Identifies the build that contains the project that produces this component.
      *
      * @return The build identifier
      */
     BuildIdentifier getBuild();
 
     /**
-     * Returns the path of the project which the component belongs to.
+     * Returns the path of the project that produces this component. This path is relative to the containing build, so for example will return ':' for the root project of a build.
      *
      * @since 1.10
      */
     String getProjectPath();
 
     /**
-     * Returns the simple name of the project.
+     * Returns the simple name of the project that produces this component.
+     *
      * @since 4.5
      */
     String getProjectName();

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/ConfigurableIncludedBuild.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/ConfigurableIncludedBuild.java
@@ -19,7 +19,6 @@ package org.gradle.api.initialization;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.DependencySubstitutions;
-import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A build that is to be included in the composite.
@@ -27,7 +26,6 @@ import org.gradle.internal.HasInternalProtocol;
  * @since 3.1
  */
 @Incubating
-@HasInternalProtocol
 public interface ConfigurableIncludedBuild extends IncludedBuild {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/IncludedBuild.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/IncludedBuild.java
@@ -18,7 +18,6 @@ package org.gradle.api.initialization;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.tasks.TaskReference;
-import org.gradle.internal.HasInternalProtocol;
 
 import java.io.File;
 
@@ -28,7 +27,6 @@ import java.io.File;
  * @since 3.1
  */
 @Incubating
-@HasInternalProtocol
 public interface IncludedBuild {
     /**
      * The name of the included build.

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -90,9 +90,11 @@ Required by:
                 def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
                 assert components.size() == 2
                 assert components[0].build.name == 'buildSrc'
+                assert components[0].build.currentBuild
                 assert components[0].projectPath == ':'
                 assert components[0].projectName == 'buildSrc'
                 assert components[1].build.name == 'buildSrc'
+                assert components[1].build.currentBuild
                 assert components[1].projectPath == ':a'
                 assert components[1].projectName == 'a'
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
@@ -32,6 +32,11 @@ public class DefaultBuildIdentifier implements BuildIdentifier {
     }
 
     @Override
+    public boolean isCurrentBuild() {
+        return true;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -40,7 +45,7 @@ public class DefaultBuildIdentifier implements BuildIdentifier {
             return false;
         }
         DefaultBuildIdentifier that = (DefaultBuildIdentifier) o;
-        return Objects.equal(name, that.name);
+        return name.equals(that.name);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 
 public class DefaultBuildIdentifier implements BuildIdentifier {
+    public static final BuildIdentifier ROOT = new DefaultBuildIdentifier(":");
     private final String name;
 
     public DefaultBuildIdentifier(String name) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ForeignBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ForeignBuildIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradle.api.artifacts.component;
-
-import org.gradle.api.Incubating;
+package org.gradle.api.internal.artifacts;
 
 /**
- * Identifies a Gradle build.
+ * A build that is not the current build. This type exists only to provide an answer to {@link #isCurrentBuild()}, which should not exist.
  */
-@Incubating
-public interface BuildIdentifier {
-    /**
-     * The name of the build.
-     */
-    String getName();
+public class ForeignBuildIdentifier extends DefaultBuildIdentifier {
+    public ForeignBuildIdentifier(String name) {
+        super(name);
+    }
 
-    /**
-     * Is this build the one that's currently executing?
-     */
-    boolean isCurrentBuild();
+    @Override
+    public boolean isCurrentBuild() {
+        return false;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildInternal.java
@@ -34,6 +34,8 @@ public interface IncludedBuildInternal {
     List<Action<? super DependencySubstitutions>> getRegisteredDependencySubstitutions();
     Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
 
+    ProjectComponentIdentifier idForProjectInThisBuild(String path);
+
     SettingsInternal getLoadedSettings();
     GradleInternal getConfiguredBuild();
     void finishBuild();

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildRegistry.java
@@ -37,7 +37,7 @@ public interface IncludedBuildRegistry {
      * Locates a build by {@link BuildIdentifier}, if present.
      */
     @Nullable
-    IncludedBuildInternal getBuild(BuildIdentifier name);
+    IncludedBuildInternal getBuild(BuildIdentifier buildIdentifier);
 
     void validateExplicitIncludedBuilds(SettingsInternal settings);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultBuildIdentity.java
@@ -27,7 +27,7 @@ public class DefaultBuildIdentity implements BuildIdentity {
 
     public DefaultBuildIdentity(BuildDefinition buildDefinition, boolean isRootBuild) {
         if (isRootBuild) {
-            this.buildIdentifier = new DefaultBuildIdentifier(":");
+            this.buildIdentifier = DefaultBuildIdentifier.ROOT;
         } else {
             // Infer a build id from the containing directory
             // Should be part of the build definition

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultBuildIdentifierTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultBuildIdentifierTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts
+
+import org.gradle.util.Matchers
+import spock.lang.Specification
+
+
+class DefaultBuildIdentifierTest extends Specification {
+    def "create build from name"() {
+        expect:
+        def id = new DefaultBuildIdentifier('thing')
+        id.name == 'thing'
+        id.currentBuild
+        id.toString() == "build 'thing'"
+    }
+
+    def "has equals"() {
+        expect:
+        def id = new DefaultBuildIdentifier('one')
+        def same = new DefaultBuildIdentifier('one')
+        def different = new DefaultBuildIdentifier('two')
+
+        Matchers.strictlyEquals(id, same)
+        id != different
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/BuildIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/BuildIdentifierSerializer.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.ForeignBuildIdentifier;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -28,11 +29,17 @@ public class BuildIdentifierSerializer extends AbstractSerializer<BuildIdentifie
     @Override
     public BuildIdentifier read(Decoder decoder) throws IOException {
         String buildName = decoder.readString();
-        return new DefaultBuildIdentifier(buildName);
+        boolean isCurrent = decoder.readBoolean();
+        if (isCurrent) {
+            return new DefaultBuildIdentifier(buildName);
+        } else {
+            return new ForeignBuildIdentifier(buildName);
+        }
     }
 
     @Override
     public void write(Encoder encoder, BuildIdentifier value) throws IOException {
         encoder.writeString(value.getName());
+        encoder.writeBoolean(value.isCurrentBuild());
     }
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -159,10 +159,6 @@ Task type `org.gradle.nativeplatform.tasks.InstallExecutable`
 
 Task types `org.gradle.language.assembler.tasks.Assemble`, `org.gradle.language.rc.tasks.WindowsResourceCompile`, `org.gradle.nativeplatform.tasks.StripSymbols`, `org.gradle.nativeplatform.tasks.ExtractSymbols`, `org.gradle.language.swift.tasks.SwiftCompile`, and `org.gradle.nativeplatform.tasks.LinkMachOBundle` were changed in similar ways.
 
-### Removed incubating method `BuildIdentifier.isCurrentBuild()`
-
-TBD - This method is not longer available, so that a `BuildIdentifier` instance may be used to represent a build from anywhere in the Gradle invocation.
-
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -98,10 +98,12 @@ Required by:
                 def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
                 assert components.size() == 2
                 assert components[0].build.name == ':'
+                assert components[0].build.currentBuild
                 assert components[0].projectPath == ':'
                 // TODO - should be 'buildA'
                 assert components[0].projectName == ':'
                 assert components[1].build.name == 'buildB'
+                assert !components[1].build.currentBuild
                 assert components[1].projectPath == ':'
                 assert components[1].projectName == 'buildB'
             }


### PR DESCRIPTION
### Context

This change adds `isCurrentBuild()` back to `BuildIdentifier`, pending a replacement and a normal deprecation cycle.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
