### PR TITLE
Add ability to use `RegularFile` and `Directory` as publishable artif…

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ArtifactHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ArtifactHandler.java
@@ -41,6 +41,8 @@ import org.gradle.api.artifacts.PublishArtifact;
  *
  * <li>{@link org.gradle.api.tasks.bundling.AbstractArchiveTask}. The information for publishing the artifact is extracted from the archive task (e.g. name, extension, ...). The task will be executed if the artifact is required.</li>
  *
+ * <li>A {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}.</li>
+ *
  * <li>A {@link org.gradle.api.provider.Provider} of {@link java.io.File}, {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}. The information for publishing the artifact is extracted from the file or directory name. When the provider represents an output of a particular task, that task will be executed if the artifact is required.</li>
  *
  * <li>{@link java.io.File}. The information for publishing the artifact is extracted from the file name.</li>

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
@@ -410,6 +410,56 @@ task checkArtifacts {
         result.assertTasksExecuted(":a:classes", ":b:checkArtifacts")
     }
 
+    def "can define artifact using RegularFile type"() {
+        settingsFile << "include 'a', 'b'"
+        buildFile << """
+            project(':a') {
+                artifacts {
+                    compile layout.projectDirectory.file('someFile.txt')
+                }
+            }
+            project(':b') {
+                dependencies {
+                    compile project(':a')
+                }
+                task checkArtifacts {
+                    inputs.files configurations.compile
+                    doLast {
+                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["someFile.txt"]
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':b:checkArtifacts'
+    }
+
+    def "can define artifact using Directory type"() {
+        settingsFile << "include 'a', 'b'"
+        buildFile << """
+            project(':a') {
+                artifacts {
+                    compile layout.projectDirectory.dir('someDir')
+                }
+            }
+            project(':b') {
+                dependencies {
+                    compile project(':a')
+                }
+                task checkArtifacts {
+                    inputs.files configurations.compile
+                    doLast {
+                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["someDir"]
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':b:checkArtifacts'
+    }
+
     // This isn't strictly supported and will be deprecated later
     def "can use a custom PublishArtifact implementation"() {
         given:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
@@ -73,7 +73,6 @@ public class FileSystemPublishArtifact implements PublishArtifact {
     private ArtifactFile getValue() {
         if (artifactFile == null) {
             artifactFile = new ArtifactFile(getFile(), version);
-
         }
         return artifactFile;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.tasks.TaskDependencies;
+import org.gradle.api.tasks.TaskDependency;
+
+import java.io.File;
+import java.util.Date;
+
+public class FileSystemPublishArtifact implements PublishArtifact {
+
+    private final FileSystemLocation fileSystemLocation;
+    private final String version;
+    private ArtifactFile artifactFile;
+
+    public FileSystemPublishArtifact(final FileSystemLocation fileSystemLocation, final String version) {
+        this.fileSystemLocation = fileSystemLocation;
+        this.version = version;
+    }
+
+    @Override
+    public String getName() {
+        return getValue().getName();
+    }
+
+    @Override
+    public String getExtension() {
+        return getValue().getExtension();
+    }
+
+    @Override
+    public String getType() {
+        return "";
+    }
+
+    @Override
+    public String getClassifier() {
+        return getValue().getClassifier();
+    }
+
+    @Override
+    public File getFile() {
+        return fileSystemLocation.getAsFile();
+    }
+
+    @Override
+    public Date getDate() {
+        return new Date();
+    }
+
+    @Override
+    public TaskDependency getBuildDependencies() {
+        return TaskDependencies.EMPTY;
+    }
+
+    private ArtifactFile getValue() {
+        if (artifactFile == null) {
+            artifactFile = new ArtifactFile(getFile(), version);
+
+        }
+        return artifactFile;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.dsl;
 import org.apache.tools.ant.Task;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact;
@@ -56,6 +57,7 @@ public class PublishArtifactNotationParserFactory implements Factory<NotationPar
                 .converter(new DecoratingConverter())
                 .converter(new ArchiveTaskNotationConverter())
                 .converter(new FileProviderNotationConverter())
+                .converter(new FileSystemLocationNotationConverter())
                 .converter(fileConverter)
                 .converter(new FileMapNotationConverter(fileConverter))
                 .toComposite();
@@ -121,6 +123,24 @@ public class PublishArtifactNotationParserFactory implements Factory<NotationPar
         protected ConfigurablePublishArtifact parseType(Provider notation) {
             Module module = metaDataProvider.getModule();
             return instantiator.newInstance(DecoratingPublishArtifact.class, new LazyPublishArtifact(notation, module.getVersion()));
+        }
+    }
+
+    private class FileSystemLocationNotationConverter extends TypedNotationConverter<FileSystemLocation, ConfigurablePublishArtifact> {
+        FileSystemLocationNotationConverter() {
+            super(FileSystemLocation.class);
+        }
+
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.candidate("Instances of RegularFile.");
+            visitor.candidate("Instances of Directory.");
+        }
+
+        @Override
+        protected ConfigurablePublishArtifact parseType(FileSystemLocation notation) {
+            Module module = metaDataProvider.getModule();
+            return instantiator.newInstance(DecoratingPublishArtifact.class, new FileSystemPublishArtifact(notation, module.getVersion()));
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactoryTest.groovy
@@ -121,6 +121,42 @@ class PublishArtifactNotationParserFactoryTest extends Specification {
         publishArtifact.classifier == null
     }
 
+    def "create artifact from RegularFile"() {
+        def value = Mock(RegularFile)
+        def file = new File("classes-1.zip")
+
+        _ * value.getAsFile() >> file
+
+        when:
+        def publishArtifact = publishArtifactNotationParser.parseNotation(value)
+
+        then:
+        publishArtifact instanceof DecoratingPublishArtifact
+        publishArtifact.file == file
+        publishArtifact.name == "classes-1"
+        publishArtifact.extension == "zip"
+        publishArtifact.classifier == null
+        publishArtifact.buildDependencies.getDependencies(null).isEmpty()
+    }
+
+    def "create artifact from Directory"() {
+        def value = Mock(Directory)
+        def directory = new File("some-directory")
+
+        _ * value.getAsFile() >> directory
+
+        when:
+        def publishArtifact = publishArtifactNotationParser.parseNotation(value)
+
+        then:
+        publishArtifact instanceof DecoratingPublishArtifact
+        publishArtifact.file == directory
+        publishArtifact.name == "some-directory"
+        publishArtifact.extension == ''
+        publishArtifact.classifier == null
+        publishArtifact.buildDependencies.getDependencies(null).isEmpty()
+    }
+
     def "create artifact from File provider"() {
         def provider = Mock(BuildableProvider)
         def file1 = new File("classes-1.zip")
@@ -246,7 +282,7 @@ class PublishArtifactNotationParserFactoryTest extends Specification {
 
         then:
         def e = thrown(UnsupportedNotationException)
-        e.message.contains(TextUtil.toPlatformLineSeparators("""
+        e.message.contains(TextUtil.toPlatformLineSeparators('''
 The following types/formats are supported:
   - Instances of ConfigurablePublishArtifact.
   - Instances of PublishArtifact.
@@ -254,8 +290,10 @@ The following types/formats are supported:
   - Instances of Provider<RegularFile>.
   - Instances of Provider<Directory>.
   - Instances of Provider<File>.
+  - Instances of RegularFile.
+  - Instances of Directory.
   - Instances of File.
-  - Maps with 'file' key"""))
+  - Maps with 'file' key'''))
     }
 
     interface BuildableProvider extends Provider, TaskDependencyContainer {


### PR DESCRIPTION
…acts

Signed-off-by: Mike Kobit <mkobit@gmail.com>

### Context
Allows the use of `Directory` and `RegularFile` artifacts from projects. `Provider<Directory>` and `Provider<RegularFile>` are already supported, so this make the "non-calculated" case supported as well

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

#### Notes

- Did not add integration tests yet, wanted to see if is an appropriate change
- `:depMan:check` - some tests seem to fail for me right now that look unrelated to this change

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
