### PR TITLE
Fix failed Java 10 tests

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,7 @@ subprojects {
         dependencies {
             compile(localGroovy())
             testCompile("org.spockframework:spock-core:1.0-groovy-2.4")
-            testCompile("cglib:cglib-nodep:3.2.5")
+            testCompile("cglib:cglib:3.2.6")
             testCompile("org.objenesis:objenesis:2.4")
             constraints {
                 compile("org.codehaus.groovy:groovy-all:2.4.12")

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -65,9 +65,6 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
                 // Read capabilities declared in capabilities.json
                 readCapabilitiesFromJson()
 
-                replaceCglibNodepWithCglib("org.spockframework:spock-core")
-                replaceCglibNodepWithCglib("org.jmock:jmock-legacy")
-
                 //TODO check if we can upgrade the following dependencies and remove the rules
                 downgradeIvy("org.codehaus.groovy:groovy-all")
                 downgradeTestNG("org.codehaus.groovy:groovy-all")
@@ -221,20 +218,6 @@ fun ComponentMetadataHandler.downgradeXmlApis(module: String) {
                     it.version { prefer("1.4.01") }
                     it.because("Gradle has trouble with the versioning scheme and pom redirects in higher versions")
                 }
-            }
-        }
-    }
-}
-
-
-fun ComponentMetadataHandler.replaceCglibNodepWithCglib(module: String) {
-    withModule(module) {
-        allVariants {
-            withDependencies {
-                filter { it.name == "cglib-nodep" }.forEach {
-                    add("${it.group}:cglib:3.2.6")
-                }
-                removeAll { it.name == "cglib-nodep" }
             }
         }
     }

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -65,6 +65,9 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
                 // Read capabilities declared in capabilities.json
                 readCapabilitiesFromJson()
 
+                replaceCglibNodepWithCglib("org.spockframework:spock-core")
+                replaceCglibNodepWithCglib("org.jmock:jmock-legacy")
+
                 //TODO check if we can upgrade the following dependencies and remove the rules
                 downgradeIvy("org.codehaus.groovy:groovy-all")
                 downgradeTestNG("org.codehaus.groovy:groovy-all")
@@ -218,6 +221,20 @@ fun ComponentMetadataHandler.downgradeXmlApis(module: String) {
                     it.version { prefer("1.4.01") }
                     it.because("Gradle has trouble with the versioning scheme and pom redirects in higher versions")
                 }
+            }
+        }
+    }
+}
+
+
+fun ComponentMetadataHandler.replaceCglibNodepWithCglib(module: String) {
+    withModule(module) {
+        allVariants {
+            withDependencies {
+                filter { it.name == "cglib-nodep" }.forEach {
+                    add("${it.group}:cglib:3.2.6")
+                }
+                removeAll { it.name == "cglib-nodep" }
             }
         }
     }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -100,13 +100,6 @@ open class TestFixturesPlugin : Plugin<Project> {
             testFixturesCompile(library("junit"))
             testFixturesCompile(testLibrary("spock"))
             testLibraries("jmock").forEach { testFixturesCompile(it) }
-
-            constraints {
-                testFixturesCompile("cglib:cglib") {
-                    version { prefer("3.2.6") }
-                    because("We need to upgrade to a Java 9 compatible version")
-                }
-            }
         }
 
         plugins.withType<IdeaPlugin> {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -102,9 +102,9 @@ open class TestFixturesPlugin : Plugin<Project> {
             testLibraries("jmock").forEach { testFixturesCompile(it) }
 
             constraints {
-                testFixturesCompile("cglib:cglib-nodep") {
-                    version { prefer("3.2.5") }
-                    because("We need to upgrade to a Java8 compatible version")
+                testFixturesCompile("cglib:cglib") {
+                    version { prefer("3.2.6") }
+                    because("We need to upgrade to a Java 9 compatible version")
                 }
             }
         }

--- a/gradle/dependency-management/capabilities.json
+++ b/gradle/dependency-management/capabilities.json
@@ -86,5 +86,13 @@
         ],
         "selected": "org.ow2.asm:asm-util",
         "upgrade": "6.1"
+    },
+    {
+        "name": "cglib",
+        "providedBy": [
+            "cglib:cglib-nodep"
+        ],
+        "selected": "cglib:cglib",
+        "upgrade": "3.2.6"
     }
 ]

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -39,12 +39,6 @@ dependencies {
     testLibraries("jmock").forEach { compile(it) }
     compile(testLibrary("spock"))
     compile(testLibrary("jsoup"))
-
-    constraints {
-        add(configurations.compile.name, "cglib:cglib:3.2.6") {
-            because("required to work with Java 9")
-        }
-    }
 }
 
 gradlebuildJava {

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     compile(testLibrary("jsoup"))
 
     constraints {
-        add(configurations.compile.name, "cglib:cglib-nodep:3.2.6") {
+        add(configurations.compile.name, "cglib:cglib:3.2.6") {
             because("required to work with Java 9")
         }
     }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -100,6 +100,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK8_OR_EARLIER({
         JavaVersion.current() <= JavaVersion.VERSION_1_8
     }),
+    JDK9_OR_EARLIER({
+        JavaVersion.current() <= JavaVersion.VERSION_1_9
+    }),
     JDK7_POSIX({
         NOT_WINDOWS.fulfilled
     }),

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -41,7 +41,7 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue(["GRADLE-2520", "https://github.com/gradle/gradle/issues/4993"])
-    @Requires(TestPrecondition.JDK8_OR_EARLIER)
+    @Requires(TestPrecondition.JDK9_OR_EARLIER)
     def canCombineLocalOptionWithOtherOptions() {
         when:
         run("javadoc")

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -40,7 +40,8 @@ class JavadocIntegrationTest extends AbstractIntegrationSpec {
         javadoc.text =~ /(?ms)Custom Taglet.*custom taglet value/
     }
 
-    @Issue("GRADLE-2520")
+    @Issue(["GRADLE-2520", "https://github.com/gradle/gradle/issues/4993"])
+    @Requires(TestPrecondition.JDK8_OR_EARLIER)
     def canCombineLocalOptionWithOtherOptions() {
         when:
         run("javadoc")

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testkit.runner
 
 import groovy.transform.NotYetImplemented
-import org.gradle.api.JavaVersion
 import spock.lang.Issue
 
 class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTest {
@@ -90,7 +89,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
         when:
         runner("writeValue", "--parallel")
-            .withGradleVersion(JavaVersion.current() > JavaVersion.VERSION_1_9 ? "4.1" : "3.1") // Gradle 4.0 can't recognize Java 10
+            .withGradleVersion("4.1")
             .build()
 
         then:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testkit.runner
 
 import groovy.transform.NotYetImplemented
+import org.gradle.api.JavaVersion
 import spock.lang.Issue
 
 class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTest {
@@ -89,7 +90,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
         when:
         runner("writeValue", "--parallel")
-            .withGradleVersion("3.1")
+            .withGradleVersion(JavaVersion.current() > JavaVersion.VERSION_1_9 ? "4.1" : "3.1") // Gradle 4.0 can't recognize Java 10
             .build()
 
         then:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testkit.runner
 
 import org.gradle.api.Action
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.RetryRuleUtil
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
 import org.gradle.testing.internal.util.RetryRule
@@ -31,8 +32,8 @@ import spock.lang.Shared
 @NonCrossVersion
 @Requires(TestPrecondition.ONLINE)
 class GradleRunnerGradleVersionIntegrationTest extends BaseGradleRunnerIntegrationTest {
-
-    public static final String VERSION = "2.10"
+    // Gradle 4.0 can't recognize Java 10
+    public static final String VERSION = JavaVersion.current() > JavaVersion.VERSION_1_9 ? "4.1" : "2.10"
 
     @Shared
     DistributionLocator locator = new DistributionLocator()

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testkit.runner
 
 import org.gradle.api.Action
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.RetryRuleUtil
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
 import org.gradle.testing.internal.util.RetryRule
@@ -32,8 +31,7 @@ import spock.lang.Shared
 @NonCrossVersion
 @Requires(TestPrecondition.ONLINE)
 class GradleRunnerGradleVersionIntegrationTest extends BaseGradleRunnerIntegrationTest {
-    // Gradle 4.0 can't recognize Java 10
-    public static final String VERSION = JavaVersion.current() > JavaVersion.VERSION_1_9 ? "4.1" : "2.10"
+    public static final String VERSION = "4.1"
 
     @Shared
     DistributionLocator locator = new DistributionLocator()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -40,7 +40,7 @@ dependencies {
 
     testCompile '$dependencyNotation',
         'org.spockframework:spock-core:1.0-groovy-2.4@jar',
-        'cglib:cglib-nodep:2.2',
+        'cglib:cglib:3.2.6',
         'org.objenesis:objenesis:1.2'
 }
 """


### PR DESCRIPTION
### Context

This PR fixes 3 issues:

- Remove `cglib-nodep` in test dependencies because it introduces a very old ASM which doesn't support Java 10. This commit is cherry-picked from `master`.
- Remove usage of `com.sun.tools.doclets.Taglet`. See #4993 
- Fix failed TestKit tests which are using old Gradle because it pre-4.1 Gradle doesn't support Java 10.