### PR TITLE
Add JavaVersion.getName() back

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -158,6 +158,11 @@ public enum JavaVersion {
         return versionName;
     }
 
+    // We have to keep this for a while: https://github.com/gradle/gradle/issues/4856
+    private String getName() {
+        return versionName;
+    }
+
     public String getMajorVersion() {
         return String.valueOf(ordinal() + 1);
     }


### PR DESCRIPTION
### Context

See #4856 :


When user click `Gradle refresh` button or import a gradle project in IDEA, IDEA will apply an internal `init.gradle` via Tooling API. However, this script uses `JavaVersion.getName()`, which is a private method here: https://github.com/JetBrains/intellij-community/blob/36a3503c9b72d5b79f3aba13360f4937706aec08/plugins/gradle/tooling-extension-impl/src/org/jetbrains/plugins/gradle/tooling/builder/ExternalProjectBuilderImpl.groovy#L207

After we refactored `JavaVersion` in #4759 and removed that private method, the IDEA-Gradle integration is broken, as reported by @timyates :

```
<ij_msg_gr>Project resolve errors<ij_msg_gr><ij_nav>/Users/tim/Code/Work/dotcom/buildSrc/buildSrc.gradle<ij_nav><i><b>root project 'buildSrc': Unable to resolve additional project configuration.</b><eol>Details: groovy.lang.MissingPropertyException: No such property: name for class: org.gradle.api.JavaVersion</i>
```

This is a huge influence. I'm very much reluctant to add `getName()` back, but seems we still need to.