### PR TITLE
Let init task use -bin distribution when --dsl kotlin

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -211,7 +211,7 @@ include("child")
         fails('init', '--dsl', 'some-unknown-dsl')
 
         then:
-        failure.assertHasDescription("The requested build script DSL 'some-unknown-dsl' is not supported.")
+        failure.assertHasCause("The requested build script DSL 'some-unknown-dsl' is not supported.")
     }
 
     def "gives decent error message when using unknown test framework"() {

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/modifiers/BuildInitDsl.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/modifiers/BuildInitDsl.java
@@ -17,22 +17,19 @@ package org.gradle.buildinit.plugins.internal.modifiers;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
-import org.gradle.api.tasks.wrapper.Wrapper;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
 public enum BuildInitDsl {
 
-    GROOVY(".gradle", Wrapper.DistributionType.BIN),
-    KOTLIN(".gradle.kts", Wrapper.DistributionType.ALL);
+    GROOVY(".gradle"),
+    KOTLIN(".gradle.kts");
 
     private final String fileExtension;
-    private final Wrapper.DistributionType wrapperDistributionType;
 
-    BuildInitDsl(String fileExtension, Wrapper.DistributionType wrapperDistributionType) {
+    BuildInitDsl(String fileExtension) {
         this.fileExtension = fileExtension;
-        this.wrapperDistributionType = wrapperDistributionType;
     }
 
     public static BuildInitDsl fromName(@Nullable String name) {
@@ -57,10 +54,6 @@ public enum BuildInitDsl {
 
     public String getId() {
         return name().toLowerCase();
-    }
-
-    public Wrapper.DistributionType getWrapperDistributionType() {
-        return wrapperDistributionType;
     }
 
     public String fileNameFor(String fileNameWithoutExtension) {

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/internal/TaskConfiguration.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/internal/TaskConfiguration.java
@@ -19,7 +19,6 @@ package org.gradle.buildinit.tasks.internal;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.wrapper.Wrapper;
@@ -62,25 +61,6 @@ public class TaskConfiguration {
                 }
             }
         });
-
-        project.getGradle().getTaskGraph().whenReady(new Action<TaskExecutionGraph>() {
-            @Override
-            public void execute(TaskExecutionGraph taskGraph) {
-                if (reasonToSkip(project) == null && taskGraph.hasTask(init)) {
-                    wrapperTaskOf(project)
-                        .setDistributionType(
-                            wrapperDistributionTypeFor(init.getDsl()));
-                }
-            }
-        });
-    }
-
-    private static Wrapper wrapperTaskOf(Project project) {
-        return (Wrapper) project.getTasks().getByName("wrapper");
-    }
-
-    private static Wrapper.DistributionType wrapperDistributionTypeFor(String dsl) {
-        return BuildInitDsl.fromName(dsl).getWrapperDistributionType();
     }
 
     private static String reasonToSkip(Project project) {

--- a/subprojects/build-init/src/testFixtures/groovy/org/gradle/buildinit/plugins/fixtures/ScriptDslFixture.groovy
+++ b/subprojects/build-init/src/testFixtures/groovy/org/gradle/buildinit/plugins/fixtures/ScriptDslFixture.groovy
@@ -76,8 +76,7 @@ class ScriptDslFixture {
         assert getBuildFile(parentFolder).exists()
         assert getSettingsFile(parentFolder).exists()
         def gradleVersion = GradleVersion.current().version
-        def distributionType = scriptDsl.wrapperDistributionType.name().toLowerCase()
-        new WrapperTestFixture(parentFolder).generated(gradleVersion, distributionType)
+        new WrapperTestFixture(parentFolder).generated(gradleVersion)
     }
 
     void assertWrapperNotGenerated(TestFile parentFolder = rootDir) {

--- a/subprojects/build-init/src/testFixtures/groovy/org/gradle/buildinit/plugins/fixtures/WrapperTestFixture.groovy
+++ b/subprojects/build-init/src/testFixtures/groovy/org/gradle/buildinit/plugins/fixtures/WrapperTestFixture.groovy
@@ -34,12 +34,12 @@ class WrapperTestFixture {
         this.projectDirectory = projectdirectory
     }
 
-    public void generated(String version = GradleVersion.current().version, String distributionType = "bin") {
+    public void generated(String version = GradleVersion.current().version) {
         projectDirectory.file(GRADLEW_BASH_SCRIPT).assertExists()
         projectDirectory.file(GRADLEW_BATCH_SCRIPT).assertExists()
         projectDirectory.file(GRADLEW_WRAPPER_JAR).assertExists()
         projectDirectory.file(GRADLEW_PROPERTY_FILE).assertExists()
-        projectDirectory.file(GRADLEW_PROPERTY_FILE).assertContents(containsString("gradle-${version}-${distributionType}.zip"))
+        projectDirectory.file(GRADLEW_PROPERTY_FILE).assertContents(containsString("gradle-${version}-bin.zip"))
     }
 
     public void notGenerated() {


### PR DESCRIPTION
No need to use a `-all` distribution as Gradle sources are downloaded on-demand by the Kotlin DSL IDE script dependencies resolver.