### PR TITLE
Make pending detection more accurate

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadIntegrationTest.groovy
@@ -24,22 +24,32 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
  */
 class PlayContinuousBuildReloadIntegrationTest extends AbstractPlayReloadIntegrationTest {
 
+    protected static final String PENDING_DETECTED_MESSAGE = 'Pending changes detected'
+
     int pendingChangesMarker
 
     def setup() {
         buildFile << """
                 def pendingChangesManager = gradle.services.get(${PendingChangesManager.canonicalName})
                 pendingChangesManager.addListener {
-                    println "Pending changes detected"
+                    println "$PENDING_DETECTED_MESSAGE"
                 }
         """
     }
 
-    private int waitForChangesToBePickedUp() {
+    protected int waitForChangesToBePickedUp() {
+        waitForConditionSatisfied { output -> output.contains(PENDING_DETECTED_MESSAGE) }
+    }
+
+    protected int waitForBuildFinish() {
+        waitForConditionSatisfied { output -> output ==~ /(?s).*BUILD (FAILED|SUCCESSFUL) in.*/ }
+    }
+
+    private int waitForConditionSatisfied(Closure predicate){
         def buildOutput = ''
         ConcurrentTestUtil.poll {
             buildOutput = buildOutputSoFar()
-            assert buildOutput.substring(pendingChangesMarker).contains("Pending changes detected")
+            assert predicate(buildOutput.substring(pendingChangesMarker))
         }
         pendingChangesMarker = buildOutput.length()
     }
@@ -74,6 +84,7 @@ class PlayContinuousBuildReloadIntegrationTest extends AbstractPlayReloadIntegra
         then:
         println "CHECKING ERROR PAGE"
         errorPageHasTaskFailure("compilePlayBinaryScala")
+        waitForBuildFinish()
         serverStartCount == 1
         !executedTasks.contains('runPlayBinary')
 


### PR DESCRIPTION
### Context

This is an attempt to fix https://github.com/gradle/gradle-private/issues/1225

Previously, the failed test tried to wait for the changes to be picked up in continuous by waiting for the keyword **"Pending changes detected"**, which is not accurate enough. We should wait for **"Pending changes detected"** and the following build completes.

This fix was pretty straightforward: we not only wait for `Pending changes detected` but also wait for a `BUILD FAILED/SUCCESSFUL`.

@big-guy Would you please take a look on it? It won't take you too much time I think.