### PR TITLE
Partial update of lock files

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.emptyList;
+
 /**
  * <p>{@code StartParameter} defines the configuration used by a Gradle instance to execute a build. The properties of {@code StartParameter} generally correspond to the command-line options of
  * Gradle.
@@ -97,6 +99,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean noBuildScan;
     private boolean interactive;
     private boolean writeDependencyLocks;
+    private List<String> lockedDependenciesToUpdate = emptyList();
 
     /**
      * {@inheritDoc}
@@ -257,6 +260,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.systemPropertiesArgs = new HashMap<String, String>(systemPropertiesArgs);
         p.interactive = interactive;
         p.writeDependencyLocks = writeDependencyLocks;
+        p.lockedDependenciesToUpdate = new ArrayList<String>(lockedDependenciesToUpdate);
         return p;
     }
 
@@ -339,7 +343,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public void setTaskNames(@Nullable Iterable<String> taskNames) {
         if (taskNames == null) {
-            this.taskRequests = Collections.emptyList();
+            this.taskRequests = emptyList();
         } else {
             this.taskRequests = Arrays.<TaskExecutionRequest>asList(new DefaultTaskExecutionRequest(taskNames));
         }
@@ -885,5 +889,32 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     @Incubating
     public boolean isWriteDependencyLocks() {
         return writeDependencyLocks;
+    }
+
+    /**
+     * Indicates that specified dependencies are to be allowed to update their version.
+     * Implicitly activates dependency locking persistence.
+     *
+     * @param lockedDependenciesToUpdate the modules to update
+     * @see #isWriteDependencyLocks()
+     *
+     * @since 4.8
+     */
+    @Incubating
+    public void setLockedDependenciesToUpdate(List<String> lockedDependenciesToUpdate) {
+        this.lockedDependenciesToUpdate = Lists.newArrayList(lockedDependenciesToUpdate);
+        this.writeDependencyLocks = true;
+    }
+
+    /**
+     * Returns the list of modules that are to be allowed to update their version compared to the lockfile.
+     *
+     * @return a list of modules allowed to have a version update
+     *
+     * @since 4.8
+     */
+    @Incubating
+    public List<String> getLockedDependenciesToUpdate() {
+        return lockedDependenciesToUpdate;
     }
 }

--- a/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -54,6 +54,7 @@ class StartParameterTest extends Specification {
         parameter.buildCacheEnabled = true
         parameter.interactive = true
         parameter.writeDependencyLocks = true
+        parameter.lockedDependenciesToUpdate = ['foo']
         parameter.includeBuild(new File('participant'))
 
         when:
@@ -124,6 +125,7 @@ class StartParameterTest extends Specification {
         !parameter.buildCacheEnabled
         !parameter.interactive
         !parameter.writeDependencyLocks
+        parameter.lockedDependenciesToUpdate.isEmpty()
 
         assertThat(parameter, isSerializable())
     }
@@ -289,6 +291,7 @@ class StartParameterTest extends Specification {
         parameter.buildCacheEnabled = true
         parameter.interactive = true
         parameter.writeDependencyLocks = true
+        parameter.lockedDependenciesToUpdate = ['foo']
 
         assertThat(parameter, isSerializable())
 
@@ -311,6 +314,7 @@ class StartParameterTest extends Specification {
         newParameter.buildCacheEnabled == parameter.buildCacheEnabled
         newParameter.interactive == parameter.interactive
         newParameter.writeDependencyLocks == parameter.writeDependencyLocks
+        newParameter.lockedDependenciesToUpdate == parameter.lockedDependenciesToUpdate
 
         newParameter.buildFile == null
         newParameter.taskRequests.empty

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -58,7 +58,8 @@ public class StartParameterBuildOptions {
         options.add(new BuildCacheOption());
         options.add(new BuildCacheDebugLoggingOption());
         options.add(new BuildScanOption());
-        options.add(new DependencyLockingOption());
+        options.add(new DependencyLockingWriteOption());
+        options.add(new DependencyLockingUpdateOption());
         StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
 
@@ -310,16 +311,28 @@ public class StartParameterBuildOptions {
         }
     }
 
-    public static class DependencyLockingOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
+    public static class DependencyLockingWriteOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
         public static final String LONG_OPTION = "write-locks";
 
-        public DependencyLockingOption() {
+        public DependencyLockingWriteOption() {
             super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Persists dependency resolution for locked configurations, ignoring existing locking information if it exists").incubating());
         }
 
         @Override
         public void applyTo(StartParameterInternal settings, Origin origin) {
             settings.setWriteDependencyLocks(true);
+        }
+    }
+
+    public static class DependencyLockingUpdateOption extends ListBuildOption<StartParameterInternal> {
+
+        public DependencyLockingUpdateOption() {
+            super(null, CommandLineOptionConfiguration.create("update-locks", "Perform a partial update of the dependency lock, letting passed in module notations change version.").incubating());
+        }
+
+        @Override
+        public void applyTo(List<String> modulesToUpdate, StartParameterInternal settings, Origin origin) {
+            settings.setLockedDependenciesToUpdate(modulesToUpdate);
         }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -435,4 +435,40 @@ dependencies {
         then:
         lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
     }
+
+    def 'updates part of the lockfile'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+        mavenRepo.module('org', 'bar', '1.0').publish()
+        mavenRepo.module('org', 'bar', '1.1').publish()
+
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf 'org:foo:[1.0,2.0)'
+    lockedConf 'org:bar:[1.0,2.0)'
+}
+"""
+
+        when:
+        succeeds 'dependencies', '--update-locks', 'org:foo'
+
+        then:
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -155,7 +155,7 @@ dependencies {
         failure.assertHasCause("Cannot find a version of 'org:foo' that satisfies the version constraints: \n" +
             "   Dependency path ':depLock:unspecified' --> 'org:foo' prefers '1.+'\n" +
             "   Constraint path ':depLock:unspecified' --> 'org:foo' prefers '1.1'\n" +
-            "   Constraint path ':depLock:unspecified' --> 'org:foo' prefers '1.0', rejects ']1.0,)' because of the following reason: dependency was locked to version 1.0")
+            "   Constraint path ':depLock:unspecified' --> 'org:foo' prefers '1.0', rejects ']1.0,)' because of the following reason: dependency was locked to version '1.0'")
     }
 
     def 'fails when lock file entry not resolved'() {
@@ -299,7 +299,7 @@ dependencies {
         failure.assertHasCause("Cannot find a version of 'org:foo' that satisfies the version constraints: \n" +
             "   Dependency path ':depLock:unspecified' --> 'org:foo' prefers '[1.0, 1.1]'\n" +
             "   Constraint path ':depLock:unspecified' --> 'org:foo' prefers '1.1'\n" +
-            "   Constraint path ':depLock:unspecified' --> 'org:foo' prefers '1.0', rejects ']1.0,)' because of the following reason: dependency was locked to version 1.0")
+            "   Constraint path ':depLock:unspecified' --> 'org:foo' prefers '1.0', rejects ']1.0,)' because of the following reason: dependency was locked to version '1.0'")
 //        failure.assertHasCause("Dependency lock out of date:\n" +
 //            "\tLock file contained 'org:bar:1.0' but it is not part of the resolved modules\n" +
 //            "\tLock file expected 'org:foo:1.0' but resolution result was 'org:foo:1.1'")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
@@ -58,7 +58,7 @@ dependencies {
 
         then:
         outputContains('org:foo:1.0')
-        outputContains('dependency was locked to version 1.0')
+        outputContains('dependency was locked to version \'1.0\'')
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
@@ -135,7 +135,7 @@ dependencies {
 
         then:
         outputContains('org:foo:1.0')
-        outputContains('dependency was locked to version 1.0')
+        outputContains('dependency was locked to version \'1.0\'')
     }
 
     def 'writes lock file entries for inherited dependencies'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.locking
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+
+class MixedDependencyLockingIntegrationTest extends AbstractDependencyResolutionTest {
+
+    def lockfileFixture = new LockfileFixture(testDirectory: testDirectory)
+
+    def setup() {
+        settingsFile << "rootProject.name = 'mixedDepLock'"
+    }
+
+    def 'can resolve locked and unlocked configurations'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    
+    unlockedConf
+}
+
+dependencies {
+    lockedConf 'org:foo:[1.0,2.0)'
+    unlockedConf 'org:foo:[1.0,2.0)'
+}
+"""
+
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+
+        when:
+        succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.0')
+        outputContains('dependency was locked to version 1.0')
+
+        when:
+        succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.1')
+        outputDoesNotContain('constraint')
+
+    }
+
+    def 'ignores the lockfile of a parent configuration when resolving an unlocked child configuration'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    
+    unlockedConf.extendsFrom lockedConf
+}
+
+dependencies {
+    lockedConf 'org:foo:[1.0,2.0)'
+}
+"""
+
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+
+        when:
+        succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.1')
+        outputDoesNotContain('constraint')
+    }
+
+    def 'applies the lock file to inherited dependencies'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    unlockedConf
+
+    lockedConf {
+        resolutionStrategy.activateDependencyLocking()
+        extendsFrom unlockedConf
+    }
+}
+
+dependencies {
+    unlockedConf 'org:foo:[1.0,2.0)'
+}
+"""
+
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+
+        when:
+        succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.0')
+        outputContains('dependency was locked to version 1.0')
+    }
+
+    def 'writes lock file entries for inherited dependencies'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    unlockedConf
+
+    lockedConf {
+        resolutionStrategy.activateDependencyLocking()
+        extendsFrom unlockedConf
+    }
+}
+
+dependencies {
+    unlockedConf 'org:foo:[1.0,2.0)'
+}
+"""
+
+        when:
+        succeeds 'dependencies', '--configuration', 'lockedConf', '--write-locks'
+
+        then:
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1'])
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.locking
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+
+class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyResolutionTest {
+
+    def firstLockFileFixture = new LockfileFixture(testDirectory: testDirectory.file('first'))
+
+    def setup() {
+        settingsFile << """
+rootProject.name = 'multiDepLock'
+include 'first', 'second'
+"""
+    }
+
+    def 'does not apply lock defined in a dependent project'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+allprojects {
+    apply plugin: 'java-library'
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+
+project(':first') {
+    configurations.all {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    dependencies {
+        api 'org:foo:[1.0,2.0)'
+    }
+}
+
+project(':second') {
+    dependencies {
+        implementation project(':first')
+    }
+}
+"""
+        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'])
+
+        when:
+        succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.0')
+
+        when:
+        succeeds ':second:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.1')
+    }
+
+    def 'does apply lock to transitive dependencies from dependent project'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+allprojects {
+    apply plugin: 'java-library'
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+
+project(':first') {
+    configurations.all {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    dependencies {
+        implementation project(':second')
+    }
+}
+
+project(':second') {
+    dependencies {
+        api 'org:foo:[1.0,2.0)'
+    }
+}
+"""
+        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'])
+
+        when:
+        succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.0')
+
+        when:
+        succeeds ':second:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
+
+        then:
+        outputContains('org:foo:1.1')
+    }
+
+    def 'creates a lock file including transitive dependencies of dependent project'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.1').publish()
+
+        buildFile << """
+allprojects {
+    apply plugin: 'java-library'
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+
+project(':first') {
+    configurations.all {
+        resolutionStrategy.activateDependencyLocking()
+    }
+    dependencies {
+        implementation project(':second')
+    }
+}
+
+project(':second') {
+    dependencies {
+        api 'org:foo:[1.0,2.0)'
+    }
+}
+"""
+        when:
+        succeeds ':first:dependencies', '--configuration', 'compileClasspath', '--write-locks'
+
+        then:
+        firstLockFileFixture.verifyLockfile('compileClasspath', ['org:foo:1.1'])
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.locking
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import spock.lang.Ignore
+
+class UsingLockingOnNonProjectConfigurationsIntegrationTest extends AbstractDependencyResolutionTest {
+
+    @Ignore('classpath configuration re-creates a resolution strategy, loosing the locking info')
+    def 'locks build script classpath configuration'() {
+        given:
+        mavenRepo.module('org.foo', 'foo-plugin', '1.0').publish()
+        mavenRepo.module('org.foo', 'foo-plugin', '1.1').publish()
+
+        settingsFile << """
+rootProject.name = 'foo'
+"""
+        buildFile << """
+buildscript {
+    repositories {
+        maven {
+            url = '$mavenRepo.uri'
+        }
+    }
+    configurations {
+        classpath {
+            resolutionStrategy.activateDependencyLocking()
+            resolutionStrategy.failOnVersionConflict()
+        }
+    }
+    dependencies {
+        classpath 'org.foo:foo-plugin:1.0'
+        classpath 'org.foo:foo-plugin:1.1'
+    }
+}
+"""
+        def lockFile = new LockfileFixture(testDirectory: testDirectory.file('gradle'))
+        lockFile.createLockfile('classpath', ['org.foo:foo-plugin:1.0'])
+
+        when:
+        succeeds 'buildEnvironment'
+
+        then:
+        outputContains('org.foo:foo-plugin:1.0')
+        outputDoesNotContain('org.foo:foo-plugin:1.1')
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 public interface DependencyLockingProvider {
 
-    DependencyLockingState findLockConstraint(String configurationName);
+    DependencyLockingState loadLockState(String configurationName);
 
     void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingState.java
@@ -26,19 +26,19 @@ import java.util.Set;
 public interface DependencyLockingState {
 
     /**
-     * Indicates if there was lock state defined for the configuration
+     * Indicates if the lock state must be validated
      *
      * @return {@code true} if lock state was found, {@code false} otherwise
      */
-    boolean hasLockState();
+    boolean mustValidateLockState();
 
     /**
      * Returns the set of locking constraints found.
      * Note that an empty set can mean either that lock state was not defined or that lock state is an empty set.
-     * Disambiguation can be done by calling {@link #hasLockState()}.
+     * Disambiguation can be done by calling {@link #mustValidateLockState()}.
      *
      * @return a set of constraints
-     * @see #hasLockState()
+     * @see #mustValidateLockState()
      */
     Set<DependencyConstraint> getLockedDependencies();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -221,6 +221,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         for (SpecRuleAction<? super ComponentSelection> ruleAction : componentSelectionRules.getRules()) {
             out.getComponentSelection().addRule(ruleAction);
         }
+        if (isDependencyLockingEnabled()) {
+            out.activateDependencyLocking();
+        }
         return out;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -75,7 +75,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
         @Override
         void maybeAddGeneratedDependencies(ImmutableList.Builder<LocalOriginDependencyMetadata> result) {
             if (configurationLocked) {
-                dependencyLockingState = dependencyLockingProvider.findLockConstraint(getName());
+                dependencyLockingState = dependencyLockingProvider.loadLockState(getName());
                 for (DependencyConstraint dependencyConstraint : dependencyLockingState.getLockedDependencies()) {
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
                         dependencyConstraint.getGroup(), dependencyConstraint.getName(), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -53,7 +53,9 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         this.partialUpdate = !lockedDependenciesToUpdate.isEmpty();
         StringBuilder patternBuilder = new StringBuilder();
         for (String module : lockedDependenciesToUpdate) {
-            patternBuilder.append(module).append(".+|");
+            for (String singleModule : module.split(",")) {
+                patternBuilder.append(singleModule).append(".+|");
+            }
         }
         updateModulePattern = Pattern.compile(patternBuilder.toString());
         converter = new DependencyLockingNotationConverter(!lockedDependenciesToUpdate.isEmpty());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
@@ -34,8 +34,12 @@ public class DefaultDependencyLockingState implements DependencyLockingState {
         lockDefined = false;
         constraints = emptySet();
     }
-    public DefaultDependencyLockingState(Set<DependencyConstraint> constraints) {
-        lockDefined = true;
+    public DefaultDependencyLockingState(boolean partialUpdate, Set<DependencyConstraint> constraints) {
+        if (partialUpdate) {
+            lockDefined = false;
+        } else {
+            lockDefined = true;
+        }
         this.constraints = constraints;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
@@ -40,7 +40,7 @@ public class DefaultDependencyLockingState implements DependencyLockingState {
     }
 
     @Override
-    public boolean hasLockState() {
+    public boolean mustValidateLockState() {
         return lockDefined;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -57,7 +57,7 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
     public void startArtifacts(RootGraphNode root) {
         RootConfigurationMetadata metadata = root.getMetadata();
         dependencyLockingState = metadata.getDependencyLockingState();
-        if (dependencyLockingState.hasLockState()) {
+        if (dependencyLockingState.mustValidateLockState()) {
             Set<DependencyConstraint> lockConstraints = dependencyLockingState.getLockedDependencies();
             lockingConstraints = Sets.newHashSetWithExpectedSize(lockConstraints.size());
             for (DependencyConstraint constraint : lockConstraints) {
@@ -75,7 +75,7 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
         ComponentIdentifier identifier = node.getOwner().getComponentId();
         if (identifier instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier id = (ModuleComponentIdentifier) identifier;
-            if (allResolvedModules.add(id) && dependencyLockingState.hasLockState()) {
+            if (allResolvedModules.add(id) && dependencyLockingState.mustValidateLockState()) {
                 String displayName = id.getDisplayName();
                 if (!lockingConstraints.remove(displayName)) {
                     extraModules.add(displayName);
@@ -96,7 +96,7 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
 
     @Override
     public void finishArtifacts() {
-        if (dependencyLockingState.hasLockState()) {
+        if (dependencyLockingState.mustValidateLockState()) {
             LOGGER.debug(" Dependency lock not matched '{}', extra resolved modules '{}'", lockingConstraints, extraModules);
             Set<String> notResolvedConstraints = Collections.emptySet();
             if (!lockingConstraints.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -36,18 +36,27 @@ class DependencyLockingNotationConverter {
         }
         DefaultDependencyConstraint constraint;
         if (updating) {
-            constraint = new DefaultDependencyConstraint(module.substring(0, groupNameSeparatorIndex),
-                module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
-                module.substring(nameVersionSeparatorIndex + 1));
-            constraint.because("dependency was locked to version '" + constraint.getVersion() + "' (update mode)");
+            constraint = createPreferConstraint(module, groupNameSeparatorIndex, nameVersionSeparatorIndex);
         } else {
-            constraint = DefaultDependencyConstraint.strictConstraint(module.substring(0, groupNameSeparatorIndex),
-                module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
-                module.substring(nameVersionSeparatorIndex + 1));
-            constraint.because("dependency was locked to version '" + constraint.getVersion() + "'");
+            constraint = createStrictConstraint(module, groupNameSeparatorIndex, nameVersionSeparatorIndex);
         }
+                 return constraint;
+    }
 
+    private DefaultDependencyConstraint createStrictConstraint(String module, int groupNameSeparatorIndex, int nameVersionSeparatorIndex) {
+        DefaultDependencyConstraint constraint;
+        constraint = DefaultDependencyConstraint.strictConstraint(module.substring(0, groupNameSeparatorIndex),
+            module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
+            module.substring(nameVersionSeparatorIndex + 1));
+        constraint.because("dependency was locked to version '" + constraint.getVersion() + "'");
+        return constraint;
+    }
 
+    private DefaultDependencyConstraint createPreferConstraint(String module, int groupNameSeparatorIndex, int nameVersionSeparatorIndex) {
+        DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(module.substring(0, groupNameSeparatorIndex),
+            module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
+            module.substring(nameVersionSeparatorIndex + 1));
+        constraint.because("dependency was locked to version '" + constraint.getVersion() + "' (update mode)");
         return constraint;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -22,17 +22,31 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstrain
 
 class DependencyLockingNotationConverter {
 
+    private final boolean updating;
+
+    public DependencyLockingNotationConverter(boolean updating) {
+        this.updating = updating;
+    }
+
     DependencyConstraint convertToDependencyConstraint(String module) {
         int groupNameSeparatorIndex = module.indexOf(':');
         int nameVersionSeparatorIndex = module.lastIndexOf(':');
         if (groupNameSeparatorIndex < 0 || nameVersionSeparatorIndex == groupNameSeparatorIndex) {
             throw new IllegalArgumentException("The module notation does not respect the lock file format of 'group:name:version' - received '" + module + "'");
         }
-        DefaultDependencyConstraint constraint = DefaultDependencyConstraint.strictConstraint(module.substring(0, groupNameSeparatorIndex),
-            module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
-            module.substring(nameVersionSeparatorIndex + 1));
+        DefaultDependencyConstraint constraint;
+        if (updating) {
+            constraint = new DefaultDependencyConstraint(module.substring(0, groupNameSeparatorIndex),
+                module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
+                module.substring(nameVersionSeparatorIndex + 1));
+            constraint.because("dependency was locked to version '" + constraint.getVersion() + "' (update mode)");
+        } else {
+            constraint = DefaultDependencyConstraint.strictConstraint(module.substring(0, groupNameSeparatorIndex),
+                module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
+                module.substring(nameVersionSeparatorIndex + 1));
+            constraint.because("dependency was locked to version '" + constraint.getVersion() + "'");
+        }
 
-        constraint.because("dependency was locked to version '" + constraint.getVersion() + "'");
 
         return constraint;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -32,7 +32,7 @@ class DependencyLockingNotationConverter {
             module.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
             module.substring(nameVersionSeparatorIndex + 1));
 
-        constraint.because("dependency was locked to version " + constraint.getVersion());
+        constraint.because("dependency was locked to version '" + constraint.getVersion() + "'");
 
         return constraint;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.locking;
+
+interface LockEntryFilter {
+
+    boolean filters(String moduleIdentifier);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilterFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilterFactory.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.locking;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class LockEntryFilterFactory {
+
+    private static final LockEntryFilter FILTERS_NONE = new LockEntryFilter() {
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            return false;
+        }
+    };
+
+    private static final LockEntryFilter FILTERS_ALL = new LockEntryFilter() {
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            return true;
+        }
+    };
+    private static final String WILDCARD_SUFFIX = "*";
+    public static final String MODULE_SEPARATOR = ":";
+
+    static LockEntryFilter forParameter(List<String> lockedDependenciesToUpdate) {
+        if (lockedDependenciesToUpdate.isEmpty()) {
+            return FILTERS_NONE;
+        }
+        HashSet<LockEntryFilter> lockEntryFilters = new HashSet<LockEntryFilter>();
+        for (String lockExcludes : lockedDependenciesToUpdate) {
+            for (String lockExclude : lockExcludes.split(",")) {
+                if (!lockExclude.contains(MODULE_SEPARATOR)) {
+                    throwInvalid(lockExclude);
+                }
+                if (lockExclude.contains(WILDCARD_SUFFIX)) {
+                    lockEntryFilters.add(extractAdvancedLockEntryFilter(lockExclude));
+                } else {
+                    lockEntryFilters.add(new BasicLockEntryFilter(lockExclude));
+                }
+            }
+            if (lockEntryFilters.isEmpty()) {
+                throwInvalid(lockExcludes);
+            }
+        }
+
+        if (lockEntryFilters.size() == 1) {
+            return lockEntryFilters.iterator().next();
+        } else {
+            return new AggregateLockEntryFilter(lockEntryFilters);
+        }
+    }
+
+    private static LockEntryFilter throwInvalid(String lockExclude) {
+        throw new IllegalArgumentException("Update lock format must be <group>:<artifact> but '" + lockExclude + "' is invalid.");
+    }
+
+    private static LockEntryFilter extractAdvancedLockEntryFilter(String lockExclude) {
+        String[] split = lockExclude.split(MODULE_SEPARATOR);
+        validateNotation(lockExclude, split);
+
+        String group = split[0];
+        String module = split[1];
+
+        if (group.equals(WILDCARD_SUFFIX) && module.equals(WILDCARD_SUFFIX)) {
+            return FILTERS_ALL;
+        }
+
+        if (module.equals(WILDCARD_SUFFIX)) {
+            if (group.contains(WILDCARD_SUFFIX)) {
+                return new GroupOnlyWildcardLockEntryFilter(group);
+            } else {
+                return new GroupStrictLockEntryFilter(group);
+            }
+        } else if (module.contains(WILDCARD_SUFFIX)) {
+            if (group.equals(WILDCARD_SUFFIX)) {
+                return new ModuleOnlyWildcardLockEntryFilter(module);
+            } else if (group.contains(WILDCARD_SUFFIX)) {
+                return new GroupModuleWildcardLockEntryFilter(group, module);
+            } else {
+                return new GroupStrictModuleWildcardLockEntryFilter(group, module);
+            }
+        } else if (group.equals("*")) {
+            return new ModuleStrictLockEntryFilter(module);
+        } else {
+            return new GroupWildcardModuleStrictLockEntryFilter(group, module);
+        }
+    }
+
+    private static void validateNotation(String lockExclude, String[] split) {
+        if (split.length != 2) {
+            throwInvalid(lockExclude);
+        }
+        String group = split[0];
+        String module = split[1];
+
+        if ((group.contains(WILDCARD_SUFFIX) && !group.endsWith(WILDCARD_SUFFIX)) || (module.contains(WILDCARD_SUFFIX) && !module.endsWith(WILDCARD_SUFFIX))) {
+            throwInvalid(lockExclude);
+        }
+
+    }
+
+    private static class AggregateLockEntryFilter implements LockEntryFilter {
+
+        private final Set<LockEntryFilter> filters;
+
+        private AggregateLockEntryFilter(Set<LockEntryFilter> filters) {
+            this.filters = filters;
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            for (LockEntryFilter filter : filters) {
+                if (filter.filters(moduleIdentifier)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static class BasicLockEntryFilter implements LockEntryFilter {
+        private final String lockExclude;
+
+        public BasicLockEntryFilter(String lockExclude) {
+            this.lockExclude = lockExclude;
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            return moduleIdentifier.startsWith(lockExclude);
+        }
+    }
+
+    private static class GroupOnlyWildcardLockEntryFilter implements LockEntryFilter {
+        private final String group;
+
+        public GroupOnlyWildcardLockEntryFilter(String group) {
+            this.group = group.substring(0, group.length() - 1);
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            return moduleIdentifier.startsWith(group);
+        }
+    }
+
+    private static class GroupStrictLockEntryFilter implements LockEntryFilter {
+        private final String group;
+
+        public GroupStrictLockEntryFilter(String group) {
+            this.group = group;
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            return moduleIdentifier.substring(0, moduleIdentifier.indexOf(MODULE_SEPARATOR)).equals(group);
+        }
+    }
+
+    private static class ModuleOnlyWildcardLockEntryFilter implements LockEntryFilter {
+        private final String module;
+
+        public ModuleOnlyWildcardLockEntryFilter(String module) {
+            this.module = module.substring(0, module.length() - 1);
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            String[] split = moduleIdentifier.split(MODULE_SEPARATOR);
+            return split[1].startsWith(this.module);
+        }
+    }
+
+    private static class GroupModuleWildcardLockEntryFilter implements LockEntryFilter {
+        private final String group;
+        private final String module;
+
+        public GroupModuleWildcardLockEntryFilter(String group, String module) {
+            this.group = group.substring(0, group.length() -1);
+            this.module = module.substring(0, module.length() - 1);
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            String[] split = moduleIdentifier.split(MODULE_SEPARATOR);
+            return split[0].startsWith(group) && split[1].startsWith(module);
+        }
+    }
+
+    private static class GroupWildcardModuleStrictLockEntryFilter implements LockEntryFilter {
+        private final String group;
+        private final String module;
+
+        public GroupWildcardModuleStrictLockEntryFilter(String group, String module) {
+            this.group = group.substring(0, group.length() -1);
+            this.module = module;
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            String[] split = moduleIdentifier.split(MODULE_SEPARATOR);
+            return split[0].startsWith(group) && split[1].equals(module);
+        }
+    }
+
+    private static class ModuleStrictLockEntryFilter implements LockEntryFilter {
+        private final String module;
+
+        public ModuleStrictLockEntryFilter(String module) {
+            this.module = module;
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            String[] split = moduleIdentifier.split(MODULE_SEPARATOR);
+            return split[1].equals(module);
+        }
+    }
+
+    private static class GroupStrictModuleWildcardLockEntryFilter implements LockEntryFilter {
+        private final String group;
+        private final String module;
+
+        public GroupStrictModuleWildcardLockEntryFilter(String group, String module) {
+            this.group = group;
+            this.module = module.substring(0, module.length() - 1);
+        }
+
+        @Override
+        public boolean filters(String moduleIdentifier) {
+            String[] split = moduleIdentifier.split(MODULE_SEPARATOR);
+            return split[0].equals(group) && split[1].startsWith(module);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -35,7 +35,7 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     }
 
     @Override
-    public DependencyLockingState findLockConstraint(String configurationName) {
+    public DependencyLockingState loadLockState(String configurationName) {
         return DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -30,8 +30,8 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
     def 'locking constraints are attached to a configuration and not its children'() {
         given:
         def constraint = new DefaultDependencyConstraint('org', 'foo', '1.1')
-        dependencyLockingHandler.findLockConstraint("conf") >> new DefaultDependencyLockingState([constraint] as Set)
-        dependencyLockingHandler.findLockConstraint("child") >> DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT
+        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(false, [constraint] as Set)
+        dependencyLockingHandler.loadLockState("child") >> DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT
         addConfiguration('conf').enableLocking()
         addConfiguration('child', ['conf']).enableLocking()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -69,7 +69,7 @@ org:foo:1.0
         def result = provider.findLockConstraint('conf')
 
         then:
-        result.hasLockState()
+        result.mustValidateLockState()
         result.getLockedDependencies() == [strictConstraint('org', 'bar', '1.3'), strictConstraint('org', 'foo', '1.0')] as Set
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -48,7 +48,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         then:
         1 * rootNode.metadata >> metadata
         1 * metadata.dependencyLockingState >> lockState
-        1 * lockState.hasLockState() >> true
+        1 * lockState.mustValidateLockState() >> true
         1 * lockState.lockedDependencies >> Collections.emptySet()
         0 * _
     }
@@ -60,7 +60,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         then:
         1 * rootNode.metadata >> metadata
         1 * metadata.dependencyLockingState >> lockState
-        1 * lockState.hasLockState() >> false
+        1 * lockState.mustValidateLockState() >> false
         0 * _
     }
 
@@ -167,7 +167,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
     private startWithoutLockState() {
         rootNode.metadata >> metadata
         metadata.dependencyLockingState >> lockState
-        lockState.hasLockState() >> false
+        lockState.mustValidateLockState() >> false
 
         visitor.startArtifacts(rootNode)
     }
@@ -175,7 +175,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
     private startWithState(List<DependencyConstraint> constraints) {
         rootNode.metadata >> metadata
         metadata.dependencyLockingState >> lockState
-        lockState.hasLockState() >> true
+        lockState.mustValidateLockState() >> true
         lockState.lockedDependencies >> constraints
 
         visitor.startArtifacts(rootNode)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingNotationConverterTest.groovy
@@ -39,7 +39,7 @@ class DependencyLockingNotationConverterTest extends Specification {
         converted.group == 'org'
         converted.name == 'foo'
         converted.version == '1.1'
-        converted.reason == 'dependency was locked to version 1.1'
+        converted.reason == 'dependency was locked to version \'1.1\''
         converted.versionConstraint.preferredVersion == '1.1'
         converted.versionConstraint.rejectedVersions == [']1.1,)']
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.locking
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LockEntryFilterFactoryTest extends Specification {
+
+    @Unroll
+    def "filters #filteredValues and accept #acceptedValues for filter with #filters"() {
+        when:
+        def filter = LockEntryFilterFactory.forParameter(filters)
+
+        then:
+        filteredValues.each {
+            assert filter.filters(it)
+        }
+        if (!acceptedValues.empty) {
+            acceptedValues.each {
+                assert !filter.filters(it)
+            }
+        }
+
+        where:
+        filters                 | filteredValues                    | acceptedValues
+        ['org:foo,com*:bar']    | ['org:foo:2.1', 'com:bar:1.1']    | ['org:baz:1.1']
+        ['org:foo']             | ['org:foo:2.1']                   | ['com:bar:1.1']
+        ['org:foo,']            | ['org:foo:2.1']                   | ['com:bar:1.1'] // Simply shows a trailing comma is ignored
+        ['co*:ba*']             | ['com:bar:2.1']                   | ['org:foo:1.1']
+        ['*:ba*']               | ['org:bar:2.1']                   | ['com:foo:1.1']
+        ['*:bar']               | ['org:bar:2.1']                   | ['com:foo:1.1']
+        ['org:f*']              | ['org:foo:1.1']                   | ['com:bar:2.1']
+        ['org:*']               | ['org:foo:1.1']                   | ['com:bar:2.1']
+        ['or*:*']               | ['org:foo:1.1']                   | ['com:bar:2.1']
+        ['*:*']                 | ['org:foo:1.1', 'com:bar:2.1']    | []
+    }
+
+    @Unroll
+    def "fails for invalid filter #filters"() {
+        when:
+        LockEntryFilterFactory.forParameter(filters)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        filters << [['*org:foo'], ['org:*foo'], ['org'], [',org:foo'], [',']]
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
@@ -29,7 +29,7 @@ class NoOpDependencyLockingProviderTest extends Specification {
         def result = provider.findLockConstraint('conf')
 
         then:
-        !result.hasLockState()
+        !result.mustValidateLockState()
     }
 
     def 'does nothing on persist'() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
@@ -26,7 +26,7 @@ class NoOpDependencyLockingProviderTest extends Specification {
 
     def 'does not find locked dependencies'() {
         when:
-        def result = provider.findLockConstraint('conf')
+        def result = provider.loadLockState('conf')
 
         then:
         !result.mustValidateLockState()

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -100,6 +100,7 @@ public class BuildActionSerializer {
             NO_NULL_STRING_MAP_SERIALIZER.write(encoder, startParameter.getProjectProperties());
             NO_NULL_STRING_MAP_SERIALIZER.write(encoder, startParameter.getSystemPropertiesArgs());
             fileListSerializer.write(encoder, startParameter.getInitScripts());
+            stringListSerializer.write(encoder, startParameter.getLockedDependenciesToUpdate());
 
             // Flags
             encoder.writeBoolean(startParameter.isBuildProjectDependencies());
@@ -170,6 +171,7 @@ public class BuildActionSerializer {
             startParameter.setProjectProperties(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));
             startParameter.setSystemPropertiesArgs(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));
             startParameter.setInitScripts(fileListSerializer.read(decoder));
+            startParameter.setLockedDependenciesToUpdate(stringListSerializer.read(decoder));
 
             // Flags
             startParameter.setBuildProjectDependencies(decoder.readBoolean());


### PR DESCRIPTION
This PR introduces a system for doing partial lock updates.

Currently it supports a very basic syntax: `--update-locks org:foo,org:bar`

Note that it implies persisting the lock.