### PR TITLE
Fix the mechanism used to add the standard C library to the C++ include path on macOS

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -205,6 +205,7 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
         configureDefaultTools(configurableToolChain);
         targetPlatformConfigurationConfiguration.apply(configurableToolChain);
         configureActions.execute(configurableToolChain);
+        configurableToolChain.compilerProbeArgs(standardLibraryDiscovery.compilerProbeArgs(targetPlatform));
 
         ToolChainAvailability result = new ToolChainAvailability();
         initTools(configurableToolChain, result);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
@@ -242,7 +242,7 @@ class GccPlatformToolProvider extends AbstractPlatformToolProvider {
     public SystemLibraries getSystemLibraries(ToolType compilerType) {
         final SearchResult<GccMetadata> gccMetadata = getGccMetadata(compilerType);
         if (gccMetadata.isAvailable()) {
-            return standardLibraryDiscovery.getSystemLibraries(gccMetadata.getComponent(), targetPlatform);
+            return gccMetadata.getComponent().getSystemLibraries();
         }
         return new EmptySystemLibraries();
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/SystemLibraryDiscovery.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/SystemLibraryDiscovery.java
@@ -17,13 +17,9 @@
 package org.gradle.nativeplatform.toolchain.internal.gcc.metadata;
 
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
-import org.gradle.nativeplatform.toolchain.internal.SystemLibraries;
 import org.gradle.nativeplatform.toolchain.internal.xcode.MacOSSdkPathLocator;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 public class SystemLibraryDiscovery {
     private final MacOSSdkPathLocator macOSSdkPathLocator;
@@ -32,38 +28,11 @@ public class SystemLibraryDiscovery {
         this.macOSSdkPathLocator = macOSSdkPathLocator;
     }
 
-    public SystemLibraries getSystemLibraries(final GccMetadata compiler, NativePlatformInternal target) {
-        final SystemLibraries compilerSystemLibraries = compiler.getSystemLibraries();
-
+    public String[] compilerProbeArgs(NativePlatformInternal target) {
         if (!target.getOperatingSystem().isMacOsX()) {
-            return compilerSystemLibraries;
+            return new String[0];
         }
-
-        // Add the macOS platform SDK, if not present
         File sdkDir = macOSSdkPathLocator.find();
-        final File platformIncludeDir = new File(sdkDir, "usr/include");
-        if (compilerSystemLibraries.getIncludeDirs().contains(platformIncludeDir)) {
-            return compilerSystemLibraries;
-        }
-
-        final List<File> dirs = new ArrayList<File>(compilerSystemLibraries.getIncludeDirs());
-        dirs.add(platformIncludeDir);
-
-        return new SystemLibraries() {
-            @Override
-            public List<File> getIncludeDirs() {
-                return dirs;
-            }
-
-            @Override
-            public List<File> getLibDirs() {
-                return compilerSystemLibraries.getLibDirs();
-            }
-
-            @Override
-            public Map<String, String> getPreprocessorMacros() {
-                return compilerSystemLibraries.getPreprocessorMacros();
-            }
-        };
+        return new String[]{"-isysroot", sdkDir.getAbsolutePath()};
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/MacOSSdkPathLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/MacOSSdkPathLocator.java
@@ -16,10 +16,10 @@
 
 package org.gradle.nativeplatform.toolchain.internal.xcode;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.process.internal.ExecActionFactory;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 import java.util.List;
 
 public class MacOSSdkPathLocator extends AbstractLocator {
@@ -30,6 +30,6 @@ public class MacOSSdkPathLocator extends AbstractLocator {
 
     @Override
     protected List<String> getXcrunFlags() {
-        return Arrays.asList("--show-sdk-path");
+        return ImmutableList.of("--show-sdk-path");
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/MacOSSdkPlatformPathLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/MacOSSdkPlatformPathLocator.java
@@ -16,10 +16,10 @@
 
 package org.gradle.nativeplatform.toolchain.internal.xcode;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.process.internal.ExecActionFactory;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 import java.util.List;
 
 public class MacOSSdkPlatformPathLocator extends AbstractLocator {
@@ -30,6 +30,6 @@ public class MacOSSdkPlatformPathLocator extends AbstractLocator {
 
     @Override
     protected List<String> getXcrunFlags() {
-        return Arrays.asList("--show-sdk-platform-path");
+        return ImmutableList.of("--show-sdk-platform-path");
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/SwiftStdlibToolLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/xcode/SwiftStdlibToolLocator.java
@@ -16,10 +16,10 @@
 
 package org.gradle.nativeplatform.toolchain.internal.xcode;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.process.internal.ExecActionFactory;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 import java.util.List;
 
 public class SwiftStdlibToolLocator extends AbstractLocator {
@@ -30,6 +30,6 @@ public class SwiftStdlibToolLocator extends AbstractLocator {
 
     @Override
     protected List<String> getXcrunFlags() {
-        return Arrays.asList("--find", "swift-stdlib-tool");
+        return ImmutableList.of("--find", "swift-stdlib-tool");
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.nativeplatform.toolchain.internal.NativeLanguage
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider
 import org.gradle.nativeplatform.toolchain.internal.ToolType
 import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.GccMetadata
+import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.SystemLibraryDiscovery
 import org.gradle.nativeplatform.toolchain.internal.metadata.CompilerMetaDataProvider
 import org.gradle.nativeplatform.toolchain.internal.tools.CommandLineToolSearchResult
 import org.gradle.nativeplatform.toolchain.internal.tools.GccCommandLineToolConfigurationInternal
@@ -66,9 +67,10 @@ class AbstractGccCompatibleToolChainTest extends Specification {
     def buildOperationExecutor = Stub(BuildOperationExecutor)
     def compilerOutputFileNamingSchemeFactory = Stub(CompilerOutputFileNamingSchemeFactory)
     def workerLeaseService = Stub(WorkerLeaseService)
+    def systemLibraryDiscovery = Stub(SystemLibraryDiscovery)
 
     def instantiator = DirectInstantiator.INSTANCE
-    def toolChain = new TestNativeToolChain("test", buildOperationExecutor, operatingSystem, fileResolver, execActionFactory, compilerOutputFileNamingSchemeFactory, toolSearchPath, metaDataProvider, instantiator, workerLeaseService)
+    def toolChain = new TestNativeToolChain("test", buildOperationExecutor, operatingSystem, fileResolver, execActionFactory, compilerOutputFileNamingSchemeFactory, toolSearchPath, metaDataProvider, systemLibraryDiscovery, instantiator, workerLeaseService)
     def platform = Stub(NativePlatformInternal)
 
     def dummyOs = new DefaultOperatingSystem("currentOS", OperatingSystem.current())
@@ -412,8 +414,8 @@ class AbstractGccCompatibleToolChainTest extends Specification {
     }
 
     static class TestNativeToolChain extends AbstractGccCompatibleToolChain {
-        TestNativeToolChain(String name, BuildOperationExecutor buildOperationExecutor, OperatingSystem operatingSystem, FileResolver fileResolver, ExecActionFactory execActionFactory, CompilerOutputFileNamingSchemeFactory compilerOutputFileNamingSchemeFactory, ToolSearchPath tools, CompilerMetaDataProvider metaDataProvider, Instantiator instantiator, WorkerLeaseService workerLeaseService) {
-            super(name, buildOperationExecutor, operatingSystem, fileResolver, execActionFactory, compilerOutputFileNamingSchemeFactory, tools, metaDataProvider, null, instantiator, workerLeaseService)
+        TestNativeToolChain(String name, BuildOperationExecutor buildOperationExecutor, OperatingSystem operatingSystem, FileResolver fileResolver, ExecActionFactory execActionFactory, CompilerOutputFileNamingSchemeFactory compilerOutputFileNamingSchemeFactory, ToolSearchPath tools, CompilerMetaDataProvider metaDataProvider, SystemLibraryDiscovery systemLibraryDiscovery, Instantiator instantiator, WorkerLeaseService workerLeaseService) {
+            super(name, buildOperationExecutor, operatingSystem, fileResolver, execActionFactory, compilerOutputFileNamingSchemeFactory, tools, metaDataProvider, systemLibraryDiscovery, instantiator, workerLeaseService)
         }
 
         @Override

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProviderTest.groovy
@@ -64,9 +64,9 @@ class GccPlatformToolProviderTest extends Specification {
             assert arguments[1] == args
             new ComponentFound(metaData)
         }
-        1 * systemLibraryDiscovery.getSystemLibraries(metaData, targetPlatform) >> libs
         1 * toolRegistry.getTool(toolType) >> new DefaultGccCommandLineToolConfiguration(toolType, 'exe')
         1 * toolSearchPath.locate(toolType, 'exe') >> Mock(CommandLineToolSearchResult)
+        _ * metaData.systemLibraries >> libs
 
         where:
         toolType                       | args

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccToolChainTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
 import org.gradle.nativeplatform.platform.internal.NativePlatformInternal
 import org.gradle.nativeplatform.toolchain.GccPlatformToolChain
+import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.SystemLibraryDiscovery
 import org.gradle.nativeplatform.toolchain.internal.metadata.CompilerMetaDataProviderFactory
 import org.gradle.process.internal.ExecActionFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -37,7 +38,7 @@ class GccToolChainTest extends Specification {
     final FileResolver fileResolver = Mock(FileResolver)
     Instantiator instantiator = DirectInstantiator.INSTANCE
 
-    final toolChain = new GccToolChain(instantiator , "gcc", Stub(BuildOperationExecutor), OperatingSystem.current(), fileResolver, Stub(ExecActionFactory), Stub(CompilerOutputFileNamingSchemeFactory), Stub(CompilerMetaDataProviderFactory), null, Stub(WorkerLeaseService))
+    final toolChain = new GccToolChain(instantiator , "gcc", Stub(BuildOperationExecutor), OperatingSystem.current(), fileResolver, Stub(ExecActionFactory), Stub(CompilerOutputFileNamingSchemeFactory), Stub(CompilerMetaDataProviderFactory), Stub(SystemLibraryDiscovery), Stub(WorkerLeaseService))
 
     def "provides default tools"() {
         def action = Mock(Action)


### PR DESCRIPTION
### Context

This change fixes the system library discovery on macOS, by using `--isysroot` during discovery rather than adding some hard-coded locations to the include path.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
