### PR TITLE
Use Lookup to invoke defineClass on Java 9+

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ClassLoaderUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ClassLoaderUtilsTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader
+
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class ClassLoaderUtilsTest extends Specification {
+    def 'can inject classes to a classloader'() {
+        given:
+        Class testClass = DefaultClassLoaderFactoryTestHelper
+        File classpath = ClasspathUtil.getClasspathForClass(testClass)
+        File classFile = new File(classpath, testClass.name.replace('.', '/') + '.class')
+        byte[] bytes = Files.readAllBytes(classFile.toPath())
+        MyClassLoader myClassLoader = new MyClassLoader()
+
+        when:
+        Class klass = ClassLoaderUtils.define(myClassLoader, DefaultClassLoaderFactoryTestHelper.name, bytes)
+
+        then:
+        !testClass.classLoader.is(myClassLoader)
+        klass.classLoader.is(myClassLoader)
+    }
+}
+
+class MyClassLoader extends ClassLoader {}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -18,6 +18,7 @@ package org.gradle.process.internal.worker.child;
 
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.ClassPathProvider;
 import org.gradle.api.specs.Spec;
 import org.gradle.cache.CacheRepository;
@@ -57,7 +58,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -116,32 +119,9 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider, Closea
             try {
                 File jarFile = jarFile(cache);
                 LOGGER.debug("Generating worker process classes to {}.", jarFile);
-
-                // TODO - calculate this list of classes dynamically
-                List<Class<?>> classes = Arrays.asList(
-                        GradleWorkerMain.class,
-                        BootstrapSecurityManager.class,
-                        EncodedStream.EncodedInput.class,
-                        ClassLoaderUtils.class,
-                        FilteringClassLoader.class,
-                        FilteringClassLoader.Spec.class,
-                        ClassLoaderHierarchy.class,
-                        ClassLoaderVisitor.class,
-                        ClassLoaderSpec.class,
-                        SystemClassLoaderSpec.class,
-                        JavaReflectionUtil.class,
-                        JavaMethod.class,
-                        GradleException.class,
-                        NoSuchPropertyException.class,
-                        NoSuchMethodException.class,
-                        UncheckedException.class,
-                        PropertyAccessor.class,
-                        PropertyMutator.class,
-                        Factory.class,
-                        Spec.class);
                 ZipOutputStream outputStream = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(jarFile)));
                 try {
-                    for (Class<?> classToMap : classes) {
+                    for (Class<?> classToMap : getClassesForWorkerJar()) {
                         remapClass(classToMap, outputStream);
                     }
                 } finally {
@@ -150,6 +130,37 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider, Closea
             } catch (Exception e) {
                 throw new GradleException("Could not generate worker process bootstrap classes.", e);
             }
+        }
+
+        private Set<Class<?>> getClassesForWorkerJar() {
+            // TODO - calculate this list of classes dynamically
+            List<Class<?>> classes = Arrays.asList(
+                GradleWorkerMain.class,
+                BootstrapSecurityManager.class,
+                EncodedStream.EncodedInput.class,
+                ClassLoaderUtils.class,
+                FilteringClassLoader.class,
+                ClassLoaderHierarchy.class,
+                ClassLoaderVisitor.class,
+                ClassLoaderSpec.class,
+                SystemClassLoaderSpec.class,
+                JavaReflectionUtil.class,
+                JavaMethod.class,
+                GradleException.class,
+                NoSuchPropertyException.class,
+                NoSuchMethodException.class,
+                UncheckedException.class,
+                PropertyAccessor.class,
+                PropertyMutator.class,
+                Factory.class,
+                Spec.class,
+                JavaVersion.class);
+            Set<Class<?>> result = new HashSet<Class<?>>(classes);
+            for (Class<?> klass : classes) {
+                result.addAll(Arrays.asList(klass.getDeclaredClasses()));
+            }
+
+            return result;
         }
 
         private void remapClass(Class<?> classToMap, ZipOutputStream jar) throws IOException {


### PR DESCRIPTION
### Context

The last step of ASM bytecode generation is injecting `byte[]` into a classloader to let it load the class. Before Java 9, we were using reflection to invoke protected `ClassLoader.defineClass`. After Java 9, the reflection is forbidden without implicit `--add-on` so we switch to `Unsafe`. Unfortunately in Java 11, `Unsafe` is removed (#4860 ). This PR selects class injection method according to Java runtime version:

- Use reflection to invoke `ClassLoader.defineClass` on Java 8 and previous.
- Use `MethodHandles.Looup` to invoke `ClassLoader.defineClass` on Java 9+.

It's verified on JDK 11 early preview version.
