### PR TITLE
Strip illegal access warnings one-by-one

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -38,8 +38,8 @@ public class LogContent {
     private final static String WORK_IN_PROGRESS_PATTERN = "\u001b\\[\\d+[a-zA-Z]> (IDLE|[:a-z][\\w\\s\\d:>/\\\\\\.]+)\u001b\\[\\d*[a-zA-Z]";
     private final static String DOWN_MOVEMENT_WITH_NEW_LINE_PATTERN = "\u001b\\[\\d+B\\n";
     private final static Pattern WORK_IN_PROGRESS_AREA_PATTERN = Pattern.compile(PROGRESS_BAR_PATTERN + "|" + WORK_IN_PROGRESS_PATTERN + "|" + DOWN_MOVEMENT_WITH_NEW_LINE_PATTERN);
-    private final static Pattern JAVA_ILLEGAL_ACCESS_WARNING_PATTERN = Pattern.compile("WARNING: An illegal reflective access operation has occurred[\n\r]+.+[\n\r]+"
-        + "WARNING: All illegal access operations will be denied in a future release[\n\r]+", Pattern.DOTALL);
+    private final static Pattern JAVA_ILLEGAL_ACCESS_WARNING_PATTERN = Pattern.compile("(?ms)WARNING: An illegal reflective access operation has occurred$.+?"
+        + "^WARNING: All illegal access operations will be denied in a future release$");
 
     private final ImmutableList<String> lines;
     private final boolean definitelyNoDebugPrefix;

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailureTest.groovy
@@ -256,7 +256,15 @@ WARNING: Use --illegal-access=warn to enable warnings of further illegal reflect
 WARNING: All illegal access operations will be denied in a future release
 Build file 'build.gradle' line: 123
 
-* What went wrong: something bad
+* What went wrong:
+WARNING: An illegal reflective access operation has occurred
+WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/home/tcagent1/agent/work/668602365d1521fc/subprojects/ivy/build/integ%20test/lib/groovy-all-2.4.12.jar) to method java.lang.Object.finalize()
+WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
+WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+WARNING: All illegal access operations will be denied in a future release
+  something bad
+* Try:
+  to fix it
 """
         when:
         def failure = OutputScrapingExecutionFailure.from(output, "")
@@ -264,6 +272,7 @@ Build file 'build.gradle' line: 123
         then:
         failure.assertHasFileName("Build file 'build.gradle'")
         failure.assertHasLineNumber(123)
+        failure.assertHasDescription("something bad")
     }
 
     def static getRawOutput() {


### PR DESCRIPTION
Prior to this commit the regex used was greedy and thus deleted all output between the start of the first and the end of the last illegal access warning.

This fixes integration test failures introduced with 960af2b99f41380b3bd877b4f35dcbd6f5d93d8c.