### PR TITLE
Handle system headers differently on the command line for GCC

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.xml
@@ -53,6 +53,9 @@
             <tr>
                 <td>includes</td>
             </tr>
+            <tr>
+                <td>systemIncludes</td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -17,9 +17,11 @@ See the User guide section on the “[Feature Lifecycle](userguide/feature_lifec
 
 The following are the features that have been promoted in this Gradle release.
 
-<!--
-### Example promoted
--->
+### Better control of native system headers
+
+In previous versions of Gradle, the native compile task include path was a single monolithic collection of files that was accessible through the `includes` property on the compile task.
+However, in Gradle 4.8, system header include directories can now be accessed separately via the `systemIncludes` property.  This allows the user fine-grained control over which system headers are used at compile time.
+Furthermore, on GCC-compatible toolchains, the system header include directories specified with `systemIncludes` will be specified on the command line using the ["-isystem" argument](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html) which marks them for special treatment by the compiler.
 
 ## Fixed issues
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,9 +6,11 @@ Here are the new features introduced in this Gradle release.
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
 
-<!--
-### Example new and noteworthy
--->
+### Better control of native system headers
+
+In previous versions of Gradle, the native compile task include path was a single monolithic collection of files that was accessible through the `includes` property on the compile task.
+However, in Gradle 4.8, system header include directories can now be accessed separately via the `systemIncludes` property.  This allows the user fine-grained control over which system headers are used at compile time.
+Furthermore, on GCC-compatible toolchains, the system header include directories specified with `systemIncludes` will be specified on the command line using the ["-isystem" argument](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html) which marks them for special treatment by the compiler.
 
 ## Promoted features
 
@@ -16,12 +18,6 @@ Promoted features are features that were incubating in previous versions of Grad
 See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
 
 The following are the features that have been promoted in this Gradle release.
-
-### Better control of native system headers
-
-In previous versions of Gradle, the native compile task include path was a single monolithic collection of files that was accessible through the `includes` property on the compile task.
-However, in Gradle 4.8, system header include directories can now be accessed separately via the `systemIncludes` property.  This allows the user fine-grained control over which system headers are used at compile time.
-Furthermore, on GCC-compatible toolchains, the system header include directories specified with `systemIncludes` will be specified on the command line using the ["-isystem" argument](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html) which marks them for special treatment by the compiler.
 
 ## Fixed issues
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.language.cpp
 
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppApp
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrariesWithApiDependencies
@@ -930,5 +932,33 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         installation("build/install/main/debug").exec().out == app.expectedOutput
         sharedLibrary("build/install/main/debug/lib/lib1").file.assertExists()
         sharedLibrary("build/install/main/debug/lib/lib2").file.assertExists()
+    }
+
+    @RequiresInstalledToolChain(ToolChainRequirement.GCC_COMPATIBLE)
+    def "system headers are not evaluated when compiler warnings are enabled"() {
+        settingsFile << "rootProject.name = 'app'"
+        def app = new CppCompilerDetectingTestApp()
+
+        given:
+        app.writeSources(file('src/main'))
+
+        and:
+        buildFile << """
+            apply plugin: 'cpp-application'
+            
+            application {
+                binaries.configureEach {
+                    compileTask.get().compilerArgs.add("-Wall")
+                    compileTask.get().compilerArgs.add("-Werror")
+                }
+            }
+         """
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(tasks.debug.allToInstall, ':assemble')
+
+        executable("build/exe/main/debug/app").assertExists()
+        installation("build/install/main/debug").exec().out == app.expectedOutput(toolChain)
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -95,7 +95,7 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
 
                 CppCompile compile = tasks.create(names.getCompileTaskName(language), CppCompile.class);
                 compile.includes(binary.getCompileIncludePath());
-                compile.includes(systemIncludes);
+                compile.systemIncludes(systemIncludes);
                 compile.source(binary.getCppSource());
                 if (binary.isDebuggable()) {
                     compile.setDebuggable(true);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -95,7 +95,7 @@ public class CppBasePlugin implements Plugin<ProjectInternal> {
 
                 CppCompile compile = tasks.create(names.getCompileTaskName(language), CppCompile.class);
                 compile.includes(binary.getCompileIncludePath());
-                compile.systemIncludes(systemIncludes);
+                compile.getSystemIncludes().from(systemIncludes);
                 compile.source(binary.getCppSource());
                 if (binary.isDebuggable()) {
                     compile.setDebuggable(true);

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractNativeCompileSpec.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractNativeCompileSpec.java
@@ -32,6 +32,7 @@ import java.util.Map;
 public abstract class AbstractNativeCompileSpec extends AbstractBinaryToolSpec implements NativeCompileSpec {
 
     private List<File> includeRoots = new ArrayList<File>();
+    private List<File> systemIncludeRoots = new ArrayList<File>();
     private List<File> sourceFiles = new ArrayList<File>();
     private List<File> removedSourceFiles = new ArrayList<File>();
     private boolean incrementalCompile;
@@ -60,6 +61,21 @@ public abstract class AbstractNativeCompileSpec extends AbstractBinaryToolSpec i
     @Override
     public void include(Iterable<File> includeRoots) {
         addAll(this.includeRoots, includeRoots);
+    }
+
+    @Override
+    public List<File> getSystemIncludeRoots() {
+        return systemIncludeRoots;
+    }
+
+    @Override
+    public void systemInclude(Iterable<File> systemIncludeRoots) {
+        addAll(this.systemIncludeRoots, systemIncludeRoots);
+    }
+
+    @Override
+    public void systemInclude(File... systemIncludeRoots) {
+        Collections.addAll(this.systemIncludeRoots, systemIncludeRoots);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractNativeCompileSpec.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractNativeCompileSpec.java
@@ -74,11 +74,6 @@ public abstract class AbstractNativeCompileSpec extends AbstractBinaryToolSpec i
     }
 
     @Override
-    public void systemInclude(File... systemIncludeRoots) {
-        Collections.addAll(this.systemIncludeRoots, systemIncludeRoots);
-    }
-
-    @Override
     public List<File> getSourceFiles() {
         return sourceFiles;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
@@ -93,7 +93,7 @@ public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
             }
         });
         FileCollectionFactory fileCollectionFactory = ((ProjectInternal) task.getProject()).getServices().get(FileCollectionFactory.class);
-        task.includes(fileCollectionFactory.create(new MinimalFileSet() {
+        task.systemIncludes(fileCollectionFactory.create(new MinimalFileSet() {
             @Override
             public Set<File> getFiles() {
                 PlatformToolProvider platformToolProvider = ((NativeToolChainInternal) binary.getToolChain()).select((NativePlatformInternal) binary.getTargetPlatform());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
@@ -93,7 +93,7 @@ public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
             }
         });
         FileCollectionFactory fileCollectionFactory = ((ProjectInternal) task.getProject()).getServices().get(FileCollectionFactory.class);
-        task.systemIncludes(fileCollectionFactory.create(new MinimalFileSet() {
+        task.getSystemIncludes().from(fileCollectionFactory.create(new MinimalFileSet() {
             @Override
             public Set<File> getFiles() {
                 PlatformToolProvider platformToolProvider = ((NativeToolChainInternal) binary.getToolChain()).select((NativePlatformInternal) binary.getTargetPlatform());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -67,6 +67,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     private boolean optimize;
     private final DirectoryProperty objectFileDir;
     private final ConfigurableFileCollection includes;
+    private final ConfigurableFileCollection systemIncludes;
     private final ConfigurableFileCollection source;
     private final Map<String, String> macros = new LinkedHashMap<String, String>();
     private final ListProperty<String> compilerArgs;
@@ -75,7 +76,9 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     public AbstractNativeCompileTask() {
         ObjectFactory objectFactory = getProject().getObjects();
         this.includes = getProject().files();
+        this.systemIncludes = getProject().files();
         dependsOn(includes);
+        dependsOn(systemIncludes);
 
         this.source = getTaskFileVarFactory().newInputFileCollection(this);
         this.objectFileDir = newOutputDirectory();
@@ -118,6 +121,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
         spec.setTempDir(getTemporaryDir());
         spec.setObjectFileDir(objectFileDir.get().getAsFile());
         spec.include(includes);
+        spec.systemInclude(systemIncludes);
         spec.source(getSource());
         spec.setMacros(getMacros());
         spec.args(getCompilerArgs().get());
@@ -241,6 +245,25 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
      */
     public void includes(Object includeRoots) {
         includes.from(includeRoots);
+    }
+
+    /**
+     * Returns the system include directories to be used for compilation.
+     *
+     * @since 4.8
+     */
+    @Internal("The paths for include directories are tracked via the includePaths property, the contents are tracked via discovered inputs")
+    public ConfigurableFileCollection getSystemIncludes() {
+        return systemIncludes;
+    }
+
+    /**
+     * Add system include directories where the compiler should search for header files.
+     *
+     * @since 4.8
+     */
+    public void systemIncludes(Object systemIncludeRoots) {
+        systemIncludes.from(systemIncludeRoots);
     }
 
     /**

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -258,15 +258,6 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     }
 
     /**
-     * Add system include directories where the compiler should search for header files.
-     *
-     * @since 4.8
-     */
-    public void systemIncludes(Object systemIncludeRoots) {
-        systemIncludes.from(systemIncludeRoots);
-    }
-
-    /**
      * Returns the source files to be compiled.
      */
     @InputFiles

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompileSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompileSpec.java
@@ -38,6 +38,12 @@ public interface NativeCompileSpec extends BinaryToolSpec {
 
     void include(File... includeRoots);
 
+    List<File> getSystemIncludeRoots();
+
+    void systemInclude(Iterable<File> systemIncludeRoots);
+
+    void systemInclude(File... systemIncludeRoots);
+
     List<File> getSourceFiles();
 
     void setSourceFiles(Collection<File> sources);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompileSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompileSpec.java
@@ -42,8 +42,6 @@ public interface NativeCompileSpec extends BinaryToolSpec {
 
     void systemInclude(Iterable<File> systemIncludeRoots);
 
-    void systemInclude(File... systemIncludeRoots);
-
     List<File> getSourceFiles();
 
     void setSourceFiles(Collection<File> sources);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
@@ -60,6 +60,11 @@ abstract class GccCompilerArgsTransformer<T extends NativeCompileSpec> implement
             args.add("-I");
             args.add(file.getAbsolutePath());
         }
+
+        for (File file : spec.getSystemIncludeRoots()) {
+            args.add("-isystem");
+            args.add(file.getAbsolutePath());
+        }
     }
 
     protected void addMacroArgs(T spec, List<String> args) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -58,6 +58,9 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
         for (File file : spec.getIncludeRoots()) {
             args.add("/I" + file.getAbsolutePath());
         }
+        for (File file : spec.getSystemIncludeRoots()) {
+            args.add("/I" + file.getAbsolutePath());
+        }
     }
 
     protected void addMacroArgs(T spec, List<String> args) {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -55,7 +55,7 @@ abstract class NativeCompilerTest extends Specification {
     }
 
     protected abstract Class<? extends NativeCompileSpec> getCompileSpecType()
-    protected abstract List<String> getCompilerSpecificArguments(File includeDir)
+    protected abstract List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir)
 
     protected CommandLineToolInvocationWorker commandLineTool = Mock(CommandLineToolInvocationWorker)
 
@@ -122,13 +122,15 @@ abstract class NativeCompilerTest extends Specification {
         def compiler = getCompiler()
         def testDir = tmpDirProvider.testDirectory
         def includeDir = testDir.file("includes")
-        def expectedArgs = getCompilerSpecificArguments(includeDir)
+        def systemIncludeDir = testDir.file("system")
+        def expectedArgs = getCompilerSpecificArguments(includeDir, systemIncludeDir)
 
         when:
         NativeCompileSpec compileSpec = Stub(getCompileSpecType()) {
             getMacros() >> [foo: "bar", empty: null]
             getAllArgs() >> ["-firstArg", "-secondArg"]
             getIncludeRoots() >> [ includeDir ]
+            getSystemIncludeRoots() >> [ systemIncludeDir ]
             getOperationLogger() >> Mock(BuildOperationLogger)
             getPrefixHeaderFile() >> null
             getPreCompiledHeaderObjectFile() >> null
@@ -222,7 +224,8 @@ abstract class NativeCompilerTest extends Specification {
         def compiler = getCompiler(invocationContext, O_EXT, true)
         def testDir = tmpDirProvider.testDirectory
         def includeDir = testDir.file("includes")
-        def commandLineArgs = getCompilerSpecificArguments(includeDir)
+        def systemIncludeDir = testDir.file("system")
+        def commandLineArgs = getCompilerSpecificArguments(includeDir, systemIncludeDir)
 
         when:
         NativeCompileSpec compileSpec = Stub(getCompileSpecType()) {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AssemblerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AssemblerTest.groovy
@@ -32,7 +32,7 @@ class AssemblerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [ '-x', 'assembler' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [ '-x', 'assembler' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CCompilerTest.groovy
@@ -32,7 +32,7 @@ class CCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [ '-x', 'c' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [ '-x', 'c' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CPCHCompilerTest.groovy
@@ -33,7 +33,7 @@ class CPCHCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '-x', 'c-header' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '-x', 'c-header' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppCompilerTest.groovy
@@ -33,7 +33,7 @@ class CppCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [ '-x', 'c++' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [ '-x', 'c++' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppPCHCompilerTest.groovy
@@ -33,7 +33,7 @@ class CppPCHCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '-x', 'c++-header' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '-x', 'c++-header' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompatibleNativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompatibleNativeCompilerTest.groovy
@@ -21,8 +21,8 @@ import org.gradle.nativeplatform.toolchain.internal.NativeCompilerTest
 
 abstract class GccCompatibleNativeCompilerTest extends NativeCompilerTest {
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [ '-c', '-Dfoo=bar', '-Dempty', '-firstArg', '-secondArg', '-I', includeDir.absoluteFile.toString() ]
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [ '-c', '-Dfoo=bar', '-Dempty', '-firstArg', '-secondArg', '-I', includeDir.absoluteFile.toString(), '-isystem', systemIncludeDir.absoluteFile.toString() ]
     }
 
     def "arguments include GCC output flag and output file name"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformerTest.groovy
@@ -43,4 +43,29 @@ class GccCompilerArgsTransformerTest extends Specification {
         false | true     | ["-O3"]
         true  | true     | ["-g", "-O3"]
     }
+
+    def "transforms system header and include args correctly"() {
+        def spec = Stub(NativeCompileSpec)
+        def includes = [ new File("/foo"), new File("/bar") ]
+        def systemIncludes = [ new File("/baz") ]
+        spec.includeRoots >> includes
+        spec.systemIncludeRoots >> systemIncludes
+
+        when:
+        def args = transformer.transform(spec)
+
+        then:
+        assertHasArguments(args, "-I", includes)
+        assertHasArguments(args, "-isystem", systemIncludes)
+
+        and:
+        args.indexOf(includes.last().absoluteFile.toString()) < args.indexOf(systemIncludes.first().absoluteFile.toString())
+    }
+
+    boolean assertHasArguments(List<String> args, String option, List<File> files) {
+        files.each { file ->
+            assert Collections.indexOfSubList(args, [option, file.absoluteFile.toString()]) > -1
+        }
+        return true
+    }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCCompilerTest.groovy
@@ -33,7 +33,7 @@ class ObjectiveCCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '-x', 'objective-c' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '-x', 'objective-c' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCPCHCompilerTest.groovy
@@ -33,7 +33,7 @@ class ObjectiveCPCHCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '-x', 'objective-c-header' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '-x', 'objective-c-header' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppCompilerTest.groovy
@@ -33,7 +33,7 @@ class ObjectiveCppCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '-x', 'objective-c++' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '-x', 'objective-c++' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppPCHCompilerTest.groovy
@@ -33,7 +33,7 @@ class ObjectiveCppPCHCompilerTest extends GccCompatibleNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '-x', 'objective-c++-header' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '-x', 'objective-c++-header' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/AssemblerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/AssemblerTest.groovy
@@ -34,8 +34,8 @@ class AssemblerTest extends VisualCppNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [''] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [''] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 
     def "check that position sensitive arguments are in the right order"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CCompilerTest.groovy
@@ -33,7 +33,7 @@ class CCompilerTest extends VisualCppNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [ '/TC' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [ '/TC' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CPCHCompilerTest.groovy
@@ -38,7 +38,7 @@ class CPCHCompilerTest extends VisualCppNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '/Yc' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '/Yc' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CppCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CppCompilerTest.groovy
@@ -34,7 +34,7 @@ class CppCompilerTest  extends VisualCppNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        [ '/TP' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        [ '/TP' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CppPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/CppPCHCompilerTest.groovy
@@ -40,7 +40,7 @@ class CppPCHCompilerTest extends VisualCppNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
-        return [ '/Yc' ] + super.getCompilerSpecificArguments(includeDir)
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
+        return [ '/Yc' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformerTest.groovy
@@ -43,4 +43,28 @@ class VisualCppCompilerArgsTransformerTest extends Specification {
         true  | true     | ["/Zi", "/O2"]
     }
 
+    def "transforms system header and include args correctly"() {
+        def spec = Stub(NativeCompileSpec)
+        def includes = [ new File("/foo"), new File("/bar") ]
+        def systemIncludes = [ new File("/baz") ]
+        spec.includeRoots >> includes
+        spec.systemIncludeRoots >> systemIncludes
+
+        when:
+        def args = transformer.transform(spec)
+
+        then:
+        assertHasArguments(args, "/I", includes)
+        assertHasArguments(args, "/I", systemIncludes)
+
+        and:
+        args.indexOf("/I" + includes.last().absoluteFile.toString()) < args.indexOf("/I" + systemIncludes.first().absoluteFile.toString())
+    }
+
+    boolean assertHasArguments(List<String> args, String option, List<File> files) {
+        files.each { file ->
+            assert args.indexOf(option + file.absoluteFile.toString()) > -1
+        }
+        return true
+    }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppNativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppNativeCompilerTest.groovy
@@ -24,9 +24,9 @@ abstract class VisualCppNativeCompilerTest extends NativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
         ['/nologo', '/c', '/Dfoo=bar', '/Dempty', '-firstArg', '-secondArg',
-         '/I' + includeDir.absoluteFile.toString()]
+         '/I' + includeDir.absoluteFile.toString(), '/I' + systemIncludeDir.absoluteFile.toString()]
     }
 
     def "arguments include MSVC output flag and output file name"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsResourceCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsResourceCompilerTest.groovy
@@ -34,9 +34,9 @@ class WindowsResourceCompilerTest extends VisualCppNativeCompilerTest {
     }
 
     @Override
-    protected List<String> getCompilerSpecificArguments(File includeDir) {
+    protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
         ['/r', '/nologo', '/Dfoo=bar', '/Dempty', '-firstArg', '-secondArg',
-         '/I' + includeDir.absoluteFile.toString()]
+         '/I' + includeDir.absoluteFile.toString(), '/I' + systemIncludeDir.absoluteFile.toString()]
     }
 
     def "check that position sensitive arguments are in the right order"() {


### PR DESCRIPTION
See https://github.com/gradle/gradle-native/issues/583

This adds support for specifying system header directories on the command line for GCC-compatible toolchains using "-isystem" rather than "-I"