### PR TITLE
Upgrade ktlint-convention plugin in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
 
 plugins {
     `kotlin-dsl`
-    id("org.gradle.kotlin.ktlint-convention") version "0.1.6" apply false
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.7" apply false
 }
 
 subprojects {


### PR DESCRIPTION
with now relocatable ktlint check tasks.

See https://github.com/gradle/kotlin-dsl/issues/822