### PR TITLE
Remove old cglib-nodep usage

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,7 @@ subprojects {
         dependencies {
             compile(localGroovy())
             testCompile("org.spockframework:spock-core:1.0-groovy-2.4")
-            testCompile("cglib:cglib-nodep:3.2.5")
+            testCompile("cglib:cglib:3.2.6")
             testCompile("org.objenesis:objenesis:2.4")
             constraints {
                 compile("org.codehaus.groovy:groovy-all:2.4.12")

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -65,6 +65,9 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
                 // Read capabilities declared in capabilities.json
                 readCapabilitiesFromJson()
 
+                replaceCglibNodepWithCglib("org.spockframework:spock-core")
+                replaceCglibNodepWithCglib("org.jmock:jmock-legacy")
+
                 //TODO check if we can upgrade the following dependencies and remove the rules
                 downgradeIvy("org.codehaus.groovy:groovy-all")
                 downgradeTestNG("org.codehaus.groovy:groovy-all")
@@ -218,6 +221,20 @@ fun ComponentMetadataHandler.downgradeXmlApis(module: String) {
                     it.version { prefer("1.4.01") }
                     it.because("Gradle has trouble with the versioning scheme and pom redirects in higher versions")
                 }
+            }
+        }
+    }
+}
+
+
+fun ComponentMetadataHandler.replaceCglibNodepWithCglib(module: String) {
+    withModule(module) {
+        allVariants {
+            withDependencies {
+                filter { it.name == "cglib-nodep" }.forEach {
+                    add("${it.group}:cglib:3.2.6")
+                }
+                removeAll { it.name == "cglib-nodep" }
             }
         }
     }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -102,9 +102,9 @@ open class TestFixturesPlugin : Plugin<Project> {
             testLibraries("jmock").forEach { testFixturesCompile(it) }
 
             constraints {
-                testFixturesCompile("cglib:cglib-nodep") {
-                    version { prefer("3.2.5") }
-                    because("We need to upgrade to a Java8 compatible version")
+                testFixturesCompile("cglib:cglib") {
+                    version { prefer("3.2.6") }
+                    because("We need to upgrade to a Java 9 compatible version")
                 }
             }
         }

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     compile(testLibrary("jsoup"))
 
     constraints {
-        add(configurations.compile.name, "cglib:cglib-nodep:3.2.6") {
+        add(configurations.compile.name, "cglib:cglib:3.2.6") {
             because("required to work with Java 9")
         }
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -40,7 +40,7 @@ dependencies {
 
     testCompile '$dependencyNotation',
         'org.spockframework:spock-core:1.0-groovy-2.4@jar',
-        'cglib:cglib-nodep:2.2',
+        'cglib:cglib:3.2.6',
         'org.objenesis:objenesis:1.2'
 }
 """


### PR DESCRIPTION
### Context

Previously there's an old `cglib-nodep` in our test dependency graph. It introduces a rather old ASM, which is not compatible with JDK 11. 

For example, without this change, our Experimental Check will fail:

https://builds.gradle.org/viewLog.html?buildId=11927611&tab=buildResultsDiv&buildTypeId=Gradle_Check_Platform_Java10_Oracle_Linux_antlr

With this change, the check can pass:

https://builds.gradle.org/viewLog.html?buildId=11931346&tab=buildResultsDiv&buildTypeId=Gradle_Check_Platform_Java10_Oracle_Linux_antlr

This work is originally done by @acourtneybrown . Now I'm trying to make it into our code base.