### PR TITLE
Fix destination for html test reports

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
@@ -72,10 +72,10 @@ class DistributionTestingPlugin : Plugin<Project> {
 
     private
     fun Project.setDedicatedTestOutputDirectoryPerTask(distributionTest: DistributionTest) {
-        distributionTest.reports.junitXml.destination = File(java.testResultsDir, distributionTest.name)
+        distributionTest.reports.junitXml.destination = java.testResultsDir.resolve(distributionTest.name)
         // TODO Confirm that this is not needed
         afterEvaluate {
-            distributionTest.reports.html.destination = file("${the<ReportingExtension>().baseDir}/$name")
+            distributionTest.reports.html.destination = file("${the<ReportingExtension>().baseDir}/${distributionTest.name}")
         }
     }
 


### PR DESCRIPTION
We have been using the wrong delegate again, resulting in using the
project name instead of the task name for the base directory of the
test report.
This causes overlapping outputs for the different test tasks resulting
in disabled caching.
