### PR TITLE
Introduce ability to declare attributes on dependencies

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -17,6 +17,8 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.HasConfigurableAttributes;
 
 import javax.annotation.Nullable;
 
@@ -26,7 +28,7 @@ import javax.annotation.Nullable;
  * @since 4.5
  */
 @Incubating
-public interface DependencyConstraint extends ModuleVersionSelector {
+public interface DependencyConstraint extends ModuleVersionSelector, HasConfigurableAttributes<DependencyConstraint> {
 
     /**
      * Configures the version constraint for this dependency constraint.
@@ -51,4 +53,26 @@ public interface DependencyConstraint extends ModuleVersionSelector {
      * @since 4.6
      */
     void because(@Nullable String reason);
+
+    /**
+     * Returns the attributes for this constraint. Mutation of the attributes of a constraint must be done through
+     * the {@link #attributes(Action)} method.
+     *
+     * @return the attributes container for this dependency
+     *
+     * @since 4.8
+     */
+    @Incubating
+    AttributeContainer getAttributes();
+
+    /**
+     * Mutates the attributes of this constraint. Attributes are used during dependency resolution to select the appropriate
+     * target variant, in particular when a single component provides different variants.
+     *
+     * @param configureAction the attributes mutation action
+     *
+     * @since 4.8
+     */
+    @Incubating
+    DependencyConstraint attributes(Action<? super AttributeContainer> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -19,6 +19,8 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.HasConfigurableAttributes;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -32,7 +34,7 @@ import static groovy.lang.Closure.DELEGATE_FIRST;
  * <p>
  * For examples on configuring the exclude rules please refer to {@link #exclude(java.util.Map)}.
  */
-public interface ModuleDependency extends Dependency {
+public interface ModuleDependency extends Dependency, HasConfigurableAttributes<ModuleDependency> {
     /**
      * Adds an exclude rule to exclude transitive dependencies of this dependency.
      * <p>
@@ -156,4 +158,25 @@ public interface ModuleDependency extends Dependency {
      */
     ModuleDependency copy();
 
+    /**
+     * Returns the attributes for this dependency. Mutation of the attributes of a dependency must be done through
+     * the {@link #attributes(Action)} method.
+     *
+     * @return the attributes container for this dependency
+     *
+     * @since 4.8
+     */
+    @Incubating
+    AttributeContainer getAttributes();
+
+    /**
+     * Mutates the attributes of this dependency. Attributes are used during dependency resolution to select the appropriate
+     * target variant, in particular when a single component provides different variants.
+     *
+     * @param configureAction the attributes mutation action
+     *
+     * @since 4.8
+     */
+    @Incubating
+    ModuleDependency attributes(Action<? super AttributeContainer> configureAction);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
 public interface DependencyResolutionServices {
     RepositoryHandler getResolveRepositoryHandler();
@@ -28,4 +29,6 @@ public interface DependencyResolutionServices {
     DependencyHandler getDependencyHandler();
 
     DependencyLockingHandler getDependencyLockingHandler();
+
+    ImmutableAttributesFactory getAttributesFactory();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -21,7 +21,13 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultExcludeRuleContainer;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.internal.Actions;
 import org.gradle.internal.ImmutableActionSet;
 
@@ -33,9 +39,13 @@ import java.util.Set;
 import static org.gradle.util.ConfigureUtil.configureUsing;
 
 public abstract class AbstractModuleDependency extends AbstractDependency implements ModuleDependency {
+    private final static Logger LOG = Logging.getLogger(AbstractModuleDependency.class);
+
+    private ImmutableAttributesFactory attributesFactory;
     private DefaultExcludeRuleContainer excludeRuleContainer = new DefaultExcludeRuleContainer();
     private Set<DependencyArtifact> artifacts = new HashSet<DependencyArtifact>();
     private Action<? super ModuleDependency> onMutate = Actions.doNothing();
+    private AttributeContainerInternal attributes;
 
     @Nullable
     private String configuration;
@@ -111,6 +121,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         target.setArtifacts(new HashSet<DependencyArtifact>(getArtifacts()));
         target.setExcludeRuleContainer(new DefaultExcludeRuleContainer(getExcludeRules()));
         target.setTransitive(isTransitive());
+        target.setAttributes(attributes);
     }
 
     protected boolean isKeyEquals(ModuleDependency dependencyRhs) {
@@ -138,15 +149,51 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         if (isTransitive() != dependencyRhs.isTransitive()) {
             return false;
         }
-        if (getArtifacts() != null ? !getArtifacts().equals(dependencyRhs.getArtifacts())
-                : dependencyRhs.getArtifacts() != null) {
+        if (!Objects.equal(getArtifacts(), dependencyRhs.getArtifacts())) {
             return false;
         }
-        if (getExcludeRules() != null ? !getExcludeRules().equals(dependencyRhs.getExcludeRules())
-                : dependencyRhs.getExcludeRules() != null) {
+        if (!Objects.equal(getExcludeRules(), dependencyRhs.getExcludeRules())) {
+            return false;
+        }
+        if (!Objects.equal(getAttributes(), dependencyRhs.getAttributes())) {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return attributes == null ? ImmutableAttributes.EMPTY : attributes.asImmutable();
+    }
+
+    @Override
+    public AbstractModuleDependency attributes(Action<? super AttributeContainer> configureAction) {
+        validateMutation();
+        if (attributesFactory == null) {
+            warnAboutInternalApiUse();
+            return this;
+        }
+        if (attributes == null) {
+            attributes = attributesFactory.mutable();
+        }
+        configureAction.execute(attributes);
+        return this;
+    }
+
+    private void warnAboutInternalApiUse() {
+        LOG.warn("Cannot set attributes for dependency \"" + this.getGroup() + ":" + this.getName() + ":" + this.getVersion() + "\": it was probably created by a plugin using internal APIs");
+    }
+
+    public void setAttributesFactory(ImmutableAttributesFactory attributesFactory) {
+        this.attributesFactory = attributesFactory;
+    }
+
+    protected ImmutableAttributesFactory getAttributesFactory() {
+        return attributesFactory;
+    }
+
+    void setAttributes(AttributeContainerInternal attributes) {
+        this.attributes = attributes;
     }
 
     @SuppressWarnings("unchecked")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependencySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependencySpec.groovy
@@ -19,7 +19,10 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.util.TestUtil
 import org.gradle.util.WrapUtil
 import spock.lang.Specification
 
@@ -32,7 +35,11 @@ abstract class AbstractModuleDependencySpec extends Specification {
     }
 
     protected ExternalModuleDependency createDependency(String group, String name, String version) {
-        createDependency(group, name, version, null)
+        def dependency = createDependency(group, name, version, null)
+        if (dependency instanceof AbstractModuleDependency) {
+            dependency.attributesFactory = TestUtil.attributesFactory()
+        }
+        dependency
     }
 
     protected abstract ExternalModuleDependency createDependency(String group, String name, String version, String configuration);
@@ -48,6 +55,7 @@ abstract class AbstractModuleDependencySpec extends Specification {
         dependency.artifacts.isEmpty()
         dependency.excludeRules.isEmpty()
         dependency.targetConfiguration == null
+        dependency.attributes == ImmutableAttributes.EMPTY
     }
 
     def "cannot create with null name"() {
@@ -99,8 +107,36 @@ abstract class AbstractModuleDependencySpec extends Specification {
         dependency.artifacts.contains(artifact2)
     }
 
+    void "can set attributes"() {
+        def attr1 = Attribute.of("attr1", String)
+        def attr2 = Attribute.of("attr2", Integer)
+
+        when:
+        dependency.attributes {
+            it.attribute(attr1, 'foo')
+            it.attribute(attr2, 123)
+        }
+
+        then:
+        dependency.attributes.keySet() == [attr1, attr2] as Set
+        dependency.attributes.getAttribute(attr1) == 'foo'
+        dependency.attributes.getAttribute(attr2) == 123
+    }
+
     void "knows if is equal to"() {
-        expect:
+        when:
+        def dep1 = createDependency("group1", "name1", "version1")
+        def dep2 = createDependency("group1", "name1", "version1")
+        def attr1 = Attribute.of("attr1", String)
+        def attr2 = Attribute.of("attr2", Integer)
+        dep1.attributes {
+            it.attribute(attr1, 'foo')
+        }
+        dep2.attributes {
+            it.attribute(attr2, 123)
+        }
+
+        then:
         createDependency("group1", "name1", "version1") == createDependency("group1", "name1", "version1")
         createDependency("group1", "name1", "version1").hashCode() == createDependency("group1", "name1", "version1").hashCode()
         createDependency("group1", "name1", "version1") != createDependency("group1", "name1", "version2")
@@ -108,6 +144,9 @@ abstract class AbstractModuleDependencySpec extends Specification {
         createDependency("group1", "name1", "version1") != createDependency("group2", "name1", "version1")
         createDependency("group1", "name1", "version1") != createDependency("group2", "name1", "version1")
         createDependency("group1", "name1", "version1", "depConf1") != createDependency("group1", "name1", "version1", "depConf2")
+
+        dep1 != dep2
+
     }
 
     def "creates deep copy"() {
@@ -125,7 +164,7 @@ abstract class AbstractModuleDependencySpec extends Specification {
         assertDeepCopy(dependency, copy)
     }
 
-    public static void assertDeepCopy(ModuleDependency dependency, ModuleDependency copiedDependency) {
+    static void assertDeepCopy(ModuleDependency dependency, ModuleDependency copiedDependency) {
         assert copiedDependency.group == dependency.group
         assert copiedDependency.name == dependency.name
         assert copiedDependency.version == dependency.version
@@ -133,6 +172,7 @@ abstract class AbstractModuleDependencySpec extends Specification {
         assert copiedDependency.transitive == dependency.transitive
         assert copiedDependency.artifacts == dependency.artifacts
         assert copiedDependency.excludeRules == dependency.excludeRules
+        assert copiedDependency.attributes == dependency.attributes
 
         assert !copiedDependency.artifacts.is(dependency.artifacts)
         assert !copiedDependency.excludeRules.is(dependency.excludeRules)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
@@ -34,12 +34,16 @@ class DefaultDependencyConstraintTest extends Specification {
 
     void "knows if is equal to"() {
         expect:
-        new DefaultDependencyConstraint("group1", "name1", "version1") == new DefaultDependencyConstraint("group1", "name1", "version1")
-        new DefaultDependencyConstraint("group1", "name1", "version1").hashCode() == new DefaultDependencyConstraint("group1", "name1", "version1").hashCode()
-        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group1", "name1", "version2")
-        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group1", "name2", "version1")
-        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group2", "name1", "version1")
-        new DefaultDependencyConstraint("group1", "name1", "version1") != new DefaultDependencyConstraint("group2", "name1", "version1")
+        constraint("group1", "name1", "version1") == constraint("group1", "name1", "version1")
+        constraint("group1", "name1", "version1").hashCode() == constraint("group1", "name1", "version1").hashCode()
+        constraint("group1", "name1", "version1") != constraint("group1", "name1", "version2")
+        constraint("group1", "name1", "version1") != constraint("group1", "name2", "version1")
+        constraint("group1", "name1", "version1") != constraint("group2", "name1", "version1")
+        constraint("group1", "name1", "version1") != constraint("group2", "name1", "version1")
+    }
+
+    DefaultDependencyConstraint constraint(String group, String name, String version) {
+        return new DefaultDependencyConstraint(group, name, version)
     }
 
     def "creates deep copy"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependenciesAttributesIntegrationTest.groovy
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.util.ToBeImplemented
+import spock.lang.Ignore
+import spock.lang.Unroll
+
+class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        buildFile << """
+            def CUSTOM_ATTRIBUTE = Attribute.of('custom', String)
+        """
+    }
+
+    def "can declare attributes on dependencies"() {
+        given:
+        repository {
+            'org:test:1.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'test value')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:test:1.0')
+            }
+        }
+
+        and:
+        outputDoesNotContain("Cannot set attributes for dependency \"org:test:1.0\": it was probably created by a plugin using internal APIs")
+    }
+
+    def "can declare attributes on constraints"() {
+        given:
+        repository {
+            'org:test:1.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:test:1.0') {
+                        attributes {
+                            attribute(CUSTOM_ATTRIBUTE, 'test value')
+                        }
+                    }
+                }
+                conf 'org:test'
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:test', 'org:test:1.0')
+                edge('org:test:1.0', 'org:test:1.0')
+            }
+        }
+
+        and:
+        outputDoesNotContain("Cannot set attributes for constraint \"org:test:1.0\": it was probably created by a plugin using internal APIs")
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    @Unroll("Selects variant #expectedVariant using custom attribute value #attributeValue")
+    @ToBeImplemented
+    @Ignore
+    def "attribute value is used during selection"() {
+        given:
+        repository {
+            'org:test:1.0' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, '$attributeValue')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:test:1.0') {
+                    variant(expectedVariant, expectedAttributes)
+                }
+            }
+        }
+
+        where:
+        attributeValue | expectedVariant | expectedAttributes
+        'c1'           | 'api'           | ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', custom: 'c2']
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -21,9 +21,12 @@ import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependency;
+import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryDelegate;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -34,25 +37,45 @@ public class DefaultDependencyFactory implements DependencyFactory {
     private final NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser;
     private final NotationParser<Object, ClientModule> clientModuleNotationParser;
     private final ProjectDependencyFactory projectDependencyFactory;
+    private final ImmutableAttributesFactory attributesFactory;
 
     public DefaultDependencyFactory(NotationParser<Object, Dependency> dependencyNotationParser,
                                     NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser,
                                     NotationParser<Object, ClientModule> clientModuleNotationParser,
-                                    ProjectDependencyFactory projectDependencyFactory) {
+                                    ProjectDependencyFactory projectDependencyFactory,
+                                    ImmutableAttributesFactory attributesFactory) {
         this.dependencyNotationParser = dependencyNotationParser;
         this.dependencyConstraintNotationParser = dependencyConstraintNotationParser;
         this.clientModuleNotationParser = clientModuleNotationParser;
         this.projectDependencyFactory = projectDependencyFactory;
+        this.attributesFactory = attributesFactory;
     }
 
     public Dependency createDependency(Object dependencyNotation) {
-        return dependencyNotationParser.parseNotation(dependencyNotation);
+        Dependency dependency = dependencyNotationParser.parseNotation(dependencyNotation);
+        injectAttributesFactory(dependency);
+        return dependency;
+    }
+
+    private void injectAttributesFactory(Dependency dependency) {
+        if (dependency instanceof AbstractModuleDependency) {
+            ((AbstractModuleDependency) dependency).setAttributesFactory(attributesFactory);
+        }
     }
 
     @Override
     public DependencyConstraint createDependencyConstraint(Object dependencyNotation) {
-        return dependencyConstraintNotationParser.parseNotation(dependencyNotation);
+        DependencyConstraint dependencyConstraint = dependencyConstraintNotationParser.parseNotation(dependencyNotation);
+        injectAttributesFactory(dependencyConstraint);
+        return dependencyConstraint;
     }
+
+    private void injectAttributesFactory(DependencyConstraint dependency) {
+        if (dependency instanceof DefaultDependencyConstraint) {
+            ((DefaultDependencyConstraint) dependency).setAttributesFactory(attributesFactory);
+        }
+    }
+
 
     public ClientModule createModule(Object dependencyNotation, Closure configureClosure) {
         ClientModule clientModule = clientModuleNotationParser.parseNotation(dependencyNotation);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -341,6 +341,11 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         public DependencyLockingHandler getDependencyLockingHandler() {
             return services.get(DependencyLockingHandler.class);
         }
+
+        @Override
+        public ImmutableAttributesFactory getAttributesFactory() {
+            return services.get(ImmutableAttributesFactory.class);
+        }
     }
 
     private static class DefaultArtifactPublicationServices implements ArtifactPublicationServices {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -131,7 +131,8 @@ class DependencyManagementBuildScopeServices {
             ClassPathRegistry classPathRegistry,
             CurrentGradleInstallation currentGradleInstallation,
             FileLookup fileLookup,
-            RuntimeShadedJarFactory runtimeShadedJarFactory
+            RuntimeShadedJarFactory runtimeShadedJarFactory,
+            ImmutableAttributesFactory attributesFactory
     ) {
         DefaultProjectDependencyFactory factory = new DefaultProjectDependencyFactory(
             projectAccessListener, instantiator, startParameter.isBuildProjectDependencies());
@@ -142,7 +143,8 @@ class DependencyManagementBuildScopeServices {
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileLookup, runtimeShadedJarFactory, currentGradleInstallation),
             DependencyConstraintNotationParser.parser(instantiator),
             new ClientModuleNotationParserFactory(instantiator).create(),
-            projectDependencyFactory);
+            projectDependencyFactory,
+            attributesFactory);
     }
 
     RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory, BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -29,8 +29,8 @@ class DependencyLockingNotationConverter {
             throw new IllegalArgumentException("The module notation does not respect the lock file format of 'group:name:version' - received '" + module + "'");
         }
         DefaultDependencyConstraint constraint = DefaultDependencyConstraint.strictConstraint(module.substring(0, groupNameSeparatorIndex),
-                                                                                            module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
-                                                                                            module.substring(nameVersionSeparatorIndex + 1));
+            module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
+            module.substring(nameVersionSeparatorIndex + 1));
 
         constraint.because("dependency was locked to version " + constraint.getVersion());
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryDelegateTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryDelegateTest.java
@@ -34,7 +34,7 @@ public class ModuleFactoryDelegateTest {
 
     private DependencyFactory dependencyFactoryStub = context.mock(DependencyFactory.class);
     private ClientModule clientModule = new DefaultClientModule("junit", "junit", "4.4");
-    
+
     private ModuleFactoryDelegate moduleFactoryDelegate = new ModuleFactoryDelegate(clientModule, dependencyFactoryStub);
 
     @Test

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,5 +1,12 @@
 {
     "acceptedApiChanges": [
-        
+        {
+            "type": "org.gradle.api.artifacts.ModuleDependency",
+            "member": "Class org.gradle.api.artifacts.ModuleDependency",
+            "acceptation": "Module dependencies now support attributes",
+            "changes": [
+                "org.gradle.api.attributes.HasConfigurableAttributes"
+            ]
+        }
     ]
 }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginDependencyResolutionServices.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginDependencyResolutionServices.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Factory;
 
 import java.util.ArrayList;
@@ -66,6 +67,11 @@ public class PluginDependencyResolutionServices implements DependencyResolutionS
     @Override
     public DependencyLockingHandler getDependencyLockingHandler() {
         return getDependencyResolutionServices().getDependencyLockingHandler();
+    }
+
+    @Override
+    public ImmutableAttributesFactory getAttributesFactory() {
+        return getDependencyResolutionServices().getAttributesFactory();
     }
 
     public PluginRepositoryHandlerProvider getPluginRepositoryHandlerProvider() {


### PR DESCRIPTION
### Context

This commit introduces the possibility to declare attributes on dependencies.
Attributes are, currently, unused. You can declare them, but they do not
participate in dependency resolution. Attributes can be mutated using the
`attributes(Action<? super AttributeContainer>)` method.

Implementation wise, in order to avoid memory overhead, an attribute container
is lazily created whenever attributes are added. This forces us to pass
the attribute factory down to the various concrete dependency implementations.
