### PR TITLE
Fix issue with LinePerThreadBufferingOutputStream being reused across threads

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
@@ -67,9 +67,10 @@ public class LinePerThreadBufferingOutputStream extends PrintStream {
 
     @Override
     public void close() {
-        PrintStream stream = maybeGetStream();
-        if (stream != null) {
-            stream.close();
+        PrintStream currentStream = maybeGetStream();
+        if (currentStream != null) {
+            currentStream.close();
+            stream.set(null);
         } else {
             handler.endOfStream(null);
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/LinePerThreadBufferingOutputStream.java
@@ -69,8 +69,8 @@ public class LinePerThreadBufferingOutputStream extends PrintStream {
     public void close() {
         PrintStream currentStream = maybeGetStream();
         if (currentStream != null) {
-            currentStream.close();
             stream.set(null);
+            currentStream.close();
         } else {
             handler.endOfStream(null);
         }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/io/LinePerThreadBufferingOutputStreamTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/io/LinePerThreadBufferingOutputStreamTest.groovy
@@ -102,4 +102,23 @@ class LinePerThreadBufferingOutputStreamTest extends ConcurrentSpec {
         1 * action.endOfStream(null)
         0 * action._
     }
+
+    def "can reuse the output stream on the same thread after it has been closed"() {
+        TextStream action = Mock()
+        def outstr = new LinePerThreadBufferingOutputStream(action)
+
+        when:
+        outstr.write("text".bytes)
+        outstr.close()
+
+        then:
+        1 * action.text("text")
+
+        when:
+        outstr.write("text".bytes)
+        outstr.close()
+
+        then:
+        1 * action.text("text")
+    }
 }


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/2635.

