### PR TITLE
Define common rules for declaring tasks

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
+++ b/subprojects/docs/src/docs/userguide/authoringMaintainableBuildScripts.adoc
@@ -82,6 +82,19 @@ Use other collections or I/O frameworks instead of `org.gradle.util.CollectionUt
 
 Gradle plugin authors may find the Designing Gradle Plugins subsection on link:https://guides.gradle.org/designing-gradle-plugins/#restricting_the_plugin_implementation_to_gradle_s_public_api[restricting the plugin implementation to Gradle's public API] helpful.
 
+[[sec:declaring_tasks]]
+=== Declaring tasks in a build script
+
+The task API gives a build author a lot of flexibility to declare tasks in a build script.
+For optimal readability and maintainability follow these rules:
+
+* The task type should be the only key-value pair that belongs within the parentheses after the task name.
+* Tasks without a specialized type should not explicitly declare api:org.gradle.api.DefaultTask[]. The type is automatically implied.
+* Any other configuration logic for a task should be defined as part of api:org.gradle.api.Project#task(java.lang.String,groovy.lang.Closure)[] if possible.
+* Task actions should only be declared with the methods api:org.gradle.api.Task#doFirst(org.gradle.api.Action)[] or api:org.gradle.api.Task#doLast(org.gradle.api.Action)[].
+* api:org.gradle.api.Task#doLast(org.gradle.api.Action)[] should be used if the task only defines a single action.
+* A task should <<sec:improving_task_discoverability,define a group and description>>.
+
 [[sec:improving_task_discoverability]]
 === Improving task discoverability
 


### PR DESCRIPTION
### Context

Gives guidelines on how to best structure task definitions.