### PR TITLE
handle pom publications with an additional non-classifier artifact properly - fix for #4985

### DIFF
--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -58,6 +58,7 @@ import org.gradle.api.publish.maven.internal.publisher.MavenProjectIdentity;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.DefaultMavenModuleResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.CollectionUtils;
@@ -349,6 +350,9 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     private MavenArtifact determineMainArtifact() {
+        if (DefaultMavenModuleResolveMetadata.POM_PACKAGING.equals(pom.getPackaging())) {
+            return null;
+        }
         Set<MavenArtifact> unclassifiedArtifacts = getUnclassifiedArtifactsWithExtension();
         if (unclassifiedArtifacts.isEmpty()) {
             return null;

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -142,6 +142,22 @@ class DefaultMavenPublicationTest extends Specification {
         publication.pom.packaging == "ext"
     }
 
+    def 'implicit pom artifact is main artifact for pom packaging'() {
+        when:
+        def mavenArtifact = Mock(MavenArtifact)
+        notationParser.parseNotation('attached') >> mavenArtifact
+        mavenArtifact.extension >> 'pom.asc'
+
+        and:
+        def publication = createPublication()
+        publication.artifact('attached')
+        publication.pom.packaging = 'pom'
+
+        then:
+        !publication.asNormalisedPublication().mainArtifact
+        publication.pom.packaging == 'pom'
+    }
+
     def 'if there is only one artifact it is the main artifact even if packaging is different'() {
         when:
         def mavenArtifact = Mock(MavenArtifact)


### PR DESCRIPTION
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes