### PR TITLE
Deprecate FileCollection.add()

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -162,6 +162,28 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
         file("build/reports/pmd/main.xml").assertContents(containsClass("org.gradle.Class2"))
     }
 
+    def "add custom rule set files"() {
+        assumeTrue(fileLockingIssuesSolved())
+
+        customCode()
+        customRuleSet()
+
+        buildFile << """
+            pmd {
+                ruleSets = []
+                ruleSetFiles = files()
+                ruleSetFiles "customRuleSet.xml"
+            }
+        """
+
+        expect:
+        fails("pmdMain")
+        failure.assertHasDescription("Execution failed for task ':pmdMain'.")
+        failure.assertThatCause(containsString("1 PMD rule violations were found. See the report at:"))
+        file("build/reports/pmd/main.xml").assertContents(not(containsClass("org.gradle.Class1")))
+        file("build/reports/pmd/main.xml").assertContents(containsClass("org.gradle.Class2"))
+    }
+
     def "use custom rule set"() {
         customCode()
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -17,6 +17,7 @@ package org.gradle.api.plugins.quality;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.resources.TextResource;
 
@@ -37,7 +38,7 @@ public class PmdExtension extends CodeQualityExtension {
     private TargetJdk targetJdk;
     private int rulePriority = 5;
     private TextResource ruleSetConfig;
-    private FileCollection ruleSetFiles;
+    private ConfigurableFileCollection ruleSetFiles;
     private boolean consoleOutput;
 
     public PmdExtension(Project project) {
@@ -166,7 +167,7 @@ public class PmdExtension extends CodeQualityExtension {
      * Example: ruleSetFiles = files("config/pmd/myRuleSet.xml")
      */
     public void setRuleSetFiles(FileCollection ruleSetFiles) {
-        this.ruleSetFiles = ruleSetFiles;
+        this.ruleSetFiles = project.files(ruleSetFiles);
     }
 
     /**
@@ -177,7 +178,7 @@ public class PmdExtension extends CodeQualityExtension {
      * @param ruleSetFiles the rule set files to be added
      */
     public void ruleSetFiles(Object... ruleSetFiles) {
-        this.ruleSetFiles.add(project.files(ruleSetFiles));
+        this.ruleSetFiles.from(ruleSetFiles);
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
@@ -129,7 +129,11 @@ public interface FileCollection extends Iterable<File>, AntBuilderAware, Buildab
      * @param collection The collection to add.
      * @return This
      * @throws UnsupportedOperationException When this collection does not allow modification.
+     *
+     * @deprecated Use {@link ConfigurableFileCollection#from(Object...)} instead. You can create configurable file collections
+     * via {@link org.gradle.api.Project#files(Object...)}.
      */
+    @Deprecated
     FileCollection add(FileCollection collection) throws UnsupportedOperationException;
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -84,4 +84,30 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec {
         output.contains "input.txt"
         output.contains "Do not cast FileCollection to FileTree. This has been deprecated and is scheduled to be removed in Gradle 5.0. Call getAsFileTree() instead."
     }
+
+    def "using 'FileCollection.add()' produces deprecation warning"() {
+        file("input.txt").createFile()
+        buildFile << """
+            files().plus(files()).add(files())
+        """
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "The FileCollection.add() method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the ConfigurableFileCollection.from() method instead."
+    }
+
+    def "using 'FileTree.add()' produces deprecation warning"() {
+        file("input.txt").createFile()
+        buildFile << """
+            files().asFileTree.plus(files().asFileTree).add(files().asFileTree)
+        """
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "The FileTree.add() method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the ConfigurableFileTree.from() method instead."
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -108,6 +108,6 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds "help"
-        output.contains "The FileTree.add() method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the ConfigurableFileTree.from() method instead."
+        output.contains "The FileCollection.add() method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the ConfigurableFileTree.from() method instead."
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
@@ -42,10 +42,8 @@ public class UnionFileCollection extends CompositeFileCollection {
         return source;
     }
 
-    @Override
-    public FileCollection add(FileCollection collection) {
+    public void uniteWith(FileCollection collection) {
         source.add(collection);
-        return this;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileCollection.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
 import java.util.Arrays;
@@ -42,7 +43,14 @@ public class UnionFileCollection extends CompositeFileCollection {
         return source;
     }
 
-    public void uniteWith(FileCollection collection) {
+    @Override
+    public FileCollection add(FileCollection collection) throws UnsupportedOperationException {
+        DeprecationLogger.nagUserOfReplacedMethod("FileCollection.add()", "ConfigurableFileCollection.from()");
+        addToUnion(collection);
+        return this;
+    }
+
+    public void addToUnion(FileCollection collection) {
         source.add(collection);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileTree.java
@@ -20,6 +20,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.internal.Cast;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,7 +53,14 @@ public class UnionFileTree extends CompositeFileTree {
         context.add(sourceTrees);
     }
 
-    public void uniteWith(FileCollection source) {
+    @Override
+    public FileCollection add(FileCollection collection) throws UnsupportedOperationException {
+        DeprecationLogger.nagUserOfReplacedMethod("FileTree.add()", "ConfigurableFileTree.from()");
+        addToUnion(collection);
+        return this;
+    }
+
+    public void addToUnion(FileCollection source) {
         if (!(source instanceof FileTree)) {
             throw new UnsupportedOperationException(String.format("Can only add FileTree instances to %s.", getDisplayName()));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileTree.java
@@ -55,7 +55,7 @@ public class UnionFileTree extends CompositeFileTree {
 
     @Override
     public FileCollection add(FileCollection collection) throws UnsupportedOperationException {
-        DeprecationLogger.nagUserOfReplacedMethod("FileTree.add()", "ConfigurableFileTree.from()");
+        DeprecationLogger.nagUserOfReplacedMethod("FileCollection.add()", "ConfigurableFileTree.from()");
         addToUnion(collection);
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/UnionFileTree.java
@@ -52,13 +52,11 @@ public class UnionFileTree extends CompositeFileTree {
         context.add(sourceTrees);
     }
 
-    @Override
-    public UnionFileTree add(FileCollection source) {
+    public void uniteWith(FileCollection source) {
         if (!(source instanceof FileTree)) {
             throw new UnsupportedOperationException(String.format("Can only add FileTree instances to %s.", getDisplayName()));
         }
 
         sourceTrees.add(Cast.cast(FileTreeInternal.class, source));
-        return this;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
@@ -68,7 +68,7 @@ class UnionFileCollectionTest extends Specification {
 
         expect:
         def collection = new UnionFileCollection([source1])
-        collection.add(source2)
+        collection.uniteWith(source2)
         collection.files == [file1, file2] as LinkedHashSet
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
@@ -68,7 +68,7 @@ class UnionFileCollectionTest extends Specification {
 
         expect:
         def collection = new UnionFileCollection([source1])
-        collection.uniteWith(source2)
+        collection.addToUnion(source2)
         collection.files == [file1, file2] as LinkedHashSet
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileTreeTest.java
@@ -42,14 +42,14 @@ public class UnionFileTreeTest {
     public void canAddFileTree() {
         FileTreeInternal set1 = context.mock(FileTreeInternal.class, "set1");
 
-        set.add(set1);
+        set.uniteWith(set1);
         assertThat(set.getSourceCollections(), equalTo((Iterable) toList((Object) set1)));
     }
 
     @Test
     public void cannotAddFileCollection() {
         try {
-            set.add(context.mock(FileCollection.class));
+            set.uniteWith(context.mock(FileCollection.class));
             fail();
         } catch (UnsupportedOperationException e) {
             assertThat(e.getMessage(), equalTo("Can only add FileTree instances to <display name>."));

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileTreeTest.java
@@ -42,14 +42,14 @@ public class UnionFileTreeTest {
     public void canAddFileTree() {
         FileTreeInternal set1 = context.mock(FileTreeInternal.class, "set1");
 
-        set.uniteWith(set1);
+        set.addToUnion(set1);
         assertThat(set.getSourceCollections(), equalTo((Iterable) toList((Object) set1)));
     }
 
     @Test
     public void cannotAddFileCollection() {
         try {
-            set.uniteWith(context.mock(FileCollection.class));
+            set.addToUnion(context.mock(FileCollection.class));
             fail();
         } catch (UnsupportedOperationException e) {
             assertThat(e.getMessage(), equalTo("Can only add FileTree instances to <display name>."));

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -34,6 +34,10 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
+### Deprecated methods on `FileCollection`
+
+- `FileCollection.add()` is now deprecated. Use `ConfigurableFileCollection.from()` instead. You can create a `ConfigurableFileCollection` via `Project.files()`.
+
 ## Potential breaking changes
 
 <!--

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
@@ -21,10 +21,10 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.UnionFileCollection;
-import org.gradle.api.internal.tasks.testing.report.DefaultTestReport;
 import org.gradle.api.internal.tasks.testing.junit.result.AggregateTestResultsProvider;
 import org.gradle.api.internal.tasks.testing.junit.result.BinaryResultBackedTestResultsProvider;
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider;
+import org.gradle.api.internal.tasks.testing.report.DefaultTestReport;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -83,14 +83,14 @@ public class TestReport extends DefaultTask {
     private void addTo(Object result, UnionFileCollection dirs) {
         if (result instanceof Test) {
             Test test = (Test) result;
-            dirs.add(getProject().files(test.getBinResultsDir()).builtBy(test));
+            dirs.uniteWith(getProject().files(test.getBinResultsDir()).builtBy(test));
         } else if (result instanceof Iterable<?>) {
             Iterable<?> iterable = (Iterable<?>) result;
             for (Object nested : iterable) {
                 addTo(nested, dirs);
             }
         } else {
-            dirs.add(getProject().files(result));
+            dirs.uniteWith(getProject().files(result));
         }
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
@@ -83,14 +83,14 @@ public class TestReport extends DefaultTask {
     private void addTo(Object result, UnionFileCollection dirs) {
         if (result instanceof Test) {
             Test test = (Test) result;
-            dirs.uniteWith(getProject().files(test.getBinResultsDir()).builtBy(test));
+            dirs.addToUnion(getProject().files(test.getBinResultsDir()).builtBy(test));
         } else if (result instanceof Iterable<?>) {
             Iterable<?> iterable = (Iterable<?>) result;
             for (Object nested : iterable) {
                 addTo(nested, dirs);
             }
         } else {
-            dirs.uniteWith(getProject().files(result));
+            dirs.addToUnion(getProject().files(result));
         }
     }
 


### PR DESCRIPTION
The method was never really working as expected, as in most cases it would throw UOE.

This also fixes a bug with PmdExtension.ruleSetFiles() always throwing the aforementioned UOE exception.
