### PR TITLE
Split up DefaultTaskExecutionPlan

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
@@ -26,6 +26,7 @@ import java.util.Set;
 public abstract class AbstractTaskDependency implements TaskDependencyInternal {
     public Set<? extends Task> getDependencies(@Nullable Task task) {
         CachingTaskDependencyResolveContext context = new CachingTaskDependencyResolveContext();
-        return context.getDependencies(task, this);
+        context.setTask(task);
+        return context.getDependencies(this);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CachingTaskDependencyResolveContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CachingTaskDependencyResolveContext.java
@@ -54,15 +54,22 @@ public class CachingTaskDependencyResolveContext implements TaskDependencyResolv
             new TaskGraphImpl());
     private Task task;
 
-    public Set<? extends Task> getDependencies(@Nullable Task task, TaskDependency container) {
+    public void setTask(Task task) {
         this.task = task;
+    }
+
+    public Set<? extends Task> getDependencies(@Nullable Task task, Object container) {
+        this.task = task;
+        return getDependencies(container);
+    }
+
+    public Set<? extends Task> getDependencies(Object container) {
         try {
             return doGetDependencies(container);
         } catch (Exception e) {
             throw new TaskDependencyResolveException(String.format("Could not determine the dependencies of %s.", task), e);
         } finally {
             queue.clear();
-            this.task = null;
         }
     }
 
@@ -71,7 +78,7 @@ public class CachingTaskDependencyResolveContext implements TaskDependencyResolv
         return task;
     }
 
-    private Set<Task> doGetDependencies(TaskDependency container) {
+    private Set<Task> doGetDependencies(Object container) {
         walker.add(container);
         return walker.findValues();
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -372,7 +372,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 maybeRemoveProcessedShouldRunAfterEdge(walkedShouldRunAfterEdges, taskNode);
                 visitingNodes.remove(taskNode, currentSegment);
                 path.pop();
-                executionPlan.put(taskNode.getTask(), taskNode);
+                Preconditions.checkState(executionPlan.put(taskNode.getTask(), taskNode) == null, "no duplicate tasks in execution plan");
                 Project project = taskNode.getTask().getProject();
                 projectLocks.put(project, getOrCreateProjectLock(project));
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -36,14 +36,10 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext;
-import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.tasks.execution.DefaultTaskProperties;
 import org.gradle.api.internal.tasks.execution.TaskProperties;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.specs.Specs;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.execution.TaskFailureHandler;
 import org.gradle.initialization.BuildCancellationToken;
@@ -78,7 +74,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -97,20 +92,16 @@ import static org.gradle.internal.resources.ResourceLockState.Disposition.RETRY;
  * methods.
  */
 public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
-    private final Set<TaskInfo> tasksInUnknownState = new LinkedHashSet<TaskInfo>();
-    private final Set<TaskInfo> entryTasks = new LinkedHashSet<TaskInfo>();
     private final LinkedHashMap<Task, TaskInfo> executionPlan = new LinkedHashMap<Task, TaskInfo>();
     private final List<TaskInfo> executionQueue = new LinkedList<TaskInfo>();
     private final Map<Project, ResourceLock> projectLocks = Maps.newHashMap();
     private final TaskFailureCollector failureCollector = new TaskFailureCollector();
-    private final TaskInfoFactory nodeFactory = new TaskInfoFactory(failureCollector);
-    private Spec<? super Task> filter = Specs.satisfyAll();
+    private final WorkGraph workGraph = new WorkGraph(failureCollector);
 
     private TaskFailureHandler failureHandler = new RethrowingFailureHandler();
 
     private final BuildCancellationToken cancellationToken;
     private final Set<TaskInfo> runningTasks = Sets.newIdentityHashSet();
-    private final Set<Task> filteredTasks = Sets.newIdentityHashSet();
     private final Map<TaskInfo, TaskMutationInfo> taskMutations = Maps.newIdentityHashMap();
     private final Map<File, String> canonicalizedFileCache = Maps.newIdentityHashMap();
     private final Map<Pair<TaskInfo, TaskInfo>, Boolean> reachableCache = Maps.newHashMap();
@@ -138,162 +129,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     }
 
     public void addToTaskGraph(Collection<? extends Task> tasks) {
-        List<TaskInfo> queue = new ArrayList<TaskInfo>();
-
-        addTaskInfosToQueue(tasks, queue);
-        resolveDependencies(queue);
-        resolveTasksInUnknownState();
-    }
-
-    private void resolveDependencies(List<TaskInfo> queue) {
-        Set<TaskInfo> visiting = new HashSet<TaskInfo>();
-        CachingTaskDependencyResolveContext context = new CachingTaskDependencyResolveContext();
-
-        while (!queue.isEmpty()) {
-            TaskInfo node = queue.get(0);
-            if (node.getDependenciesProcessed()) {
-                // Have already visited this task - skip it
-                queue.remove(0);
-                continue;
-            }
-
-            TaskInternal task = node.getTask();
-            boolean filtered = !filter.isSatisfiedBy(task);
-            if (filtered) {
-                // Task is not required - skip it
-                queue.remove(0);
-                node.dependenciesProcessed();
-                node.doNotRequire();
-                filteredTasks.add(task);
-                continue;
-            }
-
-            if (visiting.add(node)) {
-                // Have not seen this task before - add its dependencies to the head of the queue and leave this
-                // task in the queue
-
-                // Make sure it has been configured
-                ((TaskContainerInternal) task.getProject().getTasks()).prepareForExecution(task);
-                context.setTask(task);
-
-                addNodeDependencies(queue, visiting, context, node, task.getTaskDependencies());
-                addNodeFinalizers(queue, visiting, context, node, task.getFinalizedBy());
-
-                addMustSuccessors(context, node, task.getMustRunAfter());
-                addShouldSuccessors(context, node, task.getShouldRunAfter());
-
-                if (node.isRequired()) {
-                    requireSuccessors(node);
-                } else {
-                    tasksInUnknownState.add(node);
-                }
-            } else {
-                // Have visited this task's dependencies - add it to the graph
-                queue.remove(0);
-                visiting.remove(node);
-                node.dependenciesProcessed();
-            }
-        }
-    }
-
-    private void addNodeFinalizers(List<TaskInfo> queue, Set<TaskInfo> visiting, CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency finalizedBy) {
-        for (Task finalizerTask : context.getDependencies(finalizedBy)) {
-            TaskInfo targetNode = nodeFactory.createNode(finalizerTask);
-            addFinalizerNode(node, targetNode);
-            if (!visiting.contains(targetNode)) {
-                queue.add(0, targetNode);
-            }
-        }
-    }
-
-    private void addNodeDependencies(List<TaskInfo> queue, Set<TaskInfo> visiting, CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency taskDependencies) {
-        Set<? extends Task> dependsOnTasks = context.getDependencies(taskDependencies);
-        for (Task dependsOnTask : dependsOnTasks) {
-            TaskInfo targetNode = nodeFactory.createNode(dependsOnTask);
-            node.addDependencySuccessor(targetNode);
-            if (!visiting.contains(targetNode)) {
-                queue.add(0, targetNode);
-            }
-        }
-    }
-
-    private void addMustSuccessors(CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency mustRunAfterDependency) {
-        for (Task mustRunAfter : context.getDependencies(mustRunAfterDependency)) {
-            TaskInfo targetNode = nodeFactory.createNode(mustRunAfter);
-            node.addMustSuccessor(targetNode);
-        }
-    }
-
-    private void addShouldSuccessors(CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency shouldRunAfterDependencies) {
-        for (Task shouldRunAfter : context.getDependencies(shouldRunAfterDependencies)) {
-            TaskInfo targetNode = nodeFactory.createNode(shouldRunAfter);
-            node.addShouldSuccessor(targetNode);
-        }
-    }
-
-    private void requireSuccessors(TaskInfo node) {
-        for (TaskInfo successor : node.getDependencySuccessors()) {
-            if (filter.isSatisfiedBy(successor.getTask())) {
-                successor.require();
-            }
-        }
-    }
-
-    private void addTaskInfosToQueue(Collection<? extends Task> tasks, List<TaskInfo> queue) {
-        List<Task> sortedTasks = new ArrayList<Task>(tasks);
-        Collections.sort(sortedTasks);
-        for (Task task : sortedTasks) {
-            TaskInfo node = nodeFactory.createNode(task);
-            if (node.isMustNotRun()) {
-                requireWithDependencies(node);
-            } else if (filter.isSatisfiedBy(task)) {
-                node.require();
-            }
-            entryTasks.add(node);
-            queue.add(node);
-        }
-    }
-
-    private void resolveTasksInUnknownState() {
-        List<TaskInfo> queue = new ArrayList<TaskInfo>(tasksInUnknownState);
-        Set<TaskInfo> visiting = new HashSet<TaskInfo>();
-
-        while (!queue.isEmpty()) {
-            TaskInfo task = queue.get(0);
-            if (task.isInKnownState()) {
-                queue.remove(0);
-                continue;
-            }
-
-            if (visiting.add(task)) {
-                for (TaskInfo hardPredecessor : task.getDependencyPredecessors()) {
-                    if (!visiting.contains(hardPredecessor)) {
-                        queue.add(0, hardPredecessor);
-                    }
-                }
-            } else {
-                queue.remove(0);
-                visiting.remove(task);
-                task.mustNotRun();
-                for (TaskInfo predecessor : task.getDependencyPredecessors()) {
-                    assert predecessor.isRequired() || predecessor.isMustNotRun();
-                    if (predecessor.isRequired()) {
-                        task.require();
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    private void addFinalizerNode(TaskInfo node, TaskInfo finalizerNode) {
-        if (filter.isSatisfiedBy(finalizerNode.getTask())) {
-            node.addFinalizer(finalizerNode);
-            if (!finalizerNode.isInKnownState()) {
-                finalizerNode.mustNotRun();
-            }
-            finalizerNode.addMustSuccessor(node);
-        }
+        workGraph.addToTaskGraph(tasks);
     }
 
     private <T> void addAllReversed(List<T> list, TreeSet<T> set) {
@@ -302,17 +138,8 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         list.addAll(elements);
     }
 
-    private void requireWithDependencies(TaskInfo taskInfo) {
-        if (taskInfo.isMustNotRun() && filter.isSatisfiedBy(taskInfo.getTask())) {
-            taskInfo.require();
-            for (TaskInfo dependency : taskInfo.getDependencySuccessors()) {
-                requireWithDependencies(dependency);
-            }
-        }
-    }
-
     public void determineExecutionPlan() {
-        List<TaskInfoInVisitingSegment> nodeQueue = Lists.newArrayList(Iterables.transform(entryTasks, new Function<TaskInfo, TaskInfoInVisitingSegment>() {
+        List<TaskInfoInVisitingSegment> nodeQueue = Lists.newArrayList(Iterables.transform(workGraph.getEntryTasks(), new Function<TaskInfo, TaskInfoInVisitingSegment>() {
             int index;
 
             public TaskInfoInVisitingSegment apply(TaskInfo taskInfo) {
@@ -532,7 +359,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 connectedNodes.addAll(node.getMustSuccessors());
             }
         });
-        graphWalker.add(entryTasks);
+        graphWalker.add(workGraph.getEntryTasks());
         final List<TaskInfo> firstCycle = new ArrayList<TaskInfo>(graphWalker.findCycles().get(0));
         Collections.sort(firstCycle);
 
@@ -558,8 +385,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
             @Override
             public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
-                nodeFactory.clear();
-                entryTasks.clear();
+                workGraph.clear();
                 executionPlan.clear();
                 executionQueue.clear();
                 projectLocks.clear();
@@ -580,11 +406,11 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
 
     @Override
     public Set<Task> getFilteredTasks() {
-        return filteredTasks;
+        return workGraph.getFilteredTasks();
     }
 
     public void useFilter(Spec<? super Task> filter) {
-        this.filter = filter;
+        workGraph.useFilter(filter);
     }
 
     public void useFailureHandler(TaskFailureHandler handler) {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -52,11 +52,6 @@ public interface TaskExecutionPlan extends Describable {
     List<Task> getTasks();
 
     /**
-     * @return The set of all filtered tasks that don't get executed.
-     */
-    Set<Task> getFilteredTasks();
-
-    /**
      * Selects a task that's ready to execute and executes the provided action against it.  If no tasks are ready, blocks until one
      * can be executed.  If all tasks have been executed, returns false.
      *

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
@@ -16,11 +16,13 @@
 
 package org.gradle.execution.taskgraph;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.TaskInternal;
 
 import javax.annotation.Nonnull;
 import java.util.TreeSet;
 
+@NonNullApi
 public class TaskInfo implements Comparable<TaskInfo> {
 
     private enum TaskExecutionState {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkExecutionPlan.java
@@ -290,6 +290,7 @@ public class WorkExecutionPlan {
     }
 
     public void clear() {
+        workGraph.clear();
         executionPlan.clear();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkExecutionPlan.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.gradle.api.CircularReferenceException;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
+import org.gradle.api.Transformer;
+import org.gradle.internal.graph.CachingDirectedGraphWalker;
+import org.gradle.internal.graph.DirectedGraph;
+import org.gradle.internal.graph.DirectedGraphRenderer;
+import org.gradle.internal.graph.GraphNodeRenderer;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.util.CollectionUtils;
+
+import java.io.StringWriter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+@NonNullApi
+public class WorkExecutionPlan {
+    private final LinkedHashMap<Task, TaskInfo> executionPlan = new LinkedHashMap<Task, TaskInfo>();
+    private final WorkGraph workGraph;
+
+    public WorkExecutionPlan(WorkGraph workGraph) {
+        this.workGraph = workGraph;
+    }
+
+    public void determineExecutionPlan() {
+        List<TaskInfoInVisitingSegment> nodeQueue = Lists.newArrayList(Iterables.transform(workGraph.getEntryTasks(), new Function<TaskInfo, TaskInfoInVisitingSegment>() {
+            int index;
+
+            public TaskInfoInVisitingSegment apply(TaskInfo taskInfo) {
+                return new TaskInfoInVisitingSegment(taskInfo, index++);
+            }
+        }));
+        int visitingSegmentCounter = nodeQueue.size();
+
+        HashMultimap<TaskInfo, Integer> visitingNodes = HashMultimap.create();
+        Deque<GraphEdge> walkedShouldRunAfterEdges = new ArrayDeque<GraphEdge>();
+        Deque<TaskInfo> path = new ArrayDeque<TaskInfo>();
+        HashMap<TaskInfo, Integer> planBeforeVisiting = new HashMap<TaskInfo, Integer>();
+
+        while (!nodeQueue.isEmpty()) {
+            TaskInfoInVisitingSegment taskInfoInVisitingSegment = nodeQueue.get(0);
+            int currentSegment = taskInfoInVisitingSegment.visitingSegment;
+            TaskInfo taskNode = taskInfoInVisitingSegment.taskInfo;
+
+            if (taskNode.isIncludeInGraph() || executionPlan.containsKey(taskNode.getTask())) {
+                nodeQueue.remove(0);
+                visitingNodes.remove(taskNode, currentSegment);
+                maybeRemoveProcessedShouldRunAfterEdge(walkedShouldRunAfterEdges, taskNode);
+                continue;
+            }
+
+            boolean alreadyVisited = visitingNodes.containsKey(taskNode);
+            visitingNodes.put(taskNode, currentSegment);
+
+            if (!alreadyVisited) {
+                // Have not seen this task before - add its dependencies to the head of the queue and leave this
+                // task in the queue
+                recordEdgeIfArrivedViaShouldRunAfter(walkedShouldRunAfterEdges, path, taskNode);
+                removeShouldRunAfterSuccessorsIfTheyImposeACycle(visitingNodes, taskInfoInVisitingSegment);
+                takePlanSnapshotIfCanBeRestoredToCurrentTask(planBeforeVisiting, taskNode);
+                ArrayList<TaskInfo> successors = new ArrayList<TaskInfo>();
+                addAllSuccessorsInReverseOrder(taskNode, successors);
+                for (TaskInfo successor : successors) {
+                    if (visitingNodes.containsEntry(successor, currentSegment)) {
+                        if (!walkedShouldRunAfterEdges.isEmpty()) {
+                            //remove the last walked should run after edge and restore state from before walking it
+                            GraphEdge toBeRemoved = walkedShouldRunAfterEdges.pop();
+                            toBeRemoved.from.removeShouldRunAfterSuccessor(toBeRemoved.to);
+                            restorePath(path, toBeRemoved);
+                            restoreQueue(nodeQueue, visitingNodes, toBeRemoved);
+                            restoreExecutionPlan(planBeforeVisiting, toBeRemoved);
+                            break;
+                        } else {
+                            onOrderingCycle();
+                        }
+                    }
+                    nodeQueue.add(0, new TaskInfoInVisitingSegment(successor, currentSegment));
+                }
+                path.push(taskNode);
+            } else {
+                // Have visited this task's dependencies - add it to the end of the plan
+                nodeQueue.remove(0);
+                maybeRemoveProcessedShouldRunAfterEdge(walkedShouldRunAfterEdges, taskNode);
+                visitingNodes.remove(taskNode, currentSegment);
+                path.pop();
+                Preconditions.checkState(executionPlan.put(taskNode.getTask(), taskNode) == null, "no duplicate tasks in execution plan");
+
+                // Add any finalizers to the queue
+                ArrayList<TaskInfo> finalizerTasks = new ArrayList<TaskInfo>();
+                addAllReversed(finalizerTasks, taskNode.getFinalizers());
+                for (TaskInfo finalizer : finalizerTasks) {
+                    if (!visitingNodes.containsKey(finalizer)) {
+                        nodeQueue.add(finalizerTaskPosition(finalizer, nodeQueue), new TaskInfoInVisitingSegment(finalizer, visitingSegmentCounter++));
+                    }
+                }
+            }
+        }
+    }
+
+    private void maybeRemoveProcessedShouldRunAfterEdge(Deque<GraphEdge> walkedShouldRunAfterEdges, TaskInfo taskNode) {
+        if (!walkedShouldRunAfterEdges.isEmpty() && walkedShouldRunAfterEdges.peek().to.equals(taskNode)) {
+            walkedShouldRunAfterEdges.pop();
+        }
+    }
+
+    private void recordEdgeIfArrivedViaShouldRunAfter(Deque<GraphEdge> walkedShouldRunAfterEdges, Deque<TaskInfo> path, TaskInfo taskNode) {
+        if (!path.isEmpty() && path.peek().getShouldSuccessors().contains(taskNode)) {
+            walkedShouldRunAfterEdges.push(new GraphEdge(path.peek(), taskNode));
+        }
+    }
+
+    private void removeShouldRunAfterSuccessorsIfTheyImposeACycle(final HashMultimap<TaskInfo, Integer> visitingNodes, final TaskInfoInVisitingSegment taskNodeWithVisitingSegment) {
+        TaskInfo taskNode = taskNodeWithVisitingSegment.taskInfo;
+        Iterables.removeIf(taskNode.getShouldSuccessors(), new Predicate<TaskInfo>() {
+            public boolean apply(TaskInfo input) {
+                return visitingNodes.containsEntry(input, taskNodeWithVisitingSegment.visitingSegment);
+            }
+        });
+    }
+
+    private void takePlanSnapshotIfCanBeRestoredToCurrentTask(HashMap<TaskInfo, Integer> planBeforeVisiting, TaskInfo taskNode) {
+        if (taskNode.getShouldSuccessors().size() > 0) {
+            planBeforeVisiting.put(taskNode, executionPlan.size());
+        }
+    }
+
+    private void addAllSuccessorsInReverseOrder(TaskInfo taskNode, ArrayList<TaskInfo> dependsOnTasks) {
+        addAllReversed(dependsOnTasks, taskNode.getDependencySuccessors());
+        addAllReversed(dependsOnTasks, taskNode.getMustSuccessors());
+        addAllReversed(dependsOnTasks, taskNode.getShouldSuccessors());
+    }
+
+    private <T> void addAllReversed(List<T> list, TreeSet<T> set) {
+        List<T> elements = CollectionUtils.toList(set);
+        Collections.reverse(elements);
+        list.addAll(elements);
+    }
+
+    private void restorePath(Deque<TaskInfo> path, GraphEdge toBeRemoved) {
+        TaskInfo removedFromPath = null;
+        while (!toBeRemoved.from.equals(removedFromPath)) {
+            removedFromPath = path.pop();
+        }
+    }
+
+    private void restoreQueue(List<TaskInfoInVisitingSegment> nodeQueue, HashMultimap<TaskInfo, Integer> visitingNodes, GraphEdge toBeRemoved) {
+        TaskInfoInVisitingSegment nextInQueue = null;
+        while (nextInQueue == null || !toBeRemoved.from.equals(nextInQueue.taskInfo)) {
+            nextInQueue = nodeQueue.get(0);
+            visitingNodes.remove(nextInQueue.taskInfo, nextInQueue.visitingSegment);
+            if (!toBeRemoved.from.equals(nextInQueue.taskInfo)) {
+                nodeQueue.remove(0);
+            }
+        }
+    }
+
+    private void restoreExecutionPlan(HashMap<TaskInfo, Integer> planBeforeVisiting, GraphEdge toBeRemoved) {
+        Iterator<Map.Entry<Task, TaskInfo>> executionPlanIterator = executionPlan.entrySet().iterator();
+        for (int i = 0; i < planBeforeVisiting.get(toBeRemoved.from); i++) {
+            executionPlanIterator.next();
+        }
+        while (executionPlanIterator.hasNext()) {
+            executionPlanIterator.next();
+            executionPlanIterator.remove();
+        }
+    }
+
+    private void onOrderingCycle() {
+        CachingDirectedGraphWalker<TaskInfo, Void> graphWalker = new CachingDirectedGraphWalker<TaskInfo, Void>(new DirectedGraph<TaskInfo, Void>() {
+            public void getNodeValues(TaskInfo node, Collection<? super Void> values, Collection<? super TaskInfo> connectedNodes) {
+                connectedNodes.addAll(node.getDependencySuccessors());
+                connectedNodes.addAll(node.getMustSuccessors());
+            }
+        });
+        graphWalker.add(workGraph.getEntryTasks());
+        final List<TaskInfo> firstCycle = new ArrayList<TaskInfo>(graphWalker.findCycles().get(0));
+        Collections.sort(firstCycle);
+
+        DirectedGraphRenderer<TaskInfo> graphRenderer = new DirectedGraphRenderer<TaskInfo>(new GraphNodeRenderer<TaskInfo>() {
+            public void renderTo(TaskInfo node, StyledTextOutput output) {
+                output.withStyle(StyledTextOutput.Style.Identifier).text(node.getTask().getIdentityPath());
+            }
+        }, new DirectedGraph<TaskInfo, Object>() {
+            public void getNodeValues(TaskInfo node, Collection<? super Object> values, Collection<? super TaskInfo> connectedNodes) {
+                for (TaskInfo dependency : firstCycle) {
+                    if (node.getDependencySuccessors().contains(dependency) || node.getMustSuccessors().contains(dependency)) {
+                        connectedNodes.add(dependency);
+                    }
+                }
+            }
+        });
+        StringWriter writer = new StringWriter();
+        graphRenderer.renderTo(firstCycle.get(0), writer);
+        throw new CircularReferenceException(String.format("Circular dependency between the following tasks:%n%s", writer.toString()));
+    }
+
+    /**
+     * Given a finalizer task, determine where in the current node queue that it should be inserted.
+     * The finalizer should be inserted after any of it's preceding tasks.
+     */
+    private int finalizerTaskPosition(TaskInfo finalizer, final List<TaskInfoInVisitingSegment> nodeQueue) {
+        if (nodeQueue.size() == 0) {
+            return 0;
+        }
+
+        Set<TaskInfo> precedingTasks = getAllPrecedingTasks(finalizer);
+        Set<Integer> precedingTaskIndices = CollectionUtils.collect(precedingTasks, new Transformer<Integer, TaskInfo>() {
+            public Integer transform(final TaskInfo dependsOnTask) {
+                return Iterables.indexOf(nodeQueue, new Predicate<TaskInfoInVisitingSegment>() {
+                    public boolean apply(TaskInfoInVisitingSegment taskInfoInVisitingSegment) {
+                        return taskInfoInVisitingSegment.taskInfo.equals(dependsOnTask);
+                    }
+                });
+            }
+        });
+        return Collections.max(precedingTaskIndices) + 1;
+    }
+
+    private Set<TaskInfo> getAllPrecedingTasks(TaskInfo finalizer) {
+        Set<TaskInfo> precedingTasks = new HashSet<TaskInfo>();
+        Deque<TaskInfo> candidateTasks = new ArrayDeque<TaskInfo>();
+
+        // Consider every task that must run before the finalizer
+        candidateTasks.addAll(finalizer.getDependencySuccessors());
+        candidateTasks.addAll(finalizer.getMustSuccessors());
+        candidateTasks.addAll(finalizer.getShouldSuccessors());
+
+        // For each candidate task, add it to the preceding tasks.
+        while (!candidateTasks.isEmpty()) {
+            TaskInfo precedingTask = candidateTasks.pop();
+            if (precedingTasks.add(precedingTask)) {
+                // Any task that the preceding task must run after is also a preceding task.
+                candidateTasks.addAll(precedingTask.getMustSuccessors());
+            }
+        }
+
+        return precedingTasks;
+    }
+
+    public Collection<TaskInfo> getExecutionPlan() {
+        return executionPlan.values();
+    }
+
+    public Set<Task> getDependencies(Task task) {
+        TaskInfo node = executionPlan.get(task);
+        if (node == null) {
+            throw new IllegalStateException("Task is not part of the execution plan, no dependency information is available.");
+        }
+        ImmutableSet.Builder<Task> builder = ImmutableSet.builder();
+        for (TaskInfo taskInfo : node.getDependencySuccessors()) {
+            builder.add(taskInfo.getTask());
+        }
+        return builder.build();
+    }
+
+    public void clear() {
+        executionPlan.clear();
+    }
+
+    public List<Task> getTasks() {
+        return new ArrayList<Task>(executionPlan.keySet());
+    }
+
+    private static class TaskInfoInVisitingSegment {
+        private final TaskInfo taskInfo;
+        private final int visitingSegment;
+
+        private TaskInfoInVisitingSegment(TaskInfo taskInfo, int visitingSegment) {
+            this.taskInfo = taskInfo;
+            this.visitingSegment = visitingSegment;
+        }
+    }
+
+    private static class GraphEdge {
+        private final TaskInfo from;
+        private final TaskInfo to;
+
+        private GraphEdge(TaskInfo from, TaskInfo to) {
+            this.from = from;
+            this.to = to;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkGraph.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.TaskContainerInternal;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
+import org.gradle.api.tasks.TaskDependency;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@NonNullApi
+public class WorkGraph {
+
+    private final Set<TaskInfo> entryTasks = new LinkedHashSet<TaskInfo>();
+    private final TaskInfoFactory nodeFactory;
+    private Spec<? super Task> filter = Specs.satisfyAll();
+    private final Set<Task> filteredTasks = Sets.newIdentityHashSet();
+    private final Set<TaskInfo> tasksInUnknownState = new LinkedHashSet<TaskInfo>();
+
+    public WorkGraph(TaskFailureCollector failureCollector) {
+        nodeFactory = new TaskInfoFactory(failureCollector);
+    }
+
+    public void addToTaskGraph(Collection<? extends Task> tasks) {
+        List<TaskInfo> queue = new ArrayList<TaskInfo>();
+
+        addTaskInfosToQueue(tasks, queue);
+        resolveDependencies(queue);
+        resolveTasksInUnknownState();
+    }
+
+    private void addTaskInfosToQueue(Collection<? extends Task> tasks, List<TaskInfo> queue) {
+        List<Task> sortedTasks = new ArrayList<Task>(tasks);
+        Collections.sort(sortedTasks);
+        for (Task task : sortedTasks) {
+            TaskInfo node = nodeFactory.createNode(task);
+            if (node.isMustNotRun()) {
+                requireWithDependencies(node);
+            } else if (filter.isSatisfiedBy(task)) {
+                node.require();
+            }
+            entryTasks.add(node);
+            queue.add(node);
+        }
+    }
+
+    private void requireWithDependencies(TaskInfo taskInfo) {
+        if (taskInfo.isMustNotRun() && filter.isSatisfiedBy(taskInfo.getTask())) {
+            taskInfo.require();
+            for (TaskInfo dependency : taskInfo.getDependencySuccessors()) {
+                requireWithDependencies(dependency);
+            }
+        }
+    }
+
+    private void resolveDependencies(List<TaskInfo> queue) {
+        Set<TaskInfo> visiting = new HashSet<TaskInfo>();
+        CachingTaskDependencyResolveContext context = new CachingTaskDependencyResolveContext();
+
+        while (!queue.isEmpty()) {
+            TaskInfo node = queue.get(0);
+            if (node.getDependenciesProcessed()) {
+                // Have already visited this task - skip it
+                queue.remove(0);
+                continue;
+            }
+
+            TaskInternal task = node.getTask();
+            boolean filtered = !filter.isSatisfiedBy(task);
+            if (filtered) {
+                // Task is not required - skip it
+                queue.remove(0);
+                node.dependenciesProcessed();
+                node.doNotRequire();
+                filteredTasks.add(task);
+                continue;
+            }
+
+            if (visiting.add(node)) {
+                // Have not seen this task before - add its dependencies to the head of the queue and leave this
+                // task in the queue
+
+                // Make sure it has been configured
+                ((TaskContainerInternal) task.getProject().getTasks()).prepareForExecution(task);
+                context.setTask(task);
+
+                addNodeDependencies(queue, visiting, context, node, task.getTaskDependencies());
+                addNodeFinalizers(queue, visiting, context, node, task.getFinalizedBy());
+
+                addMustSuccessors(context, node, task.getMustRunAfter());
+                addShouldSuccessors(context, node, task.getShouldRunAfter());
+
+                if (node.isRequired()) {
+                    requireSuccessors(node);
+                } else {
+                    tasksInUnknownState.add(node);
+                }
+            } else {
+                // Have visited this task's dependencies - add it to the graph
+                queue.remove(0);
+                visiting.remove(node);
+                node.dependenciesProcessed();
+            }
+        }
+    }
+
+    private void addNodeFinalizers(List<TaskInfo> queue, Set<TaskInfo> visiting, CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency finalizedBy) {
+        for (Task finalizerTask : context.getDependencies(finalizedBy)) {
+            TaskInfo targetNode = nodeFactory.createNode(finalizerTask);
+            addFinalizerNode(node, targetNode);
+            if (!visiting.contains(targetNode)) {
+                queue.add(0, targetNode);
+            }
+        }
+    }
+
+    private void addFinalizerNode(TaskInfo node, TaskInfo finalizerNode) {
+        if (filter.isSatisfiedBy(finalizerNode.getTask())) {
+            node.addFinalizer(finalizerNode);
+            if (!finalizerNode.isInKnownState()) {
+                finalizerNode.mustNotRun();
+            }
+            finalizerNode.addMustSuccessor(node);
+        }
+    }
+
+    private void addNodeDependencies(List<TaskInfo> queue, Set<TaskInfo> visiting, CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency taskDependencies) {
+        Set<? extends Task> dependsOnTasks = context.getDependencies(taskDependencies);
+        for (Task dependsOnTask : dependsOnTasks) {
+            TaskInfo targetNode = nodeFactory.createNode(dependsOnTask);
+            node.addDependencySuccessor(targetNode);
+            if (!visiting.contains(targetNode)) {
+                queue.add(0, targetNode);
+            }
+        }
+    }
+
+    private void addMustSuccessors(CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency mustRunAfterDependency) {
+        for (Task mustRunAfter : context.getDependencies(mustRunAfterDependency)) {
+            TaskInfo targetNode = nodeFactory.createNode(mustRunAfter);
+            node.addMustSuccessor(targetNode);
+        }
+    }
+
+    private void addShouldSuccessors(CachingTaskDependencyResolveContext context, TaskInfo node, TaskDependency shouldRunAfterDependencies) {
+        for (Task shouldRunAfter : context.getDependencies(shouldRunAfterDependencies)) {
+            TaskInfo targetNode = nodeFactory.createNode(shouldRunAfter);
+            node.addShouldSuccessor(targetNode);
+        }
+    }
+
+    private void requireSuccessors(TaskInfo node) {
+        for (TaskInfo successor : node.getDependencySuccessors()) {
+            if (filter.isSatisfiedBy(successor.getTask())) {
+                successor.require();
+            }
+        }
+    }
+
+    private void resolveTasksInUnknownState() {
+        List<TaskInfo> queue = new ArrayList<TaskInfo>(tasksInUnknownState);
+        Set<TaskInfo> visiting = new HashSet<TaskInfo>();
+
+        while (!queue.isEmpty()) {
+            TaskInfo task = queue.get(0);
+            if (task.isInKnownState()) {
+                queue.remove(0);
+                continue;
+            }
+
+            if (visiting.add(task)) {
+                for (TaskInfo hardPredecessor : task.getDependencyPredecessors()) {
+                    if (!visiting.contains(hardPredecessor)) {
+                        queue.add(0, hardPredecessor);
+                    }
+                }
+            } else {
+                queue.remove(0);
+                visiting.remove(task);
+                task.mustNotRun();
+                for (TaskInfo predecessor : task.getDependencyPredecessors()) {
+                    assert predecessor.isRequired() || predecessor.isMustNotRun();
+                    if (predecessor.isRequired()) {
+                        task.require();
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    public void useFilter(Spec<? super Task> filter) {
+        this.filter = filter;
+    }
+
+    public Iterable<TaskInfo> getEntryTasks() {
+        return entryTasks;
+    }
+
+    public void clear() {
+        nodeFactory.clear();
+        entryTasks.clear();
+    }
+
+    public Set<Task> getFilteredTasks() {
+        return filteredTasks;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/WorkGraph.java
@@ -34,6 +34,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * The graph of work to be done. The {@link #addToTaskGraph(java.util.Collection)} and {@link #clear()} methods are NOT threadsafe, and callers must synchronize access to these
+ * methods. */
 @NonNullApi
 public class WorkGraph {
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -742,8 +742,8 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
         }
 
         then:
-        executionPlan.executionPlan[finalized].isSuccessful()
-        executionPlan.executionPlan[finalizer].state == TaskInfo.TaskExecutionState.SKIPPED
+        executionPlan.workExecutionPlan.@executionPlan[finalized].isSuccessful()
+        executionPlan.workExecutionPlan.@executionPlan[finalizer].state == TaskInfo.TaskExecutionState.SKIPPED
     }
 
     private void addToGraphAndPopulate(Task... tasks) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -66,10 +66,12 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     def workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
     def parentWorkerLease = workerLeaseService.workerLease
     def gradle = Mock(GradleInternal)
+    def failureCollector = new TaskFailureCollector()
+    def workGraph = new WorkGraph(failureCollector)
 
     def setup() {
         root = createRootProject(temporaryFolder.testDirectory)
-        executionPlan = new DefaultTaskExecutionPlan(cancellationHandler, coordinationService, workerLeaseService, Mock(GradleInternal))
+        executionPlan = new DefaultTaskExecutionPlan(workGraph, cancellationHandler, coordinationService, workerLeaseService, Mock(GradleInternal), failureCollector)
         parentWorkerLease.start()
     }
 
@@ -747,7 +749,7 @@ class DefaultTaskExecutionPlanParallelTest extends ConcurrentSpec {
     }
 
     private void addToGraphAndPopulate(Task... tasks) {
-        executionPlan.addToTaskGraph(Arrays.asList(tasks))
+        workGraph.addToTaskGraph(Arrays.asList(tasks))
         executionPlan.determineExecutionPlan()
     }
 


### PR DESCRIPTION
This PR splits up task execution plan into its different responsibilties:
- Holding the task graph (WorkGraph)
- Determining an ordered list of tasks to execute (WorkExecutionPlan)
- Determining what task to execute next (DefaultTaskExecutionPlan)

WorkExecutionPlan does not have many fields, so maybe it could be eliminated as a field from `DefaultTaskExecutionPlan` - the logic how to build it should still stay in a different class I think.