### PR TITLE
Fix NPE when partial installs of Visual Studio are found

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/CommandLineToolVersionLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/CommandLineToolVersionLocator.java
@@ -96,7 +96,11 @@ public class CommandLineToolVersionLocator extends AbstractVisualStudioVersionLo
             try {
                 reader.beginArray();
                 while (reader.hasNext()) {
-                    installs.add(readInstall(reader));
+                    VisualStudioInstallCandidate candidate = readInstall(reader);
+
+                    if (candidate != null) {
+                        installs.add(candidate);
+                    }
                 }
                 reader.endArray();
             } finally {
@@ -128,12 +132,18 @@ public class CommandLineToolVersionLocator extends AbstractVisualStudioVersionLo
 
         File visualStudioInstallDir = new File(visualStudioInstallPath);
         VisualCppInstallCandidate visualCppMetadata = findVisualCppMetadata(visualStudioInstallDir, visualStudioVersion);
-        return new VisualStudioMetadataBuilder()
-            .installDir(visualStudioInstallDir)
-            .visualCppDir(visualCppMetadata.getVisualCppDir())
-            .version(VersionNumber.parse(visualStudioVersion))
-            .visualCppVersion(visualCppMetadata.getVersion())
-            .build();
+
+        if (visualCppMetadata == null) {
+            LOGGER.debug("Ignoring candidate Visual Studio version " + visualStudioVersion + " at " + visualStudioInstallPath + " because it does not appear to be a valid installation");
+            return null;
+        } else {
+            return new VisualStudioMetadataBuilder()
+                .installDir(visualStudioInstallDir)
+                .visualCppDir(visualCppMetadata.getVisualCppDir())
+                .version(VersionNumber.parse(visualStudioVersion))
+                .visualCppVersion(visualCppMetadata.getVersion())
+                .build();
+        }
     }
 
     private VisualCppInstallCandidate findVisualCppMetadata(File installDir, String version) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/DefaultVisualCppMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/DefaultVisualCppMetadataProvider.java
@@ -55,6 +55,8 @@ public class DefaultVisualCppMetadataProvider implements VisualCppMetadataProvid
                 // Version not found at this base path
             }
         }
+
+        LOGGER.debug("No Windows registry values found for version " + version);
         return null;
     }
 


### PR DESCRIPTION
See https://github.com/gradle/gradle-native/issues/570.

This improves the error handling when parsing `vswhere` output so that we handle situations where there might be a partial installation of Visual Studio.