### PR TITLE
Fix some minor issues with the rich console

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -49,6 +49,22 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
         fails('failing')
 
         then:
+        result.groupedOutput.task(':failing').output == 'hello'
+        result.output.contains(styled("> Task :failing", Ansi.Color.RED, Ansi.Attribute.INTENSITY_BOLD))
+    }
+
+    def "group header is printed red if task failed and there is no output"() {
+        given:
+        buildFile << """
+            task failing { doFirst { 
+                throw new RuntimeException('Failure...')
+            } }
+        """
+
+        when:
+        fails('failing')
+
+        then:
         result.output.contains(styled("> Task :failing", Ansi.Color.RED, Ansi.Attribute.INTENSITY_BOLD))
     }
 


### PR DESCRIPTION
We now always print a task header when:
- we have already rendered output but the task status changes
- a task has failed, whether it has rendered output or not

