### PR TITLE
Publish dependency attributes

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -128,6 +128,10 @@ class GradleModuleMetadata {
         return values
     }
 
+    static Map<String, String> normalizeForTests(Map<String, ?> attributes) {
+        attributes?.collectEntries { k, v -> [k, v?.toString()] }
+    }
+
     static class Variant {
         final String name
         private final Map<String, Object> values
@@ -154,7 +158,7 @@ class GradleModuleMetadata {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {
                     def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
-                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions, it.reason)
+                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencies
@@ -171,7 +175,7 @@ class GradleModuleMetadata {
         List<DependencyConstraint> getDependencyConstraints() {
             if (dependencyConstraints == null) {
                 dependencyConstraints = (values.dependencyConstraints ?: []).collect {
-                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [], it.reason)
+                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencyConstraints
@@ -282,6 +286,24 @@ class GradleModuleMetadata {
                 assert find()?.reason == reason
                 this
             }
+
+            DependencyView hasAttribute(String attribute) {
+                assert find()?.attributes?.containsKey(attribute)
+                this
+            }
+
+            DependencyView hasAttribute(String attribute, Object value) {
+                String expected = value?.toString()
+                assert find()?.attributes[attribute] == expected
+                this
+            }
+
+            DependencyView hasAttributes(Map<String, Object> fullAttributeSet) {
+                Map<String, String> expectedAttributes = normalizeForTests(fullAttributeSet)
+                def actualAttributes = find()?.attributes
+                assert actualAttributes == expectedAttributes
+                this
+            }
         }
 
         class DependencyConstraintView {
@@ -317,6 +339,25 @@ class GradleModuleMetadata {
                 assert find()?.reason == reason
                 this
             }
+
+
+            DependencyConstraintView hasAttribute(String attribute) {
+                assert find()?.attributes?.containsKey(attribute)
+                this
+            }
+
+            DependencyConstraintView hasAttribute(String attribute, Object value) {
+                String expected = value?.toString()
+                assert find()?.attributes[attribute] == expected
+                this
+            }
+
+            DependencyConstraintView hasAttributes(Map<String, Object> fullAttributeSet) {
+                Map<String, String> expectedAttributes = normalizeForTests(fullAttributeSet)
+                def actualAttributes = find()?.attributes
+                assert actualAttributes == expectedAttributes
+                this
+            }
         }
     }
 
@@ -326,13 +367,15 @@ class GradleModuleMetadata {
         final String version
         final List<String> rejectsVersion
         final String reason
+        final Map<String, String> attributes
 
-        Coords(String group, String module, String version, List<String> rejectsVersion = [], String reason = null) {
+        Coords(String group, String module, String version, List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
             this.group = group
             this.module = module
             this.version = version
             this.rejectsVersion = rejectsVersion
             this.reason = reason
+            this.attributes = attributes
         }
 
         String getCoords() {
@@ -359,8 +402,8 @@ class GradleModuleMetadata {
 
     static class Dependency extends Coords {
         final List<String> excludes
-        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes, String reason) {
-            super(group, module, version, rejectedVersions, reason)
+        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
+            super(group, module, version, rejectedVersions, reason, attributes)
             this.excludes = excludes*.toString()
         }
 
@@ -374,8 +417,8 @@ class GradleModuleMetadata {
     }
 
     static class DependencyConstraint extends Coords {
-        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions, String reason) {
-            super(group, module, version, rejectedVersions, reason)
+        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
+            super(group, module, version, rejectedVersions, reason, attributes)
         }
     }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -424,4 +424,67 @@ class TestCapability implements Capability {
             noMoreDependencies()
         }
     }
+
+    def "publishes dependency/constraint attributes"() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            def attr1 = Attribute.of('custom', String)
+            def attr2 = Attribute.of('nice', Boolean)
+            
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
+                    attributes: configurations.implementation.attributes))
+
+            dependencies {
+                implementation("org:foo:1.0") {
+                   attributes {
+                      attribute(attr1, 'foo')
+                   }
+                }
+                constraints {                
+                    implementation("org:bar:2.0") {
+                        attributes {
+                           attribute(attr2, true)
+                        }
+                    }
+                }
+            }
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from comp
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = mavenRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variant('api') {
+            dependency('org:foo:1.0') {
+                hasAttribute('custom', 'foo')
+            }
+            constraint('org:bar:2.0') {
+                hasAttribute('nice', true)
+            }
+            noMoreDependencies()
+        }
+    }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -392,6 +392,7 @@ public class ModuleMetadataFileGenerator {
         }
         if (dependency instanceof ModuleDependency) {
             writeExcludes((ModuleDependency) dependency, additionalExcludes, jsonWriter);
+            writeAttributes(((ModuleDependency)dependency).getAttributes(), jsonWriter);
         }
         String reason = dependency.getReason();
         if (StringUtils.isNotEmpty(reason)) {
@@ -420,6 +421,7 @@ public class ModuleMetadataFileGenerator {
         jsonWriter.name("module");
         jsonWriter.value(dependencyConstraint.getName());
         writeVersionConstraint(dependencyConstraint.getVersionConstraint(), jsonWriter);
+        writeAttributes(dependencyConstraint.getAttributes(), jsonWriter);
         String reason = dependencyConstraint.getReason();
         if (StringUtils.isNotEmpty(reason)) {
             jsonWriter.name("reason");

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.internal.id.UniqueId
@@ -215,12 +216,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d1.name >> "m1"
         d1.version >> "v1"
         d1.transitive >> true
+        d1.attributes >> ImmutableAttributes.EMPTY
 
         def d2 = Stub(ExternalDependency)
         d2.group >> "g2"
         d2.name >> "m2"
         d2.versionConstraint >> prefersAndRejects("v2", ["v3", "v4"])
         d2.transitive >> false
+        d2.attributes >> ImmutableAttributes.EMPTY
 
         def d3 = Stub(ExternalDependency)
         d3.group >> "g3"
@@ -228,18 +231,21 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d3.versionConstraint >> prefers("v3")
         d3.transitive >> true
         d3.excludeRules >> [new DefaultExcludeRule("g4", "m4"), new DefaultExcludeRule(null, "m5"), new DefaultExcludeRule("g5", null)]
+        d3.attributes >> ImmutableAttributes.EMPTY
 
         def d4 = Stub(ExternalDependency)
         d4.group >> "g4"
         d4.name >> "m4"
         d4.versionConstraint >> prefers('')
         d4.transitive >> true
+        d4.attributes >> ImmutableAttributes.EMPTY
 
         def d5 = Stub(ExternalDependency)
         d5.group >> "g5"
         d5.name >> "m5"
         d5.versionConstraint >> prefersAndRejects('', ['1.0'])
         d5.transitive >> true
+        d5.attributes >> ImmutableAttributes.EMPTY
 
         def d6 = Stub(ExternalDependency)
         d6.group >> "g6"
@@ -247,6 +253,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d6.versionConstraint >> prefers('1.0')
         d6.transitive >> true
         d6.reason >> 'custom reason'
+        d6.attributes >> ImmutableAttributes.EMPTY
+
+        def d7 = Stub(ExternalDependency)
+        d7.group >> "g7"
+        d7.name >> "m7"
+        d7.versionConstraint >> prefers('1.0')
+        d7.transitive >> true
+        d7.attributes >> attributes(foo: 'foo', bar: 'baz')
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
@@ -256,7 +270,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
-        v2.dependencies >> [d2, d3, d4, d5, d6]
+        v2.dependencies >> [d2, d3, d4, d5, d6, d7]
 
         component.usages >> [v1, v2]
 
@@ -358,6 +372,17 @@ class ModuleMetadataFileGeneratorTest extends Specification {
             "prefers": "1.0"
           },
           "reason": "custom reason"
+        },
+        {
+          "group": "g7",
+          "module": "m7",
+          "version": {
+            "prefers": "1.0"
+          },
+          "attributes": {
+            "bar": "baz",
+            "foo": "foo"
+          }
         }
       ]
     }
@@ -375,16 +400,25 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         dc1.group >> "g1"
         dc1.name >> "m1"
         dc1.versionConstraint >> prefers("v1")
+        dc1.attributes >> ImmutableAttributes.EMPTY
 
         def dc2 = Stub(DependencyConstraint)
         dc2.group >> "g2"
         dc2.name >> "m2"
         dc2.versionConstraint >> prefersAndRejects("v2", ["v3", "v4"])
+        dc2.attributes >> ImmutableAttributes.EMPTY
 
         def dc3 = Stub(DependencyConstraint)
         dc3.group >> "g3"
         dc3.name >> "m3"
         dc3.versionConstraint >> prefers("v3")
+        dc3.attributes >> ImmutableAttributes.EMPTY
+
+        def dc4 = Stub(DependencyConstraint)
+        dc4.group >> "g4"
+        dc4.name >> "m4"
+        dc4.versionConstraint >> prefers("v4")
+        dc4.attributes >> attributes(quality: 'awesome', channel: 'canary')
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
@@ -393,7 +427,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
-        v2.dependencyConstraints >> [dc2, dc3]
+        v2.dependencyConstraints >> [dc2, dc3, dc4]
 
         component.usages >> [v1, v2]
 
@@ -453,6 +487,17 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "module": "m3",
           "version": {
             "prefers": "v3"
+          }
+        },
+        {
+          "group": "g4",
+          "module": "m4",
+          "version": {
+            "prefers": "v4"
+          },
+          "attributes": {
+            "channel": "canary",
+            "quality": "awesome"
           }
         }
       ]

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -779,17 +779,20 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         apiDependency.name >> "api"
         apiDependency.transitive >> true
         apiDependency.excludeRules >> [new DefaultExcludeRule("com.example.bad", "api")]
+        apiDependency.attributes >> ImmutableAttributes.EMPTY
 
         def runtimeDependency = Stub(ExternalDependency)
         runtimeDependency.group >> "com.acme"
         runtimeDependency.name >> "runtime"
         runtimeDependency.transitive >> true
         runtimeDependency.excludeRules >> [new DefaultExcludeRule("com.example.bad", "runtime")]
+        runtimeDependency.attributes >> ImmutableAttributes.EMPTY
 
         def intransitiveDependency = Stub(ExternalDependency)
         intransitiveDependency.group >> "com.acme"
         intransitiveDependency.name >> "intransitive"
         intransitiveDependency.transitive >> false
+        intransitiveDependency.attributes >> ImmutableAttributes.EMPTY
 
         def v1 = Stub(UsageContext)
         v1.name >> "v1"


### PR DESCRIPTION
### Context

This is a follow up to #5019, completing the simple "choose a component variant based on dependency attributes" story. This does **not** complete the full dependency attributes story as we still need to deal with selection of _components_ that match the attributes.

Closes gradle/gradle-private#1189
