### PR TITLE
Allow build cache to be enabled programatically for non root builds

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/configuration/BuildCacheConfigurationIntegrationTest.groovy
@@ -41,6 +41,23 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         !localBuildCache.empty
     }
 
+    def "can enable with settings.gradle"() {
+        settingsFile << """
+            gradle.startParameter.buildCacheEnabled = true
+            buildCache {
+                local(DirectoryBuildCache) {
+                    directory = '$cacheDir'
+                }
+            }
+        """
+
+        buildFile << customTaskCode()
+
+        expect:
+        succeeds("customTask")
+        !localBuildCache.empty
+    }
+
     def "can configure with init script"() {
         def initScript = file("initBuildCache.gradle") << """
             gradle.settingsEvaluated { settings ->
@@ -55,6 +72,25 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.withBuildCacheEnabled().usingInitScript(initScript)
+        succeeds("customTask")
+        !localBuildCache.empty
+    }
+
+    def "can enable with init script"() {
+        def initScript = file("initBuildCache.gradle") << """
+            gradle.startParameter.buildCacheEnabled = true
+            gradle.settingsEvaluated { settings ->
+                settings.buildCache {
+                    local(DirectoryBuildCache) {
+                        directory = '$cacheDir'
+                    }
+                }
+            }
+        """
+        buildFile << customTaskCode()
+
+        expect:
+        executer.usingInitScript(initScript)
         succeeds("customTask")
         !localBuildCache.empty
     }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheController.java
@@ -28,6 +28,10 @@ import java.io.Closeable;
  */
 public interface BuildCacheController extends Closeable {
 
+    boolean isEnabled();
+
+    boolean isEmitDebugLogging();
+
     @Nullable
     <T> T load(BuildCacheLoadCommand<T> command);
 

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheControllerFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/BuildCacheControllerFactory.java
@@ -30,9 +30,9 @@ import org.gradle.caching.internal.controller.service.BuildCacheServiceRole;
 import org.gradle.caching.internal.controller.service.BuildCacheServicesConfiguration;
 import org.gradle.internal.Cast;
 import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.Path;
 import org.slf4j.Logger;
@@ -64,6 +64,7 @@ public final class BuildCacheControllerFactory {
         final BuildCacheMode buildCacheState,
         final RemoteAccessMode remoteAccessMode,
         final boolean logStackTraces,
+        final boolean emitDebugLogging,
         final Instantiator instantiator
     ) {
         return buildOperationExecutor.call(new CallableBuildOperation<BuildCacheController>() {
@@ -114,7 +115,8 @@ public final class BuildCacheControllerFactory {
                         config,
                         buildOperationExecutor,
                         gradleUserHomeDir,
-                        logStackTraces
+                        logStackTraces,
+                        emitDebugLogging
                     );
                 }
             }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -44,9 +44,9 @@ import org.gradle.caching.local.internal.LocalBuildCacheService;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -69,6 +69,7 @@ public class DefaultBuildCacheController implements BuildCacheController {
 
     private final BuildCacheTempFileStore tmp;
     private final BuildOperationExecutor buildOperationExecutor;
+    private final boolean emitDebugLogging;
 
     private boolean closed;
 
@@ -76,9 +77,11 @@ public class DefaultBuildCacheController implements BuildCacheController {
         BuildCacheServicesConfiguration config,
         BuildOperationExecutor buildOperationExecutor,
         File gradleUserHomeDir,
-        boolean logStackTraces
+        boolean logStackTraces,
+        boolean emitDebugLogging
     ) {
         this.buildOperationExecutor = buildOperationExecutor;
+        this.emitDebugLogging = emitDebugLogging;
 
         if (config.local instanceof LocalBuildCacheService) {
             LocalBuildCacheService castLocal = (LocalBuildCacheService) config.local;
@@ -92,6 +95,16 @@ public class DefaultBuildCacheController implements BuildCacheController {
         }
 
         this.remote = toHandle(config.remote, config.remotePush, BuildCacheServiceRole.REMOTE, buildOperationExecutor, logStackTraces);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isEmitDebugLogging() {
+        return emitDebugLogging;
     }
 
     @Nullable

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NoOpBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NoOpBuildCacheController.java
@@ -24,6 +24,16 @@ public class NoOpBuildCacheController implements BuildCacheController {
     }
 
     @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isEmitDebugLogging() {
+        return false;
+    }
+
+    @Override
     public <T> T load(BuildCacheLoadCommand<T> command) {
         return null;
     }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/RootBuildCacheControllerRef.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/RootBuildCacheControllerRef.java
@@ -49,6 +49,16 @@ public class RootBuildCacheControllerRef {
         }
 
         @Override
+        public boolean isEnabled() {
+            return delegate.isEnabled();
+        }
+
+        @Override
+        public boolean isEmitDebugLogging() {
+            return delegate.isEmitDebugLogging();
+        }
+
+        @Override
         @Nullable
         public <T> T load(BuildCacheLoadCommand<T> command) {
             return delegate.load(command);

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/BuildCacheControllerFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/BuildCacheControllerFactoryTest.groovy
@@ -48,6 +48,9 @@ class BuildCacheControllerFactoryTest extends Specification {
         new DefaultBuildCacheServiceRegistration(TestRemoteBuildCache, TestRemoteBuildCacheServiceFactory),
     ])
 
+    boolean logStacktraces
+    boolean emitDebugLogging
+
     private DefaultBuildCacheController createController() {
         createController(DefaultBuildCacheController)
     }
@@ -60,7 +63,8 @@ class BuildCacheControllerFactoryTest extends Specification {
             config,
             buildCacheEnabled ? ENABLED : DISABLED,
             ONLINE,
-            false,
+            logStacktraces,
+            emitDebugLogging,
             DirectInstantiator.INSTANCE
         )
         assert controllerType.isInstance(controller)
@@ -136,6 +140,19 @@ class BuildCacheControllerFactoryTest extends Specification {
             local.type == "directory"
             remote.type == "remote"
         }
+    }
+
+    def "respects debug logging setting - #setting"() {
+        when:
+        emitDebugLogging = setting
+        config.remote(TestRemoteBuildCache)
+        def c = createController()
+
+        then:
+        c.emitDebugLogging == setting
+
+        where:
+        setting << [true, false]
     }
 
     def 'when caching is disabled no services are created'() {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
@@ -92,7 +92,7 @@ class DefaultBuildCacheControllerTest extends Specification {
             ),
             operations,
             tmpDir.file("dir"),
-            false
+            false, false
         )
     }
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheTaskServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/BuildCacheTaskServices.java
@@ -118,6 +118,7 @@ public class BuildCacheTaskServices {
         BuildCacheMode buildCacheMode = startParameter.isBuildCacheEnabled() ? ENABLED : DISABLED;
         RemoteAccessMode remoteAccessMode = startParameter.isOffline() ? OFFLINE : ONLINE;
         boolean logStackTraces = startParameter.getShowStacktrace() != ShowStacktrace.INTERNAL_EXCEPTIONS;
+        boolean emitDebugLogging = startParameter.isBuildCacheDebugLogging();
 
         return BuildCacheControllerFactory.create(
             buildOperationExecutor,
@@ -127,6 +128,7 @@ public class BuildCacheTaskServices {
             buildCacheMode,
             remoteAccessMode,
             logStackTraces,
+            emitDebugLogging,
             instantiatorFactory.inject(serviceRegistry)
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
@@ -95,7 +95,6 @@ public class TaskExecutionServices {
     TaskExecuter createTaskExecuter(TaskArtifactStateRepository repository,
                                     TaskOutputCacheCommandFactory taskOutputCacheCommandFactory,
                                     BuildCacheController buildCacheController,
-                                    StartParameter startParameter,
                                     ListenerManager listenerManager,
                                     TaskInputsListener inputsListener,
                                     BuildOperationExecutor buildOperationExecutor,
@@ -109,7 +108,7 @@ public class TaskExecutionServices {
                                     BuildInvocationScopeId buildInvocationScopeId
     ) {
 
-        boolean taskOutputCacheEnabled = startParameter.isBuildCacheEnabled();
+        boolean buildCacheEnabled = buildCacheController.isEnabled();
         boolean scanPluginApplied = buildScanPlugin.isBuildScanPluginApplied();
         TaskOutputChangesListener taskOutputChangesListener = listenerManager.getBroadcaster(TaskOutputChangesListener.class);
 
@@ -121,7 +120,7 @@ public class TaskExecutionServices {
             buildInvocationScopeId
         );
         executer = new OutputDirectoryCreatingTaskExecuter(executer);
-        if (taskOutputCacheEnabled) {
+        if (buildCacheEnabled) {
             executer = new SkipCachedTaskExecuter(
                 buildCacheController,
                 taskOutputChangesListener,
@@ -130,9 +129,9 @@ public class TaskExecutionServices {
             );
         }
         executer = new SkipUpToDateTaskExecuter(executer);
-        executer = new ResolveTaskOutputCachingStateExecuter(taskOutputCacheEnabled, executer);
-        if (taskOutputCacheEnabled || scanPluginApplied) {
-            executer = new ResolveBuildCacheKeyExecuter(executer, buildOperationExecutor, startParameter.isBuildCacheDebugLogging());
+        executer = new ResolveTaskOutputCachingStateExecuter(buildCacheEnabled, executer);
+        if (buildCacheEnabled || scanPluginApplied) {
+            executer = new ResolveBuildCacheKeyExecuter(executer, buildOperationExecutor, buildCacheController.isEmitDebugLogging());
         }
         executer = new ValidatingTaskExecuter(executer);
         executer = new SkipEmptySourceFilesTaskExecuter(inputsListener, cleanupRegistry, taskOutputChangesListener, executer, buildInvocationScopeId);


### PR DESCRIPTION
Previously, enabling programmatically in a buildSrc settings.gradle required the following:

```
gradle.parent.startParameter.buildCacheEnabled = true
```

While trying to do the same thing in a root settings.gradle required:

```
gradle.startParameter.buildCacheEnabled = true
```

Now, the latter works identically in both cases. 

Enabling on the parent from buildSrc no longer enables. This is a breaking change, but is obscure enough to be deemed not worthy of mention.

CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Fconsolidate-build-cache-config