### PR TITLE
Link to release notes in welcome message instead of gradle.org/releases

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
@@ -103,6 +103,6 @@ ${readReleaseFeatures()}
     }
 
     static String getReleaseNotesDetailsMessage(GradleVersion gradleVersion) {
-        "For more details see https://gradle.org/releases/#$gradleVersion.version"
+        "For more details see https://docs.gradle.org/$gradleVersion.version/release-notes.html"
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -146,7 +146,7 @@ public class CommandLineActionFactory {
 
                     if (!currentVersion.isSnapshot()) {
                         out.println();
-                        out.print("For more details see https://gradle.org/releases/#" + currentVersion.getVersion());
+                        out.print("For more details see https://docs.gradle.org/" + currentVersion.getVersion() + "/release-notes.html");
                         out.println();
                     }
 


### PR DESCRIPTION
### Context
I'm afraid I cannot do the new releases page before 4.7 RC, so point to official release notes instead.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
