### PR TITLE
Extract logic for resolving selectors out of DependencyGraphBuilder

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -767,9 +767,10 @@ task checkDeps(dependsOn: configurations.compile) {
         //only 1.5 published:
         mavenRepo.module("org", "leaf", "1.5").publish()
 
-        mavenRepo.module("org", "c", "1.0").dependsOn("org", "leaf", "2.0+").publish()
-        mavenRepo.module("org", "a", "1.0").dependsOn("org", "leaf", "1.0").publish()
-        mavenRepo.module("org", "b", "1.0").dependsOn("org", "leaf", "[1.5,1.9]").publish()
+        mavenRepo.module("org", "a", "1.0").dependsOn("org", "leaf", "(,1.0)").publish()
+        mavenRepo.module("org", "b", "1.0").dependsOn("org", "leaf", "1.0").publish()
+        mavenRepo.module("org", "c", "1.0").dependsOn("org", "leaf", "[1.5,1.9]").publish()
+        mavenRepo.module("org", "d", "1.0").dependsOn("org", "leaf", "2.0+").publish()
 
         settingsFile << "rootProject.name = 'broken'"
         buildFile << """
@@ -781,20 +782,55 @@ task checkDeps(dependsOn: configurations.compile) {
                 conf
             }
             dependencies {
-                conf 'org:a:1.0', 'org:b:1.0', 'org:c:1.0'
+                conf 'org:a:1.0', 'org:b:1.0', 'org:c:1.0', 'org:d:1.0'
             }
             task resolve {
                 doLast {
                     configurations.conf.files
                 }
             }
+            task checkGraph {
+                doLast {
+                    def result = configurations.conf.incoming.resolutionResult
+                    assert result.allComponents*.toString() as Set == ['project :', 'org:a:1.0', 'org:b:1.0', 'org:c:1.0', 'org:d:1.0', 'org:leaf:1.5'] as Set
+                    def a = result.allComponents.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'a' }
+                    def b = result.allComponents.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'b' }
+                    def c = result.allComponents.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'c' }
+                    def d = result.allComponents.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'd' }
+                    def leaf = result.allComponents.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'leaf' }
+
+                    a.dependencies.each {
+                        assert it instanceof UnresolvedDependencyResult
+                        assert it.requested.toString() == 'org:leaf:(,1.0)'
+                        assert it.failure.getMessage().startsWith('Could not find any version that matches org:leaf:(,1.0).')
+                    }
+                    b.dependencies.each {
+                        assert it instanceof ResolvedDependencyResult
+                        assert it.requested.toString() == 'org:leaf:1.0'
+                        assert it.selected == leaf
+                    }
+                    c.dependencies.each {
+                        assert it instanceof ResolvedDependencyResult
+                        assert it.requested.toString() == 'org:leaf:[1.5,1.9]'
+                        assert it.selected == leaf
+                    }
+                    d.dependencies.each {
+                        assert it instanceof UnresolvedDependencyResult
+                        assert it.requested.toString() == 'org:leaf:2.0+'
+                        assert it.failure.getMessage().startsWith('Could not find any version that matches org:leaf:2.0+.')
+                    }
+                }
+            }
         """
 
         when:
+        succeeds "checkGraph"
+
+        and:
         runAndFail "resolve"
 
         then:
-        failure.assertResolutionFailure(":conf").assertFailedDependencyRequiredBy("project : > org:c:1.0")
+        failure.assertResolutionFailure(":conf").assertFailedDependencyRequiredBy("project : > org:d:1.0")
     }
 
     def "chooses highest version that is included in both ranges"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
@@ -16,35 +16,16 @@
 
 package org.gradle.integtests.resolve
 
-import groovy.transform.Canonical
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
 import spock.lang.Unroll
 /**
  * A comprehensive test of dependency resolution of a single module version, given a set of input selectors.
- * // TODO:DAZ This is a bit _too_ comprehensive, and has coverage overlap. Consolidate and streamline.
+ * This integration test validates all scenarios in {@link VersionRangeResolveTestScenarios}, as well as some adhoc scenarios.
+ * TODO:DAZ This is a bit _too_ comprehensive, and has coverage overlap. Consolidate and streamline.
  */
 class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTest {
-
-    static final FIXED_7 = fixed(7)
-    static final FIXED_9 = fixed(9)
-    static final FIXED_10 = fixed(10)
-    static final FIXED_11 = fixed(11)
-    static final FIXED_12 = fixed(12)
-    static final FIXED_13 = fixed(13)
-    static final RANGE_7_8 = range(7, 8)
-    static final RANGE_10_11 = range(10, 11)
-    static final RANGE_10_12 = range(10, 12)
-    static final RANGE_10_14 = range(10, 14)
-    static final RANGE_10_16 = range(10, 16)
-    static final RANGE_11_12 = range(11, 12)
-    static final RANGE_12_14 = range(12, 14)
-    static final RANGE_13_14 = range(13, 14)
-    static final RANGE_14_16 = range(14, 16)
-
-    static final REJECT_11 = reject(11)
-    static final REJECT_12 = reject(12)
-    static final REJECT_13 = reject(13)
 
     def baseBuild
     def baseSettings
@@ -326,51 +307,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         resolve(candidates) == expected
 
         where:
-        permutation << StrictPermutationsProvider.check(
-            versions: [FIXED_7, FIXED_13],
-            expectedNoStrict: 13,
-            expectedStrict: [-1, 13]
-        ).and(
-            versions: [FIXED_12, FIXED_13],
-            expectedNoStrict: 13,
-            expectedStrict: [-1, 13]
-        ).and(
-            versions: [FIXED_12, RANGE_10_11],
-            expectedNoStrict: 12,
-            expectedStrict: [12, -1]
-        ).and(
-            versions: [FIXED_12, RANGE_10_14],
-            expectedNoStrict: 12,
-            expectedStrict: [12, 12]
-        ).and(
-            versions: [FIXED_12, RANGE_13_14],
-            expectedNoStrict: 13,
-            expectedStrict: [-1, 13]
-        ).and(
-            versions: [FIXED_12, RANGE_7_8],
-            expectedNoStrict: -1,
-            expectedStrict: [-1, -1]
-        ).and(
-            versions: [FIXED_12, RANGE_14_16],
-            expectedNoStrict: -1,
-            expectedStrict: [-1, -1]
-        ).and(
-            versions: [RANGE_10_11, FIXED_10],
-            expectedNoStrict: 10,
-            expectedStrict: [10, 10]
-        ).and(
-            versions: [RANGE_10_14, FIXED_13],
-            expectedNoStrict: 13,
-            expectedStrict: [13, 13]
-        ).and(
-            versions: [RANGE_10_14, RANGE_10_11],
-            expectedNoStrict: 11,
-            expectedStrict: [11, 11]
-        ).and(
-            versions: [RANGE_10_14, RANGE_10_16],
-            expectedNoStrict: 13,
-            expectedStrict: [13, 13]
-        )
+        permutation << VersionRangeResolveTestScenarios.PAIRS
     }
 
     @Unroll
@@ -383,16 +320,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         resolve(candidates) == expected
 
         where:
-        permutation << StrictPermutationsProvider.check(
-            versions: [FIXED_12, REJECT_11],
-            expectedNoStrict: 12
-        ).and(
-            versions: [FIXED_12, REJECT_12],
-            expectedNoStrict: -1
-        ).and(
-            versions: [FIXED_12, REJECT_13],
-            expectedNoStrict: 12
-        )
+        permutation << VersionRangeResolveTestScenarios.PAIRS_WITH_REJECT
     }
 
     @Unroll
@@ -405,47 +333,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         resolve(candidates) == expected
 
         where:
-        permutation << StrictPermutationsProvider.check(
-            versions: [FIXED_10, FIXED_12, FIXED_13],
-            expectedNoStrict: 13,
-            expectedStrict: [-1, -1, 13]
-        ).and(
-            ignore: true,
-            versions: [FIXED_10, FIXED_12, RANGE_10_14],
-            expectedNoStrict: 12,
-            expectedStrict: [-1, 12, 12]
-        ).and(
-            versions: [FIXED_10, RANGE_10_11, RANGE_10_14],
-            expectedNoStrict: 10,
-            expectedStrict: [10, 10, 10]
-        ).and(
-            versions: [FIXED_10, RANGE_10_11, RANGE_13_14],
-            expectedNoStrict: 13,
-            expectedStrict: [-1, -1, 13]
-        ).and(
-            ignore: true,
-            versions: [FIXED_10, RANGE_11_12, RANGE_10_14],
-            expectedNoStrict: 12,
-            expectedStrict: [-1, 12, 12]
-        ).and(
-            versions: [RANGE_10_11, RANGE_10_12, RANGE_10_14],
-            expectedNoStrict: 11,
-            expectedStrict: [11, 11, 11]
-        ).and(
-            versions: [RANGE_10_11, RANGE_10_12, RANGE_13_14],
-            expectedNoStrict: 13,
-            expectedStrict: [-1, -1, 13]
-        ).and(
-            ignore: true,
-            versions: [FIXED_10, FIXED_10, FIXED_12],
-            expectedNoStrict: 12,
-            expectedStrict: [-1, -1, 12]
-        ).and(
-            ignore: true,
-            versions: [FIXED_10, FIXED_12, RANGE_12_14],
-            expectedNoStrict: 12,
-            expectedStrict: [-1, 12, 12]
-        )
+        permutation << VersionRangeResolveTestScenarios.THREES
     }
 
     @Unroll
@@ -458,50 +346,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         resolve(candidates) == expected
 
         where:
-        permutation << StrictPermutationsProvider.check(
-            versions: [FIXED_11, FIXED_12, REJECT_11],
-            expectedNoStrict: 12,
-        ).and(
-            versions: [FIXED_11, FIXED_12, REJECT_12],
-            expectedNoStrict: -1,
-        ).and(
-            versions: [FIXED_11, FIXED_12, REJECT_13],
-            expectedNoStrict: 12,
-
-        ).and(
-            versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_11],
-            expectedNoStrict: 12,
-        ).and(
-            ignore: true, // This will require resolving RANGE_10_14 with the knowledge that FIXED_12 rejects < 12.
-            versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_12],
-            expectedNoStrict: 13,
-        ).and(
-            versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_13],
-            expectedNoStrict: 12,
-
-        ).and(
-            versions: [RANGE_10_12, RANGE_13_14, REJECT_11],
-            expectedNoStrict: 13,
-        ).and(
-            versions: [RANGE_10_12, RANGE_13_14, REJECT_12],
-            expectedNoStrict: 13,
-        ).and(
-            versions: [RANGE_10_12, RANGE_13_14, REJECT_13],
-            expectedNoStrict: -1,
-
-        ).and(
-            ignore: true,
-            versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_11],
-            expectedNoStrict: 10,
-        ).and(
-            ignore: true,
-            versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_12],
-            expectedNoStrict: 11,
-        ).and(
-            ignore: true,
-            versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_13],
-            expectedNoStrict: 11,
-        )
+        permutation << VersionRangeResolveTestScenarios.MULTIPLES_WITH_REJECT
     }
 
     @Unroll
@@ -514,52 +359,14 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         resolve(candidates) == expected
 
         where:
-        permutation << StrictPermutationsProvider.check(
-            versions: [FIXED_9, FIXED_10, FIXED_11, FIXED_12],
-            expectedNoStrict: 12
-        ).and(
-            ignore: true,
-            versions: [FIXED_10, RANGE_10_11, FIXED_12, RANGE_12_14],
-            expectedNoStrict: 12
-        ).and(
-            versions: [FIXED_10, RANGE_10_11, RANGE_10_12, RANGE_13_14],
-            expectedNoStrict: 13
-        ).and(
-            ignore: true,
-            versions: [FIXED_9, RANGE_10_11, RANGE_10_12, RANGE_10_14],
-            expectedNoStrict: 11
-        )
+        permutation << VersionRangeResolveTestScenarios.FOURS
     }
 
-    private static RenderableVersion fixed(int version) {
-        def vs = new SimpleVersion()
-        vs.version = "${version}"
-        return vs
-    }
-
-    private static RenderableVersion range(int low, int high) {
-        def vs = new SimpleVersion()
-        vs.version = "[${low},${high}]"
-        return vs
-    }
-
-    private static RenderableVersion reject(int version) {
-        def vs = new RejectVersion()
-        vs.version = version
-        vs
-    }
-
-    private static RenderableVersion strict(RenderableVersion input) {
-        def v = new StrictVersion()
-        v.version = input.version
-        v
-    }
-
-    def resolve(RenderableVersion... versions) {
+    def resolve(VersionRangeResolveTestScenarios.RenderableVersion... versions) {
         resolve(versions as List)
     }
 
-    def resolve(List<RenderableVersion> versions) {
+    def resolve(List<VersionRangeResolveTestScenarios.RenderableVersion> versions) {
         settingsFile.text = baseSettings
 
         def singleProjectConfs = []
@@ -598,7 +405,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             }
 """
         for (int i = 1; i <= versions.size(); i++) {
-            RenderableVersion version = versions.get(i - 1);
+            VersionRangeResolveTestScenarios.RenderableVersion version = versions.get(i - 1);
             def nextProjectDependency = i < versions.size() ? "conf project(path: ':p${i + 1}', configuration: 'conf')" : ""
             buildFile << """
                 project('p${i}') {
@@ -640,139 +447,5 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         assert resolvedFile.startsWith('foo-')
         assert resolvedFile.endsWith('.jar')
         return (resolvedFile =~ /\d\d/).getAt(0) as int
-    }
-
-    interface RenderableVersion {
-        String getVersion()
-
-        String render()
-    }
-
-    static class SimpleVersion implements RenderableVersion {
-        String version
-
-        @Override
-        String render() {
-            "'org:foo:${version}'"
-        }
-
-        @Override
-        String toString() {
-            return version
-        }
-    }
-
-    static class StrictVersion implements RenderableVersion {
-        String version
-
-        @Override
-        String render() {
-            return "('org:foo') { version { strictly '${version}' } }"
-        }
-
-        @Override
-        String toString() {
-            return "strictly(" + version + ")"
-        }
-    }
-
-    static class RejectVersion implements RenderableVersion {
-        String version
-
-        @Override
-        String render() {
-            "('org:foo') { version { reject '${version}' } }"
-        }
-
-        @Override
-        String toString() {
-            return "reject " + version
-        }
-    }
-
-    static class StrictPermutationsProvider implements Iterable<Candidate> {
-        private final List<Batch> batches = []
-        private int batchCount
-
-        static StrictPermutationsProvider check(Map config) {
-            new StrictPermutationsProvider().and(config)
-        }
-
-        StrictPermutationsProvider and(Map config) {
-            assert config.versions
-            assert config.expectedNoStrict
-
-            ++batchCount
-            if (!config.ignore) {
-                List<RenderableVersion> versions = config.versions
-                List<Integer> expectedStrict = config.expectedStrict
-                List<Batch> iterations = []
-                String batchName = config.description ?: "#${batchCount} (${versions})"
-                iterations.add(new Batch(batchName, versions, config.expectedNoStrict))
-                if (expectedStrict) {
-                    versions.size().times { idx ->
-                        iterations.add(new Batch(batchName, versions.withIndex().collect { RenderableVersion version, idx2 ->
-                            if (idx == idx2) {
-                                def v = new StrictVersion()
-                                v.version = version.version
-                                v
-                            } else {
-                                version
-                            }
-                        }, expectedStrict[idx]))
-                    }
-                }
-                batches.addAll(iterations)
-            }
-
-            this
-        }
-
-        @Override
-        Iterator<Candidate> iterator() {
-            new PermutationIterator()
-        }
-
-        @Canonical
-        static class Batch {
-            String batchName
-            List<RenderableVersion> versions
-            int expected
-        }
-
-        class PermutationIterator implements Iterator<Candidate> {
-            Iterator<Batch> batchesIterator = batches.iterator()
-            String currentBatch
-            Iterator<List<RenderableVersion>> current
-            int expected
-
-            @Override
-            boolean hasNext() {
-                batchesIterator.hasNext() || current?.hasNext()
-            }
-
-            @Override
-            Candidate next() {
-                if (current?.hasNext()) {
-                    return new Candidate(batch: currentBatch, candidates: current.next() as RenderableVersion[], expected: expected)
-                }
-                Batch nextBatch = batchesIterator.next()
-                expected = nextBatch.expected
-                current = nextBatch.versions.permutations().iterator()
-                currentBatch = nextBatch.batchName
-                return next()
-            }
-        }
-
-        static class Candidate {
-            String batch
-            RenderableVersion[] candidates
-            int expected
-
-            @Override
-            String toString() {
-                batch + ": " + candidates.collect { it.toString() }.join(' & ') + " -> ${expected < 0 ? 'FAIL' : expected}"
-            }
-        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -39,4 +39,5 @@ public interface ComponentResolutionState extends StringVersioned {
 
     boolean isRejected();
 
+    boolean isRoot();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StringVersioned;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -23,6 +24,8 @@ import org.gradle.internal.component.model.ComponentResolveMetadata;
 import javax.annotation.Nullable;
 
 public interface ComponentResolutionState extends StringVersioned {
+    ComponentIdentifier getComponentId();
+
     ModuleVersionIdentifier getId();
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ProjectDependencyForcingResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ProjectDependencyForcingResolver.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictResolverDetails;
 import org.gradle.internal.Cast;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,8 +38,7 @@ class ProjectDependencyForcingResolver implements ModuleConflictResolver {
         T foundProjectCandidate = null;
         // fine one or more project dependencies among conflicting modules
         for (T candidate : details.getCandidates()) {
-            ComponentResolveMetadata metaData = candidate.getMetadata();
-            if (metaData != null && metaData.getId() instanceof ProjectComponentIdentifier) {
+            if (candidate.getComponentId() instanceof ProjectComponentIdentifier) {
                 if (foundProjectCandidate == null) {
                     // found the first project dependency
                     foundProjectCandidate = candidate;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -301,6 +301,15 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return rejected;
     }
 
+    @Override
+    public boolean isRoot() {
+        for (NodeState node : nodes) {
+            if (node.isRoot()) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Describes the possible states of a component in the graph.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.external.model.ImmutableCapability;
+import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -57,10 +58,8 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private volatile ComponentResolveMetadata metadata;
 
     private ComponentSelectionState state = ComponentSelectionState.Selectable;
-    private ModuleVersionResolveException failure;
-    // The first selector that resolved this component
+    private ModuleVersionResolveException metadataResolveFailure;
     private SelectorState firstSelectedBy;
-    private List<SelectorState> selectedBy;
     private DependencyGraphBuilder.VisitState visitState = DependencyGraphBuilder.VisitState.NotSeen;
 
     private boolean rejected;
@@ -100,8 +99,8 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return id;
     }
 
-    public ModuleVersionResolveException getFailure() {
-        return failure;
+    public ModuleVersionResolveException getMetadataResolveFailure() {
+        return metadataResolveFailure;
     }
 
     public DependencyGraphBuilder.VisitState getVisitState() {
@@ -144,13 +143,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     public void selectedBy(SelectorState resolver) {
         if (firstSelectedBy == null) {
             firstSelectedBy = resolver;
-            selectedBy = Lists.newLinkedList();
         }
-        selectedBy.add(resolver);
-    }
-
-    public List<SelectorState> getSelectedBy() {
-        return selectedBy;
     }
 
     /**
@@ -159,7 +152,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
      * @return true if it has been resolved in a cheap way
      */
     public boolean alreadyResolved() {
-        return metadata != null || failure != null;
+        return metadata != null || metadataResolveFailure != null;
     }
 
     public void resolve() {
@@ -167,10 +160,13 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
             return;
         }
 
+        // Any metadata overrides (e.g classifier/artifacts/client-module) will be taken from the first dependency that referenced this component
+        ComponentOverrideMetadata componentOverrideMetadata = DefaultComponentOverrideMetadata.forDependency(firstSelectedBy.getDependencyMetadata());
+
         DefaultBuildableComponentResolveResult result = new DefaultBuildableComponentResolveResult();
-        resolver.resolve(componentIdentifier, DefaultComponentOverrideMetadata.forDependency(firstSelectedBy.getDependencyMetadata()), result);
+        resolver.resolve(componentIdentifier, componentOverrideMetadata, result);
         if (result.getFailure() != null) {
-            failure = result.getFailure();
+            metadataResolveFailure = result.getFailure();
             return;
         }
         metadata = result.getMetadata();
@@ -178,7 +174,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     public void setMetadata(ComponentResolveMetadata metaData) {
         this.metadata = metaData;
-        this.failure = null;
+        this.metadataResolveFailure = null;
     }
 
     public void addConfiguration(NodeState node) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -219,7 +219,7 @@ public class DependencyGraphBuilder {
         ComponentState currentSelection = module.getSelected();
 
         SelectorStateResolver<ComponentState> selectorStateResolver = new SelectorStateResolver<ComponentState>(moduleConflictHandler.getResolver(), resolveState);
-        ComponentState selected = null;
+        ComponentState selected;
         try {
             selected = selectorStateResolver.selectBest(module.getSelectors(), selector, currentSelection);
         } catch (ModuleVersionResolveException e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -45,6 +45,7 @@ import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.resolver.ResolveContextToComponentResolver;
@@ -218,9 +219,11 @@ public class DependencyGraphBuilder {
         ComponentState currentSelection = module.getSelected();
 
         SelectorStateResolver<ComponentState> selectorStateResolver = new SelectorStateResolver<ComponentState>(moduleConflictHandler.getResolver(), resolveState);
-        ComponentState selected = selectorStateResolver.selectBest(module.getSelectors(), selector, currentSelection);
-        if (selected == null) {
-            // Failure to resolve
+        ComponentState selected = null;
+        try {
+            selected = selectorStateResolver.selectBest(module.getSelectors(), selector, currentSelection);
+        } catch (ModuleVersionResolveException e) {
+            // Ignore: failure will be retained on selector
             return;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -58,7 +57,6 @@ import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -275,7 +273,7 @@ public class DependencyGraphBuilder {
     /**
      * Chooses the best out of 2 components for the module, considering all selectors for the module.
      */
-    private ComponentState chooseBest(ModuleResolveState module, SelectorState selector, ComponentState currentSelection, final ComponentState candidate) {
+    private ComponentState chooseBest(ModuleResolveState module, SelectorState selector, final ComponentState currentSelection, final ComponentState candidate) {
         if (currentSelection == candidate) {
             return candidate;
         }
@@ -286,12 +284,7 @@ public class DependencyGraphBuilder {
         }
 
         // See if all known selectors agree with the candidate selection. If so, use the candidate.
-        if (allSelectorsAgreeWith(module.getSelectors(), candidate.getVersion(), new Predicate<SelectorState>() {
-            @Override
-            public boolean apply(@Nullable SelectorState input) {
-                return !candidate.getSelectedBy().contains(input);
-            }
-        })) {
+        if (!currentSelection.isRoot() && allSelectorsAgreeWith(module.getSelectors(), candidate.getVersion())) {
             return candidate;
         }
 
@@ -472,25 +465,22 @@ public class DependencyGraphBuilder {
     /**
      * Check if all of the supplied selectors agree with the version chosen
      */
-    private static boolean allSelectorsAgreeWith(Collection<SelectorState> allSelectors, String version, Predicate<SelectorState> filter) {
-        boolean atLeastOneAgrees = false;
+    private static boolean allSelectorsAgreeWith(Collection<SelectorState> allSelectors, String version) {
         for (SelectorState selectorState : allSelectors) {
-            if (filter.apply(selectorState)) {
-                ResolvedVersionConstraint versionConstraint = selectorState.getVersionConstraint();
-                if (versionConstraint != null) {
-                    VersionSelector candidateSelector = versionConstraint.getPreferredSelector();
-                    if (candidateSelector == null || !candidateSelector.canShortCircuitWhenVersionAlreadyPreselected() || !candidateSelector.accept(version)) {
-                        return false;
-                    }
-                    candidateSelector = versionConstraint.getRejectedSelector();
-                    if (candidateSelector != null && candidateSelector.accept(version)) {
-                        return false;
-                    }
-                    atLeastOneAgrees = true;
-                }
+            ResolvedVersionConstraint versionConstraint = selectorState.getVersionConstraint();
+            if (versionConstraint == null) {
+                return false;
+            }
+            VersionSelector candidateSelector = versionConstraint.getPreferredSelector();
+            if (candidateSelector == null || !candidateSelector.canShortCircuitWhenVersionAlreadyPreselected() || !candidateSelector.accept(version)) {
+                return false;
+            }
+            candidateSelector = versionConstraint.getRejectedSelector();
+            if (candidateSelector != null && candidateSelector.accept(version)) {
+                return false;
             }
         }
-        return atLeastOneAgrees;
+        return true;
     }
 
     private static boolean selectorAgreesWith(SelectorState selectorState, String version) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -25,23 +25,19 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolveContext;
-import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CapabilitiesConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultCapabilitiesConflictHandler;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictResolverDetails;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ModuleConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.PotentialConflict;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.SelectorStateResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.id.IdGenerator;
@@ -52,7 +48,6 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.resolver.ResolveContextToComponentResolver;
-import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -219,21 +214,18 @@ public class DependencyGraphBuilder {
             return;
         }
 
-        ComponentIdResolveResult idResolveResult = selector.resolve();
-        if (idResolveResult.getFailure() != null) {
-            // Resolve failure, nothing more to do.
-            return;
-        }
-
-        ComponentState candidate = resolveState.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId(), idResolveResult.getMetadata());
-
         ModuleResolveState module = selector.getTargetModule();
         ComponentState currentSelection = module.getSelected();
 
-        // TODO:DAZ Should not need to select the candidate if the current selection ends up being chosen.
-        // But some of the logic to choose between currentSelection and candidate requires that these be set.
-        dependency.start(candidate);
-        selector.select(candidate);
+        SelectorStateResolver<ComponentState> selectorStateResolver = new SelectorStateResolver<ComponentState>(moduleConflictHandler.getResolver(), resolveState);
+        ComponentState selected = selectorStateResolver.selectBest(module.getSelectors(), selector, currentSelection);
+        if (selected == null) {
+            // Failure to resolve
+            return;
+        }
+
+        dependency.start(selected);
+        selector.select(selected);
 
         // If no current selection for module, just use the candidate.
         if (currentSelection == null) {
@@ -241,61 +233,19 @@ public class DependencyGraphBuilder {
             if (!moduleHasConflicts(resolveState, module)) {
                 // No conflicting modules. Select it for now
                 LOGGER.debug("Selecting new module {}", module.getId());
-                module.select(candidate);
+                module.select(selected);
             }
             return;
         }
 
-        // Choose the best option from the current selection and the new candidate.
-        // This choice is made considering _all_ selectors registered for this module.
-        ComponentState selected = chooseBest(module, selector, currentSelection, candidate);
-
         // If current selection is still the best choice, then only need to point new edge/selector at current selection.
         if (selected == currentSelection) {
-            dependency.start(currentSelection);
-            selector.select(currentSelection);
-
-            // Since we have a new selector for the current selection, check if it's now rejected.
-            // TODO:DAZ It's wasteful to recheck all of the existing selectors. Should only check the new one.
-            maybeMarkRejected(currentSelection);
             return;
         }
 
         // New candidate is a preferred choice over current selection. Reset the module state and reselect.
-        assert selected == candidate;
         resolveState.getDeselectVersionAction().execute(module.getId());
-        module.restart(candidate);
-
-        // Check the candidate against all selectors to see if it's rejected.
-        maybeMarkRejected(candidate);
-    }
-
-    /**
-     * Chooses the best out of 2 components for the module, considering all selectors for the module.
-     */
-    private ComponentState chooseBest(ModuleResolveState module, SelectorState selector, final ComponentState currentSelection, final ComponentState candidate) {
-        if (currentSelection == candidate) {
-            return candidate;
-        }
-
-        // See if the new selector agrees with the current selection. If so, keep the current selection.
-        if (selectorAgreesWith(selector, currentSelection.getVersion())) {
-            return currentSelection;
-        }
-
-        // See if all known selectors agree with the candidate selection. If so, use the candidate.
-        if (!currentSelection.isRoot() && allSelectorsAgreeWith(module.getSelectors(), candidate.getVersion())) {
-            return candidate;
-        }
-
-        // Do conflict resolution to choose the best out of current selection and candidate.
-        List<ComponentState> candidates = ImmutableList.of(currentSelection, candidate);
-        ConflictResolverDetails<ComponentState> details = new DefaultConflictResolverDetails<ComponentState>(candidates);
-        moduleConflictHandler.getResolver().select(details);
-        if (details.hasFailure()) {
-            throw UncheckedException.throwAsUncheckedException(details.getFailure());
-        }
-        return details.getSelected();
+        module.restart(selected);
     }
 
     private boolean moduleHasConflicts(ResolveState resolveState, ModuleResolveState module) {
@@ -311,21 +261,6 @@ public class DependencyGraphBuilder {
             return true;
         }
         return false;
-    }
-
-    private void maybeMarkRejected(ComponentState selected) {
-        if (selected.isRejected()) {
-            return;
-        }
-
-        String version = selected.getVersion();
-        ModuleResolveState moduleResolveState = selected.getModule();
-        for (SelectorState selector : moduleResolveState.getSelectors()) {
-            if (selector.getVersionConstraint() != null && selector.getVersionConstraint().getRejectedSelector() != null && selector.getVersionConstraint().getRejectedSelector().accept(version)) {
-                selected.reject();
-                return;
-            }
-        }
     }
 
     /**
@@ -461,39 +396,6 @@ public class DependencyGraphBuilder {
 
         visitor.finish(resolveState.getRoot());
     }
-
-    /**
-     * Check if all of the supplied selectors agree with the version chosen
-     */
-    private static boolean allSelectorsAgreeWith(Collection<SelectorState> allSelectors, String version) {
-        for (SelectorState selectorState : allSelectors) {
-            ResolvedVersionConstraint versionConstraint = selectorState.getVersionConstraint();
-            if (versionConstraint == null) {
-                return false;
-            }
-            VersionSelector candidateSelector = versionConstraint.getPreferredSelector();
-            if (candidateSelector == null || !candidateSelector.canShortCircuitWhenVersionAlreadyPreselected() || !candidateSelector.accept(version)) {
-                return false;
-            }
-            candidateSelector = versionConstraint.getRejectedSelector();
-            if (candidateSelector != null && candidateSelector.accept(version)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean selectorAgreesWith(SelectorState selectorState, String version) {
-        ResolvedVersionConstraint versionConstraint = selectorState.getVersionConstraint();
-        if (versionConstraint == null || versionConstraint.getPreferredSelector() == null) {
-            return false;
-        }
-        VersionSelector candidateSelector = versionConstraint.getPreferredSelector();
-        return !candidateSelector.requiresMetadata()
-            && candidateSelector.canShortCircuitWhenVersionAlreadyPreselected()
-            && candidateSelector.accept(version);
-    }
-
 
     enum VisitState {
         NotSeen, Visiting, Visited

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -40,29 +40,18 @@ public class RejectedModuleMessageBuilder {
         }
         StringBuilder sb = new StringBuilder();
         if (hasRejectAll) {
-            sb.append("Module ");
+            sb.append("Module '").append(module.getId()).append("' has been rejected:\n");
         } else {
-            sb.append("Cannot find a version of ");
+            sb.append("Cannot find a version of '").append(module.getId()).append("' that satisfies the version constraints: \n");
         }
-        boolean first = true;
         for (EdgeState incomingEdge : getIncomingEdges(module)) {
             SelectorState selector = incomingEdge.getSelector();
-            if (first) {
-                sb.append("'").append(module.getId()).append("'");
-                if (hasRejectAll) {
-                    sb.append(" has been rejected:\n");
-                } else {
-                    sb.append(" that satisfies the version constraints: \n");
-                }
-            }
-
             for (String path : pathTo(incomingEdge)) {
                 sb.append("   ").append(path);
                 sb.append(" ").append(renderVersionConstraint(selector.getVersionConstraint()));
                 renderReason(sb, selector);
                 sb.append("\n");
             }
-            first = false;
         }
         return sb.toString();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ComponentStateFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
@@ -47,7 +48,7 @@ import java.util.Set;
 /**
  * Global resolution state.
  */
-class ResolveState {
+class ResolveState implements ComponentStateFactory<ComponentState> {
     private final Spec<? super DependencyMetadata> edgeFilter;
     private final Map<ModuleIdentifier, ModuleResolveState> modules = new LinkedHashMap<ModuleIdentifier, ModuleResolveState>();
     private final Map<ResolvedConfigurationIdentifier, NodeState> nodes = new LinkedHashMap<ResolvedConfigurationIdentifier, NodeState>();
@@ -114,6 +115,7 @@ class ResolveState {
         return module;
     }
 
+    @Override
     public ComponentState getRevision(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier id, ComponentResolveMetadata metadata) {
         ComponentState componentState = getModule(id.getModule()).getVersion(id, componentIdentifier);
         if (!componentState.alreadyResolved()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -27,10 +27,12 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
@@ -45,7 +47,7 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 /**
  * Resolution state for a given module version selector.
  */
-class SelectorState implements DependencyGraphSelector {
+class SelectorState implements DependencyGraphSelector, ResolvableSelectorState {
     // TODO:DAZ Should inject this
     private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(new DefaultVersionComparator());
     private final Long id;
@@ -200,5 +202,11 @@ class SelectorState implements DependencyGraphSelector {
 
     public ResolvedVersionConstraint getVersionConstraint() {
         return versionConstraint;
+    }
+
+    @Override
+    public boolean isForce() {
+        return dependencyMetadata instanceof LocalOriginDependencyMetadata
+            && ((LocalOriginDependencyMetadata) dependencyMetadata).isForce();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -39,8 +38,6 @@ import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult;
-
-import java.util.List;
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.CONSTRAINT;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.REQUESTED;
@@ -103,7 +100,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
      * Return any failure to resolve the component selector to id, or failure to resolve component metadata for id.
      */
     ModuleVersionResolveException getFailure() {
-        return failure != null ? failure : selected.getFailure();
+        return failure != null ? failure : selected.getMetadataResolveFailure();
     }
 
     /**
@@ -139,11 +136,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     public void select(ComponentState selected) {
         selected.selectedBy(this);
-        ComponentSelectionDescriptorInternal selectionDescriptor = selectionDescriptionForDependency(dependencyMetadata);
-        selected.addCause(selectionDescriptor);
-        if (dependencyState.getRuleDescriptor() != null) {
-            selected.addCause(dependencyState.getRuleDescriptor());
-        }
+        addReasonsForSelector(selected.getSelectionReason());
 
         // We should never select a component for a different module, but the JVM software model dependency resolution is doing this.
         // TODO Ditch the JVM Software Model plugins and re-add this assertion
@@ -152,12 +145,24 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         this.selected = selected;
     }
 
-    private ComponentSelectionDescriptorInternal selectionDescriptionForDependency(DependencyMetadata dependencyMetadata) {
-        ComponentSelectionDescriptorInternal selectionDescriptor = dependencyMetadata.isPending() ? CONSTRAINT : REQUESTED;
-        if (dependencyMetadata.getReason() != null) {
-            selectionDescriptor = selectionDescriptor.withReason(dependencyMetadata.getReason());
+    /**
+     * Overrides the component that is the chosen for this selector.
+     * This happens when the `ModuleResolveState` is restarted, during conflict resolution or version range merging.
+     */
+    public void overrideSelection(ComponentState selected) {
+        if (this.selected == null) {
+            // Do not override if this selector hasn't yet been resolved
+            return;
         }
-        return selectionDescriptor;
+
+        this.selected = selected;
+
+        // Target module can change, if this is called as the result of a module replacement conflict.
+        this.targetModule = selected.getModule();
+
+        // TODO:DAZ It's not clear that we're setting up the correct state here:
+        // - We are not updating the selection reasons for the selected component
+        // - If the target module changed, we are not updating the set of selectors on the target modules (both current and new)
     }
 
     public ComponentSelectionReason getSelectionReason() {
@@ -172,29 +177,20 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     public ComponentSelectionReasonInternal getReasonForSelector() {
-        List<ComponentSelectionDescriptorInternal> descriptors = Lists.newArrayListWithCapacity(2);
-        descriptors.add(selectionDescriptionForDependency(dependencyMetadata));
-        if (dependencyState.getRuleDescriptor() != null) {
-            descriptors.add(dependencyState.getRuleDescriptor());
-        }
-        return VersionSelectionReasons.of(descriptors);
+        return addReasonsForSelector(VersionSelectionReasons.empty());
     }
 
-    /**
-     * Overrides the component that is the chosen for this selector.
-     * This happens when the `ModuleResolveState` is restarted, during conflict resolution or 'softSelect' with version range merging.
-     */
-    public void overrideSelection(ComponentState selectedComponent) {
-        if (this.selected == null) {
-            // Do not override if this selector hasn't yet been resolved
-            return;
+    private ComponentSelectionReasonInternal addReasonsForSelector(ComponentSelectionReasonInternal selectionReason) {
+        ComponentSelectionDescriptorInternal dependencyDescriptor = dependencyMetadata.isPending() ? CONSTRAINT : REQUESTED;
+        if (dependencyMetadata.getReason() != null) {
+            dependencyDescriptor = dependencyDescriptor.withReason(dependencyMetadata.getReason());
         }
+        selectionReason.addCause(dependencyDescriptor);
 
-        this.selected = selectedComponent;
-
-        // Target module can change, if this is called as the result of a module replacement conflict.
-        // TODO:DAZ We are not updating the set of selectors for the updated module (or for the module that the selectors were removed from)
-        this.targetModule = selectedComponent.getModule();
+        if (dependencyState.getRuleDescriptor() != null) {
+            selectionReason.addCause(dependencyState.getRuleDescriptor());
+        }
+        return selectionReason;
     }
 
     public DependencyMetadata getDependencyMetadata() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionCons
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
@@ -208,5 +209,10 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     public boolean isForce() {
         return dependencyMetadata instanceof LocalOriginDependencyMetadata
             && ((LocalOriginDependencyMetadata) dependencyMetadata).isForce();
+    }
+
+    @Override
+    public void select(ComponentResolutionState component) {
+        select((ComponentState) component);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ComponentStateFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ComponentStateFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+
+public interface ComponentStateFactory<T extends ComponentResolutionState> {
+    T getRevision(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier id, ComponentResolveMetadata metadata);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
+
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
+import org.gradle.internal.resolve.result.ComponentIdResolveResult;
+
+public interface ResolvableSelectorState {
+    ResolvedVersionConstraint getVersionConstraint();
+
+    ComponentIdResolveResult resolve();
+
+    boolean isForce();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
 
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 
 public interface ResolvableSelectorState {
@@ -24,4 +25,6 @@ public interface ResolvableSelectorState {
     ComponentIdResolveResult resolve();
 
     boolean isForce();
+
+    void select(ComponentResolutionState component);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -41,9 +41,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
         ComponentIdResolveResult idResolveResult = selector.resolve();
 
         if (idResolveResult.getFailure() != null) {
-            // Resolve failure, nothing more to do.
-            // TODO:DAZ Throw here
-            return null;
+            throw idResolveResult.getFailure();
         }
 
         T candidate = componentFactory.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId(), idResolveResult.getMetadata());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictResolverDetails;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.resolve.result.ComponentIdResolveResult;
+
+import java.util.Collection;
+import java.util.List;
+
+public class SelectorStateResolver<T extends ComponentResolutionState> {
+    private final ModuleConflictResolver conflictResolver;
+    private final ComponentStateFactory<T> componentFactory;
+
+    public SelectorStateResolver(ModuleConflictResolver conflictResolver, ComponentStateFactory<T> componentFactory) {
+        this.conflictResolver = conflictResolver;
+        this.componentFactory = componentFactory;
+    }
+
+    public T selectBest(List<? extends ResolvableSelectorState> selectors, ResolvableSelectorState selector, T currentSelection) {
+        ComponentIdResolveResult idResolveResult = selector.resolve();
+
+        if (idResolveResult.getFailure() != null) {
+            // Resolve failure, nothing more to do.
+            // TODO:DAZ Throw here
+            return null;
+        }
+
+        T candidate = componentFactory.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId(), idResolveResult.getMetadata());
+
+        // If no current selection for module, just use the candidate.
+        if (currentSelection == null) {
+            return candidate;
+        }
+
+        // Handle 'force' on local dependencies
+        if (selector.isForce()) {
+            return candidate;
+        }
+
+        // Choose the best option from the current selection and the new candidate.
+        // This choice is made considering _all_ selectors registered for this module.
+        T selected = chooseBest(selectors, currentSelection, candidate);
+
+        // TODO:DAZ It's wasteful to recheck every reject selector every time
+        maybeMarkRejected(selected, selectors);
+        return selected;
+    }
+    /**
+     * Chooses the best out of 2 components for the module, considering all selectors for the module.
+     */
+    private T chooseBest(List<? extends ResolvableSelectorState> selectors, final T currentSelection, final T candidate) {
+        if (currentSelection == candidate) {
+            return candidate;
+        }
+
+        // See if the new selector agrees with the current selection. If so, keep the current selection.
+        if (allSelectorsAgreeWith(selectors, currentSelection.getVersion())) {
+            return currentSelection;
+        }
+
+        // See if all known selectors agree with the candidate selection. If so, use the candidate.
+        if (!currentSelection.isRoot() && allSelectorsAgreeWith(selectors, candidate.getVersion())) {
+            return candidate;
+        }
+
+        // Do conflict resolution to choose the best out of current selection and candidate.
+        List<T> candidates = ImmutableList.of(currentSelection, candidate);
+        ConflictResolverDetails<T> details = new DefaultConflictResolverDetails<T>(candidates);
+        conflictResolver.select(details);
+        if (details.hasFailure()) {
+            throw UncheckedException.throwAsUncheckedException(details.getFailure());
+        }
+        return details.getSelected();
+    }
+
+    private void maybeMarkRejected(ComponentResolutionState selected, List<? extends ResolvableSelectorState> selectors) {
+        if (selected.isRejected()) {
+            return;
+        }
+
+        String version = selected.getVersion();
+        for (ResolvableSelectorState selector : selectors) {
+            if (selector.getVersionConstraint() != null && selector.getVersionConstraint().getRejectedSelector() != null && selector.getVersionConstraint().getRejectedSelector().accept(version)) {
+                selected.reject();
+                return;
+            }
+        }
+    }
+
+    /**
+     * Check if all of the supplied selectors agree with the version chosen
+     */
+    private static boolean allSelectorsAgreeWith(Collection<? extends ResolvableSelectorState> allSelectors, String version) {
+        for (ResolvableSelectorState selectorState : allSelectors) {
+            ResolvedVersionConstraint versionConstraint = selectorState.getVersionConstraint();
+            if (versionConstraint == null) {
+                return false;
+            }
+            VersionSelector candidateSelector = versionConstraint.getPreferredSelector();
+            if (candidateSelector == null || !candidateSelector.canShortCircuitWhenVersionAlreadyPreselected() || !candidateSelector.accept(version)) {
+                return false;
+            }
+            candidateSelector = versionConstraint.getRejectedSelector();
+            if (candidateSelector != null && candidateSelector.accept(version)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -45,6 +45,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
         }
 
         T candidate = componentFactory.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId(), idResolveResult.getMetadata());
+        selector.select(candidate);
 
         // If no current selection for module, just use the candidate.
         if (currentSelection == null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -128,5 +128,4 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
         }
         return true;
     }
-
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -75,9 +75,11 @@ abstract class AbstractConflictResolverTest extends Specification {
 
     private static class TestComponent implements ComponentResolutionState {
 
-        private final ModuleVersionIdentifier id
+        final ModuleVersionIdentifier id
+        ComponentResolveMetadata metadata
+        boolean root = false
+        boolean rejected = false
         private MutableVersionConstraint constraint
-        private ComponentResolveMetadata metaData
 
         TestComponent(ModuleVersionIdentifier id) {
             this.id = id
@@ -95,18 +97,8 @@ abstract class AbstractConflictResolverTest extends Specification {
         }
 
         TestComponent release() {
-            metaData = ['getStatus': {'release'}] as ComponentResolveMetadata
+            metadata = ['getStatus': {'release'}] as ComponentResolveMetadata
             this
-        }
-
-        @Override
-        ModuleVersionIdentifier getId() {
-            id
-        }
-
-        @Override
-        ComponentResolveMetadata getMetadata() {
-            metaData
         }
 
         @Override
@@ -117,11 +109,6 @@ abstract class AbstractConflictResolverTest extends Specification {
         @Override
         void reject() {
 
-        }
-
-        @Override
-        boolean isRejected() {
-            return false
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.MutableVersionConstraint
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictResolverDetails
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import spock.lang.Specification
 
@@ -76,6 +78,7 @@ abstract class AbstractConflictResolverTest extends Specification {
     private static class TestComponent implements ComponentResolutionState {
 
         final ModuleVersionIdentifier id
+        final ComponentIdentifier componentId
         ComponentResolveMetadata metadata
         boolean root = false
         boolean rejected = false
@@ -83,6 +86,7 @@ abstract class AbstractConflictResolverTest extends Specification {
 
         TestComponent(ModuleVersionIdentifier id) {
             this.id = id
+            this.componentId = DefaultModuleComponentIdentifier.newId(id)
             this.constraint = new DefaultMutableVersionConstraint(id.version)
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
+import org.gradle.internal.component.model.ComponentResolveMetadata
+import org.gradle.internal.component.model.DependencyMetadata
+import org.gradle.internal.resolve.ModuleVersionNotFoundException
+import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver
+import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult
+import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.Specification
+import spock.lang.Unroll
+/**
+ * Unit test coverage of dependency resolution of a single module version, given a set of input selectors.
+ */
+class SelectorStateResolverTest extends Specification {
+    private final componentIdResolver = new TestDependencyToComponentIdResolver()
+    private final conflictResolver = new TestModuleConflictResolver()
+    private final componentFactory = new TestComponentFactory()
+
+    private final SelectorStateResolver selectorStateResolver = new SelectorStateResolver(conflictResolver, componentFactory)
+
+    @Unroll
+    def "resolve pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        resolve(candidates) == expected
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.PAIRS
+    }
+
+    @Unroll
+    def "resolve reject pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        resolve(candidates) == expected
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.PAIRS_WITH_REJECT
+    }
+
+    @Unroll
+    def "resolve three #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        resolve(candidates) == expected
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.THREES
+    }
+
+    @Unroll
+    def "resolve deps with reject #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        resolve(candidates) == expected
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.MULTIPLES_WITH_REJECT
+    }
+
+    @Unroll
+    def "resolve four #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        resolve(candidates) == expected
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.FOURS
+    }
+
+    int resolve(VersionRangeResolveTestScenarios.RenderableVersion... versions) {
+        def selectors = []
+        def currentSelection = null
+        for (VersionRangeResolveTestScenarios.RenderableVersion version : versions) {
+            def selector = new TestSelectorState(componentIdResolver, version.versionConstraint)
+            selectors << selector
+
+            currentSelection = selectorStateResolver.selectBest(selectors, selector, currentSelection)
+
+            if (currentSelection == null) {
+                // Resolve failure
+                return -1
+            }
+
+        }
+        if (currentSelection.isRejected()) {
+            return -1
+        }
+        return Integer.parseInt(currentSelection.getVersion())
+    }
+
+    static class TestComponentFactory implements ComponentStateFactory<ComponentResolutionState> {
+        @Override
+        ComponentResolutionState getRevision(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier id, ComponentResolveMetadata metadata) {
+            return new TestComponentResolutionState(id)
+        }
+    }
+
+    static class TestModuleConflictResolver implements ModuleConflictResolver {
+        @Override
+        <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details) {
+            Comparator<T> versionComparator = new ComponentVersionComparator() as Comparator<T>
+            T max = details.candidates.max(versionComparator)
+            details.select(max)
+        }
+
+        private static class ComponentVersionComparator implements Comparator<ComponentResolutionState> {
+            private final Comparator<Version> versionComparator = new DefaultVersionComparator().asVersionComparator()
+            private final VersionParser versionParser = VersionParser.INSTANCE
+
+            @Override
+            int compare(ComponentResolutionState one, ComponentResolutionState two) {
+                Version v1 = versionParser.transform(one.version)
+                Version v2 = versionParser.transform(two.version)
+                return versionComparator.compare(v1, v2)
+            }
+        }
+    }
+    /**
+     * A resolver used for testing the provides a fixed range of component identifiers.
+     * The requested group/module is ignored, and the versions [9..13] are served.
+     */
+    class TestDependencyToComponentIdResolver implements DependencyToComponentIdResolver {
+        @Override
+        void resolve(DependencyMetadata dependency, ResolvedVersionConstraint versionConstraint, BuildableComponentIdResolveResult result) {
+            def prefer = versionConstraint.preferredSelector
+            def reject = versionConstraint.rejectedSelector
+
+            if (!prefer.isDynamic()) {
+                def id = DefaultModuleComponentIdentifier.newId("org", "module", prefer.selector)
+                result.resolved(id, DefaultModuleVersionIdentifier.newId(id))
+                return
+            }
+
+            def resolved = findDynamicVersion(prefer, reject)
+            if (resolved) {
+                def id = DefaultModuleComponentIdentifier.newId("org", "module", resolved as String)
+                result.resolved(id, DefaultModuleVersionIdentifier.newId(id))
+                return
+            }
+
+            result.failed(missing(prefer))
+        }
+
+        private Integer findDynamicVersion(VersionSelector prefer, VersionSelector reject) {
+            (13..9).find {
+                String candidateVersion = it as String
+                prefer.accept(candidateVersion) && !rejected(reject, candidateVersion)
+            }
+        }
+
+        private boolean rejected(VersionSelector reject, String version) {
+            return reject != null && reject.accept(version)
+        }
+
+        private ModuleVersionNotFoundException missing(VersionSelector prefer) {
+            def moduleComponentSelector = DefaultModuleComponentSelector.newSelector("org", "module", prefer.selector)
+            return new ModuleVersionNotFoundException(moduleComponentSelector, [])
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentSelect
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
+import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult
 import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
@@ -119,15 +120,14 @@ class SelectorStateResolverTest extends Specification {
             def selector = new TestSelectorState(componentIdResolver, version.versionConstraint)
             selectors << selector
 
-            currentSelection = selectorStateResolver.selectBest(selectors, selector, currentSelection)
-
-            if (currentSelection == null) {
-                // Resolve failure
+            try {
+                currentSelection = selectorStateResolver.selectBest(selectors, selector, currentSelection)
+            } catch (ModuleVersionResolveException e) {
                 return -1
             }
-
         }
         if (currentSelection.isRejected()) {
+            // TODO:DAZ Differentiate from other failures in test
             return -1
         }
         return Integer.parseInt(currentSelection.getVersion())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+
+import javax.annotation.Nullable;
+
+public class TestComponentResolutionState implements ComponentResolutionState {
+    private ModuleVersionIdentifier id;
+    private boolean rejected;
+
+    public TestComponentResolutionState(ModuleVersionIdentifier id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getVersion() {
+        return id.getVersion();
+    }
+
+    @Override
+    public ModuleVersionIdentifier getId() {
+        return id;
+    }
+
+    @Nullable
+    @Override
+    public ComponentResolveMetadata getMetadata() {
+        return null;
+    }
+
+    @Override
+    public void addCause(ComponentSelectionDescriptorInternal componentSelectionDescription) {
+
+    }
+
+    @Override
+    public void reject() {
+        rejected = true;
+    }
+
+    @Override
+    public boolean isRejected() {
+        return rejected;
+    }
+
+    @Override
+    public boolean isRoot() {
+        return false;
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
@@ -16,8 +16,10 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
 import javax.annotation.Nullable;
@@ -33,6 +35,11 @@ public class TestComponentResolutionState implements ComponentResolutionState {
     @Override
     public String getVersion() {
         return id.getVersion();
+    }
+
+    @Override
+    public ComponentIdentifier getComponentId() {
+        return DefaultModuleComponentIdentifier.newId(id);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestSelectorState.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionCons
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
@@ -69,6 +70,11 @@ public class TestSelectorState implements ResolvableSelectorState {
     @Override
     public boolean isForce() {
         return false;
+    }
+
+    @Override
+    public void select(ComponentResolutionState component) {
+
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestSelectorState.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
+
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
+import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
+import org.gradle.internal.resolve.result.ComponentIdResolveResult;
+import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult;
+
+public class TestSelectorState implements ResolvableSelectorState {
+
+    private static final DefaultVersionComparator VERSION_COMPARATOR = new DefaultVersionComparator();
+    private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR);
+
+    private final DependencyToComponentIdResolver resolver;
+    private ResolvedVersionConstraint versionConstraint;
+    private ComponentIdResolveResult resolved;
+
+    public TestSelectorState(DependencyToComponentIdResolver resolver, VersionConstraint versionConstraint) {
+        this.resolver = resolver;
+        this.versionConstraint = new DefaultResolvedVersionConstraint(versionConstraint, VERSION_SELECTOR_SCHEME);
+    }
+
+    @Override
+    public ResolvedVersionConstraint getVersionConstraint() {
+        return versionConstraint;
+    }
+
+    private ComponentIdResolveResult resolveVersion() {
+        BuildableComponentIdResolveResult result = new DefaultBuildableComponentIdResolveResult();
+        resolver.resolve(null, versionConstraint, result);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return versionConstraint.toString();
+    }
+
+    @Override
+    public ComponentIdResolveResult resolve() {
+        if (resolved != null) {
+            return resolved;
+        }
+
+        resolved = resolveVersion();
+        return resolved;
+    }
+
+    @Override
+    public boolean isForce() {
+        return false;
+    }
+
+}

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -17,6 +17,10 @@
 package org.gradle.resolve.scenarios
 
 import groovy.transform.Canonical
+import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+
 /**
  * A comprehensive set of test cases for dependency resolution of a single module version, given a set of input selectors.
  */
@@ -226,11 +230,18 @@ class VersionRangeResolveTestScenarios {
     interface RenderableVersion {
         String getVersion()
 
+        VersionConstraint getVersionConstraint()
+
         String render()
     }
 
     static class SimpleVersion implements RenderableVersion {
         String version
+
+        @Override
+        VersionConstraint getVersionConstraint() {
+            DefaultImmutableVersionConstraint.of(version)
+        }
 
         @Override
         String render() {
@@ -247,6 +258,11 @@ class VersionRangeResolveTestScenarios {
         String version
 
         @Override
+        VersionConstraint getVersionConstraint() {
+            new DefaultMutableVersionConstraint(version, true)
+        }
+
+        @Override
         String render() {
             return "('org:foo') { version { strictly '${version}' } }"
         }
@@ -259,6 +275,11 @@ class VersionRangeResolveTestScenarios {
 
     static class RejectVersion implements RenderableVersion {
         String version
+
+        @Override
+        VersionConstraint getVersionConstraint() {
+            DefaultImmutableVersionConstraint.of("", [version])
+        }
 
         @Override
         String render() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.resolve.scenarios
+
+import groovy.transform.Canonical
+/**
+ * A comprehensive set of test cases for dependency resolution of a single module version, given a set of input selectors.
+ */
+class VersionRangeResolveTestScenarios {
+
+    static final FIXED_7 = fixed(7)
+    static final FIXED_9 = fixed(9)
+    static final FIXED_10 = fixed(10)
+    static final FIXED_11 = fixed(11)
+    static final FIXED_12 = fixed(12)
+    static final FIXED_13 = fixed(13)
+    static final RANGE_7_8 = range(7, 8)
+    static final RANGE_10_11 = range(10, 11)
+    static final RANGE_10_12 = range(10, 12)
+    static final RANGE_10_14 = range(10, 14)
+    static final RANGE_10_16 = range(10, 16)
+    static final RANGE_11_12 = range(11, 12)
+    static final RANGE_12_14 = range(12, 14)
+    static final RANGE_13_14 = range(13, 14)
+    static final RANGE_14_16 = range(14, 16)
+
+    static final REJECT_11 = reject(11)
+    static final REJECT_12 = reject(12)
+    static final REJECT_13 = reject(13)
+
+    public static final StrictPermutationsProvider PAIRS = StrictPermutationsProvider.check(
+        versions: [FIXED_7, FIXED_13],
+        expectedNoStrict: 13,
+        expectedStrict: [-1, 13]
+    ).and(
+        versions: [FIXED_12, FIXED_13],
+        expectedNoStrict: 13,
+        expectedStrict: [-1, 13]
+    ).and(
+        versions: [FIXED_12, RANGE_10_11],
+        expectedNoStrict: 12,
+        expectedStrict: [12, -1]
+    ).and(
+        versions: [FIXED_12, RANGE_10_14],
+        expectedNoStrict: 12,
+        expectedStrict: [12, 12]
+    ).and(
+        versions: [FIXED_12, RANGE_13_14],
+        expectedNoStrict: 13,
+        expectedStrict: [-1, 13]
+    ).and(
+        versions: [FIXED_12, RANGE_7_8],
+        expectedNoStrict: -1,
+        expectedStrict: [-1, -1]
+    ).and(
+        versions: [FIXED_12, RANGE_14_16],
+        expectedNoStrict: -1,
+        expectedStrict: [-1, -1]
+    ).and(
+        versions: [RANGE_10_11, FIXED_10],
+        expectedNoStrict: 10,
+        expectedStrict: [10, 10]
+    ).and(
+        versions: [RANGE_10_14, FIXED_13],
+        expectedNoStrict: 13,
+        expectedStrict: [13, 13]
+    ).and(
+        versions: [RANGE_10_14, RANGE_10_11],
+        expectedNoStrict: 11,
+        expectedStrict: [11, 11]
+    ).and(
+        versions: [RANGE_10_14, RANGE_10_16],
+        expectedNoStrict: 13,
+        expectedStrict: [13, 13]
+    )
+    public static final StrictPermutationsProvider PAIRS_WITH_REJECT = StrictPermutationsProvider.check(
+        versions: [FIXED_12, REJECT_11],
+        expectedNoStrict: 12
+    ).and(
+        versions: [FIXED_12, REJECT_12],
+        expectedNoStrict: -1
+    ).and(
+        versions: [FIXED_12, REJECT_13],
+        expectedNoStrict: 12
+    )
+
+    public static final StrictPermutationsProvider THREES = StrictPermutationsProvider.check(
+        versions: [FIXED_10, FIXED_12, FIXED_13],
+        expectedNoStrict: 13,
+        expectedStrict: [-1, -1, 13]
+    ).and(
+        ignore: true,
+        versions: [FIXED_10, FIXED_12, RANGE_10_14],
+        expectedNoStrict: 12,
+        expectedStrict: [-1, 12, 12]
+    ).and(
+        versions: [FIXED_10, RANGE_10_11, RANGE_10_14],
+        expectedNoStrict: 10,
+        expectedStrict: [10, 10, 10]
+    ).and(
+        versions: [FIXED_10, RANGE_10_11, RANGE_13_14],
+        expectedNoStrict: 13,
+        expectedStrict: [-1, -1, 13]
+    ).and(
+        ignore: true,
+        versions: [FIXED_10, RANGE_11_12, RANGE_10_14],
+        expectedNoStrict: 12,
+        expectedStrict: [-1, 12, 12]
+    ).and(
+        versions: [RANGE_10_11, RANGE_10_12, RANGE_10_14],
+        expectedNoStrict: 11,
+        expectedStrict: [11, 11, 11]
+    ).and(
+        versions: [RANGE_10_11, RANGE_10_12, RANGE_13_14],
+        expectedNoStrict: 13,
+        expectedStrict: [-1, -1, 13]
+    ).and(
+        ignore: true,
+        versions: [FIXED_10, FIXED_10, FIXED_12],
+        expectedNoStrict: 12,
+        expectedStrict: [-1, -1, 12]
+    ).and(
+        ignore: true,
+        versions: [FIXED_10, FIXED_12, RANGE_12_14],
+        expectedNoStrict: 12,
+        expectedStrict: [-1, 12, 12]
+    )
+
+    public static final StrictPermutationsProvider MULTIPLES_WITH_REJECT = StrictPermutationsProvider.check(
+        versions: [FIXED_11, FIXED_12, REJECT_11],
+        expectedNoStrict: 12,
+    ).and(
+        versions: [FIXED_11, FIXED_12, REJECT_12],
+        expectedNoStrict: -1,
+    ).and(
+        versions: [FIXED_11, FIXED_12, REJECT_13],
+        expectedNoStrict: 12,
+
+    ).and(
+        versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_11],
+        expectedNoStrict: 12,
+    ).and(
+        ignore: true, // This will require resolving RANGE_10_14 with the knowledge that FIXED_12 rejects < 12.
+        versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_12],
+        expectedNoStrict: 13,
+    ).and(
+        versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_13],
+        expectedNoStrict: 12,
+    ).and(
+        versions: [RANGE_10_12, RANGE_13_14, REJECT_11],
+        expectedNoStrict: 13,
+    ).and(
+        versions: [RANGE_10_12, RANGE_13_14, REJECT_12],
+        expectedNoStrict: 13,
+    ).and(
+        versions: [RANGE_10_12, RANGE_13_14, REJECT_13],
+        expectedNoStrict: -1,
+    ).and(
+        ignore: true,
+        versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_11],
+        expectedNoStrict: 10,
+    ).and(
+        ignore: true,
+        versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_12],
+        expectedNoStrict: 11,
+    ).and(
+        ignore: true,
+        versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_13],
+        expectedNoStrict: 11,
+    )
+
+    public static final StrictPermutationsProvider FOURS = StrictPermutationsProvider.check(
+        versions: [FIXED_9, FIXED_10, FIXED_11, FIXED_12],
+        expectedNoStrict: 12
+    ).and(
+        ignore: true,
+        versions: [FIXED_10, RANGE_10_11, FIXED_12, RANGE_12_14],
+        expectedNoStrict: 12
+    ).and(
+        versions: [FIXED_10, RANGE_10_11, RANGE_10_12, RANGE_13_14],
+        expectedNoStrict: 13
+    ).and(
+        ignore: true,
+        versions: [FIXED_9, RANGE_10_11, RANGE_10_12, RANGE_10_14],
+        expectedNoStrict: 11
+    )
+
+    private static RenderableVersion fixed(int version) {
+        def vs = new SimpleVersion()
+        vs.version = "${version}"
+        return vs
+    }
+
+    private static RenderableVersion range(int low, int high) {
+        def vs = new SimpleVersion()
+        vs.version = "[${low},${high}]"
+        return vs
+    }
+
+    private static RenderableVersion reject(int version) {
+        def vs = new RejectVersion()
+        vs.version = version
+        vs
+    }
+
+    private static RenderableVersion strict(RenderableVersion input) {
+        def v = new StrictVersion()
+        v.version = input.version
+        v
+    }
+
+    interface RenderableVersion {
+        String getVersion()
+
+        String render()
+    }
+
+    static class SimpleVersion implements RenderableVersion {
+        String version
+
+        @Override
+        String render() {
+            "'org:foo:${version}'"
+        }
+
+        @Override
+        String toString() {
+            return version
+        }
+    }
+
+    static class StrictVersion implements RenderableVersion {
+        String version
+
+        @Override
+        String render() {
+            return "('org:foo') { version { strictly '${version}' } }"
+        }
+
+        @Override
+        String toString() {
+            return "strictly(" + version + ")"
+        }
+    }
+
+    static class RejectVersion implements RenderableVersion {
+        String version
+
+        @Override
+        String render() {
+            "('org:foo') { version { reject '${version}' } }"
+        }
+
+        @Override
+        String toString() {
+            return "reject " + version
+        }
+    }
+
+    static class StrictPermutationsProvider implements Iterable<Candidate> {
+        private final List<Batch> batches = []
+        private int batchCount
+
+        static StrictPermutationsProvider check(Map config) {
+            new StrictPermutationsProvider().and(config)
+        }
+
+        StrictPermutationsProvider and(Map config) {
+            assert config.versions
+            assert config.expectedNoStrict
+
+            ++batchCount
+            if (!config.ignore) {
+                List<RenderableVersion> versions = config.versions
+                List<Integer> expectedStrict = config.expectedStrict
+                List<Batch> iterations = []
+                String batchName = config.description ?: "#${batchCount} (${versions})"
+                iterations.add(new Batch(batchName, versions, config.expectedNoStrict))
+                if (expectedStrict) {
+                    versions.size().times { idx ->
+                        iterations.add(new Batch(batchName, versions.withIndex().collect { RenderableVersion version, idx2 ->
+                            if (idx == idx2) {
+                                strict(version)
+                            } else {
+                                version
+                            }
+                        }, expectedStrict[idx]))
+                    }
+                }
+                batches.addAll(iterations)
+            }
+
+            this
+        }
+
+        @Override
+        Iterator<Candidate> iterator() {
+            new PermutationIterator()
+        }
+
+        @Canonical
+        static class Batch {
+            String batchName
+            List<RenderableVersion> versions
+            int expected
+        }
+
+        class PermutationIterator implements Iterator<Candidate> {
+            Iterator<Batch> batchesIterator = batches.iterator()
+            String currentBatch
+            Iterator<List<RenderableVersion>> current
+            int expected
+
+            @Override
+            boolean hasNext() {
+                batchesIterator.hasNext() || current?.hasNext()
+            }
+
+            @Override
+            Candidate next() {
+                if (current?.hasNext()) {
+                    return new Candidate(batch: currentBatch, candidates: current.next() as RenderableVersion[], expected: expected)
+                }
+                Batch nextBatch = batchesIterator.next()
+                expected = nextBatch.expected
+                current = nextBatch.versions.permutations().iterator()
+                currentBatch = nextBatch.batchName
+                return next()
+            }
+        }
+
+        static class Candidate {
+            String batch
+            RenderableVersion[] candidates
+            int expected
+
+            @Override
+            String toString() {
+                batch + ": " + candidates.collect { it.toString() }.join(' & ') + " -> ${expected < 0 ? 'FAIL' : expected}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is purely a refactoring of `DependencyGraphBuilder`:
- Extracted logic for choosing the best component for a selector into `SelectortStateResolver`
- Extracted test scenarios out of existing integration test and reuse them for unit testing `SelectorStateResolver`
- Simplify some logic:
    - Clarified version range merging when the root component is involved
    - Don't resolve component metadata to determine if it's a project component for conflict resolution
    - Better support for `rejectAll` in `RejectedModuleMessageBuilder`
- Add some integTest coverage for the resolution result when some selectors fail to resolve