### PR TITLE
Rename ProjectLayout methods

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -140,7 +140,7 @@ public interface ProjectLayout {
      * @return The file collection. Never returns null.
      * @since 4.8
      */
-    FileCollection filesFor(Object... paths);
+    FileCollection files(Object... paths);
 
     /**
      * <p>Returns a {@link ConfigurableFileCollection} containing the given files. You can pass any of the following
@@ -188,5 +188,5 @@ public interface ProjectLayout {
      * @return The file collection. Never returns null.
      * @since 4.8
      */
-    ConfigurableFileCollection mutableFilesFor(Object... paths);
+    ConfigurableFileCollection configurableFiles(Object... paths);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -185,8 +185,8 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         collectionType               | expression
-        'FileCollection'             | 'project.layout.filesFor()'
-        'ConfigurableFileCollection' | 'project.layout.mutableFilesFor()'
+        'FileCollection'             | 'project.layout.files()'
+        'ConfigurableFileCollection' | 'project.layout.configurableFiles()'
     }
 
     @Unroll
@@ -207,35 +207,35 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         collectionType               | content          | expressionTemplate
-        'FileCollection'             | 'String'         | 'project.layout.filesFor("%s/src/resource/file.txt")'
-        'FileCollection'             | 'File'           | 'project.layout.filesFor(new File("%s", "src/resource/file.txt"))'
-        'FileCollection'             | 'Path'           | 'project.layout.filesFor(java.nio.file.Paths.get("%s/src/resource/file.txt"))'
-        'FileCollection'             | 'URI'            | 'project.layout.filesFor(new File("%s", "/src/resource/file.txt").toURI())'
-        'FileCollection'             | 'URL'            | 'project.layout.filesFor(new File("%s", "/src/resource/file.txt").toURI().toURL())'
-        'FileCollection'             | 'Directory'      | 'project.layout.filesFor(project.layout.projectDirectory)'
-        'FileCollection'             | 'RegularFile'    | 'project.layout.filesFor(project.layout.projectDirectory.file("src/resource/file.txt"))'
-        'FileCollection'             | 'Closure'        | 'project.layout.filesFor({ "%s/src/resource/file.txt" })'
-        'FileCollection'             | 'List'           | 'project.layout.filesFor([ "%s/src/resource/file.txt" ])'
-        'FileCollection'             | 'array'          | 'project.layout.filesFor([ "%s/src/resource/file.txt" ] as Object[])'
-        'FileCollection'             | 'FileCollection' | 'project.layout.filesFor(new org.gradle.api.internal.file.collections.SimpleFileCollection(new File("%s/src/resource/file.txt")))'
-        'FileCollection'             | 'Callable'       | "project.layout.filesFor($STRING_CALLABLE)"
-        'FileCollection'             | 'Provider'       | "project.layout.filesFor(provider($STRING_CALLABLE))"
-        'FileCollection'             | 'nested objects' | "project.layout.filesFor({[{$STRING_CALLABLE}]})"
+        'FileCollection'             | 'String'         | 'project.layout.files("%s/src/resource/file.txt")'
+        'FileCollection'             | 'File'           | 'project.layout.files(new File("%s", "src/resource/file.txt"))'
+        'FileCollection'             | 'Path'           | 'project.layout.files(java.nio.file.Paths.get("%s/src/resource/file.txt"))'
+        'FileCollection'             | 'URI'            | 'project.layout.files(new File("%s", "/src/resource/file.txt").toURI())'
+        'FileCollection'             | 'URL'            | 'project.layout.files(new File("%s", "/src/resource/file.txt").toURI().toURL())'
+        'FileCollection'             | 'Directory'      | 'project.layout.files(project.layout.projectDirectory)'
+        'FileCollection'             | 'RegularFile'    | 'project.layout.files(project.layout.projectDirectory.file("src/resource/file.txt"))'
+        'FileCollection'             | 'Closure'        | 'project.layout.files({ "%s/src/resource/file.txt" })'
+        'FileCollection'             | 'List'           | 'project.layout.files([ "%s/src/resource/file.txt" ])'
+        'FileCollection'             | 'array'          | 'project.layout.files([ "%s/src/resource/file.txt" ] as Object[])'
+        'FileCollection'             | 'FileCollection' | 'project.layout.files(new org.gradle.api.internal.file.collections.SimpleFileCollection(new File("%s/src/resource/file.txt")))'
+        'FileCollection'             | 'Callable'       | "project.layout.files($STRING_CALLABLE)"
+        'FileCollection'             | 'Provider'       | "project.layout.files(provider($STRING_CALLABLE))"
+        'FileCollection'             | 'nested objects' | "project.layout.files({[{$STRING_CALLABLE}]})"
 
-        'ConfigurableFileCollection' | 'String'         | 'project.layout.mutableFilesFor("%s/src/resource/file.txt")'
-        'ConfigurableFileCollection' | 'File'           | 'project.layout.mutableFilesFor(new File("%s", "src/resource/file.txt"))'
-        'ConfigurableFileCollection' | 'Path'           | 'project.layout.mutableFilesFor(java.nio.file.Paths.get("%s/src/resource/file.txt"))'
-        'ConfigurableFileCollection' | 'URI'            | 'project.layout.mutableFilesFor(new File("%s", "/src/resource/file.txt").toURI())'
-        'ConfigurableFileCollection' | 'URL'            | 'project.layout.mutableFilesFor(new File("%s", "/src/resource/file.txt").toURI().toURL())'
-        'ConfigurableFileCollection' | 'Directory'      | 'project.layout.mutableFilesFor(project.layout.projectDirectory)'
-        'ConfigurableFileCollection' | 'RegularFile'    | 'project.layout.mutableFilesFor(project.layout.projectDirectory.file("src/resource/file.txt"))'
-        'ConfigurableFileCollection' | 'Closure'        | 'project.layout.mutableFilesFor({ "%s/src/resource/file.txt" })'
-        'ConfigurableFileCollection' | 'List'           | 'project.layout.mutableFilesFor([ "%s/src/resource/file.txt" ])'
-        'ConfigurableFileCollection' | 'array'          | 'project.layout.mutableFilesFor([ "%s/src/resource/file.txt" ] as Object[])'
-        'ConfigurableFileCollection' | 'FileCollection' | 'project.layout.mutableFilesFor(new org.gradle.api.internal.file.collections.SimpleFileCollection(new File("%s/src/resource/file.txt")))'
-        'ConfigurableFileCollection' | 'Callable'       | "project.layout.mutableFilesFor($STRING_CALLABLE)"
-        'ConfigurableFileCollection' | 'Provider'       | "project.layout.mutableFilesFor(provider($STRING_CALLABLE))"
-        'ConfigurableFileCollection' | 'nested objects' | "project.layout.mutableFilesFor({[{$STRING_CALLABLE}]})"
+        'ConfigurableFileCollection' | 'String'         | 'project.layout.configurableFiles("%s/src/resource/file.txt")'
+        'ConfigurableFileCollection' | 'File'           | 'project.layout.configurableFiles(new File("%s", "src/resource/file.txt"))'
+        'ConfigurableFileCollection' | 'Path'           | 'project.layout.configurableFiles(java.nio.file.Paths.get("%s/src/resource/file.txt"))'
+        'ConfigurableFileCollection' | 'URI'            | 'project.layout.configurableFiles(new File("%s", "/src/resource/file.txt").toURI())'
+        'ConfigurableFileCollection' | 'URL'            | 'project.layout.configurableFiles(new File("%s", "/src/resource/file.txt").toURI().toURL())'
+        'ConfigurableFileCollection' | 'Directory'      | 'project.layout.configurableFiles(project.layout.projectDirectory)'
+        'ConfigurableFileCollection' | 'RegularFile'    | 'project.layout.configurableFiles(project.layout.projectDirectory.file("src/resource/file.txt"))'
+        'ConfigurableFileCollection' | 'Closure'        | 'project.layout.configurableFiles({ "%s/src/resource/file.txt" })'
+        'ConfigurableFileCollection' | 'List'           | 'project.layout.configurableFiles([ "%s/src/resource/file.txt" ])'
+        'ConfigurableFileCollection' | 'array'          | 'project.layout.configurableFiles([ "%s/src/resource/file.txt" ] as Object[])'
+        'ConfigurableFileCollection' | 'FileCollection' | 'project.layout.configurableFiles(new org.gradle.api.internal.file.collections.SimpleFileCollection(new File("%s/src/resource/file.txt")))'
+        'ConfigurableFileCollection' | 'Callable'       | "project.layout.configurableFiles($STRING_CALLABLE)"
+        'ConfigurableFileCollection' | 'Provider'       | "project.layout.configurableFiles(provider($STRING_CALLABLE))"
+        'ConfigurableFileCollection' | 'nested objects' | "project.layout.configurableFiles({[{$STRING_CALLABLE}]})"
     }
 
     @Unroll
@@ -261,10 +261,10 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         collectionType               | dependencyType | expression
-        'FileCollection'             | 'Task'         | 'project.layout.filesFor(project.tasks.myTask)'
-        'FileCollection'             | 'TaskOutputs'  | 'project.layout.filesFor(project.tasks.myTask.outputs)'
-        'ConfigurableFileCollection' | 'Task'         | 'project.layout.mutableFilesFor(project.tasks.myTask)'
-        'ConfigurableFileCollection' | 'TaskOutputs'  | 'project.layout.mutableFilesFor(project.tasks.myTask.outputs)'
+        'FileCollection'             | 'Task'         | 'project.layout.files(project.tasks.myTask)'
+        'FileCollection'             | 'TaskOutputs'  | 'project.layout.files(project.tasks.myTask.outputs)'
+        'ConfigurableFileCollection' | 'Task'         | 'project.layout.configurableFiles(project.tasks.myTask)'
+        'ConfigurableFileCollection' | 'TaskOutputs'  | 'project.layout.configurableFiles(project.tasks.myTask.outputs)'
     }
 
     @Unroll
@@ -295,7 +295,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         outputContains("files = [${new File(testDirectory.absolutePath, '/build/resource/file.txt').absolutePath}]")
 
         where:
-        methodName << ['filesFor', 'mutableFilesFor']
+        methodName << ['files', 'configurableFiles']
     }
 
     @Unroll
@@ -322,8 +322,8 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         collectionType               | expression
-        'FileCollection'             | 'project.layout.filesFor(configurations.other)'
-        'ConfigurableFileCollection' | 'project.layout.mutableFilesFor(configurations.other)'
+        'FileCollection'             | 'project.layout.files(configurations.other)'
+        'ConfigurableFileCollection' | 'project.layout.configurableFiles(configurations.other)'
     }
 
     @Unroll
@@ -339,8 +339,8 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         collectionType               | expression
-        'FileCollection (Object...)' | 'project.layout.filesFor((Object) null)'
-        'FileCollection (File...)'   | 'project.layout.filesFor((File) null)'
-        'ConfigurableFileCollection' | 'project.layout.mutableFilesFor(null)'
+        'FileCollection (Object...)' | 'project.layout.files((Object) null)'
+        'FileCollection (File...)'   | 'project.layout.files((File) null)'
+        'ConfigurableFileCollection' | 'project.layout.configurableFiles(null)'
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -161,12 +161,12 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     }
 
     @Override
-    public FileCollection filesFor(Object... paths) {
+    public FileCollection files(Object... paths) {
         return ImmutableFileCollection.usingResolver(fileResolver, paths);
     }
 
     @Override
-    public ConfigurableFileCollection mutableFilesFor(Object... files) {
+    public ConfigurableFileCollection configurableFiles(Object... files) {
         return new DefaultConfigurableFileCollection(fileResolver, taskResolver, files);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -853,7 +853,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
 
     @Override
     public ConfigurableFileCollection files(Object... paths) {
-        return getLayout().mutableFilesFor(paths);
+        return getLayout().configurableFiles(paths);
     }
 
     @Override

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/build.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/build.gradle
@@ -89,9 +89,9 @@ project.afterEvaluate {
                     "src/$productFlavorName/kotlin",
                     "src/$buildTypeName/kotlin"
                 ]
-                additionalSourceDirs = layout.filesFor(coverageSourceDirs)
-                sourceDirectories = layout.filesFor(coverageSourceDirs)
-                executionData = layout.filesFor("${project.buildDir}/jacoco/${testTaskName}.exec")
+                additionalSourceDirs = layout.files(coverageSourceDirs)
+                sourceDirectories = layout.files(coverageSourceDirs)
+                executionData = layout.files("${project.buildDir}/jacoco/${testTaskName}.exec")
                 reports {
                     xml.enabled = true
                     html.enabled = true


### PR DESCRIPTION
* `ProjectLayout.filesFor()` -> `files()` (we already have `file()` and we are replacing `Project.files()`, moreover the `For` suffix doesn't seem to add anything)
* `ProjectLayout.mutableFilesFor()` -> `configurableFiles()` (the result is of type `ConfigurableFileCollection`, and we regularly use "configure" as a term in our public APIs, while we don't use "mutate")
