### PR TITLE
Support POM exclusions with implicit wildcard

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -22,7 +22,7 @@ import java.io.File;
 public enum CacheLayout {
     ROOT(null, "modules", 2),
     FILE_STORE(ROOT, "files", 1),
-    META_DATA(ROOT, "metadata", 57),
+    META_DATA(ROOT, "metadata", 58),
     RESOURCES(ROOT, "resources", 1),
     TRANSFORMS(null, "transforms", 1),
     TRANSFORMS_META_DATA(TRANSFORMS, "metadata", 1),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -552,8 +552,8 @@ public class PomReader implements PomParent {
                     if (node instanceof Element && EXCLUSION.equals(node.getNodeName())) {
                         String groupId = getFirstChildText((Element) node, GROUP_ID);
                         String artifactId = getFirstChildText((Element) node, ARTIFACT_ID);
-                        if ((groupId != null) && (artifactId != null)) {
-                            exclusions.add(moduleIdentifierFactory.module(groupId, artifactId));
+                        if ((groupId != null) || (artifactId != null)) {
+                            exclusions.add(moduleIdentifierFactory.module(groupId != null ? groupId : "*", artifactId != null ? artifactId : "*"));
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -46,10 +46,10 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        cacheLayout.key == 'metadata-2.57'
-        cacheLayout.version == VersionNumber.parse("2.57.0")
-        cacheLayout.formattedVersion == '2.57'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.57')
+        cacheLayout.key == 'metadata-2.58'
+        cacheLayout.version == VersionNumber.parse("2.58.0")
+        cacheLayout.formattedVersion == '2.58'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.58')
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReaderTest.groovy
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser
+
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.data.MavenDependencyKey
@@ -850,4 +852,168 @@ class PomReaderTest extends AbstractPomReaderTest {
         pomReader.artifactId == pomReader.parentArtifactId
         pomReader.version == pomReader.parentVersion
     }
-}
+
+    @Issue("gradle/gradle#5092")
+    def 'can parse exclusion defined only by artifactId'() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group</groupId>
+    <artifactId>artifact</artifactId>
+    <version>version</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <version>version-two</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bar</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        moduleIdentifierFactory.module('*', 'bar') >> DefaultModuleIdentifier.newId('*', 'bar')
+
+        then:
+        def excluded = pomReader.dependencies[keyGroupTwo].excludedModules
+        excluded == [DefaultModuleIdentifier.newId("*", "bar")]
+    }
+
+    @Issue("gradle/gradle#5092")
+    def 'can parse exclusion defined only by groupId'() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group</groupId>
+    <artifactId>artifact</artifactId>
+    <version>version</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <version>version-two</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>bar</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        moduleIdentifierFactory.module('bar', '*') >> DefaultModuleIdentifier.newId('bar', '*')
+
+        then:
+        def excluded = pomReader.dependencies[keyGroupTwo].excludedModules
+        excluded == [DefaultModuleIdentifier.newId('bar', '*')]
+    }
+
+    @Issue("gradle/gradle#5092")
+    def 'can parse exclusion defined by groupId and artifactId'() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group</groupId>
+    <artifactId>artifact</artifactId>
+    <version>version</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <version>version-two</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>bar</groupId>
+                    <artifactId>bar</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        moduleIdentifierFactory.module('bar', 'bar') >> DefaultModuleIdentifier.newId('bar', 'bar')
+
+        then:
+        def excluded = pomReader.dependencies[keyGroupTwo].excludedModules
+        excluded == [DefaultModuleIdentifier.newId('bar', 'bar')]
+    }
+
+    @Issue("gradle/gradle#5092")
+    def 'ignores empty exclusion block'() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group</groupId>
+    <artifactId>artifact</artifactId>
+    <version>version</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <version>version-two</version>
+            <exclusions>
+                <exclusion>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+
+        then:
+        pomReader.dependencies[keyGroupTwo].excludedModules.isEmpty()
+        0 * moduleIdentifierFactory.module(_, _)
+    }
+
+    @Issue("gradle/gradle#5092")
+    def 'can parse a wildcard exclusion block'() {
+        when:
+        pomFile << """
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>group</groupId>
+    <artifactId>artifact</artifactId>
+    <version>version</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>group-two</groupId>
+            <artifactId>artifact-two</artifactId>
+            <version>version-two</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+"""
+        pomReader = new PomReader(locallyAvailableExternalResource, moduleIdentifierFactory)
+        MavenDependencyKey keyGroupTwo = new MavenDependencyKey('group-two', 'artifact-two', 'jar', null)
+        moduleIdentifierFactory.module('*', '*') >> DefaultModuleIdentifier.newId('*', '*')
+
+        then:
+        def excluded = pomReader.dependencies[keyGroupTwo].excludedModules
+        excluded == [DefaultModuleIdentifier.newId('*', '*')]
+    }}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -83,6 +83,11 @@ TBD - previously this was broken, and plugins may accidentally rely on this beha
 
 Previously, `Signature.setFile()` could be used to replace the file used for publishing a `Signature`. However, the actual signature file was still being generated at its default location. Therefore, `Signature.setFile()` is now deprecated and will be removed in a future release.
 
+### Parsing of `exclusions` in Maven POM now accepts implicit wildcards
+
+Previously, a Maven POM with an `exclusion` missing either the `groupId` or the `artifactId` was ignored by Gradle.
+This is no longer the case and thus may cause modules to be excluded from a dependency graph that were previously included.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -146,7 +146,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     public VersionNumber getArtifactCacheLayoutVersion() {
         if (isSameOrNewer("4.8-rc-1")) {
-            return VersionNumber.parse("2.57");
+            return VersionNumber.parse("2.58");
         } else if (isSameOrNewer("4.7-rc-1")) {
             return VersionNumber.parse("2.56");
         } else if (isSameOrNewer("4.6-rc-1")) {


### PR DESCRIPTION
A POM exclusion can specify only the groupId or the artifactId, implying
 that the other one is set as "*".