### PR TITLE
Enforce correct usage of output test fixtures

### DIFF
--- a/buildSrc/subprojects/buildquality/buildquality.gradle.kts
+++ b/buildSrc/subprojects/buildquality/buildquality.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":plugins"))
     implementation(project(":performance"))
     implementation("org.owasp:dependency-check-gradle:3.1.0")
+    implementation("org.codenarc:CodeNarc:1.0")
 }
 
 gradlePlugin {

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/codenarc/IntegrationTestFixturesRule.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/codenarc/IntegrationTestFixturesRule.kt
@@ -1,0 +1,61 @@
+package org.gradle.gradlebuild.buildquality.codenarc
+
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.PropertyExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codenarc.rule.AbstractAstVisitor
+import org.codenarc.rule.AbstractAstVisitorRule
+import org.codenarc.util.AstUtil
+
+
+class IntegrationTestFixturesRule : AbstractAstVisitorRule() {
+    override fun getName(): String = "IntegrationTestFixtures"
+
+    override fun getPriority(): Int = 1
+
+    override fun setPriority(priority: Int) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun setName(name: String?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getDescription(): String = "Reports incorrect usages of integration test fixtures"
+
+    override fun getAstVisitorClass(): Class<*> = IntegrationTestFixtureVisitor::class.java
+}
+
+
+class IntegrationTestFixtureVisitor : AbstractAstVisitor() {
+
+    /**
+     * Determines if the class is an integration test. It's a bit weak, but we cannot
+     * rely on the class node analysis since it doesn't give the right superclass because
+     * resolution is not complete when this visitor is executed.
+     */
+    private
+    fun isIntegrationTest(current: ClassNode) = current.name.endsWith("IntegrationTest")
+        || current.name.endsWith("IntegrationSpec")
+
+    override fun shouldVisitMethod(node: MethodNode?): Boolean = isIntegrationTest(node!!.declaringClass)
+
+    override fun visitMethodCallExpression(call: MethodCallExpression?) {
+        val mce = call!!
+        if (AstUtil.isMethodNamed(mce, "contains")) {
+            val receiver = call.receiver!!
+            if (receiver is PropertyExpression) {
+                if (receiver.propertyAsString == "output") {
+                    val objectExpr = receiver.objectExpression
+                    if (objectExpr is VariableExpression
+                        && objectExpr.name == "result") {
+                        val arg = AstUtil.getNodeText(call.arguments, sourceCode)
+                        addViolation(call, "Should use outputContains($arg) or failure.assertHasCause($arg) instead")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/config/codenarc.xml
+++ b/config/codenarc.xml
@@ -45,4 +45,6 @@
         <exclude name="FactoryMethodName"/>
         <exclude name="ClassNameSameAsSuperclass"/>
     </ruleset-ref>
+
+    <rule class='org.gradle.gradlebuild.buildquality.codenarc.IntegrationTestFixturesRule'/>
 </ruleset>

--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -51,6 +51,14 @@ fun Project.configureCheckstyle(codeQualityConfigDir: File) {
     }
 }
 
+fun getIntegrationTestFixturesRule(): Class<*>? {
+    try {
+        return Class.forName("org.gradle.gradlebuild.buildquality.codenarc.IntegrationTestFixturesRule", false, this.javaClass.classLoader)
+    } catch (e: Throwable) {
+        return null
+    }
+}
+
 fun Project.configureCodenarc(codeQualityConfigDir: File) {
     apply {
         plugin("codenarc")
@@ -70,6 +78,12 @@ fun Project.configureCodenarc(codeQualityConfigDir: File) {
                     }
                 }
             }
+        }
+        val ruleClass = getIntegrationTestFixturesRule()
+        if (ruleClass != null) {
+            "codenarc"(files(ruleClass.protectionDomain!!.codeSource!!.location))
+            "codenarc"(embeddedKotlin("stdlib"))
+            "codenarc"(embeddedKotlin("runtime"))
         }
     }
 

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -274,8 +274,8 @@ class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec imple
         executer.withArgument("--info")
         withBuildCache().run "assemble"
         then:
-        !result.output.contains("correct-username")
-        !result.output.contains("correct-password")
+        outputDoesNotContain("correct-username")
+        outputDoesNotContain("correct-password")
     }
 
     def "incorrect credentials cause build to fail"() {

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -90,9 +90,9 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
         i3Cache.listCacheFiles().size() == 1
 
         and:
-        result.assertOutputContains "Using local directory build cache for build ':buildSrc' (location = ${buildSrcCache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
-        result.assertOutputContains "Using local directory build cache for build ':i2:i3' (location = ${i3Cache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
-        result.assertOutputContains "Using local directory build cache for the root build (location = ${mainCache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
+        outputContains "Using local directory build cache for build ':buildSrc' (location = ${buildSrcCache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
+        outputContains "Using local directory build cache for build ':i2:i3' (location = ${i3Cache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
+        outputContains "Using local directory build cache for the root build (location = ${mainCache.cacheDir}, removeUnusedEntriesAfter = 7 days)."
 
         and:
         def finalizeOps = operations.all(FinalizeBuildCacheConfigurationBuildOperationType)

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheConfigurationIntegrationTest.groovy
@@ -140,7 +140,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         """
         expect:
         succeeds("help", "--build-cache", "--offline", "--info")
-        result.output.contains("Remote build cache is disabled when running with --offline.")
+        outputContains("Remote build cache is disabled when running with --offline.")
     }
 
     def "unregistered build cache type is reported even when disabled"() {
@@ -163,7 +163,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         executer.withBuildCacheEnabled()
         succeeds("tasks", "--info")
         then:
-        result.assertOutputContains("Using local directory build cache")
+        outputContains("Using local directory build cache")
     }
 
     def "command-line --no-build-cache wins over system property"() {
@@ -174,7 +174,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         when:
         succeeds("tasks", "--info")
         then:
-        !result.output.contains("Using local directory build cache")
+        outputDoesNotContain("Using local directory build cache")
     }
 
     def "command-line --build-cache wins over system property"() {
@@ -185,7 +185,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         when:
         succeeds("tasks", "--info")
         then:
-        result.assertOutputContains("Using local directory build cache")
+        outputContains("Using local directory build cache")
     }
 
     def "does not use the build cache when it is not enabled"() {
@@ -204,7 +204,8 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         executer.withBuildCacheEnabled()
         succeeds("customTask")
         then:
-        result.assertOutputContains("Task output caching is enabled, but no build caches are configured or enabled.")
+        outputContains("Task output caching is enabled, but no build caches are configured or enabled.")
+
         and:
         localBuildCache.empty
     }
@@ -224,8 +225,10 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         """
         executer.withBuildCacheEnabled()
         succeeds("customTask", "--info")
+
         then:
-        result.assertOutputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, removeUnusedEntriesAfter = 7 days).")
+        outputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, removeUnusedEntriesAfter = 7 days).")
+
         and:
         localBuildCache.empty
     }

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -34,7 +34,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         run 'tasks'
 
         then:
-        result.output.contains "init - Initializes a new Gradle build."
+        outputContains "init - Initializes a new Gradle build."
     }
 
     def "defaults to groovy build scripts"() {
@@ -83,7 +83,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
 
         then:
         result.assertTasksExecuted(":init")
-        result.output.contains("The build file '${existingDslFixture.buildFileName}' already exists. Skipping build initialization.")
+        outputContains("The build file '${existingDslFixture.buildFileName}' already exists. Skipping build initialization.")
 
         and:
         !targetDslFixture.settingsFile.exists()
@@ -107,7 +107,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
 
         then:
         result.assertTasksExecuted(":init")
-        result.output.contains("The settings file '${existingDslFixture.settingsFileName}' already exists. Skipping build initialization.")
+        outputContains("The settings file '${existingDslFixture.settingsFileName}' already exists. Skipping build initialization.")
 
         and:
         !targetDslFixture.buildFile.exists()
@@ -132,7 +132,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
 
         then:
         result.assertTasksExecuted(":init")
-        result.output.contains("The build file '${customBuildScript.name}' already exists. Skipping build initialization.")
+        outputContains("The build file '${customBuildScript.name}' already exists. Skipping build initialization.")
 
         and:
         !targetDslFixture.buildFile.exists()
@@ -161,7 +161,7 @@ include("child")
 
         then:
         result.assertTasksExecuted(":init")
-        result.output.contains("This Gradle project appears to be part of an existing multi-project Gradle build. Skipping build initialization.")
+        outputContains("This Gradle project appears to be part of an existing multi-project Gradle build. Skipping build initialization.")
 
         and:
         !targetDslFixture.buildFile.exists()
@@ -235,7 +235,7 @@ include("child")
         run('help', '--task', 'init')
 
         then:
-        result.output.contains("""Options
+        outputContains("""Options
      --dsl     Set alternative build script DSL to be used.
                Available values are:
                     groovy

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -323,7 +323,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         executer.expectDeprecationWarning()
         succeeds "checkstyleMain"
         then:
-        result.assertOutputContains("Adding 'config_loc' to checkstyle.configProperties has been deprecated and is scheduled to be removed in Gradle 5.0. Use checkstyle.configDir instead as this will behave better with up-to-date checks.")
+        outputContains("Adding 'config_loc' to checkstyle.configProperties has been deprecated and is scheduled to be removed in Gradle 5.0. Use checkstyle.configDir instead as this will behave better with up-to-date checks.")
         result.assertTaskExecuted(":checkstyleMain")
     }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -174,4 +174,11 @@ public class ${className} implements Plugin<Project> {
         }
 
     }
+
+    void outputContains(String string) {
+        // intentionally override outputContains, because this test may find messages
+        // which are after the build finished message
+        def output = result.output
+        assert output.contains(string.trim())
+    }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildCommandLineArgsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildCommandLineArgsIntegrationTest.groovy
@@ -159,7 +159,7 @@ includeBuild '../buildB'
 
     void skipped(String... taskNames) {
         for (String taskName : taskNames) {
-            result.assertOutputContains(taskName + " SKIPPED\n")
+            outputContains(taskName + " SKIPPED\n")
         }
     }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
@@ -76,7 +76,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         then:
         executed ":resolve"
         notExecuted ":buildB:jar"
-        result.assertOutputContains "[$buildBjar]"
+        outputContains "[$buildBjar]"
 
         configured("buildB") == 1
     }
@@ -90,7 +90,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
 
         then:
         executedInOrder ":buildB:jar", ":resolve"
-        result.assertOutputContains "[$buildBjar]"
+        outputContains "[$buildBjar]"
 
         configured("buildB") == 1
     }
@@ -106,7 +106,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         executedInOrder ":buildB:b1:jar", ":resolve"
         notExecuted ":buildB:jar"
 
-        result.assertOutputContains("[$buildBjar]")
+        outputContains("[$buildBjar]")
         assertResolved buildB.file('b1/build/libs/b1-1.0.jar')
 
         configured("buildB") == 1
@@ -122,7 +122,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         then:
         executed ":help"
         notExecuted ":buildB:jar"
-        result.assertOutputContains("[$buildBjar]")
+        outputContains("[$buildBjar]")
 
         configured("buildB") == 1
     }
@@ -139,7 +139,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         then:
         executedInOrder ":help"
         notExecuted ":buildB:jar"
-        result.assertOutputContains("[${publishedModuleB.artifactFile}]")
+        outputContains("[${publishedModuleB.artifactFile}]")
 
         configured("buildB") == 1
     }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -160,8 +160,8 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
 
         // buildStarted events should _not_ be logged, since the listeners are added too late
         // If they are logged, it's due to duplicate events fired.
-        assert !result.output.contains('gradle.buildStarted')
-        assert !result.output.contains('buildListener.buildStarted')
+        outputDoesNotContain('gradle.buildStarted')
+        outputDoesNotContain('buildListener.buildStarted')
     }
 
     void loggedOncePerBuild(message, def builds = [':', ':buildB', ':buildC']) {
@@ -175,16 +175,17 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     void logged(String message, int count = 1) {
-        assert result.output.contains(message)
+        outputContains(message)
         assert result.output.count(message) == count
     }
 
     void loggedAtLeast(String message, int count = 1) {
-        assert result.output.contains(message)
+        outputContains(message)
         assert result.output.count(message) >= count
     }
 
     protected void execute() {
         super.execute(buildA, ":resolveArtifacts", ["-I../gradle-user-home/init.gradle"])
     }
+
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -107,19 +107,19 @@ class CompositeContinuousBuildIntegrationTest extends Java7RequiringContinuousIn
         when:
         succeeds("run")
         then:
-        result.assertOutputContains("Hello World")
+        outputContains("Hello World")
 
         when:
         librarySource.text = librarySource.text.replace("Hello", "Goodbye")
         then:
         succeeds()
-        result.assertOutputContains("Goodbye World")
+        outputContains("Goodbye World")
 
         when:
         mainSource.text = mainSource.text.replace("World", "Friend")
         then:
         succeeds()
-        result.assertOutputContains("Goodbye Friend")
+        outputContains("Goodbye Friend")
     }
 
     def "will rebuild on change for plugin supplied by included build"() {
@@ -163,13 +163,13 @@ class CompositeContinuousBuildIntegrationTest extends Java7RequiringContinuousIn
         when:
         succeeds("tasks")
         then:
-        result.assertOutputContains("Hello World")
+        outputContains("Hello World")
 
         when:
         pluginSource.text = pluginSource.text.replace("Hello", "Goodbye")
         then:
         succeeds()
-        result.assertOutputContains("Goodbye World")
+        outputContains("Goodbye World")
     }
 
     def "will rebuild on change for build included into a multi-project build"() {
@@ -231,28 +231,28 @@ class CompositeContinuousBuildIntegrationTest extends Java7RequiringContinuousIn
         when:
         succeeds("run")
         then:
-        result.assertOutputContains("Hello First")
-        result.assertOutputContains("Hello Second")
+        outputContains("Hello First")
+        outputContains("Hello Second")
 
         when:
         librarySource.text = librarySource.text.replace("Hello", "Goodbye")
         then:
         succeeds()
-        result.assertOutputContains("Goodbye First")
-        result.assertOutputContains("Goodbye Second")
+        outputContains("Goodbye First")
+        outputContains("Goodbye Second")
 
         when:
         mainSourceSub1.text = mainSourceSub1.text.replace("First", '1st')
         then:
         succeeds()
-        result.assertOutputContains("Goodbye 1st")
-        result.assertOutputContains("Goodbye Second")
+        outputContains("Goodbye 1st")
+        outputContains("Goodbye Second")
 
         when:
         mainSourceSub2.text = mainSourceSub2.text.replace("Second", '2nd')
         then:
         succeeds()
-        result.assertOutputContains("Goodbye 1st")
-        result.assertOutputContains("Goodbye 2nd")
+        outputContains("Goodbye 1st")
+        outputContains("Goodbye 2nd")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AntBuilderLoggingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AntBuilderLoggingIntegrationTest.groovy
@@ -40,13 +40,13 @@ class AntBuilderLoggingIntegrationTest extends AbstractIntegrationSpec {
         succeeds("antTest")
 
         then:
-        result.assertOutputContains("[ant:echo] WARN message")
+        outputContains("[ant:echo] WARN message")
         result.assertHasErrorOutput("[ant:echo] ERROR message")
 
         and:
-        result.assertNotOutput("INFO message")
-        result.assertNotOutput("DEBUG message")
-        result.assertNotOutput("VERBOSE message")
+        outputDoesNotContain("INFO message")
+        outputDoesNotContain("DEBUG message")
+        outputDoesNotContain("VERBOSE message")
     }
 
     def "can increase verbosity of Ant logging" () {
@@ -58,13 +58,13 @@ class AntBuilderLoggingIntegrationTest extends AbstractIntegrationSpec {
         succeeds("antTest")
 
         then:
-        result.assertOutputContains("[ant:echo] INFO message")
-        result.assertOutputContains("[ant:echo] WARN message")
+        outputContains("[ant:echo] INFO message")
+        outputContains("[ant:echo] WARN message")
         result.assertHasErrorOutput("[ant:echo] ERROR message")
 
         and:
-        result.assertNotOutput("DEBUG message")
-        result.assertNotOutput("VERBOSE message")
+        outputDoesNotContain("DEBUG message")
+        outputDoesNotContain("VERBOSE message")
     }
 
     def "can decrease verbosity of Ant logging" () {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassPathIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassPathIntegrationTest.groovy
@@ -85,9 +85,9 @@ task foo {
 
         when:
         buildFile.text = buildFile.text.replaceAll('Original bar', 'New bar')
-        run 'foo'
+        succeeds 'foo'
 
         then:
-        !result.output.contains('Original bar')
+        outputDoesNotContain('Original bar')
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptExecutionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Test
 
+@SuppressWarnings("IntegrationTestFixtures")
 class BuildScriptExecutionIntegrationTest extends AbstractIntegrationTest {
 
     @Test

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
@@ -554,7 +554,7 @@ task print(type: MyTask) {
 
         expect:
         succeeds("print")
-        result.output.contains("transform(Class)")
+        outputContains("transform(Class)")
     }
 
     def failsWhenTryingToCallMethodWithClassValue() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ExternalScriptExecutionIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.Test
 
+@SuppressWarnings("IntegrationTestFixtures")
 class ExternalScriptExecutionIntegrationTest extends AbstractIntegrationTest {
     @Rule
     public final HttpServer server = new HttpServer()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
-import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 
@@ -93,10 +92,10 @@ try {
         buildFile << 'task doStuff'
 
         when:
-        ExecutionResult result = executer.usingInitScript(initScript).withTasks('doStuff').run()
+        result = executer.usingInitScript(initScript).withTasks('doStuff').run()
 
         then:
-        result.assertOutputContains('quiet message')
+        outputContains('quiet message')
         result.assertHasErrorOutput('error message')
     }
 
@@ -155,13 +154,13 @@ try {
         buildFile << 'task doStuff'
 
         when:
-        ExecutionResult result = executer.usingInitScript(initScript1).usingInitScript(initScript2).withTasks('doStuff').run()
+        result = executer.usingInitScript(initScript1).usingInitScript(initScript2).withTasks('doStuff').run()
 
         then:
         notThrown(Throwable)
 
         and:
-        result.output.contains("BuildClass not found as expected")
+        outputContains("BuildClass not found as expected")
     }
 
     @Requires([KOTLIN_SCRIPT])

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/SettingsScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/SettingsScriptExecutionIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Test
 
+@SuppressWarnings("IntegrationTestFixtures")
 class SettingsScriptExecutionIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void executesSettingsScriptWithCorrectEnvironment() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -24,9 +24,11 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
 
     def "displays info about local build cache configuration"() {
         buildFile << defineCacheableTask()
-        withBuildCache().run "cacheable", "--info"
+        withBuildCache()
+        succeeds "cacheable", "--info"
+
         expect:
-        result.assertOutputContains "Using local directory build cache for the root build (location = ${cacheDir}, removeUnusedEntriesAfter = 7 days)."
+        outputContains "Using local directory build cache for the root build (location = ${cacheDir}, removeUnusedEntriesAfter = 7 days)."
     }
 
     def "cache entry contains expected contents"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
@@ -65,17 +65,17 @@ task printSystemProp {
 }
 """
         when:
-        def result = run ':printSystemProp'
+        succeeds ':printSystemProp'
 
         then:
-        result.assertOutputContains('mySystemProp=properties file')
+        outputContains('mySystemProp=properties file')
 
         when:
         args '-DmySystemProp=commandline'
-        result = run ':printSystemProp'
+        succeeds ':printSystemProp'
 
         then:
-        result.assertOutputContains('mySystemProp=commandline')
+        outputContains('mySystemProp=commandline')
     }
 
     def "build property set on command line takes precedence over jvm args"() {
@@ -120,17 +120,17 @@ task printSystemProp {
 }
 """
         when:
-        def result = run ':printSystemProp'
+        succeeds ':printSystemProp'
 
         then:
-        result.assertOutputContains('mySystemProp=jvmarg')
+        outputContains('mySystemProp=jvmarg')
 
         when:
         args '-DmySystemProp=commandline'
-        result = run ':printSystemProp'
+        succeeds ':printSystemProp'
 
         then:
-        result.assertOutputContains('mySystemProp=commandline')
+        outputContains('mySystemProp=commandline')
     }
 
     def "can always change buildDir in properties file"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildScriptClasspathIntegrationSpec.groovy
@@ -67,7 +67,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
 
         then:
         succeeds("hello")
-        result.assertOutputContains("hello world")
+        outputContains("hello world")
 
         when:
         builder = artifactBuilder()
@@ -81,7 +81,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
 
         then:
         succeeds("hello")
-        result.assertOutputContains("hello again")
+        outputContains("hello again")
 
         where:
         deleteIfExists << [false, true] * 3
@@ -189,7 +189,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
 
         then:
         succeeds("hello")
-        result.assertOutputContains("hello world")
+        outputContains("hello world")
 
         when:
         builder = artifactBuilder()
@@ -200,7 +200,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
 
         then:
         succeeds("hello")
-        result.assertOutputContains("hello again")
+        outputContains("hello again")
     }
 
     void notInJarCache(String filename) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
@@ -50,10 +50,10 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
         """
 
         when:
-        run()
+        succeeds()
 
         then:
-        result.output.contains "Resolved at configuration time: [impl.jar, foo-1.0.jar]"
+        outputContains "Resolved at configuration time: [impl.jar, foo-1.0.jar]"
     }
 
     def "configuring project dependencies by map is validated"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -245,12 +245,12 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
 
         handle.releaseAll()
 
-        def result = build.waitForFinish()
+        result = build.waitForFinish()
 
         then:
-        result.assertOutputContains("Transforming test-1.3.jar to test-1.3.jar.txt")
-        result.assertOutputContains("Transforming a.jar to a.jar.txt")
-        result.assertOutputContains("Transforming b.jar to b.jar.txt")
+        outputContains("Transforming test-1.3.jar to test-1.3.jar.txt")
+        outputContains("Transforming a.jar to a.jar.txt")
+        outputContains("Transforming b.jar to b.jar.txt")
     }
 
     def "failures are collected from transformations applied parallel"() {

--- a/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginIntegrationTest.groovy
+++ b/subprojects/ide-play/src/integTest/groovy/org/gradle/play/plugins/ide/PlayIdeaPluginIntegrationTest.groovy
@@ -84,7 +84,7 @@ abstract class PlayIdeaPluginIntegrationTest extends PlayIdePluginIntegrationTes
         when:
         succeeds(ideTask)
         then:
-        result.output.contains("Validated Scala Version")
+        outputContains("Validated Scala Version")
 
         parseIml(moduleFile).dependencies.dependencies.any {
             if (it instanceof IdeaModuleFixture.ImlLibrary) {
@@ -121,7 +121,7 @@ abstract class PlayIdeaPluginIntegrationTest extends PlayIdePluginIntegrationTes
         when:
         succeeds(ideTask)
         then:
-        result.output.contains("Validated Java Version")
+        outputContains("Validated Java Version")
     }
 
     def "IDEA metadata contains correct dependencies for RUNTIME, COMPILE, TEST"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CommandLineIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CommandLineIntegrationTest.groovy
@@ -30,6 +30,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@SuppressWarnings('IntegrationTestFixtures')
 class CommandLineIntegrationTest extends AbstractIntegrationTest {
 
     @Rule

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -52,7 +52,7 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
         run 'build'
 
         then:
-        result.output.contains('it works!')
+        outputContains('it works!')
     }
 
     @LeaksFileHandles
@@ -82,7 +82,7 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
         run 'hello'
 
         then:
-        result.output.contains("Hello!")
+        outputContains("Hello!")
 
         when:
         server.stop()
@@ -90,7 +90,7 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         succeeds 'hello'
-        result.output.contains("Hello!")
+        outputContains("Hello!")
 
         cleanup: // wait for all daemons to shutdown so the test dir can be deleted
         executer.cleanup()
@@ -117,10 +117,10 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """apply { from("http://localhost:${server.port}/script.gradle.kts") }"""
 
         when:
-        run 'hello'
+        succeeds 'hello'
 
         then:
-        result.output.contains("Hello!")
+        outputContains("Hello!")
 
         when:
         server.stop()
@@ -128,7 +128,7 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         succeeds 'hello'
-        result.output.contains("Hello!")
+        outputContains("Hello!")
 
         cleanup: // wait for all daemons to shutdown so the test dir can be deleted
         executer.cleanup()
@@ -157,9 +157,9 @@ task("dumpKotlinBuildScriptModelClassPath") {
         """
 
         when:
-        run 'dumpKotlinBuildScriptModelClassPath'
+        succeeds 'dumpKotlinBuildScriptModelClassPath'
 
         then:
-        result.output.contains("gradle-kotlin-dsl!")
+        outputContains("gradle-kotlin-dsl!")
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Test
 
+@SuppressWarnings('IntegrationTestFixtures')
 class JavaProjectIntegrationTest extends AbstractIntegrationTest {
     @Test
     void compilationFailureBreaksBuild() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -149,14 +149,15 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        result = runWithMostRecentFinalRelease("myTask")
+        runWithMostRecentFinalRelease("myTask")
+
         then:
-        result.assertOutputContains("From plugin")
+        outputContains("From plugin")
 
         when:
         succeeds "myTask"
         then:
-        result.assertOutputContains("From plugin")
+        outputContains("From plugin")
     }
 
     // We register the output directory before task execution and would have deleted output files at the end of configuration.
@@ -624,7 +625,8 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private ExecutionResult runWithMostRecentFinalRelease(String... tasks) {
-        mostRecentReleaseExecuter.withTasks(tasks).run()
+        result = mostRecentReleaseExecuter.withTasks(tasks).run()
+        result
     }
 
     static String createProjectName(int projectNo) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import spock.lang.Unroll
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
+@SuppressWarnings('IntegrationTestFixtures')
 class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
     private static final String CUSTOM_TASK_WITH_CONSTRUCTOR_ARGS = """
         import javax.inject.Inject

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
@@ -28,17 +28,19 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
 
     def canRunTheApplicationUsingRunTask() {
         when:
-        def result = executer.inDirectory(sample.dir).withTasks('run').run()
+        executer.inDirectory(sample.dir)
+        succeeds('run')
 
         then:
-        result.output.contains('Greetings from the sample application.')
+        outputContains('Greetings from the sample application.')
     }
 
     @Unroll
     def canBuildAndRunTheInstalledApplication() {
         when:
         appendExecutableDir(executableDir)
-        executer.inDirectory(sample.dir).withTasks('installDist').run()
+        executer.inDirectory(sample.dir)
+        succeeds('installDist')
 
         then:
         def installDir = sample.dir.file('build/install/application')
@@ -54,7 +56,8 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
     def canBuildAndRunTheZippedDistribution() {
         when:
         appendExecutableDir(executableDir)
-        executer.inDirectory(sample.dir).withTasks('distZip').run()
+        executer.inDirectory(sample.dir)
+        succeeds('distZip')
 
         then:
         def distFile = sample.dir.file('build/distributions/application-1.0.2.zip')

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomPluginIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomPluginIntegrationTest.groovy
@@ -46,15 +46,17 @@ class SamplesCustomPluginIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(producerDir).withTasks('uploadArchives').run()
 
         when:
-        def result = executer.inDirectory(consumerDir).withTasks('greeting').run()
+        executer.inDirectory(consumerDir)
+        succeeds('greeting')
 
         then:
-        result.output.contains('howdy!')
+        outputContains('howdy!')
 
         when:
-        result = executer.inDirectory(consumerDir).withTasks('hello').run()
+        executer.inDirectory(consumerDir)
+        succeeds('hello')
 
         then:
-        result.output.contains('hello from GreetingTask')
+        outputContains('hello from GreetingTask')
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -373,6 +373,16 @@ class AbstractIntegrationSpec extends Specification {
         result.assertOutputContains(string.trim())
     }
 
+    void postBuildOutputContains(String string) {
+        assertHasResult()
+        result.assertHasPostBuildOutput(string.trim())
+    }
+
+    void outputDoesNotContain(String string) {
+        assertHasResult()
+        result.assertNotOutput(string.trim())
+    }
+
     static String jcenterRepository() {
         RepoScriptBlockUtil.jcenterRepository()
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -47,6 +47,7 @@ import static org.gradle.util.Matchers.normalizedLineSeparators
  * Plan is to bring features over as needed.
  */
 @CleanupTestDirectory
+@SuppressWarnings("IntegrationTestFixtures")
 class AbstractIntegrationSpec extends Specification {
 
     @Rule

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
@@ -129,7 +129,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         file('build/classes/java/main/TestAppHelper.class').exists()
-        result.output.contains(AnnotationProcessorPathFactory.COMPILE_CLASSPATH_DEPRECATION_MESSAGE)
+        outputContains(AnnotationProcessorPathFactory.COMPILE_CLASSPATH_DEPRECATION_MESSAGE)
     }
 
     def "empty processor path overrides processors in the compile classpath, and no deprecation warning is emitted"() {
@@ -233,7 +233,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         file('build/classes/java/main/TestAppHelper.class').exists()
-        result.output.contains(AnnotationProcessorPathFactory.PROCESSOR_PATH_DEPRECATION_MESSAGE)
+        outputContains(AnnotationProcessorPathFactory.PROCESSOR_PATH_DEPRECATION_MESSAGE)
     }
 
     def "explicit -processor option overrides automatic detection"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -746,7 +746,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         noExceptionThrown()
-        result.output.contains("You specified both --module-source-path and a sourcepath. These options are mutually exclusive. Removing sourcepath.")
+        outputContains("You specified both --module-source-path and a sourcepath. These options are mutually exclusive. Removing sourcepath.")
         file("build/classes/java/main/example/module-info.class").exists()
         file("build/classes/java/main/example/io/example/Example.class").exists()
         file("build/classes/java/main/another/module-info.class").exists()
@@ -775,7 +775,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file('build/classes/java/main/Square.class').exists()
         file('build/classes/java/main/Rectangle.class').exists()
         file('build/classes/java/main/Shape.class').exists()
-        result.output.contains("Specifying the source path in the CompilerOptions compilerArgs property has been deprecated")
+        outputContains("Specifying the source path in the CompilerOptions compilerArgs property has been deprecated")
     }
 
     def "sourcepath is respected even when exclusively specified from compilerArgs, but deprecation warning is emitted"() {
@@ -797,7 +797,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file('build/classes/java/main/Square.class').exists()
         file('build/classes/java/main/Rectangle.class').exists()
         file('build/classes/java/main/Shape.class').exists()
-        result.output.contains("Specifying the source path in the CompilerOptions compilerArgs property has been deprecated")
+        outputContains("Specifying the source path in the CompilerOptions compilerArgs property has been deprecated")
     }
 
     @Requires(adhoc = { AvailableJavaHomes.getJdk7() && AvailableJavaHomes.getJdk8() })

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -277,7 +277,7 @@ Joe!""")
         writeSourceFile()
         expect:
         succeeds("javadoc", "--info")
-        result.assertOutputContains("-J-Dpublic.api=com.sample.tools.VisibilityPublic")
+        outputContains("-J-Dpublic.api=com.sample.tools.VisibilityPublic")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2235")

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaLanguageIncrementalBuildIntegrationTest.groovy
@@ -93,7 +93,7 @@ class JavaLanguageIncrementalBuildIntegrationTest extends AbstractJvmLanguageInc
         succeeds mainCompileTaskName
 
         then:
-        result.output.contains "None of the classes needs to be compiled!"
-        result.output.contains "${mainCompileTaskName} UP-TO-DATE"
+        outputContains "None of the classes needs to be compiled!"
+        outputContains "${mainCompileTaskName} UP-TO-DATE"
     }
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalCompileIntegrationTest.groovy
@@ -219,7 +219,7 @@ model {
         executedAndNotSkipped compileTask
         and:
         outputs.recompiledFile sourceFile
-        result.assertOutputContains("NEW directory named header")
+        outputContains("NEW directory named header")
 
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
@@ -50,17 +50,17 @@ ${readReleaseFeatures()}
         !markerFile.exists()
 
         when:
-        def result = executer.run()
+        succeeds()
 
         then:
-        result.output.contains(welcomeMessage)
+        outputContains(welcomeMessage)
         markerFile.exists()
 
         when:
-        result = executer.run()
+        succeeds()
 
         then:
-        !result.output.contains(welcomeMessage)
+        outputDoesNotContain(welcomeMessage)
         markerFile.exists()
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
@@ -42,7 +42,7 @@ class BuildSrcContinuousIntegrationTest extends Java7RequiringContinuousIntegrat
 
         then:
         succeeds("a")
-        output.contains "value: original"
+        outputContains "value: original"
 
         when:
         file("buildSrc/src/main/groovy/Thing.groovy").text = """
@@ -53,7 +53,7 @@ class BuildSrcContinuousIntegrationTest extends Java7RequiringContinuousIntegrat
 
         then:
         succeeds()
-        output.contains "value: changed"
+        outputContains "value: changed"
     }
 
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonOutputToggleIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonOutputToggleIntegrationTest.groovy
@@ -24,20 +24,19 @@ class DaemonOutputToggleIntegrationTest extends DaemonIntegrationSpec {
     def "output is received when toggle is off"() {
         when:
         executer.noExtraLogging()
-        run "help"
+        succeeds "help"
 
         then:
-        result.output.contains(":help")
-        result.output.contains("BUILD SUCCESSFUL")
+        outputContains(":help")
     }
 
     def "output is not received when toggle is on"() {
         when:
         executer.withBuildJvmOpts("-D$LogToClient.DISABLE_OUTPUT=true").noExtraLogging()
-        run "help"
+        succeeds "help"
 
         then:
-        !result.output.contains(":help")
-        !result.output.contains("BUILD SUCCESSFUL")
+        outputDoesNotContain(":help")
+        outputDoesNotContain("BUILD SUCCESSFUL")
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
@@ -85,7 +85,7 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
     }
 
     void ranWithLocale(Locale locale) {
-        assert result.output.contains("defaultLocale: " + locale)
+        outputContains("defaultLocale: " + locale)
     }
 
     void runWithLocale(Locale locale) {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -81,7 +81,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
 
         then:
         wasForked()
-        output.contains("javaHome=${javaHome}")
+        outputContains("javaHome=${javaHome}")
         daemons.daemon.stops()
     }
 
@@ -148,7 +148,7 @@ assert System.getProperty('some-prop') == 'some-value'
         run "encoding", "-Dfile.encoding=$encoding"
 
         then:
-        output.contains "encoding = $encoding"
+        outputContains "encoding = $encoding"
 
         and:
         wasNotForked()
@@ -162,7 +162,7 @@ assert System.getProperty('some-prop') == 'some-value'
         succeeds()
 
         then:
-        !output.contains(DaemonStartupMessage.STARTING_DAEMON_MESSAGE)
+        outputDoesNotContain(DaemonStartupMessage.STARTING_DAEMON_MESSAGE)
         wasForked()
         daemons.daemon.stops()
     }
@@ -176,12 +176,12 @@ assert System.getProperty('some-prop') == 'some-value'
     }
 
     private void wasForked() {
-        assert result.output.contains(SingleUseDaemonClient.MESSAGE)
+        outputContains(SingleUseDaemonClient.MESSAGE)
         assert daemons.daemons.size() == 1
     }
 
     private void wasNotForked() {
-        assert !result.output.contains(SingleUseDaemonClient.MESSAGE)
+        outputDoesNotContain(SingleUseDaemonClient.MESSAGE)
         assert daemons.daemons.size() == 0
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -160,7 +160,7 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
 
         then:
         executedTasks.contains(':capture')
-        result.output.contains(SingleUseDaemonClient.MESSAGE)
+        outputContains(SingleUseDaemonClient.MESSAGE)
 
         and:
         daemons.daemon.stops()

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenSettingsPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenSettingsPublishIntegrationTest.groovy
@@ -62,6 +62,6 @@ class MavenSettingsPublishIntegrationTest extends AbstractIntegrationSpec {
         when:
         run("uploadArchives")
         then:
-        !result.output.contains("Uploading: group/root/1.0/root-1.0.jar to repository ACME at http://acme.maven.org/maven2")
+        outputDoesNotContain("Uploading: group/root/1.0/root-1.0.jar to repository ACME at http://acme.maven.org/maven2")
     }
 }

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
@@ -63,7 +63,7 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains("value = 12")
+        outputContains("value = 12")
     }
 
     def "nested configure rule is executed only as required"() {
@@ -95,7 +95,7 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains("value = 12")
+        outputContains("value = 12")
     }
 
     def "nested create rule can reference sibling as input"() {
@@ -127,10 +127,10 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains('''configure main
+        outputContains('''configure main
 configure test
 ''')
-        result.output.contains("value = 12")
+        outputContains("value = 12")
     }
 
     def "nested create rule defined using ModelMap API methods can reference sibling as input"() {
@@ -162,10 +162,10 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains('''configure main
+        outputContains('''configure main
 configure test
 ''')
-        result.output.contains("value = 12")
+        outputContains("value = 12")
     }
 
     def "nested configure rule can reference sibling as input"() {
@@ -198,10 +198,10 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains('''configure main
+        outputContains('''configure main
 configure test
 ''')
-        result.output.contains("value = 12")
+        outputContains("value = 12")
     }
 
     def "nested configure rule defined using ModelMap API methods can reference sibling as input"() {
@@ -234,10 +234,10 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains('''configure main
+        outputContains('''configure main
 configure test
 ''')
-        result.output.contains("value = 12")
+        outputContains("value = 12")
     }
 
     def "nested rule cannot reference method of delegate of outer closure"() {
@@ -320,7 +320,7 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains("value = [[a:foo], [b:foo], [c:foo], foo]")
+        outputContains("value = [[a:foo], [b:foo], [c:foo], foo]")
     }
 
     def "can create and configure elements conditionally"() {
@@ -354,7 +354,7 @@ model {
         succeeds "show"
 
         then:
-        result.output.contains("value = [foo, [test:foo]]")
+        outputContains("value = [foo, [test:foo]]")
     }
 
     def "reports nested rule location for failure in initialization action"() {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleInputDetectionIntegrationSpec.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleInputDetectionIntegrationSpec.groovy
@@ -165,7 +165,7 @@ class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec 
 
         then:
         succeeds "tasks"
-        result.output.contains '''thing configured
+        outputContains '''thing configured
 tasks configured
 '''
 
@@ -229,7 +229,7 @@ tasks configured
 
         then:
         succeeds "echo"
-        output.contains "values: [true, false, false]"
+        outputContains "values: [true, false, false]"
     }
 
     @Unroll
@@ -370,7 +370,7 @@ tasks configured
 
         then:
         succeeds "printMessage"
-        output.contains("message: [foo]")
+        outputContains("message: [foo]")
 
         where:
         code << [

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -36,9 +36,9 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         run "dependentComponents"
 
         then:
-        output.contains simpleCppUtilDependents()
-        output.contains simpleCppLibDependents()
-        output.contains simpleCppMainDependents()
+        outputContains simpleCppUtilDependents()
+        outputContains simpleCppLibDependents()
+        outputContains simpleCppMainDependents()
     }
 
     @Unroll
@@ -491,7 +491,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         succeeds("dependentComponents")
 
         then:
-        result.output.contains """
+        outputContains """
             ------------------------------------------------------------
             Root project
             ------------------------------------------------------------

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -137,10 +137,10 @@ class CustomWindowsStartScriptGenerator implements ScriptGenerator {
         file('build/install/sample').exists()
 
         when:
-        ExecutionResult result = runViaUnixStartScript()
+        runViaUnixStartScript()
 
         then:
-        result.output.contains('Hello World!')
+        outputContains('Hello World!')
     }
 
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
@@ -156,10 +156,10 @@ class CustomWindowsStartScriptGenerator implements ScriptGenerator {
         file('build/install/sample').exists()
 
         when:
-        ExecutionResult result = runViaUnixStartScriptWithJavaHome(testJavaHome.absolutePath)
+        runViaUnixStartScriptWithJavaHome(testJavaHome.absolutePath)
 
         then:
-        result.output.contains('Hello World!')
+        outputContains('Hello World!')
 
         cleanup:
         testJavaHome.usingNativeTools().deleteDir() //remove symlink
@@ -193,10 +193,10 @@ $binFile.text
         file('build/install/sample').exists()
 
         when:
-        ExecutionResult result = runViaWindowsStartScript()
+        runViaWindowsStartScript()
 
         then:
-        result.output.contains('Hello World!')
+        outputContains('Hello World!')
     }
 
     ExecutionResult runViaUnixStartScript() {
@@ -462,10 +462,10 @@ startScripts {
         when:
         succeeds('installDist')
         and:
-        ExecutionResult result = runViaStartScript()
+        runViaStartScript()
 
         then:
-        result.assertOutputContains("App Home: ${file('build/install/sample').absolutePath}")
+        outputContains("App Home: ${file('build/install/sample').absolutePath}")
     }
 
     ExecutionResult runViaStartScript() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
@@ -45,10 +45,10 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("bash")
+        runViaUnixStartScript("bash")
 
         then:
-        result.output.contains('Hello World!')
+        outputContains('Hello World!')
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
@@ -57,10 +57,10 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("dash")
+        runViaUnixStartScript("dash")
 
         then:
-        result.output.contains('Hello World!')
+        outputContains('Hello World!')
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
@@ -69,10 +69,10 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("static-sh")
+        runViaUnixStartScript("static-sh")
 
         then:
-        result.output.contains('Hello World!')
+        outputContains('Hello World!')
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("bash") })
@@ -82,10 +82,10 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("bash")
+        runViaUnixStartScript("bash")
 
         then:
-        result.assertOutputContains("App Home: ${file('build/install/sample').absolutePath}")
+        outputContains("App Home: ${file('build/install/sample').absolutePath}")
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
@@ -95,10 +95,10 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("dash")
+        runViaUnixStartScript("dash")
 
         then:
-        result.assertOutputContains("App Home: ${file('build/install/sample').absolutePath}")
+        outputContains("App Home: ${file('build/install/sample').absolutePath}")
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
@@ -108,10 +108,10 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("static-sh")
+        runViaUnixStartScript("static-sh")
 
         then:
-        result.assertOutputContains("App Home: ${file('build/install/sample').absolutePath}")
+        outputContains("App Home: ${file('build/install/sample').absolutePath}")
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("bash") })
@@ -120,13 +120,13 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("bash", "someArg1", "someArg1", "some arg 2", "-DFOO=\\\"bar < baz\\\"", "-DGOO='car < caz'")
+        runViaUnixStartScript("bash", "someArg1", "someArg1", "some arg 2", "-DFOO=\\\"bar < baz\\\"", "-DGOO='car < caz'")
 
         then:
-        result.output.contains('Arg: someArg1')
-        result.output.contains('Arg: some arg 2')
-        result.output.contains('Arg: -DFOO="bar < baz"')
-        result.output.contains('Arg: -DGOO=\'car < caz\'')
+        outputContains('Arg: someArg1')
+        outputContains('Arg: some arg 2')
+        outputContains('Arg: -DFOO="bar < baz"')
+        outputContains('Arg: -DGOO=\'car < caz\'')
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("dash") })
@@ -135,13 +135,13 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("dash", "someArg1", "some arg 2", "-DFOO=\\\"bar < baz\\\"", "-DGOO='car < caz'")
+        runViaUnixStartScript("dash", "someArg1", "some arg 2", "-DFOO=\\\"bar < baz\\\"", "-DGOO='car < caz'")
 
         then:
-        result.output.contains('Arg: someArg1')
-        result.output.contains('Arg: some arg 2')
-        result.output.contains('Arg: -DFOO="bar < baz"')
-        result.output.contains('Arg: -DGOO=\'car < caz\'')
+        outputContains('Arg: someArg1')
+        outputContains('Arg: some arg 2')
+        outputContains('Arg: -DFOO="bar < baz"')
+        outputContains('Arg: -DGOO=\'car < caz\'')
     }
 
     @Requires(adhoc = { ApplicationPluginUnixShellsIntegrationTest.shellAvailable("static-sh") })
@@ -150,13 +150,13 @@ class ApplicationPluginUnixShellsIntegrationTest extends AbstractIntegrationSpec
         succeeds('installDist')
 
         when:
-        ExecutionResult result = runViaUnixStartScript("static-sh", "someArg1", "some arg 2", "-DFOO=\\\"bar < baz\\\"", "-DGOO='car < caz'")
+        runViaUnixStartScript("static-sh", "someArg1", "some arg 2", "-DFOO=\\\"bar < baz\\\"", "-DGOO='car < caz'")
 
         then:
-        result.output.contains('Arg: someArg1')
-        result.output.contains('Arg: some arg 2')
-        result.output.contains('Arg: -DFOO="bar < baz"')
-        result.output.contains('Arg: -DGOO=\'car < caz\'')
+        outputContains('Arg: someArg1')
+        outputContains('Arg: some arg 2')
+        outputContains('Arg: -DFOO="bar < baz"')
+        outputContains('Arg: -DGOO=\'car < caz\'')
     }
 
     ExecutionResult runViaUnixStartScript(String shCommand, String... args) {
@@ -170,7 +170,7 @@ task execStartScript(type: Exec) {
     args "${args.join('", "')}"
 }
 """
-        return executer.withTasks('execStartScript').run()
+        return succeeds('execStartScript')
     }
 
     private String setUpTestPATH(String shCommand) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
@@ -136,7 +136,7 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         when:
         succeeds("myTaskMyPlugin")
         then:
-        result.assertOutputContains("From MyPlugin")
+        outputContains("From MyPlugin")
     }
 
     def "build uses jars from multi-project buildSrc"() {
@@ -167,8 +167,8 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         when:
         succeeds("myTaskMyPlugin", "myTaskMyPluginSub")
         then:
-        result.assertOutputContains("From MyPlugin")
-        result.assertOutputContains("From MyPluginSub")
+        outputContains("From MyPlugin")
+        outputContains("From MyPluginSub")
     }
 
     private void writeBuildSrcPlugin(String location, String className) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -60,7 +60,7 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
         then:
         file("build/classes/java/main").assertDoesNotExist()
         file("build/classes/main/Main.class").assertExists()
-        result.assertOutputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
+        outputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
     }
 
     def "emits deprecation message if something uses classesDir"() {
@@ -74,6 +74,6 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDeprecationWarning()
         succeeds("help")
         then:
-        result.assertOutputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
+        outputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -71,15 +71,15 @@ project(':consumer') {
 
     def "provides runtime JAR as default variant"() {
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -89,15 +89,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -109,15 +109,15 @@ project(':consumer') {
 """
 
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -127,15 +127,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
 
         where:
         usage                                          | _
@@ -151,15 +151,15 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -169,15 +169,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -193,14 +193,14 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -211,15 +211,15 @@ project(':consumer') {
 """
 
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -229,15 +229,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -248,15 +248,15 @@ project(':consumer') {
 """
 
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
-        result.assertOutputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -266,14 +266,14 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
-        result.assertOutputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -73,15 +73,15 @@ project(':consumer') {
 
     def "provides runtime JAR as default variant"() {
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -91,15 +91,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -110,15 +110,15 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
+        outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
 
         when:
         buildFile << """
@@ -128,15 +128,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
+        outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
 
         where:
         usage                                          | _
@@ -152,15 +152,15 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -170,15 +170,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -194,14 +194,14 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -212,15 +212,15 @@ project(':consumer') {
 """
 
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -230,15 +230,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -249,15 +249,15 @@ project(':consumer') {
 """
 
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
-        result.assertOutputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -267,14 +267,14 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
-        result.assertOutputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -71,15 +71,15 @@ project(':consumer') {
 
     def "provides runtime JAR as default variant"() {
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -89,15 +89,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -108,15 +108,15 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -126,15 +126,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
 
         where:
         usage                                          | _
@@ -150,15 +150,15 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -168,15 +168,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -192,14 +192,14 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
-        result.assertOutputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -209,15 +209,15 @@ project(':consumer') {
             }
 """
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -227,15 +227,15 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
-        result.assertOutputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -246,15 +246,15 @@ project(':consumer') {
 """
 
         when:
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
-        result.assertOutputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -264,14 +264,14 @@ project(':consumer') {
             }
 """
 
-        run "resolve"
+        succeeds "resolve"
 
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
-        result.assertOutputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        result.assertOutputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        result.assertOutputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
-        result.assertOutputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.usage=java-runtime-resources}")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CachedJavaCompileIntegrationTest.groovy
@@ -41,7 +41,7 @@ class CachedJavaCompileIntegrationTest extends AbstractCachedCompileIntegrationT
             }
         """.stripIndent()
 
-        file('src/main/java/Hello.java') << """
+            file('src/main/java/Hello.java') << """
             public class Hello {
                 public static void main(String... args) {
                     System.out.println("Hello!");
@@ -71,14 +71,15 @@ class CachedJavaCompileIntegrationTest extends AbstractCachedCompileIntegrationT
         succeeds appCompileJava
 
         then:
-        result.output.contains  "None of the classes needs to be compiled!"
-        result.output.contains "${appCompileJava} UP-TO-DATE"
+        outputContains "None of the classes needs to be compiled!"
+        outputContains "${appCompileJava} UP-TO-DATE"
         executedAndNotSkipped libraryCompileJava
 
         when:
-        withBuildCache().run 'clean', appCompileJava
+        withBuildCache()
+        succeeds 'clean', appCompileJava
 
         then:
-        result.output.contains "${appCompileJava} FROM-CACHE"
+        outputContains "${appCompileJava} FROM-CACHE"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/IncrementalJavaCompileIntegrationTest.groovy
@@ -119,8 +119,8 @@ class IncrementalJavaCompileIntegrationTest extends AbstractIntegrationSpec impl
         succeeds appCompileJava
 
         and:
-        result.output.contains "None of the classes needs to be compiled!"
-        result.output.contains "${appCompileJava} UP-TO-DATE"
+        outputContains "None of the classes needs to be compiled!"
+        outputContains "${appCompileJava} UP-TO-DATE"
         executedAndNotSkipped(libraryCompileJava)
     }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -25,6 +25,7 @@ import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.util.TextUtil.normaliseLineSeparators
 
+@SuppressWarnings('IntegrationTestFixtures')
 class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
     /*

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.testkit.runner.fixtures.NoDebug
 import org.gradle.tooling.GradleConnectionException
 import org.gradle.util.GradleVersion
 
+@SuppressWarnings('IntegrationTestFixtures')
 class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
     def "treats invalid argument as build failure and throws if not expected"() {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.containsString
 @InjectsPluginClasspath
 @InspectsBuildOutput
 @UsesNativeServices
+@SuppressWarnings('IntegrationTestFixtures')
 class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
     def plugin = new PluginUnderTest(1, file("plugin"))

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
@@ -105,22 +105,22 @@ public class BarTest {
         """
 
         when:
-        def result = executer.withTasks("test", "-Dtest.single=Foo").run()
+        succeeds("test", "-Dtest.single=Foo")
 
         then:
         //asserting on output because test results are kept in between invocations
-        !result.output.contains("executed Test test(BarTest)")
-        result.output.contains("executed Test test(FooTest)")
+        outputDoesNotContain("executed Test test(BarTest)")
+        outputContains("executed Test test(FooTest)")
 
         when:
-        result = executer.withTasks("test", "-Dtest.single=Bar").run()
+        succeeds("test", "-Dtest.single=Bar")
 
         then:
-        result.output.contains("executed Test test(BarTest)")
-        !result.output.contains("executed Test test(FooTest)")
+        outputContains("executed Test test(BarTest)")
+        outputDoesNotContain("executed Test test(FooTest)")
 
         when:
-        result = executer.withTasks("test", "-Dtest.single=Bar").run()
+        succeeds("test", "-Dtest.single=Bar")
 
         then:
         result.assertTaskSkipped(":test")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
@@ -133,11 +133,11 @@ class VerboseOutputListener implements TestOutputListener {
 """
 
         when:
-        def result = executer.withTasks('test').run()
+        succeeds('test')
 
         then:
-        result.output.contains('first: message from foo')
-        result.output.contains('second: message from foo')
+        outputContains('first: message from foo')
+        outputContains('second: message from foo')
     }
 
     @Test
@@ -165,10 +165,11 @@ test.testLogging {
 """
 
         when:
-        def result = executer.withTasks('test').withArguments('-i').run()
+        executer.withArgument('-i')
+        succeeds('test')
 
         then:
-        result.output.contains('message from foo')
+        outputContains('message from foo')
     }
 
     @Test
@@ -200,14 +201,17 @@ test {
 }
 """
         when: "run with quiet"
-        def result = executer.withArguments("-q").withTasks('test'). run()
+        executer.withArguments("-q")
+        succeeds('test')
+
         then:
-        !result.output.contains('output from foo')
+        outputDoesNotContain('output from foo')
 
         when: "run with lifecycle"
-        result = executer.noExtraLogging().withTasks('cleanTest', 'test').run()
+        executer.noExtraLogging()
+        succeeds('cleanTest', 'test')
 
         then:
-        result.output.contains('output from foo')
+        outputContains('output from foo')
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -233,7 +233,7 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         executer.expectDeprecationWarning()
         succeeds("test")
         then:
-        result.assertOutputContains("The setTestClassesDir(File) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the setTestClassesDirs(FileCollection) method instead.")
+        outputContains("The setTestClassesDir(File) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the setTestClassesDirs(FileCollection) method instead.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3627")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -90,10 +90,11 @@ public class OkTest {
     }
 }
 """
-        when: run "test"
+        when:
+        succeeds "test"
 
         then:
-        result.output.contains """Test class OkTest -> class loaded
+        outputContains """Test class OkTest -> class loaded
 Test class OkTest -> before class out
 Test class OkTest -> before class err
 Test class OkTest -> test constructed
@@ -180,12 +181,12 @@ dependencies { testCompile "org.slf4j:slf4j-simple:1.7.10", "org.slf4j:slf4j-api
             }
         """
 
-        when: run("test")
+        when: succeeds("test")
 
         then:
-        result.output.contains("Test foo(FooTest) -> [Test worker] INFO FooTest - slf4j info")
-        result.output.contains("Test foo(FooTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: jul info")
-        result.output.contains("Test foo(FooTest) -> ${java.util.logging.Level.WARNING.getLocalizedName()}: jul warning")
+        outputContains("Test foo(FooTest) -> [Test worker] INFO FooTest - slf4j info")
+        outputContains("Test foo(FooTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: jul info")
+        outputContains("Test foo(FooTest) -> ${java.util.logging.Level.WARNING.getLocalizedName()}: jul warning")
 
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)
         def classResult = testResult.testClass("FooTest")
@@ -226,16 +227,16 @@ public class OkTest {
 """
 
         when:
-        run("test")
+        succeeds("test")
 
         then:
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)
         def classResult = testResult.testClass("OkTest")
 
         5.times { n ->
-            assert result.output.contains("Test ok(OkTest) -> stdout from thread $n")
-            assert result.output.contains("Test ok(OkTest) -> stderr from thread $n")
-            assert result.output.contains("Test ok(OkTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: info from thread $n")
+            outputContains("Test ok(OkTest) -> stdout from thread $n")
+            outputContains("Test ok(OkTest) -> stderr from thread $n")
+            outputContains("Test ok(OkTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: info from thread $n")
 
             classResult.assertTestCaseStdout("ok", containsString("stdout from thread $n"))
             classResult.assertTestCaseStderr("ok", containsString("stderr from thread $n"))

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
@@ -84,16 +84,16 @@ public class TestNGGroupByInstancesIntegrationTest extends MultiVersionIntegrati
             }
         """
 
-        when: run "test"
+        when: succeeds "test"
 
         then:
-        result.output.contains("""
+        outputContains("""
 TestFactory[data1].beforeClass()
 TestFactory[data1].test1()
 TestFactory[data1].test2()
 TestFactory[data1].afterClass()
 """)
-        result.output.contains("""
+        outputContains("""
 TestFactory[data2].beforeClass()
 TestFactory[data2].test1()
 TestFactory[data2].test2()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -112,25 +112,25 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         '''.stripIndent()
 
         when:
-        def result = succeeds 'test'
+        succeeds 'test'
 
         then:
-        result.output.contains "START [Gradle Test Run :test] [Gradle Test Run :test]\n"
-        result.output.contains "FINISH [Gradle Test Run :test] [Gradle Test Run :test]\n"
+        outputContains "START [Gradle Test Run :test] [Gradle Test Run :test]\n"
+        outputContains "FINISH [Gradle Test Run :test] [Gradle Test Run :test]\n"
         result.output.readLines().find { it.matches "START \\[Gradle Test Executor \\d+] \\[Gradle Test Executor \\d+]" }
         result.output.readLines().find { it.matches "FINISH \\[Gradle Test Executor \\d+] \\[Gradle Test Executor \\d+]" }
-        result.output.contains "START [Test suite 'Gradle suite'] [Gradle suite]\n"
-        result.output.contains "FINISH [Test suite 'Gradle suite'] [Gradle suite]\n"
-        result.output.contains "START [Test suite 'Gradle test'] [Gradle test]\n"
-        result.output.contains "FINISH [Test suite 'Gradle test'] [Gradle test]\n"
-        result.output.contains "START [Test method pass(SomeTest)] [pass]\n"
-        result.output.contains "FINISH [Test method pass(SomeTest)] [pass] [null]\n"
-        result.output.contains "START [Test method fail(SomeTest)] [fail]\n"
-        result.output.contains "FINISH [Test method fail(SomeTest)] [fail] [java.lang.AssertionError]\n"
-        result.output.contains "START [Test method knownError(SomeTest)] [knownError]\n"
-        result.output.contains "FINISH [Test method knownError(SomeTest)] [knownError] [java.lang.RuntimeException: message]\n"
-        result.output.contains "START [Test method unknownError(SomeTest)] [unknownError]\n"
-        result.output.contains "FINISH [Test method unknownError(SomeTest)] [unknownError] [AppException]\n"
+        outputContains "START [Test suite 'Gradle suite'] [Gradle suite]\n"
+        outputContains "FINISH [Test suite 'Gradle suite'] [Gradle suite]\n"
+        outputContains "START [Test suite 'Gradle test'] [Gradle test]\n"
+        outputContains "FINISH [Test suite 'Gradle test'] [Gradle test]\n"
+        outputContains "START [Test method pass(SomeTest)] [pass]\n"
+        outputContains "FINISH [Test method pass(SomeTest)] [pass] [null]\n"
+        outputContains "START [Test method fail(SomeTest)] [fail]\n"
+        outputContains "FINISH [Test method fail(SomeTest)] [fail] [java.lang.AssertionError]\n"
+        outputContains "START [Test method knownError(SomeTest)] [knownError]\n"
+        outputContains "FINISH [Test method knownError(SomeTest)] [knownError] [java.lang.RuntimeException: message]\n"
+        outputContains "START [Test method unknownError(SomeTest)] [unknownError]\n"
+        outputContains "FINISH [Test method unknownError(SomeTest)] [unknownError] [AppException]\n"
     }
 
     @Issue("GRADLE-1532")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -89,7 +89,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
   <test name='The Foo Test'><classes><class name='FooTest'/></classes></test>
 </suite>"""
 
-        when: run "test"
+        when: succeeds "test"
 
         then:
         containsLinesThatMatch(result.output,
@@ -99,7 +99,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
             "Gradle Test Executor \\d+ -> constructor err"
         )
 
-        result.output.contains expectedOutput('The Foo Test')
+        outputContains expectedOutput('The Foo Test')
 
         /**
          * This test documents the current behavior. It's not right, we're missing a lot of output in the report.
@@ -116,7 +116,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
     }
 
     def "attaches output events to correct test descriptors"() {
-        when: run "test"
+        when: succeeds "test"
 
         then:
         containsLinesThatMatch(result.output,
@@ -126,7 +126,7 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
             "Gradle Test Executor \\d+ -> constructor err"
         )
 
-        result.output.contains expectedOutput('Gradle test')
+        outputContains expectedOutput('Gradle test')
 
         def xmlReport = new JUnitXmlTestExecutionResult(testDirectory)
         def classResult = xmlReport.testClass("FooTest")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
@@ -98,16 +98,16 @@ public class TestNGPreserveOrderIntegrationTest extends MultiVersionIntegrationS
             }
         """
 
-        when: run "test"
+        when: succeeds "test"
 
         then:
-        result.output.contains("""
+        outputContains("""
 Test1.beforeClass()
 Test1.test1()
 Test1.test2()
 Test1.afterClass()
 """)
-        result.output.contains("""
+        outputContains("""
 Test2.beforeClass()
 Test2.test1()
 Test2.test2()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
@@ -55,12 +55,12 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        when: run("test")
+        when: succeeds("test")
 
         then:
-        result.output.contains("Test method foo(FooTest) -> [Test worker] INFO FooTest - slf4j info")
-        result.output.contains("Test method foo(FooTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: jul info")
-        result.output.contains("Test method foo(FooTest) -> ${java.util.logging.Level.WARNING.getLocalizedName()}: jul warning")
+        outputContains("Test method foo(FooTest) -> [Test worker] INFO FooTest - slf4j info")
+        outputContains("Test method foo(FooTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: jul info")
+        outputContains("Test method foo(FooTest) -> ${java.util.logging.Level.WARNING.getLocalizedName()}: jul warning")
 
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)
         def classResult = testResult.testClass("FooTest")
@@ -83,10 +83,10 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        when: run("test")
+        when: succeeds("test")
         then:
-        result.output.contains("Test method foo(FooTest) -> cool output from test")
-        result.output.contains("Test method foo(FooTest) -> err output from test")
+        outputContains("Test method foo(FooTest) -> cool output from test")
+        outputContains("Test method foo(FooTest) -> err output from test")
         result.output.readLines().find { it.matches "Gradle Test Executor \\d+ -> cool output from initializer" }
 
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)
@@ -127,16 +127,16 @@ public class OkTest {
 """
 
         when:
-        run("test")
+        succeeds("test")
 
         then:
         def testResult = new JUnitXmlTestExecutionResult(testDirectory)
         def classResult = testResult.testClass("OkTest")
 
         5.times { n ->
-            assert result.output.contains("Test method ok(OkTest) -> stdout from thread $n")
-            assert result.output.contains("Test method ok(OkTest) -> stderr from thread $n")
-            assert result.output.contains("Test method ok(OkTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: info from thread $n")
+            outputContains("Test method ok(OkTest) -> stdout from thread $n")
+            outputContains("Test method ok(OkTest) -> stderr from thread $n")
+            outputContains("Test method ok(OkTest) -> ${java.util.logging.Level.INFO.getLocalizedName()}: info from thread $n")
 
             classResult.assertTestCaseStdout("ok", containsString("stdout from thread $n"))
             classResult.assertTestCaseStderr("ok", containsString("stderr from thread $n"))

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/SamplesToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/SamplesToolingApiIntegrationTest.groovy
@@ -35,11 +35,11 @@ class SamplesToolingApiIntegrationTest extends AbstractIntegrationSpec {
         tweakProject()
 
         when:
-        def result = run()
+        run()
 
         then:
-        result.output.contains("gradle-tooling-api-")
-        result.output.contains("src/main/java")
+        outputContains("gradle-tooling-api-")
+        outputContains("src/main/java")
     }
 
     @UsesSample('toolingApi/runBuild')
@@ -47,10 +47,10 @@ class SamplesToolingApiIntegrationTest extends AbstractIntegrationSpec {
         tweakProject()
 
         when:
-        def result = run()
+        run()
 
         then:
-        result.output.contains("Welcome to Gradle")
+        outputContains("Welcome to Gradle")
     }
 
     @UsesSample('toolingApi/idea')
@@ -69,11 +69,11 @@ class SamplesToolingApiIntegrationTest extends AbstractIntegrationSpec {
         tweakProject()
 
         when:
-        def result = run()
+        run()
 
         then:
-        result.output.contains("Project: model")
-        result.output.contains("    build")
+        outputContains("Project: model")
+        outputContains("    build")
     }
 
     @UsesSample('toolingApi/customModel')
@@ -83,12 +83,12 @@ class SamplesToolingApiIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         run('publish', sample.dir.file('plugin'))
-        def result = run('run', sample.dir.file('tooling'))
+        run('run', sample.dir.file('tooling'))
 
         then:
-        result.output.contains("   :a")
-        result.output.contains("   :b")
-        result.output.contains("   :c")
+        outputContains("   :a")
+        outputContains("   :b")
+        outputContains("   :c")
         noExceptionThrown()
     }
 
@@ -135,11 +135,12 @@ repositories {
 
     private ExecutionResult run(String task = 'run', File dir = sample.dir) {
         try {
-            return new GradleContextualExecuter(distribution, temporaryFolder, getBuildContext())
+            result = new GradleContextualExecuter(distribution, temporaryFolder, getBuildContext())
                     .requireGradleDistribution()
                     .inDirectory(dir)
                     .withTasks(task)
                     .run()
+            return result
         } catch (Exception e) {
             throw new IntegrationTestHint(e);
         }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependenciesIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependenciesIntegrationTest.groovy
@@ -256,7 +256,7 @@ class SourceDependenciesIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.assertTasksExecutedInOrder(":second:generate", ":first:generate", ":resolve")
-        result.output.contains("Hello from root build's plugin")
+        outputContains("Hello from root build's plugin")
     }
 
     def "prefers a source mapping defined in the root build to one defined in a nested build when the nested build requests plugins"() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
@@ -73,18 +73,17 @@ class WorkerDaemonExpirationIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'expireWorkers'
 
         then:
-        result.output.contains 'Worker Daemon(s) expired to free some system memory'
+        outputContains 'Worker Daemon(s) expired to free some system memory'
     }
 
     def "worker daemons expiration can be disabled using a system property"() {
         when:
-        def result = withDebugLogging()
+        withDebugLogging()
             .withWorkerDaemonsExpirationDisabled()
-            .withTasks('expireWorkers')
-            .run()
+        succeeds('expireWorkers')
 
         then:
-        !result.output.contains('Worker Daemon(s) expired to free some system memory')
-        result.output.contains 'Worker Daemons expiration is disabled, skipping'
+        outputDoesNotContain('Worker Daemon(s) expired to free some system memory')
+        outputContains 'Worker Daemons expiration is disabled, skipping'
     }
 }

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.util.Requires
 import org.junit.Assume
 import spock.lang.Unroll
 
+@SuppressWarnings("IntegrationTestFixtures")
 class WrapperCrossVersionIntegrationTest extends CrossVersionIntegrationSpec {
     def setup() {
         requireOwnGradleUserHomeDir()

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -151,16 +151,16 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         server.expectGet("/gradlew/dist", "jdoe", "changeit", distribution.binDistribution)
 
         when:
-        def result = wrapperExecuter.withTasks('hello').run()
+        result = wrapperExecuter.withTasks('hello').run()
 
         then:
-        result.output.contains('hello')
+        outputContains('hello')
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
 
         then:
-        result.output.contains('hello')
+        outputContains('hello')
     }
 
     def "downloads wrapper from basic authenticated server using credentials from gradle.properties"() {
@@ -175,10 +175,10 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         server.expectGet("/gradlew/dist", "jdoe", "changeit", distribution.binDistribution)
 
         when:
-        def result = wrapperExecuter.withTasks('hello').run()
+        result = wrapperExecuter.withTasks('hello').run()
 
         then:
-        result.output.contains('hello')
+        outputContains('hello')
     }
 
     def "warns about using basic authentication over insecure connection"() {
@@ -187,10 +187,10 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         server.expectGet("/gradlew/dist", "jdoe", "changeit", distribution.binDistribution)
 
         when:
-        def result = wrapperExecuter.withTasks('hello').run()
+        result = wrapperExecuter.withTasks('hello').run()
 
         then:
-        result.output.contains('Please consider using HTTPS')
+        outputContains('Please consider using HTTPS')
     }
 
     def "does not warn about using basic authentication over secure connection"() {
@@ -207,10 +207,10 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         server.expectGet("/gradlew/dist", "jdoe", "changeit", distribution.binDistribution)
 
         when:
-        def result = wrapperExecuter.withTasks('hello').run()
+        result = wrapperExecuter.withTasks('hello').run()
 
         then:
-        !result.output.contains('WARNING Using HTTP Basic Authentication over an insecure connection to download the Gradle distribution. Please consider using HTTPS.')
+        outputDoesNotContain('WARNING Using HTTP Basic Authentication over an insecure connection to download the Gradle distribution. Please consider using HTTPS.')
     }
 
     def "does not leak basic authentication credentials in output"() {
@@ -256,10 +256,10 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         server.expectGet("/gradlew/dist", "jdoe", "changeit", distribution.binDistribution)
 
         when:
-        def result = wrapperExecuter.withTasks('hello').run()
+        result = wrapperExecuter.withTasks('hello').run()
 
         then:
-        result.output.contains('hello')
+        outputContains('hello')
 
         and:
         proxyServer.requestCount == 1

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.integtests
 
-import org.gradle.integtests.fixtures.executer.ExecutionFailure
-import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -35,10 +33,10 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         when:
         args '-q'
-        def result = wrapperExecuter.withTasks("emptyTask").run()
+        result = wrapperExecuter.withTasks("emptyTask").run()
 
         then:
-        result.output.contains("Welcome to Gradle $wrapperExecuter.distribution.version.version!")
+        outputContains("Welcome to Gradle $wrapperExecuter.distribution.version.version!")
 
         when:
         args '-q'
@@ -61,13 +59,13 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
         prepareWrapper(malformedDistZip.toURI())
 
         when:
-        ExecutionResult result = wrapperExecuter
+        result = wrapperExecuter
             .withTasks("emptyTask")
             .run()
 
         then:
-        result.assertOutputContains("Could not set executable permissions")
-        result.assertOutputContains("Please do this manually if you want to use the Gradle UI.")
+        outputContains("Could not set executable permissions")
+        outputContains("Please do this manually if you want to use the Gradle UI.")
     }
 
     def "wrapper prints error and fails build if downloaded zip is empty"() {
@@ -77,7 +75,7 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
         prepareWrapper(malformedDistZip.toURI())
 
         when:
-        ExecutionFailure failure = wrapperExecuter
+        failure = wrapperExecuter
             .withTasks("emptyTask")
             .withStackTraceChecksDisabled()
             .runWithFailure()


### PR DESCRIPTION
### Context

This pull request adds a CodeNarc rule to enforce correct usage of `outputContains` instead of directly accessing the `result.output` field.

Lots of violations have been fixed, and some were not, because not relevant in the context.

