### PR TITLE
Remove gradle-build-internal repository

### DIFF
--- a/gradle/buildTagging.gradle
+++ b/gradle/buildTagging.gradle
@@ -20,7 +20,7 @@
 
 buildscript {
     repositories {
-        maven { url 'https://gradle.artifactoryonline.com/gradle/gradle-build-internal' }
+        maven { url 'https://repo.gradle.org/gradle/ext-releases-local' }
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     }
     dependencies {

--- a/gradle/buildTagging.gradle
+++ b/gradle/buildTagging.gradle
@@ -20,7 +20,6 @@
 
 buildscript {
     repositories {
-        maven { url 'https://repo.gradle.org/gradle/ext-releases-local' }
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     }
     dependencies {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -47,8 +47,6 @@ plugins {
 
 repositories {
     javaScript.googleApis()
-
-    maven { url 'https://repo.gradle.org/gradle/gradle-build-internal' }
 }
 
 configurations {


### PR DESCRIPTION
Due to the Artifactory cleanup we are currently doing we merged the `gradle-build-internal` repository into the `ext-releases-local` repository which is already included in the following virtual repositories:

* `libs-releases`

Therefore the artifacts are still accessible.

When this pull request is merged we will delete the `gradle-build-internal`.