### PR TITLE
fix document about sourceSetCompileClasspath

### DIFF
--- a/subprojects/docs/src/docs/userguide/javaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/javaPlugin.adoc
@@ -250,8 +250,8 @@ _Compile time dependencies for the given source set._ Used by `__sourceSet__Comp
 `__sourceSet__CompileOnly`::
 _Compile time only dependencies for the given source set, not used at runtime._
 
-`__sourceSet__CompileClasspath` extends `compile__SourceSet__Java`::
-_Compile classpath, used when compiling source._ Used by `__sourceSet__Compile, __sourceSet__CompileOnly, __sourceSet__Implementation`.
+`__sourceSet__CompileClasspath` extends `__sourceSet__Compile, __sourceSet__CompileOnly, __sourceSet__Implementation`::
+_Compile classpath, used when compiling source._ Used by task `compile__SourceSet__Java`.
 
 `__sourceSet__AnnotationProcessor`::
 _Annotation processors used during compilation of this source set._


### PR DESCRIPTION
sourceSetCompileClasspath documentation is wrong

Signed-off-by: Albert Zang albertzang.ys@gmail.com

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
