### PR TITLE
Increase directory cache cleanup frequency from 7 days to 24 hours

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.caching.local.internal
 
+import org.gradle.cache.internal.DefaultPersistentDirectoryCache
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
@@ -26,7 +27,7 @@ import spock.lang.Unroll
 import java.util.concurrent.TimeUnit
 
 class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
-    private final static int MAX_CACHE_AGE = 7
+    private final static int MAX_CACHE_AGE_IN_DAYS = 7
 
     def operations = new BuildOperationsFixture(executer, testDirectoryProvider)
 
@@ -61,7 +62,7 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         """
             buildCache {
                 local {
-                    removeUnusedEntriesAfterDays = ${MAX_CACHE_AGE}
+                    removeUnusedEntriesAfterDays = ${MAX_CACHE_AGE_IN_DAYS}
                 }
             }
         """
@@ -75,7 +76,7 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         when:
         def newTrashFile = cacheDir.file("0" * 32).createFile()
         def oldTrashFile = cacheDir.file("1" * 32).createFile()
-        oldTrashFile.lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE) * 2
+        oldTrashFile.lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE_IN_DAYS) * 2
         run()
         then:
         newTrashFile.assertIsFile()
@@ -115,7 +116,7 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         // One day isn't enough to trigger
         when:
         // Set the time back 1 day
-        gcFile().setLastModified(originalCheckTime - TimeUnit.DAYS.toMillis(1))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(1))
         def lastCleanupCheck = gcFile().lastModified()
         run()
         then:
@@ -123,7 +124,7 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
 
         // checkInterval-1 days is not enough to trigger
         when:
-        gcFile().setLastModified(originalCheckTime - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE - 1))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS - 1))
         lastCleanupCheck = gcFile().lastModified()
         run()
         then:
@@ -131,14 +132,14 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
 
         // checkInterval days is enough to trigger
         when:
-        gcFile().setLastModified(originalCheckTime - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS))
         run()
         then:
         assertCacheWasCleanedUpSince(lastCleanupCheck)
 
         // More than checkInterval days is enough to trigger
         when:
-        gcFile().setLastModified(originalCheckTime - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE * 10))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS * 10))
         run()
         then:
         assertCacheWasCleanedUpSince(lastCleanupCheck)
@@ -193,7 +194,7 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
 
     long markCacheForCleanup() {
         gcFile().touch()
-        gcFile().lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE) * 2
+        gcFile().lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_CACHE_AGE_IN_DAYS) * 2
         return gcFile().lastModified()
     }
 

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
@@ -109,20 +109,20 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         days << [-1, 0]
     }
 
-    def "build cache cleanup is triggered after max number of days expires"() {
+    def "build cache cleanup is triggered after max number of hours expires"() {
         run()
         def originalCheckTime = gcFile().lastModified()
 
-        // One day isn't enough to trigger
+        // One hour isn't enough to trigger
         when:
-        // Set the time back 1 day
+        // Set the time back 1 hour
         gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(1))
         def lastCleanupCheck = gcFile().lastModified()
         run()
         then:
         assertCacheWasNotCleanedUpSince(lastCleanupCheck)
 
-        // checkInterval-1 days is not enough to trigger
+        // checkInterval-1 hours is not enough to trigger
         when:
         gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS - 1))
         lastCleanupCheck = gcFile().lastModified()
@@ -130,14 +130,14 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         then:
         assertCacheWasNotCleanedUpSince(lastCleanupCheck)
 
-        // checkInterval days is enough to trigger
+        // checkInterval hours is enough to trigger
         when:
         gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS))
         run()
         then:
         assertCacheWasCleanedUpSince(lastCleanupCheck)
 
-        // More than checkInterval days is enough to trigger
+        // More than checkInterval hours is enough to trigger
         when:
         gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS * 10))
         run()

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
@@ -83,7 +83,7 @@ public interface CacheBuilder {
      *
      * A clean-up action is run when a cache is closed, but only after a certain interval of time after the last clean-up.
      *
-     * Currently, a clean-up action is run after {@value org.gradle.cache.internal.DefaultPersistentDirectoryCache#CLEANUP_INTERVAL} days.
+     * Currently, a clean-up action is run after {@value org.gradle.cache.internal.DefaultPersistentDirectoryCache#CLEANUP_INTERVAL_IN_HOURS} hours.
      *
      */
     CacheBuilder withCleanup(CleanupAction cleanup);


### PR DESCRIPTION
With this change it now makes sense to set the cleanup timeout to small numbers like a few days. Previously we'd only check for outdated entries in local directory caches once a week, which meant leaving unused files in place for much longer than the user would have expected.

This change currently affects the cleanup of the build cache and the cache used to store source dependencies.

I think it's okay not to mention the change in the release notes as it is small, and the fixed issue will also show up in the notes.

Fixes #4900.