### PR TITLE
Make task report parallel-safe

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectTaskLister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectTaskLister.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.tasks.TaskContainerInternal;
 import java.util.Collection;
 
 public class DefaultProjectTaskLister implements ProjectTaskLister {
-    public Collection<Task> listProjectTasks(Project project) {
+    public synchronized Collection<Task> listProjectTasks(Project project) {
         ProjectInternal projectInternal = (ProjectInternal) project;
         TaskContainerInternal tasks = projectInternal.getTasks();
         tasks.realize();

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
@@ -395,6 +395,16 @@ d
         TASKS_DETAILED_REPORT_TASK | true
     }
 
+    def "can run multiple task reports in parallel"() {
+        given:
+        buildFile << multiProjectBuild()
+        def projects = (1..100).collect {"project$it"}
+        settingsFile << "include '${projects.join("', '")}'"
+
+        expect:
+        succeeds(":tasks", *projects.collect { "$it:tasks" }, "--parallel")
+    }
+
     protected static String getBuildScriptContent() {
         """
             tasks.addRule("test rule") {


### PR DESCRIPTION
Discovering tasks is not parallel-safe and so needs to be synchronized.