### PR TITLE
Cache external module lookups

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -73,6 +73,15 @@ public class DefaultModuleRegistry implements ModuleRegistry {
     }
 
     public Module getExternalModule(String name) {
+        Module module = modules.get(name);
+        if (module == null) {
+            module = loadExternalModule(name);
+            modules.put(name, module);
+        }
+        return module;
+    }
+
+    private Module loadExternalModule(String name) {
         File externalJar = findJar(name);
         if (externalJar == null) {
             throw new UnknownModuleException(String.format("Cannot locate JAR for module '%s' in distribution directory '%s'.", name, gradleInstallation.getGradleHome()));


### PR DESCRIPTION
These can be quite frequent, e.g. when using methods
like localGroovy() a lot. We now cache them just like
internal module lookups.

Found while looking at the allocation profile for our own build.