### PR TITLE
Make StartParameter.systemPropertiesArgs and projectProperties mutable

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -34,6 +34,7 @@ import org.gradle.internal.serialize.SetSerializer;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -166,8 +167,8 @@ public class BuildActionSerializer {
             startParameter.setSearchUpwards(decoder.readBoolean());
 
             // Other stuff
-            startParameter.setProjectProperties(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));
-            startParameter.setSystemPropertiesArgs(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));
+            startParameter.setProjectProperties(new HashMap<String, String>(NO_NULL_STRING_MAP_SERIALIZER.read(decoder)));
+            startParameter.setSystemPropertiesArgs(new HashMap<String, String>(NO_NULL_STRING_MAP_SERIALIZER.read(decoder)));
             startParameter.setInitScripts(fileListSerializer.read(decoder));
 
             // Flags

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.tooling.internal.provider.BuildModelAction
 import org.gradle.tooling.internal.provider.ClientProvidedBuildAction
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload
+import spock.lang.Issue
 
 class BuildActionSerializerTest extends SerializerSpec {
     def "serializes ExecuteBuildAction with all defaults"() {
@@ -33,6 +34,17 @@ class BuildActionSerializerTest extends SerializerSpec {
         expect:
         def result = serialize(action, BuildActionSerializer.create())
         result instanceof ExecuteBuildAction
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/5017')
+    def "systemPropertiesArgs and projectProperties is mutable"() {
+        given:
+        def action = new ExecuteBuildAction(new StartParameterInternal())
+        def result = serialize(action, BuildActionSerializer.create())
+
+        expect:
+        result.startParameter.systemPropertiesArgs.get('key', 'defaultValue') == 'defaultValue'
+        result.startParameter.projectProperties.get('key', 'defaultValue') == 'defaultValue'
     }
 
     def "serializes ExecuteBuildAction with non-defaults"() {


### PR DESCRIPTION
### Context 

This PR fixes #5017 .

Previously `StartParameter.systemPropertiesArgs` is always mutable. Since [this commit](https://github.com/gradle/gradle/commit/4ea452bc8ee181143b7f32b327a617b0c5d8e4dc), `StartParameter.systemPropertiesArgs` became immutable. This property should be immutable, but some usage like Groovy's `Map.get("key", "defaultValue")` will try to write to it, which breaks build. Looks like we should keep it as before. 