### PR TITLE
Updated javadoc example to idiomatic gradle

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
@@ -59,8 +59,8 @@ public interface AuthenticationSupported {
      *     maven {
      *         url "${url}"
      *         credentials {
-     *             username = 'joe'
-     *             password = 'secret'
+     *             username 'joe'
+     *             password 'secret'
      *         }
      *     }
      * }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsOnAuthenticatedRepoIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsOnAuthenticatedRepoIntegrationTest.groovy
@@ -23,8 +23,8 @@ class ParallelDownloadsOnAuthenticatedRepoIntegrationTest extends ParallelDownlo
     String getAuthConfig() {
         """
         credentials {
-            username = '$USERNAME'
-            password = '$PASSWORD'
+            username '$USERNAME'
+            password '$PASSWORD'
         }
 
         authentication {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpAuthenticationDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpAuthenticationDependencyResolutionIntegrationTest.groovy
@@ -268,8 +268,8 @@ repositories {
     ivy {
         url "${ivyHttpRepo.uri}"
         credentials {
-            username = 'username'
-            password = 'password'
+            username 'username'
+            password 'password'
         }
 
         authentication {
@@ -319,8 +319,8 @@ repositories {
     maven {
         url "${mavenHttpRepo.uri}"
         credentials {
-            username = 'username'
-            password = 'password'
+            username 'username'
+            password 'password'
         }
 
         authentication {
@@ -368,8 +368,8 @@ repositories {
     ivy {
         url "${ivyHttpRepo.uri}"
         credentials {
-            username = 'username'
-            password = 'password'
+            username 'username'
+            password 'password'
         }
     }
 }
@@ -410,8 +410,8 @@ repositories {
     maven {
         url "${mavenHttpRepo.uri}"
         credentials {
-            username = 'username'
-            password = 'password'
+            username 'username'
+            password 'password'
         }
     }
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
@@ -45,8 +45,8 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
                             basic(BasicAuthentication)
                         }
                         credentials {
-                            username = "noob"
-                            password = "hunter2"
+                            username "noob"
+                            password "hunter2"
                         }
                     }
                 }
@@ -68,8 +68,8 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
                             basic(BasicAuthentication)
                         }
                         credentials {
-                            username = "noob"
-                            password = "hunter2"
+                            username "noob"
+                            password "hunter2"
                         }
                     }
                 }


### PR DESCRIPTION
Updated javadoc example to be more idiomatic gradle.

"No assignment is required during configuration as Gradle decorates the
properties to allow for a more declarative DSL." [1]

[1] https://guides.gradle.org/writing-gradle-tasks/

In addition, this make the example consistent with the AwsCredentials example
below it, which _does_ use assignment-less idiomatic gradle.

Related issue: gradle#5057

Signed-off-by: Robin A. Meade <robin.a.meade@gmail.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->

Users will see an example with proper idiomatic gradle and follow the example. They will no longer see the non-idiomatic example and be mislead into thinking that is the proper way.

<!--- Link to relevant issues or forum discussions here -->

https://stackoverflow.com/posts/41525769/revisions

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
