### PR TITLE
Make plugins.withId more efficient in the common case

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
@@ -144,6 +144,24 @@ public class DefaultPluginRegistry implements PluginRegistry {
         return uncheckedGet(idMappings, new PluginIdLookupCacheKey(pluginId, classLoader)).orNull();
     }
 
+    @Nullable
+    @Override
+    public PluginImplementation<?> maybeLookup(PluginId pluginId) {
+        PluginImplementation lookup;
+        if (parent != null) {
+            lookup = parent.maybeLookup(pluginId);
+            if (lookup != null) {
+                return lookup;
+            }
+        }
+
+        if (classLoaderScope.isLocked()) {
+            return lookup(pluginId);
+        } else {
+            return null;
+        }
+    }
+
     private static <K, V> V uncheckedGet(LoadingCache<K, V> cache, K key) {
         try {
             return cache.get(key);
@@ -222,7 +240,16 @@ public class DefaultPluginRegistry implements PluginRegistry {
             if (id.equals(pluginId)) {
                 return true;
             }
-            PluginImplementation<?> other = lookup(id, classLoader);
+
+            PluginImplementation<?> other = maybeLookup(id);
+            if (isSameClassAsThis(other)) {
+                return true;
+            }
+            other = lookup(id, classLoader);
+            return isSameClassAsThis(other);
+        }
+
+        private boolean isSameClassAsThis(PluginImplementation<?> other) {
             return other != null && other.asClass().equals(asClass());
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginRegistry.java
@@ -38,6 +38,12 @@ public interface PluginRegistry {
     @Nullable
     PluginImplementation<?> lookup(PluginId pluginId);
 
+    /**
+     * Locates the plugin with the given id. Note that the id of the result may be different to the requested id. Ignores classloader scopes that have not been locked yet.
+     */
+    @Nullable
+    PluginImplementation<?> maybeLookup(PluginId pluginId);
+
     PluginRegistry createChild(ClassLoaderScope lookupScope);
 
 }


### PR DESCRIPTION
Use the cached plugin descriptor if the plugin was
loaded by the classloader of the plugin registry that
it was added to. This is the case 90% of the time.
The only common case where this is not true is when
a plugin is loaded by an init script or script plugin.

The background for this issue is that a lot of plugins are applied by other plugins using their class name. Those plugins have a `null` ID at that point. But when someone calls `plugins.withId` we do need the id. Up until now we would reload the plugin descriptor of each of those plugins for every call to that method. This is a huge waste of memory. It is especially noticable with the Android plugin, because it makes heavy use of `plugins.withId`.

The fix is rather simple: First look in if the registry already knows a plugin by that ID and see if it is the same class. Only if we don't find it (e.g. it was added by an init script), we fall back to the expensive classloader lookup.