### PR TITLE
Make plugin lookups cheaper

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootClassLoaderScope.java
@@ -17,27 +17,32 @@
 package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
+import org.gradle.internal.classloader.CachingClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 
 public class RootClassLoaderScope extends AbstractClassLoaderScope {
 
     private final ClassLoader localClassLoader;
+    private final CachingClassLoader cachingLocalClassLoader;
     private final ClassLoader exportClassLoader;
+    private final CachingClassLoader cachingExportClassLoader;
 
     public RootClassLoaderScope(ClassLoader localClassLoader, ClassLoader exportClassLoader, ClassLoaderCache classLoaderCache) {
         super(new ClassLoaderScopeIdentifier(null, "root"), classLoaderCache);
         this.localClassLoader = localClassLoader;
+        this.cachingLocalClassLoader = new CachingClassLoader(localClassLoader);
         this.exportClassLoader = exportClassLoader;
+        this.cachingExportClassLoader = new CachingClassLoader(exportClassLoader);
     }
 
     @Override
     public ClassLoader getLocalClassLoader() {
-        return localClassLoader;
+        return cachingLocalClassLoader;
     }
 
     @Override
     public ClassLoader getExportClassLoader() {
-        return exportClassLoader;
+        return cachingExportClassLoader;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginRegistry.java
@@ -38,12 +38,6 @@ public interface PluginRegistry {
     @Nullable
     PluginImplementation<?> lookup(PluginId pluginId);
 
-    /**
-     * Locates the plugin with the given id. Note that the id of the result may be different to the requested id. Ignores classloader scopes that have not been locked yet.
-     */
-    @Nullable
-    PluginImplementation<?> maybeLookup(PluginId pluginId);
-
     PluginRegistry createChild(ClassLoaderScope lookupScope);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultClassLoaderRegistry.java
@@ -17,7 +17,6 @@
 package org.gradle.initialization;
 
 import org.gradle.api.internal.ClassPathRegistry;
-import org.gradle.internal.classloader.CachingClassLoader;
 import org.gradle.internal.classloader.FilteringClassLoader;
 
 public class DefaultClassLoaderRegistry implements ClassLoaderRegistry {
@@ -37,7 +36,7 @@ public class DefaultClassLoaderRegistry implements ClassLoaderRegistry {
     }
 
     private static ClassLoader restrictTo(FilteringClassLoader.Spec spec, ClassLoader parent) {
-        return new CachingClassLoader(new FilteringClassLoader(parent, spec));
+        return new FilteringClassLoader(parent, spec);
     }
 
     private static FilteringClassLoader.Spec apiSpecFor(ClassLoader classLoader) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -30,8 +30,6 @@ import spock.lang.Specification
 
 class DefaultClassLoaderScopeTest extends Specification {
 
-    ClassLoader rootClassLoader
-
     ClassLoaderScope root
     ClassLoaderScope scope
 
@@ -43,7 +41,7 @@ class DefaultClassLoaderScopeTest extends Specification {
 
     def setup() {
         file("root/root") << "root"
-        rootClassLoader = new URLClassLoader(classPath("root").asURLArray, getClass().classLoader.parent)
+        def rootClassLoader = new URLClassLoader(classPath("root").asURLArray, getClass().classLoader.parent)
         root = new RootClassLoaderScope(rootClassLoader, rootClassLoader, classLoaderCache)
         scope = root.createChild("child")
     }
@@ -61,8 +59,8 @@ class DefaultClassLoaderScopeTest extends Specification {
         scope.lock()
 
         then:
-        scope.localClassLoader.is rootClassLoader
-        scope.exportClassLoader.is rootClassLoader
+        scope.localClassLoader.is root.exportClassLoader
+        scope.exportClassLoader.is root.exportClassLoader
     }
 
     def "locked empty scope does not define any classes"() {
@@ -80,8 +78,8 @@ class DefaultClassLoaderScopeTest extends Specification {
         scope.lock()
 
         then:
-        scope.localClassLoader.is rootClassLoader
-        scope.exportClassLoader.is rootClassLoader
+        scope.localClassLoader.is root.exportClassLoader
+        scope.exportClassLoader.is root.exportClassLoader
     }
 
     def "locked scope with only exports uses same export and local loader"() {
@@ -93,7 +91,7 @@ class DefaultClassLoaderScopeTest extends Specification {
         scope.exportClassLoader.getResource("root").text == "root"
         scope.exportClassLoader.getResource("foo").text == "foo"
         scope.exportClassLoader instanceof URLClassLoader
-        scope.exportClassLoader.parent.is rootClassLoader
+        scope.exportClassLoader.parent.is root.exportClassLoader
         scope.localClassLoader.is scope.exportClassLoader
     }
 
@@ -127,7 +125,7 @@ class DefaultClassLoaderScopeTest extends Specification {
         scope.localClassLoader.getResource("foo").text == "foo"
         scope.localClassLoader.getResource("bar").text == "bar"
         scope.localClassLoader != scope.exportClassLoader
-        scope.exportClassLoader.is rootClassLoader
+        scope.exportClassLoader.is root.exportClassLoader
     }
 
     def "locked scope with only one local exports parent loader to children and uses loader as local loader"() {
@@ -139,8 +137,8 @@ class DefaultClassLoaderScopeTest extends Specification {
         scope.localClassLoader.getResource("root").text == "root"
         scope.localClassLoader.getResource("foo").text == "foo"
         scope.localClassLoader instanceof URLClassLoader
-        scope.localClassLoader.parent.is rootClassLoader
-        scope.exportClassLoader.is rootClassLoader
+        scope.localClassLoader.parent.is root.exportClassLoader
+        scope.exportClassLoader.is root.exportClassLoader
     }
 
     def "locked scope with local and exports exports custom ClassLoader to children"() {
@@ -156,7 +154,7 @@ class DefaultClassLoaderScopeTest extends Specification {
         scope.exportClassLoader.getResource("export").text == "bar"
         scope.exportClassLoader.getResource("local") == null
         scope.exportClassLoader instanceof URLClassLoader
-        scope.exportClassLoader.parent == rootClassLoader
+        scope.exportClassLoader.parent == root.exportClassLoader
 
         scope.localClassLoader instanceof CachingClassLoader
         scope.localClassLoader.getResource("export").text == "bar"


### PR DESCRIPTION
Use the classloader scope of the registry as often as possible
instead of using a potentially non-caching classloader.

Move classloader caching to the root classloader scope.
This is more consistent with how the child scopes work.
Also the caching is not needed for the other clients of
the classloader registry.