### PR TITLE
Fix handling of duplicate nodes in dependency graph

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -18,11 +18,11 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 
-import java.util.Collection;
+import java.util.Set;
 
 public interface DependencyLockingProvider {
 
     DependencyLockingState findLockConstraint(String configurationName);
 
-    void persistResolvedDependencies(String configurationName, Collection<ModuleComponentIdentifier> resolutionResult);
+    void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -69,7 +69,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     }
 
     @Override
-    public void persistResolvedDependencies(String configurationName, Collection<ModuleComponentIdentifier> resolvedModules) {
+    public void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolvedModules) {
         if (writeLocks) {
             lockFileReaderWriter.writeLockFile(configurationName, getModulesOrdered(resolvedModules));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -32,8 +32,8 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.RootConfigurationMetadata;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -44,7 +44,7 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
     private final DependencyLockingProvider dependencyLockingProvider;
     private final String configurationName;
     private Set<String> lockingConstraints = Collections.emptySet();
-    private List<ModuleComponentIdentifier> allResolvedModules;
+    private Set<ModuleComponentIdentifier> allResolvedModules;
     private Set<String> extraModules;
     private DependencyLockingState dependencyLockingState;
 
@@ -63,10 +63,10 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
             for (DependencyConstraint constraint : lockConstraints) {
                 lockingConstraints.add(constraint.getGroup() + ":" + constraint.getName() + ":" + constraint.getVersionConstraint().getPreferredVersion());
             }
-            allResolvedModules = Lists.newArrayListWithCapacity(this.lockingConstraints.size());
+            allResolvedModules = Sets.newHashSetWithExpectedSize(this.lockingConstraints.size());
             extraModules = new TreeSet<String>();
         } else {
-            allResolvedModules = new ArrayList<ModuleComponentIdentifier>();
+            allResolvedModules = new HashSet<ModuleComponentIdentifier>();
         }
     }
 
@@ -75,8 +75,7 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
         ComponentIdentifier identifier = node.getOwner().getComponentId();
         if (identifier instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier id = (ModuleComponentIdentifier) identifier;
-            allResolvedModules.add(id);
-            if (dependencyLockingState.hasLockState()) {
+            if (allResolvedModules.add(id) && dependencyLockingState.hasLockState()) {
                 String displayName = id.getDisplayName();
                 if (!lockingConstraints.remove(displayName)) {
                     extraModules.add(displayName);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 
-import java.util.Collection;
+import java.util.Set;
 
 public class NoOpDependencyLockingProvider implements DependencyLockingProvider {
 
@@ -40,7 +40,7 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     }
 
     @Override
-    public void persistResolvedDependencies(String configurationName, Collection<ModuleComponentIdentifier> resolutionResult) {
+    public void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult) {
         // No-op
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.internal.component.local.model.RootConfigurationMetadata
 import spock.lang.Specification
 import spock.lang.Subject
 
-import static java.util.Collections.singletonList
+import static java.util.Collections.singleton
 
 class DependencyLockingArtifactVisitorTest extends Specification {
 
@@ -146,7 +146,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         visitor.complete()
 
         then:
-        1 * dependencyLockingProvider.persistResolvedDependencies(configuration, singletonList(identifier))
+        1 * dependencyLockingProvider.persistResolvedDependencies(configuration, singleton(identifier))
 
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
@@ -34,7 +34,7 @@ class NoOpDependencyLockingProviderTest extends Specification {
 
     def 'does nothing on persist'() {
         given:
-        def result = Mock(Collection)
+        def result = Mock(Set)
 
 
         when:


### PR DESCRIPTION
Dependency locking would not filter out visited duplicate nodes causing
the lock file to have duplicate entries and lock validation to fail.