### PR TITLE
Cache resources in caching classloader

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
@@ -18,13 +18,16 @@ package org.gradle.internal.classloader;
 
 import com.google.common.collect.MapMaker;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URL;
 import java.util.concurrent.ConcurrentMap;
 
 public class CachingClassLoader extends ClassLoader implements ClassLoaderHierarchy, Closeable {
-    private static final Object MISSING_CLASS = new Object();
+    private static final Object MISSING = new Object();
     private final ConcurrentMap<String, Object> loadedClasses = new MapMaker().weakValues().makeMap();
+    private final ConcurrentMap<String, Object> resources = new MapMaker().makeMap();
     private final ClassLoader parent;
 
     static {
@@ -46,17 +49,32 @@ public class CachingClassLoader extends ClassLoader implements ClassLoaderHierar
         Object cachedValue = loadedClasses.get(name);
         if (cachedValue instanceof Class) {
             return (Class<?>) cachedValue;
-        } else if (cachedValue == MISSING_CLASS) {
+        } else if (cachedValue == MISSING) {
             throw new ClassNotFoundException(name);
         }
         Class<?> result;
         try {
             result = super.loadClass(name, resolve);
         } catch (ClassNotFoundException e) {
-            loadedClasses.putIfAbsent(name, MISSING_CLASS);
+            loadedClasses.putIfAbsent(name, MISSING);
             throw e;
         }
         loadedClasses.putIfAbsent(name, result);
+        return result;
+    }
+
+    @Nullable
+    @Override
+    public URL getResource(String name) {
+        Object cachedValue = resources.get(name);
+        if (cachedValue == MISSING) {
+            return null;
+        }
+        if (cachedValue != null) {
+            return (URL) cachedValue;
+        }
+        URL result = super.getResource(name);
+        resources.putIfAbsent(name, result != null ? result : MISSING);
         return result;
     }
 
@@ -68,6 +86,7 @@ public class CachingClassLoader extends ClassLoader implements ClassLoaderHierar
     @Override
     public void close() throws IOException {
         loadedClasses.clear();
+        resources.clear();
     }
 
     public static class Spec extends ClassLoaderSpec {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/CachingClassLoaderTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/CachingClassLoaderTest.groovy
@@ -43,6 +43,48 @@ class CachingClassLoaderTest extends Specification {
         0 * parent._
     }
 
+    def "loads resources once and caches result"() {
+        when:
+        def res = classLoader.getResource("foo.txt")
+
+        then:
+        res == new URL("file:foo.txt")
+
+        and:
+        1 * parent.getResource("foo.txt") >> new URL("file:foo.txt")
+        0 * parent._
+
+        when:
+        res = classLoader.getResource("foo.txt")
+
+        then:
+        res == new URL("file:foo.txt")
+
+        and:
+        0 * parent._
+    }
+
+    def "caches missing resources"() {
+        when:
+        def res = classLoader.getResource("foo.txt")
+
+        then:
+        res == null
+
+        and:
+        1 * parent.getResource("foo.txt") >> null
+        0 * parent._
+
+        when:
+        res = classLoader.getResource("foo.txt")
+
+        then:
+        res == null
+
+        and:
+        0 * parent._
+    }
+
     def "caches missing classes"() {
         when:
         classLoader.loadClass("someClass")


### PR DESCRIPTION
This is especially important for looking up plugin descriptors
for missing plugins. For instance, in a build with 100 projects
which all call `plugins.withId('foo')`, the plugin descriptor for
the 'foo' plugin would be looked up 100 times, because each project
could potentially contain it. Every one of those lookups will usually hit
the same classloader (if all dependencies are defined in the root project).
Caching those lookups improves configuration time a lot in those cases.
