### PR TITLE
Only archive performance report

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -12,6 +12,9 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Sta
     name = "Performance ${type.name.capitalize()} Coordinator - Linux"
 
     applyDefaultSettings(this, timeout = type.timeout)
+    artifactRules = """
+        build/report-*-performance-tests.zip => .
+    """.trimIndent()
     detectHangingBuilds = false
     maxRunningBuilds = 2
 


### PR DESCRIPTION
All the other reports/logs are not useful for the performance
coordinator.
