### PR TITLE
Increase memory for performance test JVM

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -420,7 +420,7 @@ class PerformanceTestPlugin : Plugin<Project> {
                 systemProperty(PropertyNames.baselines, baselines)
             }
 
-            jvmArgs("-Xmx2g", "-XX:+HeapDumpOnOutOfMemoryError")
+            jvmArgs("-Xmx3g", "-XX:+HeapDumpOnOutOfMemoryError")
 
             dependsOn(prepareSamplesTask)
             finalizedBy(performanceReportTask)


### PR DESCRIPTION
JFR was not able to read the snapshot for some bigger performance test: https://builds.gradle.org/viewLog.html?buildId=12307459&tab=buildResultsDiv&buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux

Increasing the memory seems to fix the problem.