### PR TITLE
Support mutating dependency attributes via component metadata rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
 
 import javax.annotation.Nullable;
 
@@ -76,4 +77,22 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      */
     @Incubating
     SELF because(String reason);
+
+    /**
+     * Returns the attributes of this dependency.
+     *
+     * @return the attributes of this dependency
+     *
+     * @since 4.8
+     */
+    @Incubating
+    AttributeContainer getAttributes();
+
+    /**
+     * Adjust the attributes of this dependency
+     *
+     * @since 4.8
+     */
+    @Incubating
+    SELF attributes(Action<? super AttributeContainer> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -58,4 +59,15 @@ public interface ModuleComponentSelector extends ComponentSelector {
      */
     @Incubating
     VersionConstraint getVersionConstraint();
+
+    /**
+     * The attributes of the module to select the component from. The attributes only include
+     * selector specific attributes. This means it typically doesn't include any consumer specific attribute.
+     *
+     * @return the attributes
+     *
+     * @since 4.8
+     */
+    @Incubating
+    AttributeContainer getAttributes();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependenciesAttributesIntegrationTest.groovy
@@ -694,7 +694,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects direct=#expectedDirectVariant, transitive=[#expectedTransitiveVariantA, #expectedTransitiveVariantB], leaf=#expectedLeafVariant making sure dependency attribute value doesn't leak to transitives")
-    def "Attribute value on dependency only affects selection of this dependency"() {
+    def "Attribute value on dependency only affects selection of this dependency (using component metadata rules)"() {
         given:
         repository {
             def modules = ['direct', 'transitive', 'leaf']
@@ -722,7 +722,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                 components {
                     // transitive module will override the configuration attribute
                     // and it shouldn't affect the selection of 'direct' or 'leaf' dependencies
-                    withModule('org:transitiveA') {
+                    withModule('org:directA') {
                         allVariants {
                             withDependencies {
                                 it.each {
@@ -733,7 +733,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                             }
                         }
                     } 
-                    withModule('org:transitiveB') {
+                    withModule('org:directB') {
                         allVariants {
                             withDependencies {
                                 it.each {
@@ -767,19 +767,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedDirectVariant", custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedTransitiveVariantA", custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedLeafVariant", custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedDirectVariant", custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedTransitiveVariantB", custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedLeafVariant", custom: configurationAttributeValue])
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
@@ -34,7 +35,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         String group = decoder.readString();
         String name = decoder.readString();
         VersionConstraint versionConstraint = readVersionConstraint(decoder);
-        return newSelector(group, name, versionConstraint);
+        return newSelector(group, name, versionConstraint, ImmutableAttributes.EMPTY);
     }
 
     public VersionConstraint readVersionConstraint(Decoder decoder) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
@@ -20,12 +20,12 @@ import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
 import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 
@@ -77,7 +77,7 @@ public class DefaultDependencyResolveDetails implements DependencyResolveDetails
         if (delegate.getTarget() instanceof ModuleComponentSelector) {
             ModuleComponentSelector target = (ModuleComponentSelector) delegate.getTarget();
             if (!version.equals(target.getVersionConstraint())) {
-                delegate.useTarget(DefaultModuleComponentSelector.newSelector(target.getGroup(), target.getModule(), version), selectionReason);
+                delegate.useTarget(DefaultModuleComponentSelector.newSelector(target.getGroup(), target.getModule(), version, target.getAttributes()), selectionReason);
             } else {
                 // Still 'updated' with reason when version remains the same.
                 delegate.useTarget(delegate.getTarget(), selectionReason);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.data.PomDe
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
@@ -223,7 +222,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private ModuleDependencyMetadata toDependencyMetadata(ModuleComponentSelector selector) {
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, null, ImmutableAttributes.EMPTY);
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, null);
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.data.PomDe
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
@@ -35,6 +36,7 @@ import org.gradle.internal.component.external.model.GradleDependencyMetadata;
 import org.gradle.internal.component.external.model.MavenDependencyDescriptor;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableMavenModuleResolveMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 import org.slf4j.Logger;
@@ -44,6 +46,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -220,7 +223,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private ModuleDependencyMetadata toDependencyMetadata(ModuleComponentSelector selector) {
-        return new GradleDependencyMetadata(selector, false, null);
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, null, ImmutableAttributes.EMPTY);
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -46,7 +46,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
 
     public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
-            nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint());
+            nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
         return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
             Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true, dependencyConstraint.getReason());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -40,7 +40,11 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
         boolean changing = externalModuleDependency.isChanging();
         boolean transitive = externalModuleDependency.isTransitive();
 
-        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(nullToEmpty(dependency.getGroup()), nullToEmpty(dependency.getName()), ((VersionConstraintInternal)externalModuleDependency.getVersionConstraint()).asImmutable());
+        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
+            nullToEmpty(dependency.getGroup()),
+            nullToEmpty(dependency.getName()),
+            ((VersionConstraintInternal)externalModuleDependency.getVersionConstraint()).asImmutable(),
+            dependency.getAttributes());
 
         List<ExcludeMetadata> excludes = convertExcludeRules(clientConfiguration, dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
@@ -59,7 +59,7 @@ public class ModuleForcingResolveRule implements Action<DependencySubstitutionIn
             ModuleIdentifier key = moduleIdentifierFactory.module(selector.getGroup(), selector.getModule());
             if (forcedModules.containsKey(key)) {
                 DefaultImmutableVersionConstraint versionConstraint = new DefaultImmutableVersionConstraint(forcedModules.get(key));
-                details.useTarget(newSelector(key.getGroup(), key.getName(), versionConstraint), VersionSelectionReasons.FORCED);
+                details.useTarget(newSelector(key.getGroup(), key.getName(), versionConstraint, selector.getAttributes()), VersionSelectionReasons.FORCED);
 
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -18,11 +18,10 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.DependenciesMetadata;
+import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.GradleDependencyMetadata;
@@ -112,7 +111,7 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     }
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
-        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getGroup(), details.getName(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()));
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isPending(), details.getReason(), ((AttributeContainerInternal)details.getAttributes()).asImmutable());
+        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getGroup(), details.getName(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes());
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isPending(), details.getReason());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -22,13 +22,17 @@ import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.DependenciesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.GradleDependencyMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
 import java.util.AbstractList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -37,8 +41,10 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     protected final Map<Integer, T> dependencyMetadataAdapters;
     private final Instantiator instantiator;
     private final NotationParser<Object, T> dependencyNotationParser;
+    private final ImmutableAttributesFactory attributesFactory;
 
-    public AbstractDependenciesMetadataAdapter(List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata, Instantiator instantiator, NotationParser<Object, T> dependencyNotationParser) {
+    public AbstractDependenciesMetadataAdapter(ImmutableAttributesFactory attributesFactory, List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata, Instantiator instantiator, NotationParser<Object, T> dependencyNotationParser) {
+        this.attributesFactory = attributesFactory;
         this.dependenciesMetadata = dependenciesMetadata;
         this.dependencyMetadataAdapters = Maps.newHashMap();
         this.instantiator = instantiator;
@@ -52,7 +58,7 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     @Override
     public T get(int index) {
         if (!dependencyMetadataAdapters.containsKey(index)) {
-            dependencyMetadataAdapters.put(index, instantiator.newInstance(adapterImplementationType(), dependenciesMetadata, index));
+            dependencyMetadataAdapters.put(index, instantiator.newInstance(adapterImplementationType(), attributesFactory, dependenciesMetadata, index));
         }
         return dependencyMetadataAdapters.get(index);
     }
@@ -92,6 +98,13 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     private void doAdd(Object dependencyNotation, @Nullable Action<? super T> configureAction) {
         T dependencyMetadata = dependencyNotationParser.parseNotation(dependencyNotation);
+        if (dependencyMetadata instanceof AbstractDependencyImpl) {
+            // This is not super nice, but dependencies are created through reflection, for decoration
+            // and assume a constructor with 3 arguments (Group, Name, Version) which is suitable for
+            // most cases. We could create an empty attribute set directly in the AbstractDependencyImpl,
+            // but then it wouldn't be mutable. Therefore we proceed with "late injection" of the attributes
+            ((AbstractDependencyImpl) dependencyMetadata).setAttributes(attributesFactory.mutable());
+        }
         if (configureAction != null) {
             configureAction.execute(dependencyMetadata);
         }
@@ -100,6 +113,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getGroup(), details.getName(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()));
-        return new GradleDependencyMetadata(selector, isPending(), details.getReason());
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isPending(), details.getReason(), ((AttributeContainerInternal)details.getAttributes()).asImmutable());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyImpl.java
@@ -20,7 +20,9 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Cast;
 
 public abstract class AbstractDependencyImpl<T extends DependencyMetadata> implements DependencyMetadata<T> {
@@ -28,6 +30,7 @@ public abstract class AbstractDependencyImpl<T extends DependencyMetadata> imple
     private final String name;
     private MutableVersionConstraint versionConstraint;
     private String reason;
+    private AttributeContainer attributes = ImmutableAttributes.EMPTY;
 
     public AbstractDependencyImpl(String group, String name, String version) {
         this.group = group;
@@ -57,6 +60,12 @@ public abstract class AbstractDependencyImpl<T extends DependencyMetadata> imple
     }
 
     @Override
+    public T attributes(Action<? super AttributeContainer> configureAction) {
+        configureAction.execute(attributes);
+        return Cast.uncheckedCast(this);
+    }
+
+    @Override
     public String getReason() {
         return reason;
     }
@@ -65,6 +74,15 @@ public abstract class AbstractDependencyImpl<T extends DependencyMetadata> imple
     public T because(String reason) {
         this.reason = reason;
         return Cast.uncheckedCast(this);
+    }
+
+    public void setAttributes(AttributeContainer attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return attributes;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
@@ -20,11 +20,13 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyMetadata;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Cast;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 
 import java.util.List;
@@ -90,14 +92,16 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
 
     @Override
     public AttributeContainer getAttributes() {
-        return getOriginalMetadata().getAttributes();
+        return getOriginalMetadata().getSelector().getAttributes();
     }
 
     @Override
     public T attributes(Action<? super AttributeContainer> configureAction) {
-        AttributeContainer attributes = attributesFactory.mutable(getOriginalMetadata().getAttributes());
+        ModuleComponentSelector selector = getOriginalMetadata().getSelector();
+        AttributeContainerInternal attributes = attributesFactory.mutable((AttributeContainerInternal) selector.getAttributes());
         configureAction.execute(attributes);
-        ModuleDependencyMetadata metadata = getOriginalMetadata().withAttributes(((AttributeContainerInternal) attributes).asImmutable());
+        ModuleComponentSelector target = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), attributes.asImmutable());
+        ModuleDependencyMetadata metadata = (ModuleDependencyMetadata) getOriginalMetadata().withTarget(target);
         updateMetadata(metadata);
         return Cast.uncheckedCast(this);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintMetadataAdapter.java
@@ -17,13 +17,14 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 
 import java.util.List;
 
 public class DependencyConstraintMetadataAdapter extends AbstractDependencyMetadataAdapter<DependencyConstraintMetadata> implements DependencyConstraintMetadata {
 
-    public DependencyConstraintMetadataAdapter(List<ModuleDependencyMetadata> container, int originalIndex) {
-        super(container, originalIndex);
+    public DependencyConstraintMetadataAdapter(ImmutableAttributesFactory attributesFactory, List<ModuleDependencyMetadata> container, int originalIndex) {
+        super(attributesFactory, container, originalIndex);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DependencyConstraintsMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -25,9 +26,11 @@ import java.util.List;
 
 public class DependencyConstraintsMetadataAdapter extends AbstractDependenciesMetadataAdapter<DependencyConstraintMetadata> implements DependencyConstraintsMetadata {
 
-    public DependencyConstraintsMetadataAdapter(List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata, Instantiator instantiator,
+    public DependencyConstraintsMetadataAdapter(ImmutableAttributesFactory attributesFactory,
+                                                List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata,
+                                                Instantiator instantiator,
                                                 NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintsNotationParser) {
-        super(dependenciesMetadata, instantiator, dependencyConstraintsNotationParser);
+        super(attributesFactory, dependenciesMetadata, instantiator, dependencyConstraintsNotationParser);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
@@ -18,15 +18,18 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
 import java.util.List;
 
 public class DirectDependenciesMetadataAdapter extends AbstractDependenciesMetadataAdapter<DirectDependencyMetadata> implements DirectDependenciesMetadata {
-    public DirectDependenciesMetadataAdapter(List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata, Instantiator instantiator,
+    public DirectDependenciesMetadataAdapter(ImmutableAttributesFactory attributesFactory,
+                                             List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata,
+                                             Instantiator instantiator,
                                              NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser) {
-        super(dependenciesMetadata, instantiator, dependencyNotationParser);
+        super(attributesFactory, dependenciesMetadata, instantiator, dependencyNotationParser);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -17,13 +17,14 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.DirectDependencyMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 
 import java.util.List;
 
 public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataAdapter<DirectDependencyMetadata> implements DirectDependencyMetadata {
 
-    public DirectDependencyMetadataAdapter(List<ModuleDependencyMetadata> container, int originalIndex) {
-        super(container, originalIndex);
+    public DirectDependencyMetadataAdapter(ImmutableAttributesFactory attributesFactory, List<ModuleDependencyMetadata> container, int originalIndex) {
+        super(attributesFactory, container, originalIndex);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
@@ -102,7 +102,7 @@ public class DefaultIvyModulePublishMetadata implements IvyModulePublishMetadata
                 new DefaultImmutableVersionConstraint(
                     VERSION_TRANSFORMER.transform(versionConstraint.getPreferredVersion()),
                     CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER));
-            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), transformedConstraint);
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), transformedConstraint, selector.getAttributes());
             return dependency.withTarget(newSelector);
         }
         return dependency;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -63,7 +63,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
     private HashValue contentHash = EMPTY_CONTENT;
     private /*Mutable*/AttributeContainerInternal componentLevelAttributes;
 
-    private final VariantMetadataRules variantMetadataRules = new VariantMetadataRules();
+    private final VariantMetadataRules variantMetadataRules;
 
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
@@ -73,6 +73,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         this.componentId = componentIdentifier;
         this.moduleVersionId = moduleVersionId;
         this.componentLevelAttributes = defaultAttributes(attributesFactory);
+        this.variantMetadataRules = new VariantMetadataRules(attributesFactory);
     }
 
     AbstractMutableModuleComponentResolveMetadata(ModuleComponentResolveMetadata metadata) {
@@ -86,6 +87,7 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         this.variants = metadata.getVariants();
         this.attributesFactory = metadata.getAttributesFactory();
         this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
+        this.variantMetadataRules = new VariantMetadataRules(attributesFactory);
     }
 
     private static AttributeContainerInternal defaultAttributes(ImmutableAttributesFactory attributesFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -44,20 +44,18 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private final ModuleComponentIdentifier componentId;
     private final ExternalDependencyDescriptor dependencyDescriptor;
     private final String reason;
-    private final ImmutableAttributes attributes;
 
     private boolean alwaysUseAttributeMatching;
 
-    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, String reason, ImmutableAttributes attributes) {
+    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, String reason) {
         this.configuration = configuration;
         this.componentId = componentId;
         this.dependencyDescriptor = dependencyDescriptor;
         this.reason = reason;
-        this.attributes = attributes;
     }
 
     public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {
-        this(configuration, componentId, dependencyDescriptor, null, ImmutableAttributes.EMPTY);
+        this(configuration, componentId, dependencyDescriptor, null);
     }
 
     public ConfigurationBoundExternalDependencyMetadata alwaysUseAttributeMatching() {
@@ -98,7 +96,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleTarget = (ModuleComponentSelector) target;
-            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getModule(), moduleTarget.getVersionConstraint());
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getModule(), moduleTarget.getVersionConstraint(), moduleTarget.getAttributes());
             if (newSelector.equals(getSelector())) {
                 return this;
             }
@@ -117,7 +115,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion);
+        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion, selector.getAttributes());
         return withRequested(newSelector);
     }
 
@@ -126,20 +124,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         if (Objects.equal(reason, this.getReason())) {
             return this;
         }
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason, attributes);
-    }
-
-    @Override
-    public ImmutableAttributes getAttributes() {
-        return attributes;
-    }
-
-    @Override
-    public ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes) {
-        if (Objects.equal(attributes, this.getAttributes())) {
-            return this;
-        }
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason, attributes);
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason);
     }
 
     private ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -44,17 +44,20 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private final ModuleComponentIdentifier componentId;
     private final ExternalDependencyDescriptor dependencyDescriptor;
     private final String reason;
+    private final ImmutableAttributes attributes;
+
     private boolean alwaysUseAttributeMatching;
 
-    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, String reason) {
+    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, String reason, ImmutableAttributes attributes) {
         this.configuration = configuration;
         this.componentId = componentId;
         this.dependencyDescriptor = dependencyDescriptor;
         this.reason = reason;
+        this.attributes = attributes;
     }
 
     public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {
-        this(configuration, componentId, dependencyDescriptor, null);
+        this(configuration, componentId, dependencyDescriptor, null, ImmutableAttributes.EMPTY);
     }
 
     public ConfigurationBoundExternalDependencyMetadata alwaysUseAttributeMatching() {
@@ -123,12 +126,20 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         if (Objects.equal(reason, this.getReason())) {
             return this;
         }
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason);
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason, attributes);
     }
 
     @Override
     public ImmutableAttributes getAttributes() {
-        return ImmutableAttributes.EMPTY;
+        return attributes;
+    }
+
+    @Override
+    public ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes) {
+        if (Objects.equal(attributes, this.getAttributes())) {
+            return this;
+        }
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason, attributes);
     }
 
     private ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -20,21 +20,27 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     private final String group;
     private final String module;
     private final ImmutableVersionConstraint versionConstraint;
+    private final ImmutableAttributes attributes;
 
-    private DefaultModuleComponentSelector(String group, String module, ImmutableVersionConstraint version) {
+    private DefaultModuleComponentSelector(String group, String module, ImmutableVersionConstraint version, ImmutableAttributes attributes) {
         assert group != null : "group cannot be null";
         assert module != null : "module cannot be null";
         assert version != null : "version cannot be null";
+        assert attributes != null : "attributes cannot be null";
         this.group = group;
         this.module = module;
         this.versionConstraint = version;
+        this.attributes = attributes;
     }
 
     public String getDisplayName() {
@@ -71,6 +77,11 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         return versionConstraint;
     }
 
+    @Override
+    public AttributeContainer getAttributes() {
+        return attributes;
+    }
+
     public boolean matchesStrictly(ComponentIdentifier identifier) {
         assert identifier != null : "identifier cannot be null";
 
@@ -104,6 +115,9 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         if (!versionConstraint.equals(that.versionConstraint)) {
             return false;
         }
+        if (!attributes.equals(that.attributes)) {
+            return false;
+        }
 
         return true;
     }
@@ -113,6 +127,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         int result = group.hashCode();
         result = 31 * result + module.hashCode();
         result = 31 * result + versionConstraint.hashCode();
+        result = 31 * result + attributes.hashCode();
         return result;
     }
 
@@ -121,15 +136,19 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         return getDisplayName();
     }
 
+    public static ModuleComponentSelector newSelector(String group, String name, VersionConstraint version, AttributeContainer attributes) {
+        return new DefaultModuleComponentSelector(group, name, DefaultImmutableVersionConstraint.of(version), ((AttributeContainerInternal)attributes).asImmutable());
+    }
+
     public static ModuleComponentSelector newSelector(String group, String name, VersionConstraint version) {
-        return new DefaultModuleComponentSelector(group, name, DefaultImmutableVersionConstraint.of(version));
+        return new DefaultModuleComponentSelector(group, name, DefaultImmutableVersionConstraint.of(version), ImmutableAttributes.EMPTY);
     }
 
     public static ModuleComponentSelector newSelector(String group, String name, String version) {
-        return new DefaultModuleComponentSelector(group, name, DefaultImmutableVersionConstraint.of(version));
+        return new DefaultModuleComponentSelector(group, name, DefaultImmutableVersionConstraint.of(version), ImmutableAttributes.EMPTY);
     }
 
     public static ModuleComponentSelector newSelector(ModuleVersionSelector selector) {
-        return new DefaultModuleComponentSelector(selector.getGroup(), selector.getName(), DefaultImmutableVersionConstraint.of(selector.getVersion()));
+        return new DefaultModuleComponentSelector(selector.getGroup(), selector.getName(), DefaultImmutableVersionConstraint.of(selector.getVersion()), ImmutableAttributes.EMPTY);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -39,14 +39,12 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     private final List<ExcludeMetadata> excludes;
     private final boolean pending;
     private final String reason;
-    private final ImmutableAttributes attributes;
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean pending, String reason, ImmutableAttributes attributes) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean pending, String reason) {
         this.selector = selector;
         this.excludes = excludes;
         this.reason = reason;
         this.pending = pending;
-        this.attributes = attributes;
     }
 
     @Override
@@ -59,7 +57,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion), excludes, pending, reason, attributes);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion, selector.getAttributes()), excludes, pending, reason);
     }
 
     @Override
@@ -67,26 +65,13 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (Objects.equal(reason, this.reason)) {
             return this;
         }
-        return new GradleDependencyMetadata(selector, excludes, pending, reason, attributes);
-    }
-
-    @Override
-    public ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes) {
-        if (Objects.equal(attributes, this.attributes)) {
-            return this;
-        }
-        return new GradleDependencyMetadata(selector, excludes, pending, reason, attributes);
-    }
-
-    @Override
-    public ImmutableAttributes getAttributes() {
-        return attributes;
+        return new GradleDependencyMetadata(selector, excludes, pending, reason);
     }
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
-            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, pending, reason, attributes);
+            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, pending, reason);
         }
         return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this);
     }
@@ -128,7 +113,6 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     public String getReason() {
         return reason;
     }
-
 
     @Override
     public String toString() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -32,7 +32,6 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
-import java.util.Collections;
 import java.util.List;
 
 public class GradleDependencyMetadata implements ModuleDependencyMetadata {
@@ -40,19 +39,14 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     private final List<ExcludeMetadata> excludes;
     private final boolean pending;
     private final String reason;
+    private final ImmutableAttributes attributes;
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, boolean pending, String reason) {
-        this.selector = selector;
-        this.reason = reason;
-        this.excludes = Collections.emptyList();
-        this.pending = pending;
-    }
-
-    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, String reason) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean pending, String reason, ImmutableAttributes attributes) {
         this.selector = selector;
         this.excludes = excludes;
         this.reason = reason;
-        this.pending = false;
+        this.pending = pending;
+        this.attributes = attributes;
     }
 
     @Override
@@ -65,7 +59,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion), pending, reason);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion), excludes, pending, reason, attributes);
     }
 
     @Override
@@ -73,18 +67,26 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (Objects.equal(reason, this.reason)) {
             return this;
         }
-        return new GradleDependencyMetadata(selector, pending, reason);
+        return new GradleDependencyMetadata(selector, excludes, pending, reason, attributes);
+    }
+
+    @Override
+    public ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes) {
+        if (Objects.equal(attributes, this.attributes)) {
+            return this;
+        }
+        return new GradleDependencyMetadata(selector, excludes, pending, reason, attributes);
     }
 
     @Override
     public ImmutableAttributes getAttributes() {
-        return ImmutableAttributes.EMPTY;
+        return attributes;
     }
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
-            return new GradleDependencyMetadata((ModuleComponentSelector) target, pending, reason);
+            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, pending, reason, attributes);
         }
         return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
@@ -17,7 +17,6 @@ package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.DependencyMetadata;
 
 public interface ModuleDependencyMetadata extends DependencyMetadata {
@@ -32,6 +31,4 @@ public interface ModuleDependencyMetadata extends DependencyMetadata {
     @Override
     ModuleDependencyMetadata withReason(String reason);
 
-    @Override
-    ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
@@ -17,6 +17,7 @@ package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.DependencyMetadata;
 
 public interface ModuleDependencyMetadata extends DependencyMetadata {
@@ -30,4 +31,7 @@ public interface ModuleDependencyMetadata extends DependencyMetadata {
 
     @Override
     ModuleDependencyMetadata withReason(String reason);
+
+    @Override
+    ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -43,23 +43,13 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     @Override
     public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
         ModuleComponentSelector selector = getSelector();
-        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion);
+        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion, selector.getAttributes());
         return new ModuleDependencyMetadataWrapper(delegate.withTarget(newSelector));
     }
 
     @Override
     public ModuleDependencyMetadata withReason(String reason) {
         return new ModuleDependencyMetadataWrapper(delegate.withReason(reason));
-    }
-
-    @Override
-    public ImmutableAttributes getAttributes() {
-        return delegate.getAttributes();
-    }
-
-    @Override
-    public ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes) {
-        return (ModuleDependencyMetadata) delegate.withAttributes(attributes);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -58,6 +58,11 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
+    public ModuleDependencyMetadata withAttributes(ImmutableAttributes attributes) {
+        return (ModuleDependencyMetadata) delegate.withAttributes(attributes);
+    }
+
+    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         return delegate.withTarget(target);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -62,15 +62,15 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), ImmutableAttributes.EMPTY));
+            dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason()));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
             dependencies.add(new GradleDependencyMetadata(
                 DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
-                dependencyConstraint.getReason(),
-                ImmutableAttributes.EMPTY));
+                dependencyConstraint.getReason()
+            ));
         }
         this.dependencies = ImmutableList.copyOf(dependencies);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -35,6 +35,7 @@ import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -61,10 +62,15 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            dependencies.add(new GradleDependencyMetadata(selector, excludes, dependency.getReason()));
+            dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), ImmutableAttributes.EMPTY));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
-            dependencies.add(new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()), true, dependencyConstraint.getReason()));
+            dependencies.add(new GradleDependencyMetadata(
+                DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()),
+                Collections.<ExcludeMetadata>emptyList(),
+                true,
+                dependencyConstraint.getReason(),
+                ImmutableAttributes.EMPTY));
         }
         this.dependencies = ImmutableList.copyOf(dependencies);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -43,9 +43,14 @@ import java.util.Iterator;
 import java.util.List;
 
 public class VariantMetadataRules {
+    private final ImmutableAttributesFactory attributesFactory;
     private DependencyMetadataRules dependencyMetadataRules;
     private VariantAttributesRules variantAttributesRules;
     private CapabilitiesRules capabilitiesRules;
+
+    public VariantMetadataRules(ImmutableAttributesFactory attributesFactory) {
+        this.attributesFactory = attributesFactory;
+    }
 
     public ImmutableAttributes applyVariantAttributeRules(VariantResolveMetadata variant, AttributeContainerInternal source) {
         if (variantAttributesRules != null) {
@@ -71,14 +76,14 @@ public class VariantMetadataRules {
 
     public void addDependencyAction(Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser, VariantAction<? super DirectDependenciesMetadata> action) {
         if (dependencyMetadataRules == null) {
-            dependencyMetadataRules = new DependencyMetadataRules(instantiator, dependencyNotationParser, dependencyConstraintNotationParser);
+            dependencyMetadataRules = new DependencyMetadataRules(instantiator, dependencyNotationParser, dependencyConstraintNotationParser, attributesFactory);
         }
         dependencyMetadataRules.addDependencyAction(action);
     }
 
     public void addDependencyConstraintAction(Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser, VariantAction<? super DependencyConstraintsMetadata> action) {
         if (dependencyMetadataRules == null) {
-            dependencyMetadataRules = new DependencyMetadataRules(instantiator, dependencyNotationParser, dependencyConstraintNotationParser);
+            dependencyMetadataRules = new DependencyMetadataRules(instantiator, dependencyNotationParser, dependencyConstraintNotationParser, attributesFactory);
         }
         dependencyMetadataRules.addDependencyConstraintAction(action);
     }
@@ -129,6 +134,10 @@ public class VariantMetadataRules {
 
     private static class ImmutableRules extends VariantMetadataRules {
         private final static ImmutableRules INSTANCE = new ImmutableRules();
+
+        private ImmutableRules() {
+            super(null);
+        }
 
         @Override
         public void addDependencyAction(Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser, VariantAction<? super DirectDependenciesMetadata> action) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -91,13 +91,4 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
         return delegate.withReason(reason);
     }
 
-    @Override
-    public ImmutableAttributes getAttributes() {
-        return delegate.getAttributes();
-    }
-
-    @Override
-    public DependencyMetadata withAttributes(ImmutableAttributes attributes) {
-        return delegate.withAttributes(attributes);
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -95,4 +95,9 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     public ImmutableAttributes getAttributes() {
         return delegate.getAttributes();
     }
+
+    @Override
+    public DependencyMetadata withAttributes(ImmutableAttributes attributes) {
+        return delegate.withAttributes(attributes);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -17,9 +17,7 @@
 package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -111,21 +109,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public ImmutableAttributes getAttributes() {
-        if (source instanceof ModuleDependency) {
-            AttributeContainerInternal attributes = (AttributeContainerInternal) ((ModuleDependency) source).getAttributes();
-            return attributes.asImmutable();
-        }
-        return delegate.getAttributes();
-    }
-
-    @Override
     public ComponentSelector getSelector() {
         return delegate.getSelector();
     }
 
-    @Override
-    public DependencyMetadata withAttributes(ImmutableAttributes attributes) {
-        return delegate.withAttributes(attributes);
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -123,4 +123,9 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     public ComponentSelector getSelector() {
         return delegate.getSelector();
     }
+
+    @Override
+    public DependencyMetadata withAttributes(ImmutableAttributes attributes) {
+        return delegate.withAttributes(attributes);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -78,7 +78,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                 dependencyLockingState = dependencyLockingProvider.findLockConstraint(getName());
                 for (DependencyConstraint dependencyConstraint : dependencyLockingState.getLockedDependencies()) {
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
-                        dependencyConstraint.getGroup(), dependencyConstraint.getName(), dependencyConstraint.getVersionConstraint());
+                        dependencyConstraint.getGroup(), dependencyConstraint.getName(), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
                     result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
                         Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true, dependencyConstraint.getReason()));
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -84,7 +84,4 @@ public interface DependencyMetadata {
      */
     DependencyMetadata withReason(String reason);
 
-    ImmutableAttributes getAttributes();
-
-    DependencyMetadata withAttributes(ImmutableAttributes attributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -85,4 +85,6 @@ public interface DependencyMetadata {
     DependencyMetadata withReason(String reason);
 
     ImmutableAttributes getAttributes();
+
+    DependencyMetadata withAttributes(ImmutableAttributes attributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintsMetadataAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependenciesMetadataAdapter;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
@@ -60,13 +61,16 @@ public class DependencyMetadataRules {
     private final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser;
     private final List<VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata>> dependencyActions = Lists.newArrayList();
     private final List<VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata>> dependencyConstraintActions = Lists.newArrayList();
+    private final ImmutableAttributesFactory attributesFactory;
 
     public DependencyMetadataRules(Instantiator instantiator,
                                    NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser,
-                                   NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser) {
+                                   NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser,
+                                   ImmutableAttributesFactory attributesFactory) {
         this.instantiator = instantiator;
         this.dependencyNotationParser = dependencyNotationParser;
         this.dependencyConstraintNotationParser = dependencyConstraintNotationParser;
+        this.attributesFactory = attributesFactory;
     }
 
     public void addDependencyAction(VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> action) {
@@ -88,7 +92,7 @@ public class DependencyMetadataRules {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
         for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
             dependenciesMetadataAction.maybeExecute(variant, instantiator.newInstance(
-                DirectDependenciesMetadataAdapter.class, calculatedDependencies, instantiator, dependencyNotationParser));
+                DirectDependenciesMetadataAdapter.class, attributesFactory, calculatedDependencies, instantiator, dependencyNotationParser));
         }
         return calculatedDependencies;
     }
@@ -97,7 +101,7 @@ public class DependencyMetadataRules {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
         for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
             dependencyConstraintsMetadataAction.maybeExecute(variant, instantiator.newInstance(
-                DependencyConstraintsMetadataAdapter.class, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
+                DependencyConstraintsMetadataAdapter.class, attributesFactory, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
         }
         return calculatedDependencies;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -186,19 +186,6 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         return copyWithReason(reason);
     }
 
-    @Override
-    public ImmutableAttributes getAttributes() {
-        return dependencyAttributes;
-    }
-
-    @Override
-    public DependencyMetadata withAttributes(ImmutableAttributes attributes) {
-        if (Objects.equal(attributes, this.dependencyAttributes)) {
-            return this;
-        }
-        return copyWithAttributes(attributes);
-    }
-
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
         return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
     }
@@ -207,7 +194,4 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
     }
 
-    private LocalOriginDependencyMetadata copyWithAttributes(ImmutableAttributes attributes) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, attributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -53,7 +53,8 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             AttributeContainer moduleAttributes,
                                             AttributeContainer dependencyAttributes,
                                             String dependencyConfiguration,
-                                            List<IvyArtifactName> artifactNames, List<ExcludeMetadata> excludes,
+                                            List<IvyArtifactName> artifactNames,
+                                            List<ExcludeMetadata> excludes,
                                             boolean force, boolean changing, boolean transitive, boolean pending,
                                             String reason) {
         this.componentId = componentId;
@@ -190,11 +191,23 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         return dependencyAttributes;
     }
 
+    @Override
+    public DependencyMetadata withAttributes(ImmutableAttributes attributes) {
+        if (Objects.equal(attributes, this.dependencyAttributes)) {
+            return this;
+        }
+        return copyWithAttributes(attributes);
+    }
+
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
         return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
     }
 
     private LocalOriginDependencyMetadata copyWithReason(String reason) {
         return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
+    }
+
+    private LocalOriginDependencyMetadata copyWithAttributes(ImmutableAttributes attributes) {
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, attributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -49,7 +49,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         given:
         def dependency = Mock(ModuleDependencyMetadata)
         def result = Mock(BuildableModuleVersionListingResolveResult)
-        dependency.getSelector() >> new DefaultModuleComponentSelector('a', 'b', DefaultImmutableVersionConstraint.of('1.0'))
+        dependency.getSelector() >> DefaultModuleComponentSelector.newSelector('a', 'b', DefaultImmutableVersionConstraint.of('1.0'))
 
         when: 'repo is not blacklisted'
         repositoryBlacklister.isBlacklisted(REPOSITORY_ID) >> false

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -53,7 +53,7 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
 
     def "serializes ModuleComponentSelector"() {
         given:
-        ModuleComponentSelector selection = new DefaultModuleComponentSelector('group-one', 'name-one', constraint('version-one'))
+        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector('group-one', 'name-one', constraint('version-one'))
 
         when:
         ModuleComponentSelector result = serialize(selection, serializer)
@@ -99,7 +99,7 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
 
     def "serializes strict constraint"() {
         given:
-        ModuleComponentSelector selection = new DefaultModuleComponentSelector('group-one', 'name-one', constraint('version-one', true))
+        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector('group-one', 'name-one', constraint('version-one', true))
 
         when:
         ModuleComponentSelector result = serialize(selection, serializer)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -253,7 +253,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
     }
 
     private DependencyResult dep(String requested, Exception failure = null, String selected = requested) {
-        def selector = new DefaultModuleComponentSelector("x", requested, DefaultImmutableVersionConstraint.of("1"))
+        def selector = DefaultModuleComponentSelector.newSelector("x", requested, DefaultImmutableVersionConstraint.of("1"))
         def moduleVersionSelector = newSelector("x", requested, new DefaultMutableVersionConstraint("1"))
         failure = failure == null ? null : new ModuleVersionResolveException(moduleVersionSelector, failure)
         new DummyInternalDependencyResult(requested: selector, selected: id(selected), failure: failure)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.internal.component.external.model.GradleDependencyMetadata
 import org.gradle.internal.component.model.DependencyMetadata
@@ -185,15 +184,15 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].selector.group == "org.gradle.test"
         dependenciesMetadata[0].selector.module == "module1"
         dependenciesMetadata[0].selector.version == "1.0"
-        dependenciesMetadata[0].attributes.keySet() == [attr] as Set
-        dependenciesMetadata[0].attributes.getAttribute(attr) == 'foo'
+        dependenciesMetadata[0].selector.attributes.keySet() == [attr] as Set
+        dependenciesMetadata[0].selector.attributes.getAttribute(attr) == 'foo'
     }
 
     private fillDependencyList(int size) {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
             ModuleComponentSelector requested = newSelector("org.gradle.test", "module$size", "1.0")
-            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null, ImmutableAttributes.EMPTY) ]
+            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null) ]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -17,10 +17,13 @@
 package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.internal.component.external.model.GradleDependencyMetadata
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
@@ -169,18 +172,35 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].selector.version == "2.0"
     }
 
+    def "can modify dependency attributes"() {
+        given:
+        def attr = Attribute.of('test', String)
+        fillDependencyList(1)
+
+        when:
+        adapter.get(0).attributes { it.attribute(attr, 'foo') }
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].selector.group == "org.gradle.test"
+        dependenciesMetadata[0].selector.module == "module1"
+        dependenciesMetadata[0].selector.version == "1.0"
+        dependenciesMetadata[0].attributes.keySet() == [attr] as Set
+        dependenciesMetadata[0].attributes.getAttribute(attr) == 'foo'
+    }
+
     private fillDependencyList(int size) {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
             ModuleComponentSelector requested = newSelector("org.gradle.test", "module$size", "1.0")
-            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], null) ]
+            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null, ImmutableAttributes.EMPTY) ]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }
 
     class TestDependenciesMetadataAdapter extends AbstractDependenciesMetadataAdapter {
         TestDependenciesMetadataAdapter(List<DependencyMetadata> dependenciesMetadata) {
-            super(dependenciesMetadata, DirectInstantiator.INSTANCE, DependencyMetadataNotationParser.parser(DirectInstantiator.INSTANCE, DirectDependencyMetadataImpl.class))
+            super(TestUtil.attributesFactory(), dependenciesMetadata, DirectInstantiator.INSTANCE, DependencyMetadataNotationParser.parser(DirectInstantiator.INSTANCE, DirectDependencyMetadataImpl.class))
         }
 
         @Override


### PR DESCRIPTION
### Context

This commit allows mutating attributes of module dependencies via component metadata rules.
Even if a published module doesn't declare any attribute on a dependency, it is now possible
to mutate the module metadata so that dependencies have attributes, which would then be used
in dependency resolution.

It also adds tests to make sure that attributes defined on a specific dependency only affect that very specific dependency (they don't leak transitively).

