### PR TITLE
Do not fail build if a .sha1 file cannot be processed during dependency cache access

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
@@ -23,7 +23,6 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
-import org.gradle.api.resources.ResourceException;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.Factory;
 import org.gradle.internal.hash.HashUtil;
@@ -174,7 +173,8 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
             });
             return result == null ? null : result.getResult();
         } catch (Exception e) {
-            throw new ResourceException(location.getUri(), String.format("Failed to download SHA1 for resource '%s'.", location), e);
+            LOGGER.debug(String.format("Failed to download SHA1 for resource '%s'.", location), e);
+            return null;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/DefaultExternalResourceRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/DefaultExternalResourceRepository.java
@@ -22,15 +22,12 @@ import org.gradle.internal.resource.BuildOperationFiringExternalResourceDecorato
 import org.gradle.internal.resource.ExternalResource;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceRepository;
+import org.gradle.internal.resource.transfer.AccessorBackedExternalResource;
 import org.gradle.internal.resource.transfer.ExternalResourceAccessor;
 import org.gradle.internal.resource.transfer.ExternalResourceLister;
 import org.gradle.internal.resource.transfer.ExternalResourceUploader;
-import org.gradle.internal.resource.transfer.AccessorBackedExternalResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DefaultExternalResourceRepository implements ExternalResourceRepository {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExternalResourceRepository.class);
     private final String name;
     private final ExternalResourceAccessor accessor;
     private final ExternalResourceUploader uploader;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -37,6 +37,7 @@ import org.gradle.internal.resource.metadata.ExternalResourceMetaData
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.BuildCommencedTimeProvider
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 
 class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
@@ -289,6 +290,56 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         cachedMetaData.lastModified >> null
         1 * repository.resource(new ExternalResourceName("thing.sha1"), true) >> remoteSha1
         1 * remoteSha1.withContentIfPresent(_) >> null
+        1 * repository.withProgressLogging() >> progressLoggingRepo
+        1 * progressLoggingRepo.resource(location, true) >> remoteResource
+        1 * remoteResource.withContentIfPresent(_) >> { ExternalResource.ContentAction a ->
+            a.execute(new ByteArrayInputStream(), remoteMetaData)
+        }
+        0 * _._
+
+        and:
+        1 * cacheLockingManager.useCache(_) >> { org.gradle.internal.Factory factory ->
+            return factory.create()
+        }
+        1 * fileStore.moveIntoCache(tempFile) >> localResource
+        1 * index.store("thing", cachedFile, remoteMetaData)
+        1 * fileRepository.resource(cachedFile, location.uri, remoteMetaData) >> resultResource
+        0 * _._
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/4893')
+    def "downloads resource directly when remote sha1 is not readable"() {
+        given:
+        def localCandidates = Mock(LocallyAvailableResourceCandidates)
+        def fileStore = Mock(CacheAwareExternalResourceAccessor.ResourceFileStore)
+        def cachedMetaData = Mock(ExternalResourceMetaData)
+        def remoteMetaData = Mock(ExternalResourceMetaData)
+        def remoteResource = Mock(ExternalResource)
+        def remoteSha1 = Mock(ExternalResource)
+        def location = new ExternalResourceName("thing")
+        def localResource = new DefaultLocallyAvailableResource(cachedFile)
+        def resultResource = Stub(LocallyAvailableExternalResource)
+
+        when:
+        def result = cache.getResource(location, null, fileStore, localCandidates)
+
+        then:
+        result == resultResource
+
+        and:
+        1 * index.lookup("thing") >> null
+        1 * repository.resource(location, true) >> remoteResource
+        1 * remoteResource.metaData >> remoteMetaData
+        localCandidates.none >> false
+        remoteMetaData.sha1 >> null
+        remoteMetaData.etag >> null
+        remoteMetaData.lastModified >> null
+        cachedMetaData.etag >> null
+        cachedMetaData.lastModified >> null
+        1 * repository.resource(new ExternalResourceName("thing.sha1"), true) >> remoteSha1
+        1 * remoteSha1.withContentIfPresent(_) >> { Transformer t ->
+            ExternalResourceReadResult.of(1, t.transform(new ByteArrayInputStream("proc".bytes)))
+        }
         1 * repository.withProgressLogging() >> progressLoggingRepo
         1 * progressLoggingRepo.resource(location, true) >> remoteResource
         1 * remoteResource.withContentIfPresent(_) >> { ExternalResource.ContentAction a ->


### PR DESCRIPTION
See: https://github.com/gradle/gradle/issues/4893#issuecomment-378522461