### PR TITLE
Re-add AbstractFileCollection.getBuildDependencies()

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -123,4 +123,21 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec {
         failureHasCause "File collection does not contain any files."
         output.contains "The FileCollection.stopExecutionIfEmpty() method has been deprecated and is scheduled to be removed in Gradle 5.0."
     }
+
+    def "getting build dependencies from custom file collection produces deprecation warning"() {
+        buildFile << """
+            class CustomFileCollection extends org.gradle.api.internal.file.AbstractFileCollection {
+                String displayName = "custom"
+                Set<File> files = []
+            }
+
+            new CustomFileCollection().buildDependencies
+        """
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "The AbstractFileCollection.getBuildDependencies() method has been deprecated and is scheduled to be removed in Gradle 5.0. Do not extend AbstractFileCollection, use Project.files() instead."
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -196,7 +196,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public TaskDependency getBuildDependencies() {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()");
+        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()", "Do not extend AbstractFileCollection, use Project.files() instead.");
         return TaskDependencies.EMPTY;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.FileBackedDirectoryFileTree;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencies;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -191,6 +192,12 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
             return getAsFileTree();
         }
         return DefaultGroovyMethods.asType(this, type);
+    }
+
+    @Override
+    public TaskDependency getBuildDependencies() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()");
+        return TaskDependencies.EMPTY;
     }
 
     @Override


### PR DESCRIPTION
It seems like some plugins implement their own FileCollections, and the removal of this method breaks them. At least it broke the Shadow plugin.
