### PR TITLE
Fix flakiness in debug log level tests

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/LoggingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/LoggingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TestResources
@@ -165,6 +166,7 @@ class LoggingIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void debugLogging() {
+        disableStacktraceCheckOnJava7()
         checkOutput(this.&run, logOutput.debug)
     }
 
@@ -200,7 +202,20 @@ class LoggingIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void multiThreadedDebugLogging() {
+        disableStacktraceCheckOnJava7()
         checkOutput(this.&runMultiThreaded, multiThreaded.debug)
+    }
+
+    /**
+     * Sometimes on Java7, when another client tries to connect to the daemon, we
+     * get a spurious stacktrace in the debug output from the daemon related to the
+     * other connection.  It doesn't affect this test functionally, but the stacktrace
+     * check fails the test anyways because the logged error shows up in the debug output.
+     */
+    def disableStacktraceCheckOnJava7() {
+        if (JavaVersion.current().isJava7()) {
+            executer.withStackTraceChecksDisabled()
+        }
     }
 
     def run(LogLevel level) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.java.compile.daemon
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.java.compile.JavaCompilerIntegrationSpec
 import org.gradle.util.Requires
@@ -80,6 +81,16 @@ class DaemonJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
 
     def setup() {
         executer.withArguments("-d")
+
+        /*
+         * Sometimes on Java7, when another client attempts to connect to the daemon, we
+         * get a spurious stacktrace in the debug output from the daemon related to the
+         * other connection.  It doesn't affect this test functionally, but the stacktrace
+         * check fails the test anyways because the logged error shows up in the debug output.
+         */
+        if (JavaVersion.current().isJava7()) {
+            executer.withStackTraceChecksDisabled()
+        }
     }
 
     def compilerConfiguration() {


### PR DESCRIPTION
This fixes an issue we've been seeing on Java 7 where infrequently (like once or twice a month) we'll see an issue where, when two clients will try to connect to a daemon simultaneously, the daemon will log an error related to the client that failed to connect.  Meanwhile, if the successful client is running with debug log level, he'll get the log message from the daemon and the stacktrace check at the end of the test will fail.

This change relaxes the stacktrace check on Java 7 for the tests where we sometimes see this issue.  It also adds an explicit test for the simultaneous connection scenario to validate that the clients and daemon handle it gracefully.