### PR TITLE
Consume dependency attributes

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -17,11 +17,13 @@ package org.gradle.util
 
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.api.Task
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.DefaultInstantiatorFactory
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
 import org.gradle.api.internal.model.DefaultObjectFactory
@@ -205,6 +207,16 @@ class TestUtil {
 
     static String createUniqueId() {
         return new UID().toString();
+    }
+
+    static ImmutableAttributes attributes(Map<String, ?> values) {
+        def attrs = ImmutableAttributes.EMPTY
+        if (values) {
+            values.each { String key, Object value ->
+                attrs = attributesFactory().concat(attrs, Attribute.of(key, value.class), value)
+            }
+        }
+        return attrs
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -31,11 +33,18 @@ import java.util.List;
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector;
 
 public class ModuleComponentSelectorSerializer implements Serializer<ModuleComponentSelector> {
+    private final AttributeContainerSerializer attributeContainerSerializer;
+
+    public ModuleComponentSelectorSerializer(AttributeContainerSerializer attributeContainerSerializer) {
+        this.attributeContainerSerializer = attributeContainerSerializer;
+    }
+
     public ModuleComponentSelector read(Decoder decoder) throws IOException {
         String group = decoder.readString();
         String name = decoder.readString();
         VersionConstraint versionConstraint = readVersionConstraint(decoder);
-        return newSelector(group, name, versionConstraint, ImmutableAttributes.EMPTY);
+        ImmutableAttributes attributes = readAttributes(decoder);
+        return newSelector(group, name, versionConstraint, attributes);
     }
 
     public VersionConstraint readVersionConstraint(Decoder decoder) throws IOException {
@@ -52,12 +61,14 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         encoder.writeString(value.getGroup());
         encoder.writeString(value.getModule());
         writeVersionConstraint(encoder, value.getVersionConstraint());
+        writeAttributes(encoder, ((AttributeContainerInternal)value.getAttributes()).asImmutable());
     }
 
-    public void write(Encoder encoder, String group, String module, VersionConstraint version) throws IOException {
+    public void write(Encoder encoder, String group, String module, VersionConstraint version, ImmutableAttributes attributes) throws IOException {
         encoder.writeString(group);
         encoder.writeString(module);
         writeVersionConstraint(encoder, version);
+        writeAttributes(encoder, attributes);
     }
 
     public void writeVersionConstraint(Encoder encoder, VersionConstraint cst) throws IOException {
@@ -67,5 +78,13 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         for (String rejectedVersion : rejectedVersions) {
             encoder.writeString(rejectedVersion);
         }
+    }
+
+    private ImmutableAttributes readAttributes(Decoder decoder) throws IOException {
+        return attributeContainerSerializer.read(decoder);
+    }
+
+    private void writeAttributes(Encoder encoder, ImmutableAttributes attributes) throws IOException {
+        attributeContainerSerializer.write(encoder, attributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
@@ -20,4 +20,5 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 public interface ResolvedVersionConstraint extends ImmutableVersionConstraint {
     VersionSelector getPreferredSelector();
     VersionSelector getRejectedSelector();
+    boolean isRejectAll();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
@@ -58,4 +58,19 @@ public class DefaultResolvedVersionConstraint extends DefaultImmutableVersionCon
     public VersionSelector getRejectedSelector() {
         return rejectedVersionsSelector;
     }
+
+    @Override
+    public boolean isRejectAll() {
+        return "".equals(getPreferredVersion())
+            && hasMatchAllSelector(getRejectedVersions());
+    }
+
+    private static boolean hasMatchAllSelector(List<String> rejectedVersions) {
+        for (String version : rejectedVersions) {
+            if ("+".equals(version)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 56),
+    META_DATA(ROOT, "metadata", 57),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -439,7 +439,7 @@ public class ModuleMetadataSerializer {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
                 String reason = decoder.readNullableString();
                 ImmutableList<ExcludeMetadata> excludes = readVariantDependencyExcludes();
-                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason);
+                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason, ImmutableAttributes.EMPTY);
             }
         }
 
@@ -448,7 +448,7 @@ public class ModuleMetadataSerializer {
             for (int i = 0; i < count; i++) {
                 ModuleComponentSelector selector = COMPONENT_SELECTOR_SERIALIZER.read(decoder);
                 String reason = decoder.readNullableString();
-                variant.addDependencyConstraint(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), reason);
+                variant.addDependencyConstraint(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), reason, ImmutableAttributes.EMPTY);
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.attributes.AttributeMergingException;
@@ -50,9 +51,16 @@ class IncompatibleDependencyAttributesMessageBuilder {
 
     private static String formatAttributeQuery(SelectorState state, Attribute<?> attribute) {
         DependencyMetadata dependencyMetadata = state.getDependencyMetadata();
-        StringBuilder sb = new StringBuilder("wants '" + state.getRequested() + "' with attribute " + attribute.getName() + " = ");
-        sb.append(((ModuleComponentSelector) dependencyMetadata.getSelector()).getAttributes().getAttribute(attribute));
-        return sb.toString();
+        ComponentSelector selector = dependencyMetadata.getSelector();
+        if (selector instanceof ModuleComponentSelector) {
+            StringBuilder sb = new StringBuilder("wants '" + state.getRequested() + "' with attribute " + attribute.getName() + " = ");
+            sb.append(((ModuleComponentSelector) selector).getAttributes().getAttribute(attribute));
+            return sb.toString();
+        } else {
+            // This is a safety net, it's unsure whether this can happen, because it's likely (certain?)
+            // that for a specific module resolve state, all selectors are of the same type
+            return "doesn't provide any value for attribute " + attribute.getName();
+        }
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.internal.attributes.AttributeMergingException;
+import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.text.TreeFormatter;
+
+import java.util.Set;
+
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.MessageBuilderHelper.getIncomingEdges;
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.MessageBuilderHelper.pathTo;
+
+class IncompatibleDependencyAttributesMessageBuilder {
+    static String buildMergeErrorMessage(ModuleResolveState module, AttributeMergingException e) {
+        Attribute<?> attribute = e.getAttribute();
+        TreeFormatter fmt = new TreeFormatter();
+        fmt.node("Cannot select a variant of '" + module.getId());
+        fmt.append("' because different values for attribute '");
+        fmt.append(attribute.toString());
+        fmt.append("' are requested");
+        fmt.startChildren();
+        Set<EdgeState> incomingEdges = getIncomingEdges(module);
+        incomingEdges.addAll(module.getUnattachedDependencies());
+        for (EdgeState incomingEdge : incomingEdges) {
+            SelectorState selector = incomingEdge.getSelector();
+            for (String path : pathTo(incomingEdge, false)) {
+                String requestedAttribute = formatAttributeQuery(selector, attribute);
+                fmt.node(path + " " + requestedAttribute);
+            }
+        }
+        fmt.endChildren();
+        return fmt.toString();
+    }
+
+    private static String formatAttributeQuery(SelectorState state, Attribute<?> attribute) {
+        DependencyMetadata dependencyMetadata = state.getDependencyMetadata();
+        StringBuilder sb = new StringBuilder("wants '" + state.getRequested() + "' with attribute " + attribute.getName() + " = ");
+        sb.append(((ModuleComponentSelector) dependencyMetadata.getSelector()).getAttributes().getAttribute(attribute));
+        return sb.toString();
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
@@ -24,7 +24,6 @@ import org.gradle.internal.text.TreeFormatter;
 
 import java.util.Set;
 
-import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.MessageBuilderHelper.getIncomingEdges;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.MessageBuilderHelper.pathTo;
 
 class IncompatibleDependencyAttributesMessageBuilder {
@@ -36,7 +35,7 @@ class IncompatibleDependencyAttributesMessageBuilder {
         fmt.append(attribute.toString());
         fmt.append("' are requested");
         fmt.startChildren();
-        Set<EdgeState> incomingEdges = getIncomingEdges(module);
+        Set<EdgeState> incomingEdges = module.getIncomingEdges();
         incomingEdges.addAll(module.getUnattachedDependencies());
         for (EdgeState incomingEdge : incomingEdges) {
             SelectorState selector = incomingEdge.getSelector();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -79,8 +79,11 @@ abstract class MessageBuilderHelper {
 
     static Set<EdgeState> getIncomingEdges(ModuleResolveState module) {
         Set<EdgeState> incoming = Sets.newLinkedHashSet();
-        for (NodeState nodeState : module.getSelected().getNodes()) {
-            incoming.addAll(nodeState.getIncomingEdges());
+        ComponentState selected = module.getSelected();
+        if (selected != null) {
+            for (NodeState nodeState : selected.getNodes()) {
+                incoming.addAll(nodeState.getIncomingEdges());
+            }
         }
         return incoming;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.CompositeVersionSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+abstract class MessageBuilderHelper {
+    static Collection<String> pathTo(EdgeState edge) {
+        return pathTo(edge, true);
+    }
+
+    static Collection<String> pathTo(EdgeState edge, boolean includeLast) {
+        List<List<EdgeState>> acc = Lists.newArrayListWithExpectedSize(1);
+        pathTo(edge, Lists.<EdgeState>newArrayList(), acc, Sets.<NodeState>newHashSet());
+        List<String> result = Lists.newArrayListWithCapacity(acc.size());
+        for (List<EdgeState> path : acc) {
+            EdgeState target = Iterators.getLast(path.iterator());
+            StringBuilder sb = new StringBuilder();
+            if (target.getSelector().getDependencyMetadata().isPending()) {
+                sb.append("Constraint path ");
+            } else {
+                sb.append("Dependency path ");
+            }
+            boolean first = true;
+            for (EdgeState e : path) {
+                if (!first) {
+                    sb.append(" --> ");
+                }
+                first = false;
+                ModuleVersionIdentifier id = e.getFrom().getResolvedConfigurationId().getId();
+                sb.append('\'').append(id).append('\'');
+            }
+            if (includeLast) {
+                sb.append(" --> ");
+                ModuleIdentifier moduleId = edge.getSelector().getTargetModule().getId();
+                sb.append('\'').append(moduleId.getGroup()).append(':').append(moduleId.getName()).append('\'');
+            }
+            result.add(sb.toString());
+        }
+        return result;
+    }
+
+    static void pathTo(EdgeState component, List<EdgeState> currentPath, List<List<EdgeState>> accumulator, Set<NodeState> alreadySeen) {
+        if (alreadySeen.add(component.getFrom())) {
+            currentPath.add(0, component);
+            for (EdgeState dependent : component.getFrom().getIncomingEdges()) {
+                List<EdgeState> otherPath = Lists.newArrayList(currentPath);
+                pathTo(dependent, otherPath, accumulator, alreadySeen);
+            }
+            if (component.getFrom().isRoot()) {
+                accumulator.add(currentPath);
+            }
+        }
+    }
+
+    static Set<EdgeState> getIncomingEdges(ModuleResolveState module) {
+        Set<EdgeState> incoming = Sets.newLinkedHashSet();
+        for (NodeState nodeState : module.getSelected().getNodes()) {
+            incoming.addAll(nodeState.getIncomingEdges());
+        }
+        return incoming;
+    }
+
+    static String renderVersionConstraint(ResolvedVersionConstraint constraint) {
+        if (isRejectAll(constraint)) {
+            return "rejects all versions";
+        }
+        VersionSelector preferredSelector = constraint.getPreferredSelector();
+        VersionSelector rejectedSelector = constraint.getRejectedSelector();
+        StringBuilder sb = new StringBuilder("prefers ");
+        sb.append('\'');
+        sb.append(preferredSelector.getSelector());
+        sb.append('\'');
+        if (rejectedSelector != null) {
+            sb.append(", rejects ");
+            if (rejectedSelector instanceof CompositeVersionSelector) {
+                sb.append("any of \"");
+                int i = 0;
+                for (VersionSelector selector : ((CompositeVersionSelector) rejectedSelector).getSelectors()) {
+                    if (i++ > 0) {
+                        sb.append(", ");
+                    }
+                    sb.append('\'');
+                    sb.append(selector.getSelector());
+                    sb.append('\'');
+                }
+                sb.append("\"");
+            } else {
+                sb.append('\'');
+                sb.append(rejectedSelector.getSelector());
+                sb.append('\'');
+            }
+        }
+        return sb.toString();
+    }
+
+    static boolean isRejectAll(ResolvedVersionConstraint constraint) {
+        return "".equals(constraint.getPreferredVersion())
+            && hasMatchAllSelector(constraint.getRejectedVersions());
+    }
+
+    private static boolean hasMatchAllSelector(List<String> rejectedVersions) {
+        for (String version : rejectedVersions) {
+            if ("+".equals(version)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -77,19 +77,8 @@ abstract class MessageBuilderHelper {
         }
     }
 
-    static Set<EdgeState> getIncomingEdges(ModuleResolveState module) {
-        Set<EdgeState> incoming = Sets.newLinkedHashSet();
-        ComponentState selected = module.getSelected();
-        if (selected != null) {
-            for (NodeState nodeState : selected.getNodes()) {
-                incoming.addAll(nodeState.getIncomingEdges());
-            }
-        }
-        return incoming;
-    }
-
     static String renderVersionConstraint(ResolvedVersionConstraint constraint) {
-        if (isRejectAll(constraint)) {
+        if (constraint.isRejectAll()) {
             return "rejects all versions";
         }
         VersionSelector preferredSelector = constraint.getPreferredSelector();
@@ -119,19 +108,5 @@ abstract class MessageBuilderHelper {
             }
         }
         return sb.toString();
-    }
-
-    static boolean isRejectAll(ResolvedVersionConstraint constraint) {
-        return "".equals(constraint.getPreferredVersion())
-            && hasMatchAllSelector(constraint.getRejectedVersions());
-    }
-
-    private static boolean hasMatchAllSelector(List<String> rejectedVersions) {
-        for (String version : rejectedVersions) {
-            if ("+".equals(version)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -212,4 +212,8 @@ class ModuleResolveState implements CandidateModule {
     public List<SelectorState> getSelectors() {
         return selectors;
     }
+
+    List<EdgeState> getUnattachedDependencies() {
+        return unattachedDependencies;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -37,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Resolution state for a given module.
@@ -246,6 +248,16 @@ class ModuleResolveState implements CandidateModule {
             attributeMergingError = e;
         }
         return dependencyAttributes;
+    }
+
+    Set<EdgeState> getIncomingEdges() {
+        Set<EdgeState> incoming = Sets.newLinkedHashSet();
+        if (selected != null) {
+            for (NodeState nodeState : selected.getNodes()) {
+                incoming.addAll(nodeState.getIncomingEdges());
+            }
+        }
+        return incoming;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -16,27 +16,18 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
-import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.CompositeVersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class RejectedModuleMessageBuilder {
     public String buildFailureMessage(ModuleResolveState module) {
         boolean hasRejectAll = false;
         for (SelectorState candidate : module.getSelectors()) {
-            hasRejectAll |= isRejectAll(candidate.getVersionConstraint());
+            hasRejectAll |= MessageBuilderHelper.isRejectAll(candidate.getVersionConstraint());
         }
         StringBuilder sb = new StringBuilder();
         if (hasRejectAll) {
@@ -44,48 +35,16 @@ public class RejectedModuleMessageBuilder {
         } else {
             sb.append("Cannot find a version of '").append(module.getId()).append("' that satisfies the version constraints: \n");
         }
-        for (EdgeState incomingEdge : getIncomingEdges(module)) {
+        for (EdgeState incomingEdge : MessageBuilderHelper.getIncomingEdges(module)) {
             SelectorState selector = incomingEdge.getSelector();
-            for (String path : pathTo(incomingEdge)) {
+            for (String path : MessageBuilderHelper.pathTo(incomingEdge)) {
                 sb.append("   ").append(path);
-                sb.append(" ").append(renderVersionConstraint(selector.getVersionConstraint()));
+                sb.append(" ").append(MessageBuilderHelper.renderVersionConstraint(selector.getVersionConstraint()));
                 renderReason(sb, selector);
                 sb.append("\n");
             }
         }
         return sb.toString();
-    }
-
-    private Collection<EdgeState> getIncomingEdges(ModuleResolveState module) {
-        Set<EdgeState> incoming = Sets.newLinkedHashSet();
-        for (NodeState nodeState : module.getSelected().getNodes()) {
-            incoming.addAll(nodeState.getIncomingEdges());
-        }
-        return incoming;
-    }
-
-    private static Collection<String> pathTo(EdgeState edge) {
-        List<List<EdgeState>> acc = Lists.newArrayListWithExpectedSize(1);
-        pathTo(edge, Lists.<EdgeState>newArrayList(), acc, Sets.<NodeState>newHashSet());
-        List<String> result = Lists.newArrayListWithCapacity(acc.size());
-        for (List<EdgeState> path : acc) {
-            EdgeState target = Iterators.getLast(path.iterator());
-            StringBuilder sb = new StringBuilder();
-            if (target.getSelector().getDependencyMetadata().isPending()) {
-                sb.append("Constraint path ");
-            } else {
-                sb.append("Dependency path ");
-            }
-            for (EdgeState e : path) {
-                ModuleVersionIdentifier id = e.getFrom().getResolvedConfigurationId().getId();
-                sb.append('\'').append(id).append('\'');
-                sb.append(" --> ");
-            }
-            ModuleIdentifier moduleId = edge.getSelector().getTargetModule().getId();
-            sb.append('\'').append(moduleId.getGroup()).append(':').append(moduleId.getName()).append('\'');
-            result.add(sb.toString());
-        }
-        return result;
     }
 
     private static void renderReason(StringBuilder sb, SelectorState selector) {
@@ -108,63 +67,4 @@ public class RejectedModuleMessageBuilder {
         }
     }
 
-    private static void pathTo(EdgeState component, List<EdgeState> currentPath, List<List<EdgeState>> accumulator, Set<NodeState> alreadySeen) {
-        if (alreadySeen.add(component.getFrom())) {
-            currentPath.add(0, component);
-            for (EdgeState dependent : component.getFrom().getIncomingEdges()) {
-                List<EdgeState> otherPath = Lists.newArrayList(currentPath);
-                pathTo(dependent, otherPath, accumulator, alreadySeen);
-            }
-            if (component.getFrom().isRoot()) {
-                accumulator.add(currentPath);
-            }
-        }
-    }
-
-    private static String renderVersionConstraint(ResolvedVersionConstraint constraint) {
-        if (isRejectAll(constraint)) {
-            return "rejects all versions";
-        }
-        VersionSelector preferredSelector = constraint.getPreferredSelector();
-        VersionSelector rejectedSelector = constraint.getRejectedSelector();
-        StringBuilder sb = new StringBuilder("prefers ");
-        sb.append('\'');
-        sb.append(preferredSelector.getSelector());
-        sb.append('\'');
-        if (rejectedSelector != null) {
-            sb.append(", rejects ");
-            if (rejectedSelector instanceof CompositeVersionSelector) {
-                sb.append("any of \"");
-                int i = 0;
-                for (VersionSelector selector : ((CompositeVersionSelector) rejectedSelector).getSelectors()) {
-                    if (i++ > 0) {
-                        sb.append(", ");
-                    }
-                    sb.append('\'');
-                    sb.append(selector.getSelector());
-                    sb.append('\'');
-                }
-                sb.append("\"");
-            } else {
-                sb.append('\'');
-                sb.append(rejectedSelector.getSelector());
-                sb.append('\'');
-            }
-        }
-        return sb.toString();
-    }
-
-    private static boolean isRejectAll(ResolvedVersionConstraint constraint) {
-        return "".equals(constraint.getPreferredVersion())
-            && hasMatchAllSelector(constraint.getRejectedVersions());
-    }
-
-    private static boolean hasMatchAllSelector(List<String> rejectedVersions) {
-        for (String version : rejectedVersions) {
-            if ("+".equals(version)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -27,7 +27,7 @@ public class RejectedModuleMessageBuilder {
     public String buildFailureMessage(ModuleResolveState module) {
         boolean hasRejectAll = false;
         for (SelectorState candidate : module.getSelectors()) {
-            hasRejectAll |= MessageBuilderHelper.isRejectAll(candidate.getVersionConstraint());
+            hasRejectAll |= candidate.getVersionConstraint().isRejectAll();
         }
         StringBuilder sb = new StringBuilder();
         if (hasRejectAll) {
@@ -35,7 +35,7 @@ public class RejectedModuleMessageBuilder {
         } else {
             sb.append("Cannot find a version of '").append(module.getId()).append("' that satisfies the version constraints: \n");
         }
-        for (EdgeState incomingEdge : MessageBuilderHelper.getIncomingEdges(module)) {
+        for (EdgeState incomingEdge : module.getIncomingEdges()) {
             SelectorState selector = incomingEdge.getSelector();
             for (String path : MessageBuilderHelper.pathTo(incomingEdge)) {
                 sb.append("   ").append(path);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -109,7 +109,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     public ModuleResolveState getModule(ModuleIdentifier id) {
         ModuleResolveState module = modules.get(id);
         if (module == null) {
-            module = new ModuleResolveState(idGenerator, id, metaDataResolver, variantNameBuilder);
+            module = new ModuleResolveState(idGenerator, id, metaDataResolver, variantNameBuilder, attributesFactory);
             modules.put(id, module);
         }
         return module;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -22,8 +22,10 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
@@ -36,18 +38,28 @@ import java.util.List;
 
 public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSelector> {
 
+    private final AttributeContainerSerializer attributeContainerSerializer;
+
+    public ComponentSelectorSerializer(AttributeContainerSerializer attributeContainerSerializer) {
+        this.attributeContainerSerializer = attributeContainerSerializer;
+    }
+
     public ComponentSelector read(Decoder decoder) throws IOException {
         byte id = decoder.readByte();
 
         if (Implementation.BUILD.getId() == id) {
             return new DefaultProjectComponentSelector(decoder.readString(), decoder.readString());
         } else if (Implementation.MODULE.getId() == id) {
-            return DefaultModuleComponentSelector.newSelector(decoder.readString(), decoder.readString(), readVersionConstraint(decoder));
+            return DefaultModuleComponentSelector.newSelector(decoder.readString(), decoder.readString(), readVersionConstraint(decoder), readAttributes(decoder));
         } else if (Implementation.LIBRARY.getId() == id) {
             return new DefaultLibraryComponentSelector(decoder.readString(), decoder.readNullableString(), decoder.readNullableString());
         }
 
         throw new IllegalArgumentException("Unable to find component selector with id: " + id);
+    }
+
+    private ImmutableAttributes readAttributes(Decoder decoder) throws IOException {
+        return attributeContainerSerializer.read(decoder);
     }
 
     ImmutableVersionConstraint readVersionConstraint(Decoder decoder) throws IOException {
@@ -75,6 +87,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             encoder.writeString(moduleComponentSelector.getModule());
             VersionConstraint versionConstraint = moduleComponentSelector.getVersionConstraint();
             writeVersionConstraint(encoder, versionConstraint);
+            writeAttributes(encoder, moduleComponentSelector.getAttributes());
         } else if (implementation == Implementation.BUILD) {
             ProjectComponentSelector projectComponentSelector = (ProjectComponentSelector) value;
             encoder.writeString(projectComponentSelector.getBuildName());
@@ -87,6 +100,10 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         } else {
             throw new IllegalStateException("Unsupported implementation type: " + implementation);
         }
+    }
+
+    private void writeAttributes(Encoder encoder, AttributeContainer attributes) throws IOException {
+        attributeContainerSerializer.write(encoder, attributes);
     }
 
     private void writeVersionConstraint(Encoder encoder, VersionConstraint versionConstraint) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -69,7 +69,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         this.componentResultSerializer = new ComponentResultSerializer(moduleIdentifierFactory, attributeContainerSerializer);
         this.store = store;
         this.cache = cache;
-        this.componentSelectorSerializer = new ComponentSelectorSerializer();
+        this.componentSelectorSerializer = new ComponentSelectorSerializer(attributeContainerSerializer);
     }
 
     public ResolutionResult complete() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -274,13 +274,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
 
         @Override
-        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason) {
-            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason));
+        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes) {
+            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes));
         }
 
         @Override
-        public void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason) {
-            dependencyConstraints.add(new DependencyConstraintImpl(group, module, versionConstraint, reason));
+        public void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes) {
+            dependencyConstraints.add(new DependencyConstraintImpl(group, module, versionConstraint, reason, attributes));
         }
 
         @Override
@@ -343,13 +343,15 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         private final VersionConstraint versionConstraint;
         private final ImmutableList<ExcludeMetadata> excludes;
         private final String reason;
+        private final ImmutableAttributes attributes;
 
-        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason) {
+        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
             this.excludes = ImmutableList.copyOf(excludes);
             this.reason = reason;
+            this.attributes = attributes;
         }
 
         @Override
@@ -391,12 +393,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
                 && Objects.equal(module, that.module)
                 && Objects.equal(versionConstraint, that.versionConstraint)
                 && Objects.equal(excludes, that.excludes)
-                && Objects.equal(reason, that.reason);
+                && Objects.equal(reason, that.reason)
+                && Objects.equal(attributes, that.attributes);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(group, module, versionConstraint, excludes, reason);
+            return Objects.hashCode(group, module, versionConstraint, excludes, reason, attributes);
         }
     }
 
@@ -405,12 +408,14 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         private final String module;
         private final VersionConstraint versionConstraint;
         private final String reason;
+        private final ImmutableAttributes attributes;
 
-        DependencyConstraintImpl(String group, String module, VersionConstraint versionConstraint, String reason) {
+        DependencyConstraintImpl(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
             this.reason = reason;
+            this.attributes = attributes;
         }
 
         @Override
@@ -446,12 +451,13 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
             return Objects.equal(group, that.group)
                 && Objects.equal(module, that.module)
                 && Objects.equal(versionConstraint, that.versionConstraint)
-                && Objects.equal(reason, that.reason);
+                && Objects.equal(reason, that.reason)
+                && Objects.equal(attributes, that.attributes);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(group, module, versionConstraint, reason);
+            return Objects.hashCode(group, module, versionConstraint, reason, attributes);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -380,6 +380,11 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         }
 
         @Override
+        public ImmutableAttributes getAttributes() {
+            return attributes;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -436,6 +441,11 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         @Override
         public String getReason() {
             return reason;
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return attributes;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
@@ -45,6 +46,8 @@ public interface ComponentVariant extends VariantResolveMetadata {
         ImmutableList<ExcludeMetadata> getExcludes();
 
         String getReason();
+
+        ImmutableAttributes getAttributes();
     }
 
     interface DependencyConstraint {
@@ -55,6 +58,8 @@ public interface ComponentVariant extends VariantResolveMetadata {
         VersionConstraint getVersionConstraint();
 
         String getReason();
+
+        ImmutableAttributes getAttributes();
     }
 
     interface File {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ExcludeMetadata;
 
 import java.util.List;
@@ -24,9 +25,9 @@ import java.util.List;
 public interface MutableComponentVariant {
     void addFile(String name, String uri);
 
-    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason);
+    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes);
 
-    void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason);
+    void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes);
 
     void addCapability(String group, String name, String version);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -60,13 +60,13 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         this.variantMetadataRules = variantMetadataRules;
         List<GradleDependencyMetadata> dependencies = new ArrayList<GradleDependencyMetadata>(variant.getDependencies().size());
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
-            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint());
+            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint(), dependency.getAttributes());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
             dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason()));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
             dependencies.add(new GradleDependencyMetadata(
-                DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint()),
+                DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
                 dependencyConstraint.getReason()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -17,21 +17,25 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer
+import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.serialize.SerializerSpec
 import spock.lang.Unroll
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
+import static org.gradle.util.TestUtil.attributes
+import static org.gradle.util.TestUtil.attributesFactory
 
 class ModuleComponentSelectorSerializerTest extends SerializerSpec {
-    private serializer = new ModuleComponentSelectorSerializer()
+    private serializer = new ModuleComponentSelectorSerializer(new AttributeContainerSerializer(attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     @Unroll
     def "serializes"() {
         when:
-        def result = serialize(newSelector("org", "foo", new DefaultMutableVersionConstraint(version, rejects)), serializer)
+        def result = serialize(newSelector("org", "foo", new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar')), serializer)
 
         then:
-        result == newSelector("org", "foo", new DefaultMutableVersionConstraint(version, rejects))
+        result == newSelector("org", "foo", new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar'))
 
         where:
         version | rejects

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.56'
-        cacheLayout.version == VersionNumber.parse("2.56.0")
-        cacheLayout.formattedVersion == '2.56'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.56')
+        cacheLayout.key == 'metadata-2.57'
+        cacheLayout.version == VersionNumber.parse("2.57.0")
+        cacheLayout.formattedVersion == '2.57'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.57')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -58,7 +58,7 @@ class ModuleMetadataParserTest extends Specification {
         def metadata = Mock(MutableModuleComponentResolveMetadata)
 
         when:
-        parser.parse(resource('{ "formatVersion": "0.3" }'), metadata)
+        parser.parse(resource('{ "formatVersion": "0.4" }'), metadata)
 
         then:
         0 * metadata._
@@ -70,7 +70,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v" },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
@@ -86,7 +86,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v", "attributes": {"foo": "bar", "org.gradle.status": "release" } },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
@@ -104,7 +104,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -119,7 +119,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant
         1 * variant.addFile("a.zip", "a.zop")
-        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null)
+        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
         0 * _
     }
 
@@ -131,7 +131,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -159,7 +159,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -199,7 +199,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -235,15 +235,15 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null)
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null)
-        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null)
-        1 * variant1.addDependency("g3", "m3", prefers("v3"), excludes("gx:mx", "*:*"), null)
+        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g3", "m3", prefers("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null)
-        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]), [], null)
-        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null)
-        1 * variant2.addDependency("g6", "m6", prefers("v6"), [], "v5 is buggy")
+        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]), [], null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g6", "m6", prefers("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY)
         0 * _
     }
 
@@ -255,7 +255,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -286,14 +286,54 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependencyConstraint("g1", "m1", prefers("v1"), null)
-        1 * variant1.addDependencyConstraint("g2", "m2", prefers("v2"), null)
-        1 * variant1.addDependencyConstraint("g3", "m3", prefers("v3"), null)
+        1 * variant1.addDependencyConstraint("g1", "m1", prefers("v1"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependencyConstraint("g2", "m2", prefers("v2"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependencyConstraint("g3", "m3", prefers("v3"), null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependencyConstraint("g3", "m3", prefers("v3"), null)
-        1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]), null)
-        1 * variant2.addDependencyConstraint("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), null)
-        1 * variant2.addDependencyConstraint("g6", "m6", prefers("v6"), "v5 is buggy")
+        1 * variant2.addDependencyConstraint("g3", "m3", prefers("v3"), null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]), null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependencyConstraint("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependencyConstraint("g6", "m6", prefers("v6"), "v5 is buggy", ImmutableAttributes.EMPTY)
+        0 * _
+    }
+
+    def "parses content with dependency attributes"() {
+        def metadata = Mock(MutableModuleComponentResolveMetadata)
+        def variant1 = Mock(MutableComponentVariant)
+        def variant2 = Mock(MutableComponentVariant)
+
+        when:
+        parser.parse(resource('''
+    { 
+        "formatVersion": "0.4", 
+        "variants": [
+            {
+                "name": "api",
+                "dependencies": [ 
+                    { "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
+                    { "version": { "prefers": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
+                ],
+                "attributes": { "usage": "compile" }
+            },
+            {
+                "attributes": { "usage": "runtime", "packaging": "zip" },
+                "dependencyConstraints": [ 
+                    { "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
+                    { "version": { "prefers": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
+                ],
+                "name": "runtime"
+            }
+        ]
+    }
+'''), metadata)
+
+        then:
+        1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null, attributes(custom: 'foo'))
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, attributes(custom: 'foo', other:'bar'))
+        1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
+        1 * variant2.addDependencyConstraint("g1", "m1", prefers("v1"), null, attributes(custom: 'foo'))
+        1 * variant2.addDependencyConstraint("g2", "m2", prefers("v2"), null, attributes(custom: 'foo', other: 'bar'))
         0 * _
     }
 
@@ -305,7 +345,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -344,7 +384,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } },
         "variants": [
             {
@@ -368,7 +408,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api"
@@ -397,7 +437,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -425,9 +465,9 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null)
+        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g2", "m2", prefers("v2"), [], null)
+        1 * variant2.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY)
         0 * _
     }
 
@@ -447,7 +487,7 @@ class ModuleMetadataParserTest extends Specification {
 
         when:
         parser.parse(resource('''{ 
-            "formatVersion": "0.3",
+            "formatVersion": "0.4",
             "otherString": "string",
             "otherNumber": 123,
             "otherBoolean": true,
@@ -466,7 +506,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -493,7 +533,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -524,7 +564,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.3", 
+        "formatVersion": "0.4", 
         "variants": [
             {
                 "name": "api",
@@ -549,7 +589,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes()) >> variant
-        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null)
+        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY)
         0 * metadata._
     }
 
@@ -606,7 +646,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         def e = thrown(MetaDataParseException)
         e.message == "Could not parse module metadata <resource>"
-        e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 0.3 only."
+        e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 0.4 only."
     }
 
     def attributes(Map<String, ?> values) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser
 
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.VersionConstraint
-import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -30,6 +29,8 @@ import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource
 import org.gradle.util.TestUtil
 import spock.lang.Specification
+
+import static org.gradle.util.TestUtil.attributes
 
 class ModuleMetadataParserTest extends Specification {
     def identifierFactory = new DefaultImmutableModuleIdentifierFactory()
@@ -424,8 +425,8 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes()) >> variant1
-        1 * metadata.addVariant("runtime", attributes()) >> variant2
+        1 * metadata.addVariant("api", attributes([:])) >> variant1
+        1 * metadata.addVariant("runtime", attributes([:])) >> variant2
         0 * _
     }
 
@@ -522,7 +523,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes())
+        1 * metadata.addVariant("api", attributes([:]))
         0 * metadata._
     }
 
@@ -553,7 +554,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes()) >> variant
+        1 * metadata.addVariant("api", attributes([:])) >> variant
         0 * metadata._
     }
 
@@ -588,7 +589,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
-        1 * metadata.addVariant("api", attributes()) >> variant
+        1 * metadata.addVariant("api", attributes([:])) >> variant
         1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY)
         0 * metadata._
     }
@@ -647,16 +648,6 @@ class ModuleMetadataParserTest extends Specification {
         def e = thrown(MetaDataParseException)
         e.message == "Could not parse module metadata <resource>"
         e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 0.4 only."
-    }
-
-    def attributes(Map<String, ?> values) {
-        def attrs = ImmutableAttributes.EMPTY
-        if (values) {
-            values.each { String key, Object value ->
-                attrs = TestUtil.attributesFactory().concat(attrs, Attribute.of(key, value.class), value)
-            }
-        }
-        return attrs
     }
 
     def resource(String content) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -23,15 +23,17 @@ import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector
 import org.gradle.internal.component.local.model.TestComponentIdentifiers
 import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
 class ComponentSelectorSerializerTest extends SerializerSpec {
     private final DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
-    private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer()
+    private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     private ImmutableVersionConstraint constraint(String version, boolean strict = false) {
         def reject = strict ? versionSelectorScheme.complementForRejection(versionSelectorScheme.parseSelector(version)) : null

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -93,9 +93,9 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         defaultVariant = metadata.addVariant("default", attributes)
         deps.each { name ->
             if (addAllDependenciesAsConstraints()) {
-                defaultVariant.addDependencyConstraint("org.test", name, new DefaultMutableVersionConstraint("1.0"), null)
+                defaultVariant.addDependencyConstraint("org.test", name, new DefaultMutableVersionConstraint("1.0"), null, ImmutableAttributes.EMPTY)
             } else {
-                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null)
+                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY)
             }
         }
         metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.model.ComponentResolveMetadata
@@ -231,10 +232,10 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
 
         given:
         def v1 = metadata.addVariant("api", attributes(usage: "compile"),)
-        v1.addDependency("g1", "m1", v("v1"), [], null)
-        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested")
+        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY)
+        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested", ImmutableAttributes.EMPTY)
         def v2 = metadata.addVariant("runtime", attributes(usage: "runtime"),)
-        v2.addDependency("g1", "m1", v("v1"), [], null)
+        v2.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY)
 
         expect:
         metadata.variants.size() == 2
@@ -282,11 +283,11 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         def v1 = metadata.addVariant("api", attributes1,)
         v1.addFile("f1.jar", "f1.jar")
         v1.addFile("f2.jar", "f2-1.2.jar")
-        v1.addDependency("g1", "m1", v("v1"), [], null)
+        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY)
         def v2 = metadata.addVariant("runtime", attributes2,)
         v2.addFile("f2", "f2-version.zip")
-        v2.addDependency("g2", "m2", v("v2"), [], null)
-        v2.addDependency("g3", "m3", v("v3"), [], null)
+        v2.addDependency("g2", "m2", v("v2"), [], null, ImmutableAttributes.EMPTY)
+        v2.addDependency("g3", "m3", v("v3"), [], null, ImmutableAttributes.EMPTY)
 
         expect:
         def immutable = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
@@ -17,16 +17,14 @@
 package org.gradle.internal.component.external.model
 
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
-import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 import static org.gradle.util.Matchers.strictlyEquals
+import static org.gradle.util.TestUtil.attributes
 
 class DefaultModuleComponentSelectorTest extends Specification {
     private static ImmutableVersionConstraint v(String version) {
@@ -85,11 +83,11 @@ class DefaultModuleComponentSelectorTest extends Specification {
         assert t.message == assertionMessage
 
         where:
-        group        | name        | version          | attrs                     | assertionMessage
+        group        | name        | version          | attrs                      | assertionMessage
         null         | 'some-name' | v('1.0') | attributes(custom: 'foo') | 'group cannot be null'
-        'some-group' | null        | v('1.0') | attributes(custom: 'foo') | 'module cannot be null'
-        'some-group' | 'some-name' | null             | attributes(custom: 'foo') | 'version cannot be null'
-        'some-group' | 'some-name' | v('1.0') | null                      | 'attributes cannot be null'
+        'some-group' | null        | v('1.0') | attributes(custom: 'foo')          | 'module cannot be null'
+        'some-group' | 'some-name' | null             | attributes(custom: 'foo')  | 'version cannot be null'
+        'some-group' | 'some-name' | v('1.0') | null                               | 'attributes cannot be null'
     }
 
     @Unroll
@@ -177,13 +175,4 @@ class DefaultModuleComponentSelectorTest extends Specification {
         'some-group'  | 'some-name'  | '2.0'   | false
     }
 
-    static AttributeContainer attributes(Map<String, ?> values) {
-        def attrs = ImmutableAttributes.EMPTY
-        if (values) {
-            values.each { String key, Object value ->
-                attrs = TestUtil.attributesFactory().concat(attrs, Attribute.of(key, value.class), value)
-            }
-        }
-        return attrs
-    }
 }

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/boolean-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/boolean-attributes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "builtBy": { "gradle": { "version": "123", "buildId": "abc" } },
     "variants": [
         {

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/dependencies-with-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/dependencies-with-attributes.module
@@ -1,0 +1,71 @@
+{
+    "formatVersion": "0.4",
+    "variants": [
+        {
+            "name": "api",
+            "dependencies": [
+                {
+                    "group": "g0",
+                    "module": "m0"
+                },
+                {
+                    "group": "g1",
+                    "module": "m1",
+                    "version": {
+                        "prefers": "v1"
+                    }
+                },
+                {
+                    "version": {
+                        "prefers": "v2"
+                    },
+                    "group": "g2",
+                    "module": "m2"
+                },
+                {
+                    "group": "g3",
+                    "module": "m3",
+                    "version": {
+                        "prefers": "v3"
+                    },
+                    "excludes": [
+                        {
+                            "group": "gx",
+                            "module": "mx"
+                        },
+                        {
+                            "group": "*",
+                            "module": "*"
+                        }
+                    ],
+                    "attributes": {
+                        "custom": "foo"
+                    }
+                }
+            ],
+            "attributes": {
+                "usage": "compile"
+            }
+        },
+        {
+            "attributes": {
+                "usage": "runtime",
+                "packaging": "zip"
+            },
+            "dependencies": [
+                {
+                    "module": "m3",
+                    "group": "g3",
+                    "version": {
+                        "prefers": "v3"
+                    },
+                    "attributes": {
+                        "custom": "foo",
+                        "other": "bar"
+                    }
+                }
+            ],
+            "name": "runtime"
+        }
+    ]
+}

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/java-library-with-excludes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/java-library-with-excludes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "component": {
         "group": "org.gradle.test",
         "module": "publishTest",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-capabilities.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-capabilities.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-variants.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-variants.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-custom-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-custom-attributes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "component": {
         "group": "org.gradle.test",
         "module": "publishTest",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-nondefault-status.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-nondefault-status.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "component": {
         "group": "org.gradle.test",
         "module": "publishTest",

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -282,8 +282,12 @@ class ModuleVersionSpec {
                         new FileSpec("${module.module}-${module.version}-$it.name.${it.ext}", it.url)
                     }
                     variant.dependsOn.each {
-                        def args = it.split(':') as List
-                        dependsOn(*args)
+                        if (it instanceof VariantSpec.DependencySpec) {
+                            dependsOn(it.group, it.name, it.version, it.configuration)
+                        } else {
+                            def args = it.split(':') as List
+                            dependsOn(*args)
+                        }
                     }
                     capabilities = variant.capabilities.collect {
                         new CapabilitySpec(group: it.group, name: it.name, version:it.version)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/VariantSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/VariantSpec.groovy
@@ -55,6 +55,19 @@ class VariantSpec {
         capabilities << new CapabilitySpec(group: 'org.test', name: name, version: '1.0')
     }
 
+    void dependsOn(String notation, @DelegatesTo(value=org.gradle.test.fixtures.gradle.DependencySpec, strategy=Closure.DELEGATE_FIRST)  Closure<?> configuration) {
+        def gav = notation.split(':')
+        doDependOn(gav[0], gav[1], gav[2], configuration)
+    }
+
+    void dependsOn(String group, String name, String version, @DelegatesTo(value=org.gradle.test.fixtures.gradle.DependencySpec, strategy=Closure.DELEGATE_FIRST)  Closure<?> configuration) {
+        doDependOn(group, name, version, configuration)
+    }
+
+    private void doDependOn(String group, String name, String version, @DelegatesTo(value=org.gradle.test.fixtures.gradle.DependencySpec, strategy=Closure.DELEGATE_FIRST)  Closure<?> configuration) {
+        dependsOn << new DependencySpec(group: group, name: name, version: version, configuration: configuration)
+    }
+
     static class ArtifactSpec {
         String name
         String url
@@ -65,5 +78,12 @@ class VariantSpec {
         String group
         String name
         String version
+    }
+
+    static class DependencySpec {
+        String group
+        String name
+        String version
+        Closure<?> configuration
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
@@ -30,7 +30,7 @@ class AbstractRenderableDependencyResultSpec extends Specification {
 
     def "renders name for ModuleComponentSelector"() {
         given:
-        def requested = DefaultModuleComponentSelector.newSelector('org.mockito', 'mockito-core', new DefaultMutableVersionConstraint('1.0'))
+        def requested = DefaultModuleComponentSelector.newSelector('org.mockito', 'mockito-core', new DefaultMutableVersionConstraint('1.0'),)
 
         expect:
         dep(requested, DefaultModuleComponentIdentifier.newId('org.mockito', 'mockito-core', '1.0')).name == 'org.mockito:mockito-core:1.0'

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorterSpec.groovy
@@ -49,8 +49,8 @@ class DependencyResultSorterSpec extends Specification {
         t.message == "Dependency edge or the requested component selector may not be null"
 
         where:
-        d1           | d2
-        null         | null
+        d1                                                                                                                                                          | d2
+        null                                                                                                                                                        | null
         null         | newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
         newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0")) | null
         newDependency(null, DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0")) | newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -2,7 +2,7 @@
 
 _Note: this format is not yet stable and may change at any time. Gradle does not guarantee to offer any long term support for this version of the format. Any version before 1.0 is intentionally assumed not backwards compatible, and the parsers are not required to support pre 1.0 releases._
 
-This document describes version 0.3 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
+This document describes version 0.4 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
 
 The module metadata file is a JSON file published alongside the existing repository specific metadata files, such as a Maven POM or Ivy descriptor. It adds additional metadata that can be used by Gradle versions and other tooling that understand the format. This allows the rich Gradle model to be mapped to and "tunnelled" through existing repository formats, while continuing to support existing Gradle versions and tooling that does not understand the format. 
 
@@ -10,7 +10,7 @@ The module metadata file is intended to be machine generated rather than written
 
 The module metadata file is also intended to fully describe the binaries in the module where it is present so that it can replace the existing metadata files. This would allow a Gradle repository format to be added, for example.
 
-In version 0.3, the module metadata file can describe only those modules that contain a single _component_, which is some piece of software such as a library or application. Support for more sophisticated mappings will be added by later versions.
+In version 0.4, the module metadata file can describe only those modules that contain a single _component_, which is some piece of software such as a library or application. Support for more sophisticated mappings will be added by later versions.
 
 ## Usage in a Maven repository
 
@@ -24,7 +24,7 @@ The file must be encoded using UTF-8.
 
 The file must contain a JSON object with the following values:
 
-- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"0.3"`
+- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"0.4"`
 - `component`: optional. Describes the identity of the component contained in the module.
 - `builtBy`: optional. Describes the producer of this metadata file and the contents of the module.
 - `variants`: optional. Describes the variants of the component packaged in the module, if any.
@@ -83,7 +83,7 @@ This valud must contain an array of 0 or more capabilities. Each capability is a
 
 This value must contain an object with the following values:
 
-- `url`: The location of the metadata file that describes the variant. A string. In version 0.3, this must be a path relative to the module.
+- `url`: The location of the metadata file that describes the variant. A string. In version 0.4, this must be a path relative to the module.
 - `group`: The group of the module. A string
 - `module`: The name of the module. A string
 - `version`: The version of the module. A string
@@ -99,6 +99,7 @@ This value must contain an array with zero or more elements. Each element must b
    - `rejects`: optional. An array of rejected versions for this dependency.
 - `excludes`: optional. Defines the exclusions that apply to this dependency. 
 - `reason`: optional. A explanation why the dependency is used. Can typically be used to explain why a specific version is requested.
+- `attributes`: optional. If set, attributes will override the consumer attributes during dependency resolution for this specific dependency.
 
 #### `excludes` value
 
@@ -121,13 +122,14 @@ This value must contain an array with zero or more elements. Each element must b
    - `prefers`: optional. The preferred version for this dependency constraint
    - `rejects`: optional. An array of rejected versions for this dependency constraint.
 - `reason`: optional. A explanation why the constraint is used. Can typically be used to explain why a specific version is rejected, or from where a platform comes from.
+- `attributes`: optional. If set, attributes will override the consumer attributes during dependency resolution for this specific dependency.
 
 ### `files` value
 
 This value must contain an array with zero or more elements. Each element must be an object with the following values:
 
 - `name`: The name of the file. A string. This will be used to calculate the name of the file in the cache.
-- `url`: The location of the file. A string. In version 0.3, this must be a path relative to the module.
+- `url`: The location of the file. A string. In version 0.4, this must be a path relative to the module.
 - `size`: The size of the file in bytes. A number.
 - `sha1`: The SHA1 hash of the file content. A hex string.
 - `md5`: The MD5 hash of the file content. A hex string.
@@ -136,7 +138,7 @@ This value must contain an array with zero or more elements. Each element must b
 
 ```
 {
-    "formatVersion": "0.3",
+    "formatVersion": "0.4",
     "component": {
         "group": "my.group",
         "module": "mylib",
@@ -167,10 +169,13 @@ This value must contain an array with zero or more elements. Each element must b
                 { 
                     "group": "some.group", 
                     "module": "other-lib", 
-                    "version": { "prefers": "3.4" } 
+                    "version": { "prefers": "3.4" },
                     "excludes": [
                         { "group": "*", "module": "excluded-lib" }
-                    ]
+                    ],
+                    "attributes": {
+                       "buildType": "debug"
+                    }
                 }
             ]
         },

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -145,7 +145,9 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     public VersionNumber getArtifactCacheLayoutVersion() {
-        if (isSameOrNewer("4.7-rc-1")) {
+        if (isSameOrNewer("4.8-rc-1")) {
+            return VersionNumber.parse("2.57");
+        } else if (isSameOrNewer("4.7-rc-1")) {
             return VersionNumber.parse("2.56");
         } else if (isSameOrNewer("4.6-rc-1")) {
             return VersionNumber.parse("2.53");

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -34,7 +34,7 @@ class GradleModuleMetadata {
             JsonReader reader = new JsonReader(r)
             values = readObject(reader)
         }
-        assert values.formatVersion == '0.3'
+        assert values.formatVersion == '0.4'
         assert values.createdBy.gradle.version == GradleVersion.current().version
         assert values.createdBy.gradle.buildId
         variants = (values.variants ?: []).collect { new Variant(it.name, it) }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -128,6 +128,10 @@ class GradleModuleMetadata {
         return values
     }
 
+    static Map<String, String> normalizeForTests(Map<String, ?> attributes) {
+        attributes?.collectEntries { k, v -> [k, v?.toString()] }
+    }
+
     static class Variant {
         final String name
         private final Map<String, Object> values
@@ -154,7 +158,7 @@ class GradleModuleMetadata {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {
                     def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
-                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions, it.reason)
+                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencies
@@ -171,7 +175,7 @@ class GradleModuleMetadata {
         List<DependencyConstraint> getDependencyConstraints() {
             if (dependencyConstraints == null) {
                 dependencyConstraints = (values.dependencyConstraints ?: []).collect {
-                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [], it.reason)
+                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencyConstraints
@@ -282,6 +286,24 @@ class GradleModuleMetadata {
                 assert find()?.reason == reason
                 this
             }
+
+            DependencyView hasAttribute(String attribute) {
+                assert find()?.attributes?.containsKey(attribute)
+                this
+            }
+
+            DependencyView hasAttribute(String attribute, Object value) {
+                String expected = value?.toString()
+                assert find()?.attributes[attribute] == expected
+                this
+            }
+
+            DependencyView hasAttributes(Map<String, Object> fullAttributeSet) {
+                Map<String, String> expectedAttributes = normalizeForTests(fullAttributeSet)
+                def actualAttributes = find()?.attributes
+                assert actualAttributes == expectedAttributes
+                this
+            }
         }
 
         class DependencyConstraintView {
@@ -317,6 +339,25 @@ class GradleModuleMetadata {
                 assert find()?.reason == reason
                 this
             }
+
+
+            DependencyConstraintView hasAttribute(String attribute) {
+                assert find()?.attributes?.containsKey(attribute)
+                this
+            }
+
+            DependencyConstraintView hasAttribute(String attribute, Object value) {
+                String expected = value?.toString()
+                assert find()?.attributes[attribute] == expected
+                this
+            }
+
+            DependencyConstraintView hasAttributes(Map<String, Object> fullAttributeSet) {
+                Map<String, String> expectedAttributes = normalizeForTests(fullAttributeSet)
+                def actualAttributes = find()?.attributes
+                assert actualAttributes == expectedAttributes
+                this
+            }
         }
     }
 
@@ -326,13 +367,15 @@ class GradleModuleMetadata {
         final String version
         final List<String> rejectsVersion
         final String reason
+        final Map<String, String> attributes
 
-        Coords(String group, String module, String version, List<String> rejectsVersion = [], String reason = null) {
+        Coords(String group, String module, String version, List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
             this.group = group
             this.module = module
             this.version = version
             this.rejectsVersion = rejectsVersion
             this.reason = reason
+            this.attributes = attributes
         }
 
         String getCoords() {
@@ -359,8 +402,8 @@ class GradleModuleMetadata {
 
     static class Dependency extends Coords {
         final List<String> excludes
-        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes, String reason) {
-            super(group, module, version, rejectedVersions, reason)
+        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
+            super(group, module, version, rejectedVersions, reason, attributes)
             this.excludes = excludes*.toString()
         }
 
@@ -374,8 +417,8 @@ class GradleModuleMetadata {
     }
 
     static class DependencyConstraint extends Coords {
-        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions, String reason) {
-            super(group, module, version, rejectedVersions, reason)
+        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
+            super(group, module, version, rejectedVersions, reason, attributes)
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
@@ -25,12 +25,14 @@ class DependencyConstraintSpec {
     String prefers
     List<String> rejects
     String reason
+    Map<String, ?> attributes
 
-    DependencyConstraintSpec(String g, String m, String version, List<String> r, String desc) {
+    DependencyConstraintSpec(String g, String m, String version, List<String> r, String desc, Map<String, ?> attrs) {
         group = g
         module = m
         prefers = version
         rejects = r?:Collections.<String>emptyList()
         reason = desc
+        attributes = attrs
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -45,4 +45,9 @@ class DependencySpec {
         this.reason = reason
         this.attributes = attributes
     }
+
+    DependencySpec attribute(String name, Object value) {
+        attributes[name] = value
+        this
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -28,8 +28,9 @@ class DependencySpec {
     List<String> rejects
     List<ExcludeSpec> exclusions = []
     String reason
+    Map<String, ?> attributes
 
-    DependencySpec(String g, String m, String version, List<String> r, Collection<Map> e, String reason) {
+    DependencySpec(String g, String m, String version, List<String> r, Collection<Map> e, String reason, Map<String, ?> attributes) {
         group = g
         module = m
         prefers = version
@@ -42,5 +43,6 @@ class DependencySpec {
             }
         }
         this.reason = reason
+        this.attributes = attributes
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -87,6 +87,13 @@ class GradleFileModuleAdapter {
                                     }
                                 })
                             }
+                            if (d.attributes) {
+                                attributes {
+                                    d.attributes.each { key, value ->
+                                        "$key" value
+                                    }
+                                }
+                            }
                         }
                     })
                     dependencyConstraints(v.dependencyConstraints.collect { dc ->
@@ -103,6 +110,13 @@ class GradleFileModuleAdapter {
                             }
                             if (dc.reason) {
                                 reason dc.reason
+                            }
+                            if (dc.attributes) {
+                                attributes {
+                                    dc.attributes.each { key, value ->
+                                        "$key" value
+                                    }
+                                }
                             }
                         }
                     })

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -17,6 +17,7 @@
 package org.gradle.test.fixtures.gradle
 
 import groovy.json.JsonBuilder
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
 import org.gradle.test.fixtures.file.TestFile
 
 class GradleFileModuleAdapter {
@@ -39,7 +40,7 @@ class GradleFileModuleAdapter {
         def file = moduleDir.file("$module-${version}.module")
         def jsonBuilder = new JsonBuilder()
         jsonBuilder {
-            formatVersion '0.3'
+            formatVersion ModuleMetadataParser.FORMAT_VERSION
             builtBy {
                 gradle { }
             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -48,7 +48,15 @@ class VariantMetadataSpec {
         attributes[name] = value
     }
 
-    void dependsOn(String group, String module, String version, String reason = null) {
-        dependencies += new DependencySpec(group, module, version, null, null, reason)
+    void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes=[:]) {
+        dependencies += new DependencySpec(group, module, version, null, null, reason, attributes)
+    }
+
+    void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
+        def spec = new DependencySpec(group, module, version, null, null, null, [:])
+        config.delegate = spec
+        config.resolveStrategy = Closure.DELEGATE_FIRST
+        config()
+        dependencies += spec
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -397,10 +397,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, d.exclusions, d.reason)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
-                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.rejects, d.reason)
+                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts ?: defaultArtifacts,
                     v.capabilities

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -437,10 +437,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, d.exclusions, d.reason)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
-                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.rejects, d.reason)
+                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts?:defaultArtifacts,
                     v.capabilities

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -424,4 +424,67 @@ class TestCapability implements Capability {
             noMoreDependencies()
         }
     }
+
+    def "publishes dependency/constraint attributes"() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            def attr1 = Attribute.of('custom', String)
+            def attr2 = Attribute.of('nice', Boolean)
+            
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
+                    attributes: configurations.implementation.attributes))
+
+            dependencies {
+                implementation("org:foo:1.0") {
+                   attributes {
+                      attribute(attr1, 'foo')
+                   }
+                }
+                constraints {                
+                    implementation("org:bar:2.0") {
+                        attributes {
+                           attribute(attr2, true)
+                        }
+                    }
+                }
+            }
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from comp
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = mavenRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variant('api') {
+            dependency('org:foo:1.0') {
+                hasAttribute('custom', 'foo')
+            }
+            constraint('org:bar:2.0') {
+                hasAttribute('nice', true)
+            }
+            noMoreDependencies()
+        }
+    }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -392,6 +392,7 @@ public class ModuleMetadataFileGenerator {
         }
         if (dependency instanceof ModuleDependency) {
             writeExcludes((ModuleDependency) dependency, additionalExcludes, jsonWriter);
+            writeAttributes(((ModuleDependency)dependency).getAttributes(), jsonWriter);
         }
         String reason = dependency.getReason();
         if (StringUtils.isNotEmpty(reason)) {
@@ -420,6 +421,7 @@ public class ModuleMetadataFileGenerator {
         jsonWriter.name("module");
         jsonWriter.value(dependencyConstraint.getName());
         writeVersionConstraint(dependencyConstraint.getVersionConstraint(), jsonWriter);
+        writeAttributes(dependencyConstraint.getAttributes(), jsonWriter);
         String reason = dependencyConstraint.getReason();
         if (StringUtils.isNotEmpty(reason)) {
             jsonWriter.name("reason");

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.internal.id.UniqueId
@@ -215,12 +216,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d1.name >> "m1"
         d1.version >> "v1"
         d1.transitive >> true
+        d1.attributes >> ImmutableAttributes.EMPTY
 
         def d2 = Stub(ExternalDependency)
         d2.group >> "g2"
         d2.name >> "m2"
         d2.versionConstraint >> prefersAndRejects("v2", ["v3", "v4"])
         d2.transitive >> false
+        d2.attributes >> ImmutableAttributes.EMPTY
 
         def d3 = Stub(ExternalDependency)
         d3.group >> "g3"
@@ -228,18 +231,21 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d3.versionConstraint >> prefers("v3")
         d3.transitive >> true
         d3.excludeRules >> [new DefaultExcludeRule("g4", "m4"), new DefaultExcludeRule(null, "m5"), new DefaultExcludeRule("g5", null)]
+        d3.attributes >> ImmutableAttributes.EMPTY
 
         def d4 = Stub(ExternalDependency)
         d4.group >> "g4"
         d4.name >> "m4"
         d4.versionConstraint >> prefers('')
         d4.transitive >> true
+        d4.attributes >> ImmutableAttributes.EMPTY
 
         def d5 = Stub(ExternalDependency)
         d5.group >> "g5"
         d5.name >> "m5"
         d5.versionConstraint >> prefersAndRejects('', ['1.0'])
         d5.transitive >> true
+        d5.attributes >> ImmutableAttributes.EMPTY
 
         def d6 = Stub(ExternalDependency)
         d6.group >> "g6"
@@ -247,6 +253,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d6.versionConstraint >> prefers('1.0')
         d6.transitive >> true
         d6.reason >> 'custom reason'
+        d6.attributes >> ImmutableAttributes.EMPTY
+
+        def d7 = Stub(ExternalDependency)
+        d7.group >> "g7"
+        d7.name >> "m7"
+        d7.versionConstraint >> prefers('1.0')
+        d7.transitive >> true
+        d7.attributes >> attributes(foo: 'foo', bar: 'baz')
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
@@ -256,7 +270,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
-        v2.dependencies >> [d2, d3, d4, d5, d6]
+        v2.dependencies >> [d2, d3, d4, d5, d6, d7]
 
         component.usages >> [v1, v2]
 
@@ -358,6 +372,17 @@ class ModuleMetadataFileGeneratorTest extends Specification {
             "prefers": "1.0"
           },
           "reason": "custom reason"
+        },
+        {
+          "group": "g7",
+          "module": "m7",
+          "version": {
+            "prefers": "1.0"
+          },
+          "attributes": {
+            "bar": "baz",
+            "foo": "foo"
+          }
         }
       ]
     }
@@ -375,16 +400,25 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         dc1.group >> "g1"
         dc1.name >> "m1"
         dc1.versionConstraint >> prefers("v1")
+        dc1.attributes >> ImmutableAttributes.EMPTY
 
         def dc2 = Stub(DependencyConstraint)
         dc2.group >> "g2"
         dc2.name >> "m2"
         dc2.versionConstraint >> prefersAndRejects("v2", ["v3", "v4"])
+        dc2.attributes >> ImmutableAttributes.EMPTY
 
         def dc3 = Stub(DependencyConstraint)
         dc3.group >> "g3"
         dc3.name >> "m3"
         dc3.versionConstraint >> prefers("v3")
+        dc3.attributes >> ImmutableAttributes.EMPTY
+
+        def dc4 = Stub(DependencyConstraint)
+        dc4.group >> "g4"
+        dc4.name >> "m4"
+        dc4.versionConstraint >> prefers("v4")
+        dc4.attributes >> attributes(quality: 'awesome', channel: 'canary')
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
@@ -393,7 +427,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
-        v2.dependencyConstraints >> [dc2, dc3]
+        v2.dependencyConstraints >> [dc2, dc3, dc4]
 
         component.usages >> [v1, v2]
 
@@ -453,6 +487,17 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "module": "m3",
           "version": {
             "prefers": "v3"
+          }
+        },
+        {
+          "group": "g4",
+          "module": "m4",
+          "version": {
+            "prefers": "v4"
+          },
+          "attributes": {
+            "channel": "canary",
+            "quality": "awesome"
           }
         }
       ]

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -779,17 +779,20 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         apiDependency.name >> "api"
         apiDependency.transitive >> true
         apiDependency.excludeRules >> [new DefaultExcludeRule("com.example.bad", "api")]
+        apiDependency.attributes >> ImmutableAttributes.EMPTY
 
         def runtimeDependency = Stub(ExternalDependency)
         runtimeDependency.group >> "com.acme"
         runtimeDependency.name >> "runtime"
         runtimeDependency.transitive >> true
         runtimeDependency.excludeRules >> [new DefaultExcludeRule("com.example.bad", "runtime")]
+        runtimeDependency.attributes >> ImmutableAttributes.EMPTY
 
         def intransitiveDependency = Stub(ExternalDependency)
         intransitiveDependency.group >> "com.acme"
         intransitiveDependency.name >> "intransitive"
         intransitiveDependency.transitive >> false
+        intransitiveDependency.attributes >> ImmutableAttributes.EMPTY
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.VersionConstraint
-import org.gradle.api.attributes.Attribute
 import org.gradle.api.capabilities.Capability
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
@@ -31,7 +30,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
-import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.internal.id.UniqueId
@@ -42,6 +40,8 @@ import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Specification
+
+import static org.gradle.util.TestUtil.attributes
 
 class ModuleMetadataFileGeneratorTest extends Specification {
 
@@ -478,7 +478,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         v1.attributes >> attributes(usage: "compile", debuggable: true, platform: platform, linkage: SomeEnum.VALUE_1)
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
-        v2.attributes >> attributes()
+        v2.attributes >> attributes([:])
 
         component.usages >> [v1, v2]
 
@@ -826,16 +826,6 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         publication.component >> component
         publication.coordinates >> coords
         return publication
-    }
-
-    def attributes(Map<String, ?> values) {
-        def attrs = ImmutableAttributes.EMPTY
-        if (values) {
-            values.each { String key, Object value ->
-                attrs = TestUtil.attributesFactory().concat(attrs, Attribute.of(key, value.class), value)
-            }
-        }
-        return attrs
     }
 
     interface TestComponent extends ComponentWithVariants, SoftwareComponentInternal {


### PR DESCRIPTION
### Context

This pull request builds on top of #5006 and adds attributes to Gradle module metadata. It makes it possible to consume published modules which define attributes on dependencies.

Closes gradle/gradle-private#1190