### PR TITLE
Let distributions contain a gradle-api-parameter-names jar

### DIFF
--- a/buildSrc/subprojects/packaging/packaging.gradle.kts
+++ b/buildSrc/subprojects/packaging/packaging.gradle.kts
@@ -6,10 +6,12 @@ apply { plugin("org.gradle.kotlin.kotlin-dsl") }
 
 dependencies {
     implementation(project(":configuration"))
+    implementation(project(":build"))
     implementation(project(":kotlinDsl"))
     implementation("com.google.guava:guava-jdk5:14.0.1")
     implementation("org.ow2.asm:asm:6.0")
     implementation("org.ow2.asm:asm-commons:6.0")
+    implementation("com.thoughtworks.qdox:qdox:2.0-M8")
 }
 
 gradlePlugin {
@@ -17,6 +19,10 @@ gradlePlugin {
         "minify" {
             id = "gradlebuild.minify"
             implementationClass = "org.gradle.gradlebuild.packaging.MinifyPlugin"
+        }
+        "parameter-names" {
+            id = "gradlebuild.parameter-names"
+            implementationClass = "org.gradle.gradlebuild.packaging.ParameterNamesPlugin"
         }
     }
 }

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ParameterNamesPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ParameterNamesPlugin.kt
@@ -1,0 +1,103 @@
+package org.gradle.gradlebuild.packaging
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.bundling.Jar
+
+import org.gradle.internal.classloader.ClassLoaderFactory
+import org.gradle.internal.classpath.DefaultClassPath
+
+import accessors.base
+import org.gradle.build.ReproduciblePropertiesWriter
+
+import com.thoughtworks.qdox.JavaProjectBuilder
+import com.thoughtworks.qdox.library.SortedClassLibraryBuilder
+
+import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.serviceOf
+
+
+open class ParameterNamesExtension(project: Project, val jarTask: Jar) {
+
+    val sources = project.objects.property<FileTree>()
+    val classpath = project.objects.property<FileCollection>()
+    val baseName = project.objects.property<String>()
+}
+
+
+open class ParameterNamesPlugin : Plugin<Project> {
+
+    override fun apply(project: Project): Unit = project.run {
+
+        val parameterNamesResource by tasks.creating(ParameterNamesResourceTask::class)
+        val parameterNamesJar by tasks.creating(Jar::class)
+
+        val extension = extensions.create("parameterNames", ParameterNamesExtension::class.java, project, parameterNamesJar)
+
+        afterEvaluate {
+            parameterNamesResource.apply {
+                sources = extension.sources.get()
+                classpath = extension.classpath.get()
+                destinationFile.set(layout.buildDirectory.file("generated-resources/parameter-names/${extension.baseName.get()}.properties"))
+            }
+            parameterNamesJar.apply {
+                from(parameterNamesResource)
+                destinationDir = base.libsDir
+                archiveName = "${extension.baseName.get()}-$version.jar"
+            }
+        }
+    }
+}
+
+
+@CacheableTask
+open class ParameterNamesResourceTask : DefaultTask() {
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    lateinit var sources: FileTree
+
+    @InputFiles
+    @Classpath
+    lateinit var classpath: FileCollection
+
+    @OutputFile
+    @PathSensitive(PathSensitivity.NONE)
+    val destinationFile = project.layout.fileProperty()
+
+    @TaskAction
+    fun generate() {
+
+        val libraryBuilder = SortedClassLibraryBuilder()
+        libraryBuilder.appendClassLoader(project.serviceOf<ClassLoaderFactory>().createIsolatedClassLoader(DefaultClassPath.of(classpath.files)))
+        val qdoxBuilder = JavaProjectBuilder(libraryBuilder)
+        val qdoxSources = sources.asSequence().mapNotNull { qdoxBuilder.addSource(it) }
+
+        val properties = qdoxSources.flatMap { it.classes.asSequence().filter { it.isPublic } }
+            .flatMap { it.methods.asSequence().filter { it.isPublic && it.parameterTypes.isNotEmpty() } }
+            .map {
+                val parameters = it.parameters.joinToString(separator = ",") { p ->
+                    if (p.isVarArgs || p.javaClass.isArray) "${p.type.binaryName}[]"
+                    else p.type.binaryName
+                }
+                val key = "${it.declaringClass.binaryName}.${it.name}($parameters)"
+                val value = it.parameters.joinToString(separator = ",") { it.name }
+                Pair(key, value)
+            }.toMap(linkedMapOf())
+
+        destinationFile.get().asFile.let { file ->
+            file.parentFile.mkdirs()
+            ReproduciblePropertiesWriter.store(properties, file)
+        }
+    }
+}

--- a/subprojects/distributions/distributions.gradle
+++ b/subprojects/distributions/distributions.gradle
@@ -18,6 +18,10 @@ import org.gradle.gradlebuild.unittestandcompile.ModuleType
  * limitations under the License.
  */
 
+plugins {
+    id("gradlebuild.parameter-names")
+}
+
 // This is a groovy project because we have int tests.
 // Remove any pre-configured archives
 configurations.all {
@@ -46,6 +50,14 @@ gradlebuildJava {
     moduleType = ModuleType.INTERNAL
 }
 
+parameterNames {
+    sources = ProjectGroups.INSTANCE.getJavaProjects(project)
+        .collect { it.sourceSets.main.allJava.asFileTree }
+        .inject { acc, fileTree -> acc.plus(fileTree) }
+        .matching { include(PublicApi.includes) exclude(PublicApi.excludes) }
+    classpath = rootProject.configurations.runtime + rootProject.configurations.gradlePlugins
+    baseName = "gradle-api-parameter-names"
+}
 
 evaluationDependsOn ":docs"
 
@@ -61,6 +73,7 @@ ext {
         }
         into('lib') {
             from rootProject.configurations.runtime
+            from parameterNames.jarTask
             into('plugins') {
                 from rootProject.configurations.gradlePlugins - rootProject.configurations.runtime
             }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        193
+        194
     }
 
     def "no duplicate entries"() {
@@ -110,7 +110,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         // Core libs
         def coreLibs = contentsDir.file("lib").listFiles().findAll {
-            it.name.startsWith("gradle-") && !it.name.startsWith("gradle-kotlin-dsl")
+            it.name.startsWith("gradle-") && !it.name.startsWith("gradle-kotlin-dsl") && !it.name.startsWith("gradle-api-parameter-names")
         }
         assert coreLibs.size() == 22
         coreLibs.each { assertIsGradleJar(it) }


### PR DESCRIPTION
### Context
For the Kotlin DSL we generate Kotlin extensions over the Gradle public API. To generate meaningful extensions we need the method parameter names.

This metadata can be made available in the Gradle public API byte code once the Gradle distribution contains class files compiled using Java 8 and the `-parameters` argument of `javac`. But until that happens, it is not.

This PR adds tasks to the `:distributions` project that generate a `gradle-api-parameter-names` external module jar shipped in the distribution (43KB) including a single file that contains the required metadata.

See https://github.com/gradle/kotlin-dsl/pull/815 that retrieves the generated jar as an external module and generates Kotlin extensions for the whole Gradle public API.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status

