### PR TITLE
Fix task graph computation for multi-layer composites

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
@@ -16,6 +16,7 @@
 
 package org.gradle.composite.internal;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.internal.concurrent.CompositeStoppable;
@@ -60,7 +61,7 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
         boolean tasksDiscovered = true;
         while (tasksDiscovered) {
             tasksDiscovered = false;
-            for (IncludedBuildController buildController : buildControllers.values()) {
+            for (IncludedBuildController buildController : ImmutableList.copyOf(buildControllers.values())) {
                 if (buildController.populateTaskGraph()) {
                     tasksDiscovered = true;
                 }


### PR DESCRIPTION
The task graph construction would result in a ConcurrentModificationException
if new substitutions were discovered while building the task graph for the
first level projects. This is trivially fixed by making a defensive copy.