### PR TITLE
Point users to IDEA's import feature in IDEA plugin chapter

### DIFF
--- a/subprojects/docs/src/docs/userguide/basePlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/basePlugin.adoc
@@ -39,7 +39,9 @@ Plugins and build authors should attach their verification tasks, such as ones t
 Plugins and build authors should attach tasks that produce distributions and other consumable artifacts to this lifecycle task. For example, `jar` produces the consumable artifact for Java libraries. Attach tasks to this lifecycle task using `assemble.dependsOn(__task__)`.
 
 `build` — _lifecycle task_::
-(Depends on `assemble` and `check`) Intended to build everything, including running all tests, producing the production artifacts and generating documentation. You will probably rarely attach concrete tasks directly to `build` as `assemble` and `check` are typically more appropriate.
+_Depends on_: `check`, `assemble`
++
+Intended to build everything, including running all tests, producing the production artifacts and generating documentation. You will probably rarely attach concrete tasks directly to `build` as `assemble` and `check` are typically more appropriate.
 
 `build__Configuration__` — task rule::
 Assembles those artifacts attached to the named configuration. For example, `buildArchives` will execute any task that is required to create any artifact attached to the `archives` configuration.

--- a/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
@@ -56,13 +56,19 @@ The IDEA plugin also adds a `cleanIdea` task to the project. This task deletes t
 The IDEA plugin adds the tasks shown below to a project. Notice that the `clean` task does not depend on the `cleanIdeaWorkspace` task. This is because the workspace typically contains a lot of user specific temporary data and it is not desirable to manipulate it outside IDEA.
 
 [[ideatasks]]
-`idea` — depends on: `ideaProject`, `ideaModule`, `ideaWorkspace`::
+`idea`::
+_Depends on_: `ideaProject`, `ideaModule`, `ideaWorkspace`
++  
 Generates all IDEA configuration files
 
-`openIdea` — depends on: `idea`::
+`openIdea`::
+_Depends on_: `idea`
++
 Generates all IDEA configuration files and opens the project in IDEA
 
-`cleanIdea` — type: api:org.gradle.api.tasks.Delete[], depends on: `cleanIdeaProject`, `cleanIdeaModule`::
+`cleanIdea` — type: api:org.gradle.api.tasks.Delete[]::
+_Depends on_: `cleanIdeaProject`, `cleanIdeaModule`
++
 Removes all IDEA configuration files
 
 `cleanIdeaProject` — type: api:org.gradle.api.tasks.Delete[]::

--- a/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
@@ -87,7 +87,7 @@ Generates the `.iws` file. This task is only added to the root project.
 [[sec:idea_configuration]]
 === Configuration
 
-The plugin adds some configuration options that allow to customize the IDEA project and module files that it generates. These take the form of both simple properties and more advanced mechanisms that modify the generated files directly. For example, you can add source and resource directories, as well as inject your own fragments of XML. The former type of configuration is honored by IDEA's import facility, whereas the latter is not.
+The plugin adds some configuration options that allow to customize the IDEA project and module files that it generates. These take the form of both model properties and lower-level mechanisms that modify the generated files directly. For example, you can add source and resource directories, as well as inject your own fragments of XML. The former type of configuration is honored by IDEA's import facility, whereas the latter is not.
 
 Here are the configuration properties you can use:
 

--- a/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
@@ -19,7 +19,7 @@ The IDEA plugin generates files that are used by http://www.jetbrains.com/idea/[
 
 [NOTE]
 ====
-If you simply want to load a Gradle project into IntelliJ IDEA, then use the IDE's https://www.jetbrains.com/help/idea/gradle.html#gradle_import[import facility]. You do not need to apply this plugin to import your project into IDEA!
+If you simply want to load a Gradle project into IntelliJ IDEA, then use the IDE's https://www.jetbrains.com/help/idea/gradle.html#gradle_import[import facility]. You do not need to apply this plugin to import your project into IDEA, although if you do, the import will take account of any extra IDEA configuration you have that doesn't directly modify the generated files — see the <<sec:idea_configuration,Configuration>> section for more details.
 ====
 
 What exactly the IDEA plugin generates depends on which other plugins are used:
@@ -87,28 +87,35 @@ Generates the `.iws` file. This task is only added to the root project.
 [[sec:idea_configuration]]
 === Configuration
 
+The plugin adds some configuration options that allow to customize the IDEA project and module files that it generates. These take the form of both simple properties and more advanced mechanisms that modify the generated files directly. For example, you can add source and resource directories, as well as inject your own fragments of XML. The former type of configuration is honored by IDEA's import facility, whereas the latter is not.
+
+Here are the configuration properties you can use:
 
 [[idea-configuration]]
 
-`idea` — api:org.gradle.plugins.ide.idea.model.IdeaModel[]::
+`idea` — type: api:org.gradle.plugins.ide.idea.model.IdeaModel[]::
 Top level element that enables configuration of the idea plugin in a DSL-friendly fashion
 
-`idea.project` — api:org.gradle.plugins.ide.idea.model.IdeaProject[]::
+`idea.project` — type: api:org.gradle.plugins.ide.idea.model.IdeaProject[]::
 Allows configuring project information
 
-`idea.module` — api:org.gradle.plugins.ide.idea.model.IdeaModule[]::
+`idea.module` — type: api:org.gradle.plugins.ide.idea.model.IdeaModule[]::
 Allows configuring module information
 
-`idea.workspace` — api:org.gradle.plugins.ide.idea.model.IdeaWorkspace[]::
+`idea.workspace` — type: api:org.gradle.plugins.ide.idea.model.IdeaWorkspace[]::
 Allows configuring the workspace XML
+
+Follow the links to the types for examples of using these configuration properties.
 
 
 [[sec:idea_customizing_the_generated_files]]
 === Customizing the generated files
 
-The IDEA plugin provides hooks and behavior for customizing the generated content. The workspace file can effectively only be manipulated via the `withXml` hook because its corresponding domain object is essentially empty.
+The IDEA plugin provides hooks and behavior for customizing the generated content in a more controlled and detailed way. In addition, the `withXml` hook is the only practical way to modify the workspace file because its corresponding domain object is essentially empty.
 
-The tasks recognize existing IDEA files, and merge them with the generated content.
+NOTE: The techniques we discuss in this section don't work with IDEA's import facility
+
+The tasks recognize existing IDEA files and merge them with the generated content.
 
 
 [[sec:merging_with_idea_files]]

--- a/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/ideaPlugin.adoc
@@ -17,20 +17,18 @@
 
 The IDEA plugin generates files that are used by http://www.jetbrains.com/idea/[IntelliJ IDEA], thus making it possible to open the project from IDEA (`File` - `Open Project`). Both external dependencies (including associated source and Javadoc files) and project dependencies are considered.
 
+[NOTE]
+====
+If you simply want to load a Gradle project into IntelliJ IDEA, then use the IDE's https://www.jetbrains.com/help/idea/gradle.html#gradle_import[import facility]. You do not need to apply this plugin to import your project into IDEA!
+====
+
 What exactly the IDEA plugin generates depends on which other plugins are used:
 
-.IDEA plugin behavior
-[cols="a,a", options="header"]
-|===
-| Plugin
-| Description
+*Always*::
+Generates an IDEA module file. Also generates an IDEA project and workspace file if the project is the root project.
 
-| None
-| Generates an IDEA module file. Also generates an IDEA project and workspace file if the project is the root project.
-
-| <<java_plugin,Java>>
-| Adds Java configuration to the module and project files.
-|===
+*<<java_plugin,Java Plugin>>*::
+Additionally adds Java configuration to the IDEA module and project files.
 
 One focus of the IDEA plugin is to be open to customization. The plugin provides a standardized set of hooks for adding and removing content from the generated files.
 
@@ -42,8 +40,8 @@ To use the IDEA plugin, include this in your build script:
 
 ++++
 <sample id="useIdeaPlugin" dir="idea" title="Using the IDEA plugin">
-            <sourcefile file="build.gradle" snippet="use-plugin"/>
-        </sample>
+    <sourcefile file="build.gradle" snippet="use-plugin"/>
+</sample>
 ++++
 
 The IDEA plugin adds a number of tasks to your project. The `idea` task generates an IDEA module file for the project. When the project is the root project, the `idea` task also generates an IDEA project and workspace. The IDEA project includes modules for each of the projects in the Gradle build.
@@ -58,59 +56,32 @@ The IDEA plugin also adds a `cleanIdea` task to the project. This task deletes t
 The IDEA plugin adds the tasks shown below to a project. Notice that the `clean` task does not depend on the `cleanIdeaWorkspace` task. This is because the workspace typically contains a lot of user specific temporary data and it is not desirable to manipulate it outside IDEA.
 
 [[ideatasks]]
-.IDEA plugin - Tasks
-[cols="a,a,a,a", options="header"]
-|===
-| Task name
-| Depends on
-| Type
-| Description
+`idea` — depends on: `ideaProject`, `ideaModule`, `ideaWorkspace`::
+Generates all IDEA configuration files
 
-| `idea`
-| `ideaProject`, `ideaModule`, `ideaWorkspace`
-| -
-| Generates all IDEA configuration files
+`openIdea` — depends on: `idea`::
+Generates all IDEA configuration files and opens the project in IDEA
 
-| `openIdea`
-| `idea`
-| -
-| Generates all IDEA configuration files and opens the project in IDEA
+`cleanIdea` — type: api:org.gradle.api.tasks.Delete[], depends on: `cleanIdeaProject`, `cleanIdeaModule`::
+Removes all IDEA configuration files
 
-| `cleanIdea`
-| `cleanIdeaProject`, `cleanIdeaModule`
-| api:org.gradle.api.tasks.Delete[]
-| Removes all IDEA configuration files
+`cleanIdeaProject` — type: api:org.gradle.api.tasks.Delete[]::
+Removes the IDEA project file
 
-| `cleanIdeaProject`
-| -
-| api:org.gradle.api.tasks.Delete[]
-| Removes the IDEA project file
+`cleanIdeaModule` — type: api:org.gradle.api.tasks.Delete[]::
+Removes the IDEA module file
 
-| `cleanIdeaModule`
-| -
-| api:org.gradle.api.tasks.Delete[]
-| Removes the IDEA module file
+`cleanIdeaWorkspace` — type: api:org.gradle.api.tasks.Delete[]::
+Removes the IDEA workspace file
 
-| `cleanIdeaWorkspace`
-| -
-| api:org.gradle.api.tasks.Delete[]
-| Removes the IDEA workspace file
+`ideaProject` — type: api:org.gradle.plugins.ide.idea.GenerateIdeaProject[]::
+Generates the `.ipr` file. This task is only added to the root project.
 
-| `ideaProject`
-| -
-| api:org.gradle.plugins.ide.idea.GenerateIdeaProject[]
-| Generates the `.ipr` file. This task is only added to the root project.
+`ideaModule` — type: api:org.gradle.plugins.ide.idea.GenerateIdeaModule[]::
+Generates the `.iml` file
 
-| `ideaModule`
-| -
-| api:org.gradle.plugins.ide.idea.GenerateIdeaModule[]
-| Generates the `.iml` file
-
-| `ideaWorkspace`
-| -
-| api:org.gradle.plugins.ide.idea.GenerateIdeaWorkspace[]
-| Generates the `.iws` file. This task is only added to the root project.
-|===
+`ideaWorkspace` — type: api:org.gradle.plugins.ide.idea.GenerateIdeaWorkspace[]::
+Generates the `.iws` file. This task is only added to the root project.
 
 
 [[sec:idea_configuration]]
@@ -118,29 +89,18 @@ The IDEA plugin adds the tasks shown below to a project. Notice that the `clean`
 
 
 [[idea-configuration]]
-.Configuration of the idea plugin
-[cols="a,a,a", options="header"]
-|===
-| Model
-| Reference name
-| Description
 
-| api:org.gradle.plugins.ide.idea.model.IdeaModel[]
-| `idea`
-| Top level element that enables configuration of the idea plugin in a DSL-friendly fashion
+`idea` — api:org.gradle.plugins.ide.idea.model.IdeaModel[]::
+Top level element that enables configuration of the idea plugin in a DSL-friendly fashion
 
-| api:org.gradle.plugins.ide.idea.model.IdeaProject[]
-| `idea.project`
-| Allows configuring project information
+`idea.project` — api:org.gradle.plugins.ide.idea.model.IdeaProject[]::
+Allows configuring project information
 
-| api:org.gradle.plugins.ide.idea.model.IdeaModule[]
-| `idea.module`
-| Allows configuring module information
+`idea.module` — api:org.gradle.plugins.ide.idea.model.IdeaModule[]::
+Allows configuring module information
 
-| api:org.gradle.plugins.ide.idea.model.IdeaWorkspace[]
-| `idea.workspace`
-| Allows configuring the workspace XML
-|===
+`idea.workspace` — api:org.gradle.plugins.ide.idea.model.IdeaWorkspace[]::
+Allows configuring the workspace XML
 
 
 [[sec:idea_customizing_the_generated_files]]
@@ -169,56 +129,50 @@ This strategy can also be used for individual files that the plugin would genera
 
 The plugin provides objects modeling the sections of the metadata files that are generated by Gradle. The generation lifecycle is as follows:
 
-. The file is read; or a default version provided by Gradle is used if it does not exist
-. The `beforeMerged` hook is executed with a domain object representing the existing file
-. The existing content is merged with the configuration inferred from the Gradle build or defined explicitly in the eclipse DSL
-. The `whenMerged` hook is executed with a domain object representing contents of the file to be persisted
-. The `withXml` hook is executed with a raw representation of the XML that will be persisted
-. The final XML is persisted
- The following table lists the domain object used for each of the model types:
+ 1. The file is read; or a default version provided by Gradle is used if it does not exist
+ 2. The `beforeMerged` hook is executed with a domain object representing the existing file
+ 3. The existing content is merged with the configuration inferred from the Gradle build or defined explicitly in the eclipse DSL
+ 4. The `whenMerged` hook is executed with a domain object representing contents of the file to be persisted
+ 5. The `withXml` hook is executed with a raw representation of the XML that will be persisted
+ 6. The final XML is persisted
+
+The following are the domain objects used for each of the model types:
 
 [[idea-hooks]]
-.Idea plugin hooks
-[cols="a,a,a,a", options="header"]
-|===
-| Model
-| `beforeMerged { arg -> }` argument type
-| `whenMerged { arg -> }` argument type
-| `withXml { arg -> }` argument type
+api:org.gradle.plugins.ide.idea.model.IdeaProject[]::
++
+ * `beforeMerged { api:org.gradle.plugins.ide.idea.model.Project[] arg \-> ... }`
+ * `whenMerged { api:org.gradle.plugins.ide.idea.model.Project[] arg \-> ... }`
+ * `withXml { api:org.gradle.api.XmlProvider[] arg \-> ... }`
 
-| api:org.gradle.plugins.ide.idea.model.IdeaProject[]
-| api:org.gradle.plugins.ide.idea.model.Project[]
-| api:org.gradle.plugins.ide.idea.model.Project[]
-| api:org.gradle.api.XmlProvider[]
+api:org.gradle.plugins.ide.idea.model.IdeaModule[]::
+ * `beforeMerged { api:org.gradle.plugins.ide.idea.model.Module[] arg \-> ... }`
+ * `whenMerged { api:org.gradle.plugins.ide.idea.model.Module[] arg \-> ... }`
+ * `withXml { api:org.gradle.api.XmlProvider[] arg \-> ... }`
 
-| api:org.gradle.plugins.ide.idea.model.IdeaModule[]
-| api:org.gradle.plugins.ide.idea.model.Module[]
-| api:org.gradle.plugins.ide.idea.model.Module[]
-| api:org.gradle.api.XmlProvider[]
-
-| api:org.gradle.plugins.ide.idea.model.IdeaWorkspace[]
-| api:org.gradle.plugins.ide.idea.model.Workspace[]
-| api:org.gradle.plugins.ide.idea.model.Workspace[]
-| api:org.gradle.api.XmlProvider[]
-|===
+api:org.gradle.plugins.ide.idea.model.IdeaWorkspace[]::
+ * `beforeMerged { api:org.gradle.plugins.ide.idea.model.Workspace[] arg \-> ... }`
+ * `whenMerged { api:org.gradle.plugins.ide.idea.model.Workspace[] arg \-> ... }`
+ * `withXml { api:org.gradle.api.XmlProvider[] arg \-> ... }`
 
 
 [[sec:partial-rewrite]]
 ===== Partial rewrite of existing content
 
 A <<sec:complete-rewrite,complete rewrite>> causes all existing content to be discarded, thereby losing any changes made directly in the IDE. The `beforeMerged` hook makes it possible to overwrite just certain parts of the existing content. The following example removes all existing dependencies from the `Module` domain object:
+
 ++++
 <sample id="partialRewrites" dir="idea" title="Partial Rewrite for Module">
-                        <sourcefile file="build.gradle" snippet="module-before-merged"/>
-                    </sample>
+    <sourcefile file="build.gradle" snippet="module-before-merged"/>
+</sample>
 ++++
 
 The resulting module file will only contain Gradle-generated dependency entries, but not any other dependency entries that may have been present in the original file. (In the case of dependency entries, this is also the default behavior.) Other sections of the module file will be either left as-is or merged. The same could be done for the module paths in the project file:
 
 ++++
 <sample id="partialRewritesProject" dir="idea" title="Partial Rewrite for Project">
-                        <sourcefile file="build.gradle" snippet="project-before-merged"/>
-                    </sample>
+    <sourcefile file="build.gradle" snippet="project-before-merged"/>
+</sample>
 ++++
 
 
@@ -226,10 +180,11 @@ The resulting module file will only contain Gradle-generated dependency entries,
 ===== Modifying the fully populated domain objects
 
 The `whenMerged` hook allows you to manipulate the fully populated domain objects. Often this is the preferred way to customize IDEA files. Here is how you would export all the dependencies of an IDEA module:
+
 ++++
 <sample id="exportDependencies" dir="idea" title="Export Dependencies">
-                        <sourcefile file="build.gradle" snippet="module-when-merged"/>
-                    </sample>
+    <sourcefile file="build.gradle" snippet="module-when-merged"/>
+</sample>
 ++++
 
 
@@ -237,11 +192,12 @@ The `whenMerged` hook allows you to manipulate the fully populated domain object
 ===== Modifying the XML representation
 
 The `withXml` hook allows you to manipulate the in-memory XML representation just before the file gets written to disk. Although Groovy's XML support makes up for a lot, this approach is less convenient than manipulating the domain objects. In return, you get total control over the generated file, including sections not modeled by the domain objects.
+
 ++++
 <sample id="projectWithXml" dir="idea" title="Customizing the XML">
-                        <sourcefile file="build.gradle" snippet="project-with-xml"/>
-                        <test args="idea"/>
-                    </sample>
+    <sourcefile file="build.gradle" snippet="project-with-xml"/>
+    <test args="idea"/>
+</sample>
 ++++
 
 


### PR DESCRIPTION
Issue dotorg-docs#219. Added a note that users can use the Gradle import
feature of IDEA without applying the IDEA plugin.

I have also converted tables to definition lists and cleaned up the indentation
of code samples.
