### PR TITLE
Add createLater convenience methods for tasks without configuration

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -239,7 +239,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    <T extends Task> Provider<T> createLater(String name, Class<T> type, @Nullable Action<? super T> configurationAction);
+    <T extends Task> Provider<T> createLater(String name, Class<T> type, Action<? super T> configurationAction);
 
     /**
      * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link #getByName(String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -239,7 +239,40 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    <T extends Task> Provider<T> createLater(String name, Class<T> type, Action<? super T> configurationAction);
+    <T extends Task> Provider<T> createLater(String name, Class<T> type, @Nullable Action<? super T> configurationAction);
+
+    /**
+     * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link #getByName(String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.
+     *
+     * <p>It is generally more efficient to use this method instead of {@link #create(String, Class, Action)} or {@link #create(String, Class)}, as those methods will eagerly create and configure the task, regardless of whether that task is required for the current build or not. This method, on the other hand, will defer creation until required.</p>
+     *
+     * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
+     *
+     * @param name The name of the task.
+     * @param type The task type.
+     * @param <T> The task type
+     * @return A {@link Provider} that whose value will be the task, when queried.
+     * @throws InvalidUserDataException If a task with the given name already exists in this project.
+     * @since 4.8
+     */
+    @Incubating
+    <T extends Task> Provider<T> createLater(String name, Class<T> type);
+
+    /**
+     * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link #getByName(String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.
+     *
+     * <p>It is generally more efficient to use this method instead of {@link #create(String)}, as that methods will eagerly create he task, regardless of whether that task is required for the current build or not. This method, on the other hand, will defer creation until required.</p>
+     *
+     * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
+     *
+     * @param name The name of the task.
+     * @param <T> The task type
+     * @return A {@link Provider} that whose value will be the task, when queried.
+     * @throws InvalidUserDataException If a task with the given name already exists in this project.
+     * @since 4.8
+     */
+    @Incubating
+    <T extends Task> Provider<T> createLater(String name);
 
     /**
      * <p>Creates a {@link Task} with the given name and adds it to this container, replacing any existing task with the

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -55,6 +55,7 @@ import org.gradle.model.internal.type.ModelType;
 import org.gradle.util.ConfigureUtil;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -287,6 +288,16 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return provider;
     }
 
+    @Override
+    public <T extends Task> Provider<T> createLater(String name, Class<T> type) {
+        return createLater(name, type, null);
+    }
+
+    @Override
+    public <T extends Task> Provider<T> createLater(String name) {
+        return Cast.uncheckedCast(createLater(name, DefaultTask.class));
+    }
+
     public <T extends Task> T replace(String name, Class<T> type) {
         T task = taskFactory.create(name, type);
         return addTask(task, true);
@@ -493,7 +504,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         Action<? super T> configureAction;
         T task;
 
-        public TaskCreatingProvider(Class<T> type, String name, Action<? super T> configureAction) {
+        public TaskCreatingProvider(Class<T> type, String name, @Nullable Action<? super T> configureAction) {
             super(type, name);
             this.configureAction = configureAction;
             statistics.lazyTask();
@@ -509,8 +520,10 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                         task = createTask(name, type, NO_ARGS);
                         statistics.lazyTaskRealized();
                         add(task);
-                        configureAction.execute(task);
-                        configureAction = null;
+                        if (configureAction != null) {
+                            configureAction.execute(task);
+                            configureAction = null;
+                        }
                     }
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -276,7 +276,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
-    public <T extends Task> Provider<T> createLater(final String name, final Class<T> type, Action<? super T> configurationAction) {
+    public <T extends Task> Provider<T> createLater(final String name, final Class<T> type, @Nullable  Action<? super T> configurationAction) {
         if (hasWithName(name)) {
             duplicateTask(name);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -430,6 +430,42 @@ class DefaultTaskContainerTest extends Specification {
 
         then:
         1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_)
+        result == task
+    }
+
+    void "can define task to create later given name and type"() {
+        when:
+        def provider = container.createLater("task", DefaultTask)
+
+        then:
+        0 * _
+
+        and:
+        container.names.contains("task")
+        container.size() == 1
+        !container.empty
+        !provider.present
+    }
+
+    void "can define task to create later given name"() {
+        def task = task("task")
+
+        when:
+        def provider = container.createLater("task")
+
+        then:
+        0 * _
+
+        and:
+        container.names.contains("task")
+        container.size() == 1
+
+        when:
+        def result = provider.get()
+
+        then:
+        1 * taskFactory.create("task", DefaultTask) >> task
         result == task
     }
 


### PR DESCRIPTION
Adds convenience methods for `createLater(name, type)` and `createLater(name)` on `TaskContainer`.

See https://github.com/gradle/gradle-native/issues/628.