### PR TITLE
Fix NPE in RestartEveryNTestClassProcessor.stopNow()

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RestartEveryNTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RestartEveryNTestClassProcessor.java
@@ -66,8 +66,9 @@ public class RestartEveryNTestClassProcessor implements TestClassProcessor {
     @Override
     public void stopNow() {
         stoppedNow = true;
-        if (processor != null) {
-            processor.stopNow();
+        TestClassProcessor toStop = processor;
+        if (toStop != null) {
+            toStop.stopNow();
         }
     }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/RestartEveryNTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/RestartEveryNTestClassProcessorTest.groovy
@@ -192,6 +192,24 @@ class RestartEveryNTestClassProcessorTest extends Specification {
         0 * _._
     }
 
+    def "stopNow does nothing after stop completed"() {
+        when:
+        processor.startProcessing(resultProcessor)
+        processor.processTestClass(test1)
+        processor.stop()
+
+        then:
+        1 * factory.create() >> delegate
+        1 * delegate.startProcessing(resultProcessor)
+        1 * delegate.processTestClass(test1)
+        1 * delegate.stop()
+
+        when:
+        processor.stopNow()
+        then:
+        0 * _._
+    }
+
     def "processTestClass has no effect after stopNow"() {
         when:
         processor.startProcessing(resultProcessor)


### PR DESCRIPTION
CI Build https://builds.gradle.org/viewLog.html?buildId=12381164&buildTypeId=Gradle_Check_Parallel_Java7_Ibm_Linux_testingJvm revealed a potential NPE during the fail fast behavior in `RestartEveryNTestClassProcessor`.