### PR TITLE
File buildFinished for the root builds only after all included builds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.build.BuildTestFile
-/**
- * Tests for resolving dependency cycles in a composite build.
- */
+
 class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrationTest {
     BuildTestFile buildB
     BuildTestFile buildC
@@ -128,7 +126,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         // `:buildB` is executed twice
         loggedAtLeast('buildListener.settingsEvaluated [:buildB]', 2)
         loggedAtLeast('buildListener.projectsEvaluated [:buildB]', 2)
-        loggedAtLeast('buildListener.buildFinished [:buildB]',2)
+        loggedAtLeast('buildListener.buildFinished [:buildB]', 2)
     }
 
     def "fires build listener events for included builds with additional discovered (compileOnly) dependencies"() {
@@ -148,6 +146,54 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
 
         then:
         verifyBuildEvents()
+    }
+
+    def "buildFinished for root build is guaranteed to complete after included builds"() {
+        given:
+
+        dependency 'org.test:b1:1.0'
+        dependency 'org.test:buildC:1.0'
+        buildC.buildFile << """
+            dependencies {
+                compileOnly 'org.test:b2:1.0'
+            }
+            
+            gradle.buildFinished {
+                sleep 500
+            }
+        """
+
+        buildB.file("b2/build.gradle") << """
+            task wait {
+                doLast {
+                    sleep 500
+                }
+            }
+            
+            jar.finalizedBy wait
+        """
+
+        when:
+        execute()
+
+        then:
+        def outputLines = result.normalizedOutput.readLines()
+        def rootBuildFinishedPosition = outputLines.indexOf("gradle.buildFinished [:]")
+        rootBuildFinishedPosition >= 0
+
+        def buildSuccessfulPosition = outputLines.indexOf("BUILD SUCCESSFUL in 0s")
+        buildSuccessfulPosition >= 0
+
+        def buildBFinishedPosition = outputLines.indexOf("gradle.buildFinished [:buildB]")
+        buildBFinishedPosition >= 0
+        def buildCFinishedPosition = outputLines.indexOf("gradle.buildFinished [:buildC]")
+        buildCFinishedPosition >= 0
+
+        buildBFinishedPosition < rootBuildFinishedPosition
+        buildBFinishedPosition < buildSuccessfulPosition
+
+        buildCFinishedPosition < rootBuildFinishedPosition
+        buildCFinishedPosition < buildSuccessfulPosition
     }
 
     void verifyBuildEvents() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -194,6 +194,14 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
 
         buildCFinishedPosition < rootBuildFinishedPosition
         buildCFinishedPosition < buildSuccessfulPosition
+
+        def lastRootBuildTaskPosition = outputLines.indexOf("> Task :resolveArtifacts")
+        lastRootBuildTaskPosition >= 0
+
+        def lateIncludedBuildTaskPosition = outputLines.indexOf("> Task :buildB:b2:wait")
+        lastRootBuildTaskPosition < lateIncludedBuildTaskPosition
+
+        lateIncludedBuildTaskPosition < rootBuildFinishedPosition
     }
 
     void verifyBuildEvents() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -33,9 +33,9 @@ import org.gradle.execution.BuildExecuter;
 import org.gradle.execution.TaskGraphExecuter;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
 import org.gradle.util.Path;
@@ -151,10 +151,12 @@ public class DefaultGradleLauncher implements GradleLauncher {
             return;
         }
 
-        buildListener.buildFinished(result);
         if (!isNestedBuild()) {
             gradle.getServices().get(IncludedBuildControllers.class).stopTaskExecution();
         }
+
+        buildListener.buildFinished(result);
+
         stage = Stage.Finished;
     }
 


### PR DESCRIPTION
This provides _a_ way to run something after all builds have completed. Additionally that this isn't the behaviour has tripped me up twice, which is an indication that users will assume that this is already the behaviour.

CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Ffinish-included-builds-before-root-build