### PR TITLE
Remove potentially duplicate startup line

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -144,10 +144,7 @@ project.logger.debug("debug logging");
     }
 
     private removeStartupWarnings(String output) {
-        if (output.startsWith('Starting a Gradle Daemon')) {
-            output = output.substring(output.indexOf('\n') + 1)
-        }
-        if (output.startsWith('Parallel execution is an incubating feature.')) {
+        while (output.startsWith('Starting a Gradle Daemon') || output.startsWith('Parallel execution is an incubating feature.')) {
             output = output.substring(output.indexOf('\n') + 1)
         }
         output


### PR DESCRIPTION

### Context

This is an attempt to fix https://github.com/gradle/gradle-private/issues/1223, see it for the context.

We found in some rare cased, 'Starting a Gradle Daemon xxx' occurred twice, which makes the test flaky.
This tries to remove all startup warnings, no matter how many times the occur.

@marcphilipp could you please take a look at it? It wouldn't take you too much time.