### PR TITLE
Add more practices to authoring maintainable build scripts in user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
+++ b/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
@@ -157,6 +157,28 @@ Now that the build logic has been translated into a plugin, you can apply it in 
 </sample>
 ++++
 
+[[sec:avoiding_use_of_gradlebuild]]
+=== Avoiding the use of `GradleBuild`
+
+A build script can define task for invocation other Gradle builds through the task type api:org.gradle.api.tasks.GradleBuild[]. The use of this type is generally discouraged. There are some corner cases where the invoked build doesn't expose the same runtime behavior as from the command line or through the Tooling API leading to unexpected results.
+
+Usually, there's a better way to model the requirement. The appropriate approach depends on the problem at hand. Here're some options:
+
+* Model the build as <<multi_project_builds,multi-project build>> if the intention is to execute tasks from different modules as unified build.
+* Use <<composite_builds,composite builds>> for projects that are physically separated but should occasionally be built as a single unit.
+
+[[sec:avoiding_inter_project_configuration]]
+=== Avoiding inter-project configuration
+
+Gradle does not restrict build script author to reach into the domain model from one project into another one in a <<multi_project_builds,multi-project build>>. Strongly-coupled projects hurts <<sec:parallel_execution,build execution performance>> as well as readability and maintainability of code.
+
+The following practices should be avoided:
+
+* Explicitly depending on a task from another project via api:org.gradle.api.Task#dependsOn(java.lang.Object...)[].
+* Setting property values or calling methods on domain objects from another project.
+* Executing another portion of the build with <<sec:avoiding_use_of_gradlebuild,GradleBuild>>.
+* Declaring unnecessary <<sec:declaring_project_dependency,project dependencies>>.
+
 [[sec:avoiding_passwords_in_plain_text]]
 === Avoiding passwords in plain text
 

--- a/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
+++ b/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
@@ -15,7 +15,9 @@
 [[authoring_maintainable_build_scripts]]
 == Authoring Maintainable Build Scripts
 
-Gradle build scripts combine the qualities of declarative build logic, expressiveness as well as flexibility and rigidity as needed. As a build script author it is easy to fall into the trap of striking the wrong balance or applying poor coding habits. This chapter describes best practices for writing your build script in a meaningful, yet flexible and efficient way.
+Gradle build scripts combine the qualities of declarative build logic, expressiveness as well as flexibility and rigidity as needed.
+As a build script author it is easy to fall into the trap of striking the wrong balance or applying poor coding habits.
+This chapter describes best practices for writing your build script in a meaningful, yet flexible and efficient way.
 
 [NOTE]
 ====
@@ -67,9 +69,12 @@ org/gradle/workers/**
 
 ==== Alternatives for oft-used internal APIs
 
-To provide a nested DSL for your custom task, don't use `org.gradle.internal.reflect.Instantiator`; use api:org.gradle.api.model.ObjectFactory[] instead. It may also be helpful to read <<lazy_configuration>>.
+To provide a nested DSL for your custom task, don't use `org.gradle.internal.reflect.Instantiator`; use api:org.gradle.api.model.ObjectFactory[] instead.
+It may also be helpful to read <<lazy_configuration>>.
 
-Don't use `org.gradle.api.internal.ConventionMapping`. Use api:org.gradle.api.provider.Provider[] and/or api:org.gradle.api.provider.Property[]. You can find an example for capturing user input to configure runtime behavior in the link:https://guides.gradle.org/implementing-gradle-plugins/#capturing_user_input_to_configure_plugin_runtime_behavior[implementing plugins guide].
+Don't use `org.gradle.api.internal.ConventionMapping`.
+Use api:org.gradle.api.provider.Provider[] and/or api:org.gradle.api.provider.Property[].
+You can find an example for capturing user input to configure runtime behavior in the link:https://guides.gradle.org/implementing-gradle-plugins/#capturing_user_input_to_configure_plugin_runtime_behavior[implementing plugins guide].
 
 Instead of `org.gradle.internal.os.OperatingSystem`, use another method to detect operating system, such as link:https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/SystemUtils.html[Apache commons-lang SystemUtils] or `System.getProperty("os.name")`.
 
@@ -80,9 +85,14 @@ Gradle plugin authors may find the Designing Gradle Plugins subsection on link:h
 [[sec:improving_task_discoverability]]
 === Improving task discoverability
 
-Even new users to a build should to be able to find crucial information quickly and effortlessly. In Gradle you can declare a api:org.gradle.api.Task#setGroup(java.lang.String)[group] and a api:org.gradle.api.Task#setDescription(java.lang.String)[description] for any task of the build. The <<sec:listing_tasks,tasks report>> uses the assigned values to organize and render the task for easy discoverability. Assigning a group and description is most helpful for any task that you expect build users to invoke.
+Even new users to a build should to be able to find crucial information quickly and effortlessly.
+In Gradle you can declare a api:org.gradle.api.Task#setGroup(java.lang.String)[group] and a api:org.gradle.api.Task#setDescription(java.lang.String)[description] for any task of the build.
+The <<sec:listing_tasks,tasks report>> uses the assigned values to organize and render the task for easy discoverability.
+Assigning a group and description is most helpful for any task that you expect build users to invoke.
 
-The example task `generateDocs` generates documentation for a project in the form of HTML pages. The task should be organized underneath the bucket `Documentation`. The description should express its intent.
+The example task `generateDocs` generates documentation for a project in the form of HTML pages.
+The task should be organized underneath the bucket `Documentation`.
+The description should express its intent.
 
 ++++
 <sample id="taskGroupDescription" dir="userguide/bestPractices/taskGroupDescription" title="A task declaring the group and description">
@@ -105,9 +115,14 @@ generateDocs - Generates the HTML documentation for this project.
 [[sec:minimize_logic_executed_configuration_phase]]
 === Minimize logic executed during the configuration phase
 
-It's important for every build script developer to understand the different phases of the <<build_lifecycle,build lifecycle>> and their implications on performance and evaluation order of build logic. During the configuration phase the project and its domain objects should be _configured_, whereas the execution phase only executes the actions of the task(s) requested on the command line plus their dependencies. Be aware that any code that is not part of a task action will be executed with _every single run_ of the build. A link:https://scans.gradle.com/get-started[build scan] can help you with identifying the time spent during each of the lifecycle phases. It's an invaluable tool for diagnosing common performance issues.
+It's important for every build script developer to understand the different phases of the <<build_lifecycle,build lifecycle>> and their implications on performance and evaluation order of build logic.
+During the configuration phase the project and its domain objects should be _configured_, whereas the execution phase only executes the actions of the task(s) requested on the command line plus their dependencies.
+Be aware that any code that is not part of a task action will be executed with _every single run_ of the build.
+A link:https://scans.gradle.com/get-started[build scan] can help you with identifying the time spent during each of the lifecycle phases.
+It's an invaluable tool for diagnosing common performance issues.
 
-Let's consider the following incantation of the anti-pattern described above. In the build script you can see that the dependencies assigned to the configuration `printArtifactNames` are resolved outside of the task action.
+Let's consider the following incantation of the anti-pattern described above.
+In the build script you can see that the dependencies assigned to the configuration `printArtifactNames` are resolved outside of the task action.
 
 ++++
 <sample id="logicDuringConfigurationPhase" dir="userguide/bestPractices/logicDuringConfiguration/dont" title="Executing logic during configuration should be avoided">
@@ -126,14 +141,20 @@ The code for resolving the dependencies should be moved into the task action to 
 [[sec:avoid_imperative_logic_in_scripts]]
 === Avoiding imperative logic in scripts
 
-The Gradle runtime does not enforce a specific style for build logic. For that very reason, it's easy to end up with a build script that mixes declarative DSL elements with imperative, procedural code. Let's talk about some concrete examples.
+The Gradle runtime does not enforce a specific style for build logic.
+For that very reason, it's easy to end up with a build script that mixes declarative DSL elements with imperative, procedural code.
+Let's talk about some concrete examples.
 
 * _Declarative code:_ Built-in, language-agnostic DSL elements (e.g. api:org.gradle.api.Project#dependencies(groovy.lang.Closure)[] or api:org.gradle.api.Project#repositories(groovy.lang.Closure)[]) or DSLs exposed by plugins
 * _Imperative code:_ Conditional logic or very complex task action implementations
 
-The end goal of every build script should be to only contain declarative language elements which makes the code easier to understand and maintain. Imperative logic should live in binary plugins and which in turn is applied to the build script. As a side product, you automatically enable your team to link:https://guides.gradle.org/designing-gradle-plugins/#reusable_logic_should_be_written_as_binary_plugin[reuse the plugin logic in other projects] if you publish the artifact to a binary repository.
+The end goal of every build script should be to only contain declarative language elements which makes the code easier to understand and maintain.
+Imperative logic should live in binary plugins and which in turn is applied to the build script.
+As a side product, you automatically enable your team to link:https://guides.gradle.org/designing-gradle-plugins/#reusable_logic_should_be_written_as_binary_plugin[reuse the plugin logic in other projects] if you publish the artifact to a binary repository.
 
-The following sample build shows a negative example of using conditional logic directly in the build script. While this code snippet is small, it is easy to imagine a full-blown build script using numerous procedural statements and the impact it would have on readability and maintainability. By moving the code into a class link:https://guides.gradle.org/testing-gradle-plugins/[testability] also becomes a valid option.
+The following sample build shows a negative example of using conditional logic directly in the build script.
+While this code snippet is small, it is easy to imagine a full-blown build script using numerous procedural statements and the impact it would have on readability and maintainability.
+By moving the code into a class link:https://guides.gradle.org/testing-gradle-plugins/[testability] also becomes a valid option.
 
 ++++
 <sample id="conditionalLogicDont" dir="userguide/bestPractices/conditionalLogic/dont" title="A build script using conditional logic to create a task">
@@ -141,7 +162,9 @@ The following sample build shows a negative example of using conditional logic d
 </sample>
 ++++
 
-Let's compare the build script with the same logic implemented as a binary plugin. The code might look more involved at first but clearly looks more like typical application code. This particular plugin class lives in the <<sec:build_sources,`buildSrc` directory>> which makes it available to the build script automatically.
+Let's compare the build script with the same logic implemented as a binary plugin.
+The code might look more involved at first but clearly looks more like typical application code.
+This particular plugin class lives in the <<sec:build_sources,`buildSrc` directory>> which makes it available to the build script automatically.
 
 ++++
 <sample id="conditionalLogicDo" dir="userguide/bestPractices/conditionalLogic/do/buildSrc/src/main/java/com/enterprise" title="A binary plugin implementing imperative logic">
@@ -149,7 +172,8 @@ Let's compare the build script with the same logic implemented as a binary plugi
 </sample>
 ++++
 
-Now that the build logic has been translated into a plugin, you can apply it in the build script. The build script has been shrunk from 8 lines of code to a one liner.
+Now that the build logic has been translated into a plugin, you can apply it in the build script.
+The build script has been shrunk from 8 lines of code to a one liner.
 
 ++++
 <sample id="conditionalLogicDo" dir="userguide/bestPractices/conditionalLogic/do" title="A build script applying a plugin that encapsulates imperative logic">
@@ -160,9 +184,11 @@ Now that the build logic has been translated into a plugin, you can apply it in 
 [[sec:avoiding_use_of_gradlebuild]]
 === Avoiding the use of `GradleBuild`
 
-A build script can define task for invocation other Gradle builds through the task type api:org.gradle.api.tasks.GradleBuild[]. The use of this type is generally discouraged. There are some corner cases where the invoked build doesn't expose the same runtime behavior as from the command line or through the Tooling API leading to unexpected results.
+A build script can define task for invocation other Gradle builds through the task type api:org.gradle.api.tasks.GradleBuild[]. The use of this type is generally discouraged.
+There are some corner cases where the invoked build doesn't expose the same runtime behavior as from the command line or through the Tooling API leading to unexpected results.
 
-Usually, there's a better way to model the requirement. The appropriate approach depends on the problem at hand. Here're some options:
+Usually, there's a better way to model the requirement.
+The appropriate approach depends on the problem at hand. Here're some options:
 
 * Model the build as <<multi_project_builds,multi-project build>> if the intention is to execute tasks from different modules as unified build.
 * Use <<composite_builds,composite builds>> for projects that are physically separated but should occasionally be built as a single unit.
@@ -170,7 +196,8 @@ Usually, there's a better way to model the requirement. The appropriate approach
 [[sec:avoiding_inter_project_configuration]]
 === Avoiding inter-project configuration
 
-Gradle does not restrict build script author to reach into the domain model from one project into another one in a <<multi_project_builds,multi-project build>>. Strongly-coupled projects hurts <<sec:parallel_execution,build execution performance>> as well as readability and maintainability of code.
+Gradle does not restrict build script author to reach into the domain model from one project into another one in a <<multi_project_builds,multi-project build>>.
+Strongly-coupled projects hurts <<sec:parallel_execution,build execution performance>> as well as readability and maintainability of code.
 
 The following practices should be avoided:
 
@@ -182,6 +209,12 @@ The following practices should be avoided:
 [[sec:avoiding_passwords_in_plain_text]]
 === Avoiding passwords in plain text
 
-Most builds need to consume one or many passwords. The reasons for this need may vary. Some builds need a password for publishing artifacts to a secured binary repository, other builds need a password for downloading binary files. Passwords should always kept safe to prevent fraud. Under no circumstance should you add the password to the build script as property in plain text or declare it in a `gradle.properties`. Those files usually live in a version control repository and can be viewed by anyone that has access to it.
+Most builds need to consume one or many passwords.
+The reasons for this need may vary.
+Some builds need a password for publishing artifacts to a secured binary repository, other builds need a password for downloading binary files.
+Passwords should always kept safe to prevent fraud.
+Under no circumstance should you add the password to the build script as property in plain text or declare it in a `gradle.properties`.
+Those files usually live in a version control repository and can be viewed by anyone that has access to it.
 
-Passwords should be stored in encrypted fashion. At the moment Gradle does not provide a built-in mechanism for encrypting, storing and accessing passwords. A good solution for solving this problem is the link:https://github.com/etiennestuder/gradle-credentials-plugin[Gradle Credentials plugin].
+Passwords should be stored in encrypted fashion. At the moment Gradle does not provide a built-in mechanism for encrypting, storing and accessing passwords.
+A good solution for solving this problem is the link:https://github.com/etiennestuder/gradle-credentials-plugin[Gradle Credentials plugin].

--- a/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
+++ b/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
@@ -184,7 +184,8 @@ The build script has been shrunk from 8 lines of code to a one liner.
 [[sec:avoiding_use_of_gradlebuild]]
 === Avoiding the use of `GradleBuild`
 
-A build script can define task for invocation other Gradle builds through the task type api:org.gradle.api.tasks.GradleBuild[]. The use of this type is generally discouraged.
+The api:org.gradle.api.tasks.GradleBuild[] task type allows a build script to define a task that invokes another Gradle build.
+The use of this type is generally discouraged.
 There are some corner cases where the invoked build doesn't expose the same runtime behavior as from the command line or through the Tooling API leading to unexpected results.
 
 Usually, there's a better way to model the requirement.
@@ -196,7 +197,7 @@ The appropriate approach depends on the problem at hand. Here're some options:
 [[sec:avoiding_inter_project_configuration]]
 === Avoiding inter-project configuration
 
-Gradle does not restrict build script author to reach into the domain model from one project into another one in a <<multi_project_builds,multi-project build>>.
+Gradle does not restrict build script authors from reaching into the domain model from one project into another one in a <<multi_project_builds,multi-project build>>.
 Strongly-coupled projects hurts <<sec:parallel_execution,build execution performance>> as well as readability and maintainability of code.
 
 The following practices should be avoided:


### PR DESCRIPTION
### Context

- Avoiding the use of `GradleBuild`
- Avoiding inter-project configuration