### PR TITLE
Improve performance of the console

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SetupLoggingActionExecuter.java
@@ -40,6 +40,7 @@ public class SetupLoggingActionExecuter implements BuildExecuter {
     public Object execute(BuildAction action, BuildRequestContext requestContext, BuildActionParameters actionParameters, ServiceRegistry contextServices) {
         StartParameter startParameter = action.getStartParameter();
         loggingManager.setLevelInternal(startParameter.getLogLevel());
+        loggingManager.enableUserStandardOutputListeners();
         loggingManager.start();
         try {
             return delegate.execute(action, requestContext, actionParameters, contextServices);

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractLoggingHooksFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractLoggingHooksFunctionalTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console.taskgrouping
+
+
+abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGroupedTaskFunctionalTest{
+    def setup() {
+        buildFile << """
+            class CollectingListener implements StandardOutputListener {
+                def result = new StringBuilder()
+                
+                String toString() {
+                    return result.toString()
+                }
+                
+                void onOutput(CharSequence output) {
+                    result.append(output)
+                }
+            }
+        """
+    }
+
+    def "listener added to task receives only the output generated while the task is running"() {
+        buildFile << """
+            def o = new CollectingListener()
+            def e = new CollectingListener()
+            def none = new CollectingListener()
+            task log {
+                doLast {
+                    logging.addStandardOutputListener(o)
+                    logging.addStandardErrorListener(e)
+                    System.out.println "output" 
+                    System.err.println "error" 
+                }
+            }
+            task other {
+                dependsOn log
+                doLast {
+                    System.out.println "other" 
+                    System.err.println "other" 
+                }
+            }
+            
+            gradle.buildFinished {
+                log.logging.addStandardOutputListener(none)
+                log.logging.addStandardErrorListener(none)
+                println "finished"
+                assert o.toString().readLines() == [":log", "output"]
+                assert e.toString().readLines() == ["error"]
+                assert none.toString().readLines() == []
+            }
+        """
+
+        expect:
+        succeeds("log", "other")
+    }
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/plain/PlainConsoleLoggingHooksFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/plain/PlainConsoleLoggingHooksFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.logging.console.taskgrouping
+package org.gradle.internal.logging.console.taskgrouping.plain
 
 import org.gradle.api.logging.configuration.ConsoleOutput
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.RichConsoleStyling
+import org.gradle.internal.logging.console.taskgrouping.AbstractLoggingHooksFunctionalTest
 
-/**
- * A base class for testing the console.
- */
-abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
-    def setup() {
-        executer.beforeExecute {
-            it.withConsole(consoleType)
-        }
-    }
 
-    abstract ConsoleOutput getConsoleType()
+class PlainConsoleLoggingHooksFunctionalTest extends AbstractLoggingHooksFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Plain
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleLoggingHooksFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleLoggingHooksFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.logging.console.taskgrouping
+package org.gradle.internal.logging.console.taskgrouping.rich
 
 import org.gradle.api.logging.configuration.ConsoleOutput
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.RichConsoleStyling
+import org.gradle.internal.logging.console.taskgrouping.AbstractLoggingHooksFunctionalTest
 
-/**
- * A base class for testing the console.
- */
-abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
-    def setup() {
-        executer.beforeExecute {
-            it.withConsole(consoleType)
-        }
-    }
 
-    abstract ConsoleOutput getConsoleType()
+class RichConsoleLoggingHooksFunctionalTest extends AbstractLoggingHooksFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Rich
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleLoggingHooksFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/verbose/VerboseConsoleLoggingHooksFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.logging.console.taskgrouping
+package org.gradle.internal.logging.console.taskgrouping.verbose
 
 import org.gradle.api.logging.configuration.ConsoleOutput
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.RichConsoleStyling
+import org.gradle.internal.logging.console.taskgrouping.AbstractLoggingHooksFunctionalTest
 
-/**
- * A base class for testing the console.
- */
-abstract class AbstractConsoleGroupedTaskFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
-    def setup() {
-        executer.beforeExecute {
-            it.withConsole(consoleType)
-        }
-    }
 
-    abstract ConsoleOutput getConsoleType()
+class VerboseConsoleLoggingHooksFunctionalTest extends AbstractLoggingHooksFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
 }

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/LoggingManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/LoggingManager.java
@@ -20,7 +20,7 @@ import org.gradle.internal.HasInternalProtocol;
 
 /**
  * <p>A {@code LoggingManager} provides access to and control over the Gradle logging system. Using this interface, you
- * can control the current logging level and standard output and error capture.</p>
+ * can control standard output and error capture and receive logging events.</p>
  */
 @HasInternalProtocol
 public interface LoggingManager extends LoggingOutput {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingManagerInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingManagerInternal.java
@@ -17,6 +17,7 @@ package org.gradle.internal.logging;
 
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.LoggingManager;
+import org.gradle.api.logging.StandardOutputListener;
 
 /**
  * Provides access to and control over the logging system. Log manager represents some 'scope', and log managers can be nested in a stack.
@@ -50,4 +51,11 @@ public interface LoggingManagerInternal extends LoggingManager, StandardOutputCa
     LoggingManagerInternal captureStandardError(LogLevel level);
 
     LoggingManagerInternal setLevelInternal(LogLevel logLevel);
+
+    /**
+     * Allows {@link org.gradle.api.logging.LoggingOutput#addStandardOutputListener(StandardOutputListener)} and {@link org.gradle.api.logging.LoggingOutput#addStandardErrorListener(StandardOutputListener)} to be used.
+     *
+     * <p>This should be used only when custom user listeners are required, i.e. only in the build JVM around the build execution.
+     */
+    LoggingManagerInternal enableUserStandardOutputListeners();
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/config/LoggingRouter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/config/LoggingRouter.java
@@ -21,4 +21,6 @@ import org.gradle.internal.logging.LoggingOutputInternal;
 
 public interface LoggingRouter extends LoggingSystem, LoggingOutputInternal {
     void configure(LogLevel logLevel);
+
+    void enableUserStandardOutputListeners();
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
@@ -41,6 +41,7 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
     private final StartableLoggingSystem stdErrLoggingSystem;
     private final StartableLoggingSystem javaUtilLoggingSystem;
     private final StartableLoggingRouter loggingRouter;
+    private boolean enableStdOutListeners;
     private final LoggingOutputInternal loggingOutput;
     private final Set<StandardOutputListener> stdoutListeners = new LinkedHashSet<StandardOutputListener>();
     private final Set<StandardOutputListener> stderrListeners = new LinkedHashSet<StandardOutputListener>();
@@ -59,6 +60,9 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
     @Override
     public DefaultLoggingManager start() {
         started = true;
+        if (enableStdOutListeners) {
+            loggingRouter.loggingRouter.enableUserStandardOutputListeners();
+        }
         for (StandardOutputListener stdoutListener : stdoutListeners) {
             loggingOutput.addStandardOutputListener(stdoutListener);
         }
@@ -146,6 +150,12 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
     @Override
     public LogLevel getStandardErrorCaptureLevel() {
         return stdErrLoggingSystem.level;
+    }
+
+    @Override
+    public LoggingManagerInternal enableUserStandardOutputListeners() {
+        enableStdOutListeners = true;
+        return this;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -238,9 +238,9 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
                 new BuildStatusRenderer(
                     new WorkInProgressRenderer(
                         new BuildLogLevelFilterRenderer(
-                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), clock, new PrettyPrefixedLogHeaderFormatter(), verbose)),
+                            new GroupingProgressLogEventGenerator(new StyledTextOutputBackedRenderer(console.getBuildOutputArea()), new PrettyPrefixedLogHeaderFormatter(), verbose)),
                         console.getBuildProgressArea(), new DefaultWorkInProgressFormatter(consoleMetaData), new ConsoleLayoutCalculator(consoleMetaData)),
-                    console.getStatusBar(), console, consoleMetaData, clock),
+                    console.getStatusBar(), console, consoleMetaData),
                 console),
             clock);
         return addConsoleChain(consoleChain, stdout, stderr);
@@ -254,7 +254,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
         OutputEventListener stdoutChain = new UserInputStandardOutputRenderer(new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(outputListener)), clock);
         OutputEventListener consoleChain = new ThrottlingOutputEventListener(
             new BuildLogLevelFilterRenderer(
-                new GroupingProgressLogEventGenerator(stdoutChain, clock, new PrettyPrefixedLogHeaderFormatter(), true)
+                new GroupingProgressLogEventGenerator(stdoutChain, new PrettyPrefixedLogHeaderFormatter(), true)
             ),
             clock
         );

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -81,11 +81,11 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
             new LazyListener(new Factory<OutputEventListener>() {
                 @Override
                 public OutputEventListener create() {
-                    OutputEventListener stdOutChain = new UserInputStandardOutputRenderer(new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stdoutListeners.getSource())), clock);
+                    OutputEventListener stdOutChain = new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stdoutListeners.getSource()));
                     OutputEventListener stdErrChain = new StyledTextOutputBackedRenderer(new StreamingStyledTextOutput(stderrListeners.getSource()));
 
                     return new BuildLogLevelFilterRenderer(
-                        new ProgressLogEventGenerator(new LogEventDispatcher(stdOutChain, stdErrChain), false)
+                        new ProgressLogEventGenerator(new LogEventDispatcher(stdOutChain, stdErrChain))
                     );
                 }
             })

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
@@ -44,12 +44,10 @@ public class ProgressLogEventGenerator implements OutputEventListener {
     private static final String EOL = SystemProperties.getInstance().getLineSeparator();
 
     private final OutputEventListener listener;
-    private final boolean deferHeader;
     private final Map<OperationIdentifier, Operation> operations = new LinkedHashMap<OperationIdentifier, Operation>();
 
-    public ProgressLogEventGenerator(OutputEventListener listener, boolean deferHeader) {
+    public ProgressLogEventGenerator(OutputEventListener listener) {
         this.listener = listener;
-        this.deferHeader = deferHeader;
     }
 
     public void onOutput(OutputEvent event) {
@@ -100,7 +98,7 @@ public class ProgressLogEventGenerator implements OutputEventListener {
         Operation operation = new Operation(progressStartEvent.getCategory(), progressStartEvent.getLoggingHeader(), progressStartEvent.getTimestamp(), progressStartEvent.getBuildOperationId());
         operations.put(progressStartEvent.getProgressOperationId(), operation);
 
-        if (!deferHeader || !(progressStartEvent.getLoggingHeader() != null && progressStartEvent.getLoggingHeader().equals(progressStartEvent.getShortDescription()))) {
+        if (!(progressStartEvent.getLoggingHeader() != null && progressStartEvent.getLoggingHeader().equals(progressStartEvent.getShortDescription()))) {
             operation.startHeader();
         }
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContext.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContext.java
@@ -24,7 +24,6 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-import java.io.OutputStream;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,15 +36,11 @@ public class OutputEventListenerBackedLoggerContext implements ILoggerFactory {
     static final String META_INF_EXTENSION_MODULE_LOGGER_NAME = "org.codehaus.groovy.runtime.m12n.MetaInfExtensionModule";
 
     private final ConcurrentMap<String, Logger> loggers = new ConcurrentHashMap<String, Logger>();
-    private final OutputStream defaultOutputStream;
-    private final OutputStream defaultErrorStream;
     private final AtomicReference<LogLevel> level = new AtomicReference<LogLevel>();
     private final AtomicReference<OutputEventListener> outputEventListener = new AtomicReference<OutputEventListener>();
     private final Clock clock;
 
-    public OutputEventListenerBackedLoggerContext(OutputStream defaultOutputStream, OutputStream defaultErrorStream, Clock clock) {
-        this.defaultOutputStream = defaultOutputStream;
-        this.defaultErrorStream = defaultErrorStream;
+    public OutputEventListenerBackedLoggerContext(Clock clock) {
         this.clock = clock;
         applyDefaultLoggersConfig();
         reset();
@@ -83,8 +78,7 @@ public class OutputEventListenerBackedLoggerContext implements ILoggerFactory {
     public void reset() {
         setLevel(DEFAULT_LOG_LEVEL);
         OutputEventRenderer renderer = new OutputEventRenderer(clock);
-        renderer.addStandardOutputListener(defaultOutputStream);
-        renderer.addStandardErrorListener(defaultErrorStream);
+        renderer.attachSystemOutAndErr();
         setOutputEventListener(renderer);
     }
 

--- a/subprojects/logging/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/subprojects/logging/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -27,7 +27,7 @@ public class StaticLoggerBinder implements LoggerFactoryBinder {
     private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
     private static final String LOGGER_FACTORY_CLASS_STR = OutputEventListenerBackedLoggerContext.class.getName();
 
-    private final OutputEventListenerBackedLoggerContext factory = new OutputEventListenerBackedLoggerContext(System.out, System.err, Time.clock());
+    private final OutputEventListenerBackedLoggerContext factory = new OutputEventListenerBackedLoggerContext(Time.clock());
 
     public static StaticLoggerBinder getSingleton() {
         return SINGLETON;

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
@@ -18,19 +18,19 @@ package org.gradle.internal.logging.console
 
 import org.gradle.internal.logging.OutputSpecification
 import org.gradle.internal.logging.events.OutputEventListener
+import org.gradle.internal.logging.events.UpdateNowEvent
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData
-import org.gradle.internal.time.Clock
 
 class BuildStatusRendererTest extends OutputSpecification {
     def listener = Mock(OutputEventListener)
     def console = new ConsoleStub()
     def consoleMetaData = Mock(ConsoleMetaData)
-    def timeProvider = Mock(Clock)
     long currentTimeMs
-    def renderer = new BuildStatusRenderer(listener, console.statusBar, console, consoleMetaData, timeProvider)
+    def renderer = new BuildStatusRenderer(listener, console.statusBar, console, consoleMetaData)
 
-    def setup() {
-        timeProvider.getCurrentTime() >> { currentTimeMs }
+    @Override
+    UpdateNowEvent updateNow() {
+        return new UpdateNowEvent(currentTimeMs)
     }
 
     def "forwards event list to` listener"() {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/services/LoggingServiceRegistryTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/services/LoggingServiceRegistryTest.groovy
@@ -106,6 +106,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def logger = LoggerFactory.getLogger("category")
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
 
         when:
@@ -122,7 +123,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         then:
         1 * listener.onOutput('warning')
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         0 * listener._
 
         when:
@@ -140,6 +141,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def logger = Logger.getLogger("category")
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
 
         when:
@@ -156,7 +158,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         then:
         1 * listener.onOutput('warning')
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         0 * listener._
 
         when:
@@ -209,6 +211,7 @@ class LoggingServiceRegistryTest extends Specification {
         System.err == outputs.stdErrPrintStream
 
         when:
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -247,6 +250,7 @@ class LoggingServiceRegistryTest extends Specification {
         loggingManager.captureStandardError(LogLevel.WARN)
         loggingManager.captureStandardOutput(LogLevel.INFO)
         loggingManager.levelInternal = LogLevel.INFO
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -285,6 +289,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -332,6 +337,7 @@ class LoggingServiceRegistryTest extends Specification {
         System.err == outputs.stdErrPrintStream
 
         when:
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -352,6 +358,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def loggingManager = registry.newInstance(LoggingManagerInternal)
 
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -407,6 +414,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         when:
         loggingManager.levelInternal = LogLevel.WARN
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -415,9 +423,9 @@ class LoggingServiceRegistryTest extends Specification {
 
         then:
         1 * listener.onOutput("warning")
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         1 * listener.onOutput("error")
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         0 * listener._
     }
 
@@ -427,6 +435,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.setLevelInternal(LogLevel.INFO)
@@ -439,9 +448,9 @@ class LoggingServiceRegistryTest extends Specification {
 
         then:
         1 * listener.onOutput("info")
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         1 * listener.onOutput("error")
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         0 * listener._
 
         and:
@@ -455,6 +464,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.levelInternal = LogLevel.WARN
@@ -481,6 +491,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def logger = Logger.getLogger("category")
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.levelInternal = LogLevel.WARN
@@ -502,9 +513,9 @@ class LoggingServiceRegistryTest extends Specification {
 
         then:
         1 * listener.onOutput('warning')
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         1 * listener.onOutput('error')
-        1 * listener.onOutput(TextUtil.platformLineSeparator)
+        1 * listener.onOutput(SystemProperties.instance.lineSeparator)
         0 * listener._
 
         when:
@@ -566,6 +577,7 @@ class LoggingServiceRegistryTest extends Specification {
         when:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -611,6 +623,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         when:
         loggingManager.levelInternal = LogLevel.WARN
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
         loggingManager.start()
@@ -656,6 +669,7 @@ class LoggingServiceRegistryTest extends Specification {
         when:
         def registry = LoggingServiceRegistry.newNestedLogging()
         def loggingManager = registry.newInstance(LoggingManagerInternal)
+        loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.start()
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/GroupingProgressLogEventGeneratorTest.groovy
@@ -28,15 +28,13 @@ import org.gradle.internal.logging.events.UpdateNowEvent
 import org.gradle.internal.logging.format.LogHeaderFormatter
 import org.gradle.internal.operations.BuildOperationCategory
 import org.gradle.internal.operations.OperationIdentifier
-import org.gradle.internal.time.MockClock
 import spock.lang.Subject
 
 class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
     private final OutputEventListener downstreamListener = Mock(OutputEventListener)
     def logHeaderFormatter = Mock(LogHeaderFormatter)
-    def timeProvider = new MockClock()
     @Subject
-    listener = new GroupingProgressLogEventGenerator(downstreamListener, timeProvider, logHeaderFormatter, false)
+    listener = new GroupingProgressLogEventGenerator(downstreamListener, logHeaderFormatter, false)
 
     def setup() {
         logHeaderFormatter.format(_, _, _, _, _) >> { h, d, s, st, f -> [new StyledTextOutputEvent.Span("Header $d")] }
@@ -169,7 +167,7 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         given:
         def taskStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :foo", ":foo", null, null, 0, true, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)
         def taskCompleteEvent = new ProgressCompleteEvent(taskStartEvent.progressOperationId, tenAm, "STATUS", false)
-        def listener = new GroupingProgressLogEventGenerator(downstreamListener, timeProvider, logHeaderFormatter, true)
+        def listener = new GroupingProgressLogEventGenerator(downstreamListener, logHeaderFormatter, true)
 
         when:
         listener.onOutput(taskStartEvent)
@@ -193,7 +191,7 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
         def startEvent4 = new ProgressStartEvent(new OperationIdentifier(-7L), new OperationIdentifier(-4L), tenAm, CATEGORY, "Execute :d", ":d", null, null, 0, true, new OperationIdentifier(5L), null, BuildOperationCategory.TASK)
         def logEvent4 = event('d message', LogLevel.WARN, startEvent4.buildOperationId)
         def completeEvent4 = new ProgressCompleteEvent(startEvent4.progressOperationId, tenAm, "STATUS", false)
-        def listener = new GroupingProgressLogEventGenerator(downstreamListener, timeProvider, logHeaderFormatter, true)
+        def listener = new GroupingProgressLogEventGenerator(downstreamListener, logHeaderFormatter, true)
 
         when:
         listener.onOutput(startEvent1)
@@ -317,10 +315,10 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
 
     def "does not forward a batched group of events after receiving update now event before flush period"() {
         given:
-        def olderTimestamp = timeProvider.currentTime
+        def olderTimestamp = 0
         def taskAStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), olderTimestamp, CATEGORY, "Execute :a", ":a", null, null, 0, true, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)
         def taskAOutput = event(olderTimestamp, 'message for task a', LogLevel.WARN, taskAStartEvent.buildOperationId)
-        def updateNowEvent = new UpdateNowEvent(timeProvider.currentTime)
+        def updateNowEvent = new UpdateNowEvent(olderTimestamp + 100)
 
         when:
         listener.onOutput(taskAStartEvent)
@@ -338,10 +336,10 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
 
     def "forwards a batched group of events after receiving update now event after flush period"() {
         given:
-        def olderTimestamp = timeProvider.currentTime - GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT
+        def olderTimestamp = 0
         def taskAStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), olderTimestamp, CATEGORY, "Execute :a", ":a", null, null, 0, true, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)
         def taskAOutput = event(olderTimestamp, 'message for task a', LogLevel.WARN, taskAStartEvent.buildOperationId)
-        def updateNowEvent = new UpdateNowEvent(timeProvider.currentTime)
+        def updateNowEvent = new UpdateNowEvent(olderTimestamp + GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT + 10)
 
         when:
         listener.onOutput(taskAStartEvent)
@@ -361,12 +359,12 @@ class GroupingProgressLogEventGeneratorTest extends OutputSpecification {
 
     def "forwards multiple batched groups of events after receiving update now event after flush period"() {
         given:
-        def olderTimestamp = timeProvider.currentTime - GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT
+        def olderTimestamp = 0
         def taskAStartEvent = new ProgressStartEvent(new OperationIdentifier(-3L), new OperationIdentifier(-4L), olderTimestamp, CATEGORY, "Execute :a", ":a", null, null, 0, true, new OperationIdentifier(2L), null, BuildOperationCategory.TASK)
         def taskAOutput = event(olderTimestamp, 'message for task a', LogLevel.WARN, taskAStartEvent.buildOperationId)
         def taskBStartEvent = new ProgressStartEvent(new OperationIdentifier(-13L), new OperationIdentifier(-14L), olderTimestamp, CATEGORY, "Execute :b", ":b", null, null, 0, true, new OperationIdentifier(12L), null, BuildOperationCategory.TASK)
         def taskBOutput = event(olderTimestamp, 'message for task b', LogLevel.WARN, taskBStartEvent.buildOperationId)
-        def updateNowEvent = new UpdateNowEvent(timeProvider.currentTime)
+        def updateNowEvent = new UpdateNowEvent(olderTimestamp + GroupingProgressLogEventGenerator.HIGH_WATERMARK_FLUSH_TIMEOUT + 10)
 
         when:
         listener.onOutput(taskAStartEvent)

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -65,19 +65,7 @@ class OutputEventRendererTest extends OutputSpecification {
         outputs.stdErr.readLines() == ['message']
     }
 
-    def rendersLogEventsWhenLogLevelIsDebug() {
-        def listener = new TestListener()
-
-        when:
-        renderer.configure(LogLevel.DEBUG)
-        renderer.addStandardOutputListener(listener)
-        renderer.onOutput(event(tenAm, 'message', LogLevel.INFO))
-
-        then:
-        listener.value.readLines() == ['10:00:00.000 [INFO] [category] message']
-    }
-
-    def rendersLogEventsToStdOutandStdErrWhenLogLevelIsDebug() {
+    def rendersLogEventsToStdOutAndStdErrWhenLogLevelIsDebug() {
         when:
         renderer.configure(LogLevel.DEBUG)
         renderer.attachSystemOutAndErr()
@@ -93,6 +81,7 @@ class OutputEventRendererTest extends OutputSpecification {
         def listener = new TestListener()
 
         when:
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardOutputListener(listener)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
@@ -105,6 +94,7 @@ class OutputEventRendererTest extends OutputSpecification {
         def listener = new TestListener()
 
         when:
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardOutputListener(listener)
         renderer.removeStandardOutputListener(listener)
         renderer.onOutput(event('info', LogLevel.INFO))
@@ -119,6 +109,7 @@ class OutputEventRendererTest extends OutputSpecification {
 
         when:
         renderer.configure(LogLevel.DEBUG)
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardOutputListener(listener)
         renderer.onOutput(event(tenAm, 'message', LogLevel.INFO))
 
@@ -130,6 +121,7 @@ class OutputEventRendererTest extends OutputSpecification {
         def listener = new TestListener()
 
         when:
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardErrorListener(listener)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
@@ -142,6 +134,7 @@ class OutputEventRendererTest extends OutputSpecification {
         def listener = new TestListener()
 
         when:
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardErrorListener(listener)
         renderer.removeStandardErrorListener(listener)
         renderer.onOutput(event('info', LogLevel.INFO))
@@ -156,11 +149,26 @@ class OutputEventRendererTest extends OutputSpecification {
 
         when:
         renderer.configure(LogLevel.DEBUG)
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardErrorListener(listener)
         renderer.onOutput(event(tenAm, 'message', LogLevel.ERROR))
 
         then:
         listener.value.readLines() == ['10:00:00.000 [ERROR] [category] message']
+    }
+
+    def cannotAddStdOutListenerWhenNotEnabled() {
+        when:
+        renderer.addStandardOutputListener(Stub(StandardOutputListener))
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        renderer.addStandardErrorListener(Stub(StandardOutputListener))
+
+        then:
+        thrown(IllegalStateException)
     }
 
     def forwardsOutputEventsToListener() {
@@ -225,6 +233,7 @@ class OutputEventRendererTest extends OutputSpecification {
         def listener = new TestListener()
 
         given:
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardOutputListener(listener)
         renderer.configure(LogLevel.INFO)
         def snapshot = renderer.snapshot()
@@ -243,6 +252,7 @@ class OutputEventRendererTest extends OutputSpecification {
         def listener = new TestListener()
 
         when:
+        renderer.enableUserStandardOutputListeners()
         renderer.addStandardOutputListener(listener)
         renderer.onOutput(start(loggingHeader: 'description', buildOperationId: 1L, buildOperationCategory: BuildOperationCategory.TASK))
         renderer.onOutput(complete('status'))

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContextTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContextTest.groovy
@@ -25,8 +25,7 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME
 
 @Unroll
 class OutputEventListenerBackedLoggerContextTest extends Specification {
-
-    OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(System.out, System.err, Time.clock());
+    OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(Time.clock())
 
     private OutputEventListenerBackedLogger logger(String name) {
         context.getLogger(name)

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerDefaultConfigurationTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerDefaultConfigurationTest.groovy
@@ -18,26 +18,30 @@ package org.gradle.internal.logging.slf4j
 
 import org.gradle.api.logging.Logging
 import org.gradle.internal.time.Time
+import org.gradle.util.RedirectStdOutAndErr
 import org.gradle.util.TextUtil
+import org.junit.Rule
 import org.slf4j.Logger
 import spock.lang.Specification
 
 class OutputEventListenerBackedLoggerDefaultConfigurationTest extends Specification {
 
-    def outStream = new ByteArrayOutputStream()
-    def errStream = new ByteArrayOutputStream()
-
-    def context = new OutputEventListenerBackedLoggerContext(new PrintStream(outStream), new PrintStream(errStream), Time.clock())
+    @Rule RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
 
     String getOut() {
-        outStream.toString()
+        outputs.stdOut
     }
 
     String getErr() {
-        errStream.toString()
+        outputs.stdErr
     }
 
+    def context
+
     Logger logger() {
+        if (context == null) {
+            context = new OutputEventListenerBackedLoggerContext(Time.clock())
+        }
         context.getLogger("foo")
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerTest.groovy
@@ -31,7 +31,12 @@ import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
 
-import static org.gradle.api.logging.LogLevel.*
+import static org.gradle.api.logging.LogLevel.DEBUG
+import static org.gradle.api.logging.LogLevel.ERROR
+import static org.gradle.api.logging.LogLevel.INFO
+import static org.gradle.api.logging.LogLevel.LIFECYCLE
+import static org.gradle.api.logging.LogLevel.QUIET
+import static org.gradle.api.logging.LogLevel.WARN
 import static org.slf4j.Logger.ROOT_LOGGER_NAME
 
 @Unroll
@@ -46,7 +51,7 @@ class OutputEventListenerBackedLoggerTest extends Specification {
         }
 
     }
-    final OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(System.out, System.err, timeProvider)
+    final OutputEventListenerBackedLoggerContext context = new OutputEventListenerBackedLoggerContext(timeProvider)
     private final CurrentBuildOperationRef currentBuildOperationRef = CurrentBuildOperationRef.instance()
 
     def setup() {


### PR DESCRIPTION
### Context

A number of changes to improve the performance of the logging system and console.

- Wire in the standard output listener pipeline only in the build process, rather than the Gradle command-line client, worker process or tapi client JVMs where there are never any such listeners. Previously this was always wired in and rendered text regardless of whether there were any listeners or not.
- Simplify the buffering that is done in the console pipeline, to use fewer threads and to avoid touching the clock many times.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
