### PR TITLE
Fix issue with header cycle and relative paths

### DIFF
--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
@@ -413,7 +413,7 @@ class IncrementalCompileProcessorTest extends Specification {
     }
 
     def sourceFile(def name) {
-        tmpDir.createFile(name) << "initial text"
+        tmpDir.createFile(name) << name
     }
 
     SourceIncludesResolver.IncludeResolutionResult resolveDeps(Collection<File> deps) {


### PR DESCRIPTION
See https://github.com/gradle/gradle-native/issues/615.

This fixes a regression from 4.5 where headers that form a cycle and use relative paths can cause a StackOverflowError.