### PR TITLE
Cache parsing of version strings

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -31,7 +31,9 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.RepositoryBlackli
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.DefaultModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
@@ -279,7 +281,9 @@ class DependencyManagementBuildScopeServices {
                                               BuildCommencedTimeProvider buildCommencedTimeProvider,
                                               VersionSelectorScheme versionSelectorScheme,
                                               VersionComparator versionComparator,
-                                              ImmutableModuleIdentifierFactory moduleIdentifierFactory, RepositoryBlacklister repositoryBlacklister) {
+                                              ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                              RepositoryBlacklister repositoryBlacklister,
+                                              VersionParser versionParser) {
         StartParameterResolutionOverride startParameterResolutionOverride = new StartParameterResolutionOverride(startParameter);
         return new ResolveIvyFactory(
             moduleRepositoryCacheProvider,
@@ -288,7 +292,7 @@ class DependencyManagementBuildScopeServices {
             versionSelectorScheme,
             versionComparator,
             moduleIdentifierFactory,
-            repositoryBlacklister);
+            repositoryBlacklister, versionParser);
     }
 
     ArtifactDependencyResolver createArtifactDependencyResolver(ResolveIvyFactory resolveIvyFactory,
@@ -298,7 +302,9 @@ class DependencyManagementBuildScopeServices {
                                                                 ModuleExclusions moduleExclusions,
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 ComponentSelectorConverter componentSelectorConverter,
-                                                                ImmutableAttributesFactory attributesFactory) {
+                                                                ImmutableAttributesFactory attributesFactory,
+                                                                VersionSelectorScheme versionSelectorScheme,
+                                                                VersionParser versionParser) {
         return new DefaultArtifactDependencyResolver(
             buildOperationExecutor,
             resolverFactories,
@@ -307,7 +313,7 @@ class DependencyManagementBuildScopeServices {
             versionComparator,
             moduleExclusions,
             componentSelectorConverter,
-            attributesFactory);
+            attributesFactory, versionSelectorScheme, versionParser);
     }
 
     ProjectPublicationRegistry createProjectPublicationRegistry() {
@@ -328,6 +334,14 @@ class DependencyManagementBuildScopeServices {
 
     ComponentSelectorConverter createModuleVersionSelectorFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
         return new DefaultComponentSelectorConverter(moduleIdentifierFactory, componentIdentifierFactory, localComponentRegistry);
+    }
+
+    VersionParser createVersionParser() {
+        return new VersionParser();
+    }
+
+    VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {
+        return new DefaultVersionSelectorScheme(versionComparator, versionParser);
     }
 
     private static class VcsOrProjectResolverProviderFactory implements ResolverProviderFactory {
@@ -352,8 +366,8 @@ class DependencyManagementBuildScopeServices {
         }
     }
 
-    VcsDependencyResolver createVcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, NestedBuildFactory nestedBuildFactory) {
-        return new VcsDependencyResolver(vcsWorkingDirectoryRoot, projectDependencyResolver, localComponentRegistry, vcsResolver, versionControlSystemFactory, versionSelectorScheme, versionComparator, buildRegistry, nestedBuildFactory);
+    VcsDependencyResolver createVcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, NestedBuildFactory nestedBuildFactory, VersionParser versionParser) {
+        return new VcsDependencyResolver(vcsWorkingDirectoryRoot, projectDependencyResolver, localComponentRegistry, vcsResolver, versionControlSystemFactory, versionSelectorScheme, versionComparator, buildRegistry, nestedBuildFactory, versionParser);
     }
 
     ResolverProviderFactory createVcsResolverProviderFactory(VcsDependencyResolver vcsDependencyResolver, ProjectDependencyResolver projectDependencyResolver, VcsResolver vcsResolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.RepositoryBlackli
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.CachingVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -341,7 +342,7 @@ class DependencyManagementBuildScopeServices {
     }
 
     VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {
-        return new DefaultVersionSelectorScheme(versionComparator, versionParser);
+        return new CachingVersionSelectorScheme(new DefaultVersionSelectorScheme(versionComparator, versionParser));
     }
 
     private static class VcsOrProjectResolverProviderFactory implements ResolverProviderFactory {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -19,26 +19,24 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultLocalComponentMetadataBuilder;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalConfigurationMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultDependencyDescriptorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleIvyDependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectIvyDependencyDescriptorFactory;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;
+import org.gradle.internal.resource.local.FileResourceConnector;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.transport.file.FileConnectorFactory;
-import org.gradle.internal.resource.local.FileResourceConnector;
 
 class DependencyManagementGlobalScopeServices {
     FileResourceRepository createFileResourceRepository(FileSystem fileSystem){
@@ -57,15 +55,11 @@ class DependencyManagementGlobalScopeServices {
         return new DefaultExcludeRuleConverter(moduleIdentifierFactory);
     }
 
-    VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator) {
-        return new DefaultVersionSelectorScheme(versionComparator);
-    }
-
     VersionComparator createVersionComparator() {
         return new DefaultVersionComparator();
     }
 
-    ExternalModuleIvyDependencyDescriptorFactory createExternalModuleDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter, VersionSelectorScheme versionSelectorScheme) {
+    ExternalModuleIvyDependencyDescriptorFactory createExternalModuleDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter) {
         return new ExternalModuleIvyDependencyDescriptorFactory(excludeRuleConverter);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.VersionConstraintInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 
 import javax.annotation.Nullable;
@@ -56,7 +57,7 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
         // When strict version is used, we need to parse the preferred selector early, in order to compute its complement.
         // Hopefully this shouldn't happen too often. If it happens to become a performance problem, we need to reconsider
         // how we compute the "reject" clause
-        DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator());
+        DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser());
         VersionSelector preferredSelector = versionSelectorScheme.parseSelector(prefer);
         VersionSelector rejectedSelector = versionSelectorScheme.complementForRejection(preferredSelector);
         this.rejects.clear();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectionInternal;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.DefaultComponentSelection;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -37,9 +38,11 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
     private final ComponentSelectionRulesProcessor rulesProcessor = new ComponentSelectionRulesProcessor();
     private final VersionComparator versionComparator;
     private final ComponentSelectionRulesInternal componentSelectionRules;
+    private final VersionParser versionParser;
 
-    DefaultVersionedComponentChooser(VersionComparator versionComparator, ComponentSelectionRulesInternal componentSelectionRules) {
+    DefaultVersionedComponentChooser(VersionComparator versionComparator, VersionParser versionParser, ComponentSelectionRulesInternal componentSelectionRules) {
         this.versionComparator = versionComparator;
+        this.versionParser = versionParser;
         this.componentSelectionRules = componentSelectionRules;
     }
 
@@ -48,7 +51,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
             return two == null ? one : two;
         }
 
-        int comparison = versionComparator.compare(new VersionInfo(one.getModuleVersionId().getVersion()), new VersionInfo(two.getModuleVersionId().getVersion()));
+        int comparison = versionComparator.compare(new VersionInfo(versionParser.transform(one.getModuleVersionId().getVersion())), new VersionInfo(versionParser.transform(two.getModuleVersionId().getVersion())));
 
         if (comparison == 0) {
             if (isMissingModuleDescriptor(one) && !isMissingModuleDescriptor(two)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
@@ -40,10 +41,10 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final VersionSelectorScheme versionSelectorScheme;
 
-    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme) {
+    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.versionSelectorScheme = versionSelectorScheme;
-        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, metaDataFactory);
+        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory);
     }
 
     public void add(ModuleComponentRepository repository) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -36,11 +37,12 @@ public class UserResolverChain implements ComponentResolvers {
     public UserResolverChain(VersionSelectorScheme versionSelectorScheme,
                              VersionComparator versionComparator,
                              ComponentSelectionRulesInternal componentSelectionRules,
-                             ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+                             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                             VersionParser versionParser) {
         this.componentSelectionRules = componentSelectionRules;
-        VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, componentSelectionRules);
+        VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules);
         ModuleTransformer metaDataFactory = new ModuleTransformer();
-        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, moduleIdentifierFactory, versionSelectorScheme);
+        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, moduleIdentifierFactory, versionSelectorScheme, versionParser);
         componentResolver = new RepositoryChainComponentMetaDataResolver(componentChooser, metaDataFactory);
         artifactResolver = new RepositoryChainArtifactResolver();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionInfo.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionInfo.java
@@ -16,13 +16,12 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 
 public class VersionInfo implements Versioned {
     private final Version version;
 
-    public VersionInfo(String version) {
-        this.version = VersionParser.INSTANCE.transform(version);
+    public VersionInfo(Version version) {
+        this.version = version;
     }
 
     public Version getVersion() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionVersionSelector.java
@@ -17,12 +17,15 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
 public abstract class AbstractVersionVersionSelector extends AbstractVersionSelector {
-    protected AbstractVersionVersionSelector(String selector) {
+    protected final VersionParser versionParser;
+
+    protected AbstractVersionVersionSelector(VersionParser versionParser, String selector) {
         super(selector);
+        this.versionParser = versionParser;
     }
 
     @Override
     public boolean accept(String candidate) {
-        return accept(VersionParser.INSTANCE.transform(candidate));
+        return accept(versionParser.transform(candidate));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/CachingVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/CachingVersionSelectorScheme.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class CachingVersionSelectorScheme implements VersionSelectorScheme {
+    private final Map<String, VersionSelector> cachedSelectors = Maps.newConcurrentMap();
+    private final VersionSelectorScheme delegate;
+
+    public CachingVersionSelectorScheme(VersionSelectorScheme delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public VersionSelector parseSelector(String selectorString) {
+        VersionSelector versionSelector = cachedSelectors.get(selectorString);
+        if (versionSelector == null) {
+            versionSelector = delegate.parseSelector(selectorString);
+            cachedSelectors.put(selectorString, versionSelector);
+        }
+        return versionSelector;
+    }
+
+    @Override
+    public String renderSelector(VersionSelector selector) {
+        return delegate.renderSelector(selector);
+    }
+
+    @Override
+    public VersionSelector complementForRejection(VersionSelector selector) {
+        return delegate.complementForRejection(selector);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
@@ -18,14 +18,25 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
 public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
     private final VersionComparator versionComparator;
+    private final VersionParser versionParser;
 
+    /**
+     * This constructor is here to maintain backwards compatibility with the nebula plugins
+     * and should be removed as soon as possible.
+     */
+    @Deprecated
     public DefaultVersionSelectorScheme(VersionComparator versionComparator) {
+        this(versionComparator, new VersionParser());
+    }
+
+    public DefaultVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {
         this.versionComparator = versionComparator;
+        this.versionParser = versionParser;
     }
 
     public VersionSelector parseSelector(String selectorString) {
         if (VersionRangeSelector.ALL_RANGE.matcher(selectorString).matches()) {
-            return new VersionRangeSelector(selectorString, versionComparator.asVersionComparator());
+            return new VersionRangeSelector(selectorString, versionComparator.asVersionComparator(), versionParser);
         }
 
         if (selectorString.endsWith("+")) {
@@ -46,13 +57,13 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
     @Override
     public VersionSelector complementForRejection(VersionSelector selector) {
         if (selector instanceof ExactVersionSelector) {
-            return new VersionRangeSelector("]" + selector.getSelector() + ",)", versionComparator.asVersionComparator());
+            return new VersionRangeSelector("]" + selector.getSelector() + ",)", versionComparator.asVersionComparator(), versionParser);
         }
         if (selector instanceof VersionRangeSelector) {
             VersionRangeSelector vrs = (VersionRangeSelector) selector;
             if (vrs.getUpperBound() != null) {
                 String lowerBoundInclusion = vrs.isUpperInclusive() ? "]" : "[";
-                return new VersionRangeSelector(lowerBoundInclusion + vrs.getUpperBound() + ",)", versionComparator.asVersionComparator());
+                return new VersionRangeSelector(lowerBoundInclusion + vrs.getUpperBound() + ",)", versionComparator.asVersionComparator(), versionParser);
             }
         }
         throw new IllegalArgumentException("Version '" + renderSelector(selector) + "' cannot be converted to a strict version constraint.");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
@@ -16,20 +16,36 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
+import com.google.common.collect.Maps;
 import com.google.common.primitives.Longs;
 import org.gradle.api.Transformer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class VersionParser implements Transformer<Version, String> {
-    public static final VersionParser INSTANCE = new VersionParser();
+    private final Map<String, Version> cache = Maps.newConcurrentMap();
 
     public VersionParser() {
     }
 
     @Override
     public Version transform(String original) {
+        Version version = cache.get(original);
+        if (version != null) {
+            return version;
+        }
+        return parseAndCache(original);
+    }
+
+    private Version parseAndCache(String original) {
+        Version version = parse(original);
+        cache.put(original, version);
+        return version;
+    }
+
+    private Version parse(String original) {
         List<String> parts = new ArrayList<String>();
         boolean digit = false;
         int startPart = 0;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
@@ -107,8 +107,8 @@ public class VersionRangeSelector extends AbstractVersionVersionSelector {
     private final Version lowerBoundVersion;
     private final Comparator<Version> comparator;
 
-    public VersionRangeSelector(String selector, Comparator<Version> comparator) {
-        super(selector);
+    public VersionRangeSelector(String selector, Comparator<Version> comparator, VersionParser versionParser) {
+        super(versionParser, selector);
         this.comparator = comparator;
 
         Matcher matcher;
@@ -145,8 +145,8 @@ public class VersionRangeSelector extends AbstractVersionVersionSelector {
                 }
             }
         }
-        lowerBoundVersion = lowerBound == null ? null : VersionParser.INSTANCE.transform(lowerBound);
-        upperBoundVersion = upperBound == null ? null : VersionParser.INSTANCE.transform(upperBound);
+        lowerBoundVersion = lowerBound == null ? null : versionParser.transform(lowerBound);
+        upperBoundVersion = upperBound == null ? null : versionParser.transform(upperBound);
     }
 
     public boolean isDynamic() {
@@ -316,6 +316,6 @@ public class VersionRangeSelector extends AbstractVersionVersionSelector {
         if (lower != null && lower.equals(upper) && !lowerInc) {
             return null;
         }
-        return new VersionRangeSelector(sb.toString(), comparator);
+        return new VersionRangeSelector(sb.toString(), comparator, versionParser);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionSelector.java
@@ -18,6 +18,9 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
 
 import org.gradle.api.artifacts.ComponentMetadata;
 
+/**
+ * Implementations of version selector are expected to be immutable and thread-safe.
+ */
 public interface VersionSelector {
     /**
      * Indicates if the given version selector is dynamic.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
@@ -29,9 +29,11 @@ import java.util.Map;
 
 class LatestModuleConflictResolver implements ModuleConflictResolver {
     private final Comparator<Version> versionComparator;
+    private final VersionParser versionParser;
 
-    LatestModuleConflictResolver(VersionComparator versionComparator) {
+    LatestModuleConflictResolver(VersionComparator versionComparator, VersionParser versionParser) {
         this.versionComparator = versionComparator.asVersionComparator();
+        this.versionParser = versionParser;
     }
 
     @Override
@@ -40,7 +42,7 @@ class LatestModuleConflictResolver implements ModuleConflictResolver {
         Version baseVersion = null;
         Map<Version, T> matches = new LinkedHashMap<Version, T>();
         for (T candidate : details.getCandidates()) {
-            Version version = VersionParser.INSTANCE.transform(candidate.getVersion());
+            Version version = versionParser.transform(candidate.getVersion());
             if (baseVersion == null || versionComparator.compare(version.getBaseVersion(), baseVersion) > 0) {
                 matches.clear();
                 baseVersion = version.getBaseVersion();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
@@ -74,6 +75,7 @@ public class DependencyGraphBuilder {
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
     private final ImmutableAttributesFactory attributesFactory;
     private final CapabilitiesConflictHandler capabilitiesConflictHandler;
+    private final VersionSelectorScheme versionSelectorScheme;
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
@@ -84,7 +86,7 @@ public class DependencyGraphBuilder {
                                   ModuleExclusions moduleExclusions,
                                   BuildOperationExecutor buildOperationExecutor, ModuleReplacementsData moduleReplacementsData,
                                   DependencySubstitutionApplicator dependencySubstitutionApplicator, ComponentSelectorConverter componentSelectorConverter,
-                                  ImmutableAttributesFactory attributesFactory) {
+                                  ImmutableAttributesFactory attributesFactory, VersionSelectorScheme versionSelectorScheme) {
         this.idResolver = componentIdResolver;
         this.metaDataResolver = componentMetaDataResolver;
         this.moduleResolver = resolveContextToComponentResolver;
@@ -98,6 +100,7 @@ public class DependencyGraphBuilder {
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributesFactory = attributesFactory;
         this.capabilitiesConflictHandler = capabilitiesConflictHandler;
+        this.versionSelectorScheme = versionSelectorScheme;
     }
 
     public void resolve(final ResolveContext resolveContext, final DependencyGraphVisitor modelVisitor) {
@@ -106,7 +109,7 @@ public class DependencyGraphBuilder {
         DefaultBuildableComponentResolveResult rootModule = new DefaultBuildableComponentResolveResult();
         moduleResolver.resolve(resolveContext, rootModule);
 
-        final ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleExclusions, moduleReplacementsData, componentSelectorConverter, attributesFactory, dependencySubstitutionApplicator);
+        final ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleExclusions, moduleReplacementsData, componentSelectorConverter, attributesFactory, dependencySubstitutionApplicator, versionSelectorScheme);
 
         traverseGraph(resolveState);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ComponentStateFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -68,12 +69,13 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     private final ImmutableAttributesFactory attributesFactory;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
     private final VariantNameBuilder variantNameBuilder = new VariantNameBuilder();
+    private final VersionSelectorScheme versionSelectorScheme;
 
     public ResolveState(IdGenerator<Long> idGenerator, ComponentResolveResult rootResult, String rootConfigurationName, DependencyToComponentIdResolver idResolver,
                         ComponentMetaDataResolver metaDataResolver, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema,
                         ModuleExclusions moduleExclusions, ModuleReplacementsData moduleReplacementsData,
                         ComponentSelectorConverter componentSelectorConverter, ImmutableAttributesFactory attributesFactory,
-                        DependencySubstitutionApplicator dependencySubstitutionApplicator) {
+                        DependencySubstitutionApplicator dependencySubstitutionApplicator, VersionSelectorScheme versionSelectorScheme) {
         this.idGenerator = idGenerator;
         this.idResolver = idResolver;
         this.metaDataResolver = metaDataResolver;
@@ -84,6 +86,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributesFactory = attributesFactory;
         this.dependencySubstitutionApplicator = dependencySubstitutionApplicator;
+        this.versionSelectorScheme = versionSelectorScheme;
         ComponentState rootVersion = getRevision(rootResult.getId(), rootResult.getModuleVersionId(), rootResult.getMetadata());
         final ResolvedConfigurationIdentifier id = new ResolvedConfigurationIdentifier(rootVersion.getId(), rootConfigurationName);
         ConfigurationMetadata configurationMetadata = rootVersion.getMetadata().getConfiguration(id.getConfiguration());
@@ -146,7 +149,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         ComponentSelector requested = dependencyState.getRequested();
         SelectorState resolveState = selectors.get(requested);
         if (resolveState == null) {
-            resolveState = new SelectorState(idGenerator.generateId(), dependencyState, idResolver, this, moduleIdentifier);
+            resolveState = new SelectorState(idGenerator.generateId(), dependencyState, idResolver, versionSelectorScheme, this, moduleIdentifier);
             selectors.put(requested, resolveState);
         }
         return resolveState;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -21,8 +21,6 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
@@ -51,24 +49,24 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
  *    In this case {@link #resolved} will be `true` and {@link ModuleResolveState#selected} will point to the selected component.
  */
 class SelectorState implements DependencyGraphSelector, ResolvableSelectorState {
-    // TODO:DAZ Should inject this
-    private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(new DefaultVersionComparator());
     private final Long id;
     private final DependencyState dependencyState;
     private final DependencyMetadata dependencyMetadata;
     private final DependencyToComponentIdResolver resolver;
     private final ResolvedVersionConstraint versionConstraint;
+    private final VersionSelectorScheme versionSelectorScheme;
 
     private ComponentIdResolveResult idResolveResult;
     private ModuleVersionResolveException failure;
     private ModuleResolveState targetModule;
     private boolean resolved;
 
-    SelectorState(Long id, DependencyState dependencyState, DependencyToComponentIdResolver resolver, ResolveState resolveState, ModuleIdentifier targetModuleId) {
+    SelectorState(Long id, DependencyState dependencyState, DependencyToComponentIdResolver resolver, VersionSelectorScheme versionSelectorScheme, ResolveState resolveState, ModuleIdentifier targetModuleId) {
         this.id = id;
         this.dependencyState = dependencyState;
         this.dependencyMetadata = dependencyState.getDependency();
         this.resolver = resolver;
+        this.versionSelectorScheme = versionSelectorScheme;
         this.targetModule = resolveState.getModule(targetModuleId);
         this.versionConstraint = resolveVersionConstraint(dependencyMetadata.getSelector());
         targetModule.addSelector(this);
@@ -76,7 +74,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     private ResolvedVersionConstraint resolveVersionConstraint(ComponentSelector selector) {
         if (selector instanceof ModuleComponentSelector) {
-            return new DefaultResolvedVersionConstraint(((ModuleComponentSelector) selector).getVersionConstraint(), VERSION_SELECTOR_SCHEME);
+            return new DefaultResolvedVersionConstraint(((ModuleComponentSelector) selector).getVersionConstraint(), versionSelectorScheme);
         }
         return null;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -73,8 +73,9 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
     private final NestedBuildFactory nestedBuildFactory;
     private final File baseWorkingDir;
     private final Map<String, VersionRef> selectedVersionCache = new HashMap<String, VersionRef>();
+    private final VersionParser versionParser;
 
-    public VcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, NestedBuildFactory nestedBuildFactory) {
+    public VcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, NestedBuildFactory nestedBuildFactory, VersionParser versionParser) {
         this.baseWorkingDir = vcsWorkingDirRoot.getDir();
         this.projectDependencyResolver = projectDependencyResolver;
         this.localComponentRegistry = localComponentRegistry;
@@ -84,6 +85,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
         this.versionComparator = versionComparator;
         this.buildRegistry = buildRegistry;
         this.nestedBuildFactory = nestedBuildFactory;
+        this.versionParser = versionParser;
     }
 
     @Override
@@ -172,7 +174,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
         Version bestVersion = null;
         VersionRef bestCandidate = null;
         for (VersionRef candidate : versions) {
-            Version candidateVersion = VersionParser.INSTANCE.transform(candidate.getVersion());
+            Version candidateVersion = versionParser.transform(candidate.getVersion());
             if (versionSelector.accept(candidateVersion)) {
                 if (bestCandidate == null || versionComparator.asVersionComparator().compare(candidateVersion, bestVersion) > 0) {
                     bestVersion = candidateVersion;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -34,11 +34,12 @@ import org.gradle.internal.rules.SpecRuleAction
 import spock.lang.Specification
 
 class DefaultVersionedComponentChooserTest extends Specification {
-    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    def versionParser = new VersionParser()
+    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
     def versionComparator = new DefaultVersionComparator()
     def componentSelectionRules = Mock(ComponentSelectionRulesInternal)
 
-    def chooser = new DefaultVersionedComponentChooser(versionComparator, componentSelectionRules)
+    def chooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules)
 
     def "chooses latest version for component meta data"() {
         def one = Stub(ComponentResolveMetadata) {
@@ -333,6 +334,6 @@ class DefaultVersionedComponentChooserTest extends Specification {
     }
 
     def version(String version) {
-        return VersionParser.INSTANCE.transform(version)
+        return versionParser.transform(version)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataCache
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCacheProvider
@@ -55,6 +56,7 @@ class ResolveIvyFactoryTest extends Specification {
     VersionComparator versionComparator
     ImmutableModuleIdentifierFactory moduleIdentifierFactory
     RepositoryBlacklister repositoryBlacklister
+    VersionParser versionParser
 
     def setup() {
         moduleVersionsCache = Mock(ModuleVersionsCache)
@@ -71,9 +73,10 @@ class ResolveIvyFactoryTest extends Specification {
         versionSelectorScheme = Mock(VersionSelectorScheme)
         versionComparator = Mock(VersionComparator)
         repositoryBlacklister = Mock(RepositoryBlacklister)
+        versionParser = new VersionParser()
 
         resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, buildCommencedTimeProvider,
-            versionSelectorScheme, versionComparator, moduleIdentifierFactory, repositoryBlacklister)
+            versionSelectorScheme, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser)
     }
 
     def "returns an empty resolver when no repositories are configured" () {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -23,7 +23,9 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -44,7 +46,7 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     final FileResourceRepository fileRepository = TestFiles.fileRepository()
-    final GradlePomModuleDescriptorParser parser = new GradlePomModuleDescriptorParser(new DefaultVersionSelectorScheme(), moduleIdentifierFactory, fileRepository, mavenMetadataFactory)
+    final GradlePomModuleDescriptorParser parser = new GradlePomModuleDescriptorParser(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser()), moduleIdentifierFactory, fileRepository, mavenMetadataFactory)
     final parseContext = Mock(DescriptorParseContext)
     TestFile pomFile
     MutableMavenModuleResolveMetadata metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -19,10 +19,11 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.VersionInfo
 import spock.lang.Specification
 
 class DefaultVersionComparatorTest extends Specification {
+    def versionParser = new VersionParser()
     def comparator = new DefaultVersionComparator()
 
     def compare(String s1, String s2) {
-        return comparator.compare(new VersionInfo(s1), new VersionInfo(s2))
+        return comparator.compare(new VersionInfo(versionParser.transform(s1)), new VersionInfo(versionParser.transform(s2)))
     }
 
     def "compares versions numerically when parts are digits"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
@@ -20,7 +20,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class DefaultVersionSelectorSchemeTest extends Specification {
-    def matcher = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    def matcher = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser())
 
     def "creates version range selector"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/MavenVersionSelectorSchemeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/MavenVersionSelectorSchemeTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 import spock.lang.Specification
 
 class MavenVersionSelectorSchemeTest extends Specification {
-    def defaultMatcher = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    def defaultMatcher = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser())
     def mapper = new MavenVersionSelectorScheme(defaultMatcher)
 
     def "translates to maven syntax"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/UnionVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/UnionVersionSelectorTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class UnionVersionSelectorTest extends Specification {
-    private final VersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    private final VersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser())
     private final VersionParser parser = new VersionParser()
     private final List<VersionSelector> members = []
     private final UnionVersionSelector union = new UnionVersionSelector(members)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParserTest.groovy
@@ -17,10 +17,15 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 
 import spock.lang.Specification
+import spock.lang.Subject
 
 import static org.gradle.util.Matchers.strictlyEqual
 
 class VersionParserTest extends Specification {
+
+    @Subject
+    VersionParser versionParser = new VersionParser()
+
     def "parsed version is equal when source string is equal"() {
         def v = parse("1.2.b")
         def equal = parse("1.2.b")
@@ -116,6 +121,6 @@ class VersionParserTest extends Specification {
     }
 
     def parse(String v) {
-        return VersionParser.INSTANCE.transform(v)
+        return versionParser.transform(v)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorIntersectionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorIntersectionTest.groovy
@@ -20,6 +20,7 @@ import spock.lang.Unroll
 
 class VersionRangeSelectorIntersectionTest extends Specification {
     def comparator = new DefaultVersionComparator().asVersionComparator()
+    def versionParser = new VersionParser()
 
     @Unroll
     def "intersects ranges #first and #second"() {
@@ -80,6 +81,6 @@ class VersionRangeSelectorIntersectionTest extends Specification {
 
 
     private VersionRangeSelector range(String str) {
-        new VersionRangeSelector(str, comparator)
+        new VersionRangeSelector(str, comparator, versionParser)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelectorTest.groovy
@@ -163,6 +163,6 @@ public class VersionRangeSelectorTest extends AbstractStringVersionSelectorTest 
 
     @Override
     VersionSelector getSelector(String selector) {
-        return new VersionRangeSelector(selector, new DefaultVersionComparator().asVersionComparator())
+        return new VersionRangeSelector(selector, new DefaultVersionComparator().asVersionComparator(), new VersionParser())
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -25,8 +25,10 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleD
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyXmlModuleDescriptorParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -154,7 +156,7 @@ class ModuleMetadataSerializerTest extends Specification {
 
     private GradlePomModuleDescriptorParser pomParser() {
         new GradlePomModuleDescriptorParser(
-            new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme()),
+            new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser())),
             moduleIdentifierFactory,
             Stub(FileResourceRepository),
             mavenMetadataFactory

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -30,6 +30,8 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphPathResolver
@@ -107,6 +109,7 @@ class DependencyGraphBuilderTest extends Specification {
 
     def moduleConflictHandler = new DefaultConflictHandler(conflictResolver, moduleReplacements)
     def capabilitiesConflictHandler = new DefaultCapabilitiesConflictHandler()
+    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
 
     DependencyGraphBuilder builder
 
@@ -115,7 +118,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme)
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -566,7 +569,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme)
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolverTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import spock.lang.Unroll
 
 class LatestModuleConflictResolverTest extends AbstractConflictResolverTest {
 
     def setup() {
-        resolver = new LatestModuleConflictResolver(new DefaultVersionComparator())
+        resolver = new LatestModuleConflictResolver(new DefaultVersionComparator(), new VersionParser())
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -202,7 +202,7 @@ class SelectorStateResolverTest extends Specification {
 
         private static class ComponentVersionComparator implements Comparator<ComponentResolutionState> {
             private final Comparator<Version> versionComparator = new DefaultVersionComparator().asVersionComparator()
-            private final VersionParser versionParser = VersionParser.INSTANCE
+            private final VersionParser versionParser = new VersionParser()
 
             @Override
             int compare(ComponentResolutionState one, ComponentResolutionState two) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestSelectorState.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
@@ -29,8 +30,9 @@ import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResu
 
 public class TestSelectorState implements ResolvableSelectorState {
 
+    private static final VersionParser VERSION_PARSER = new VersionParser();
     private static final DefaultVersionComparator VERSION_COMPARATOR = new DefaultVersionComparator();
-    private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR);
+    private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR, VERSION_PARSER);
 
     private final DependencyToComponentIdResolver resolver;
     private ResolvedVersionConstraint versionConstraint;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector
@@ -32,7 +33,8 @@ import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
 class ComponentSelectorSerializerTest extends SerializerSpec {
-    private final DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    private final VersionParser versionParser = new VersionParser()
+    private final DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
     private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     private ImmutableVersionConstraint constraint(String version, boolean strict = false) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -24,6 +24,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.reporting.Reporting;
@@ -115,6 +116,11 @@ public class HtmlDependencyReportTask extends ConventionTask implements Reportin
         throw new UnsupportedOperationException();
     }
 
+    @Inject
+    protected  VersionParser getVersionParser() {
+        throw new UnsupportedOperationException();
+    }
+
     @TaskAction
     public void generate() {
         if (!reports.getHtml().isEnabled()) {
@@ -122,7 +128,7 @@ public class HtmlDependencyReportTask extends ConventionTask implements Reportin
             return;
         }
 
-        HtmlDependencyReporter reporter = new HtmlDependencyReporter(getVersionSelectorScheme(), getVersionComparator());
+        HtmlDependencyReporter reporter = new HtmlDependencyReporter(getVersionSelectorScheme(), getVersionComparator(), getVersionParser());
         reporter.render(getProjects(), reports.getHtml().getDestination());
 
         getProject().getLogger().lifecycle("See the report at: {}", new ConsoleRenderer().asClickableFileUrl(reports.getHtml().getEntryPoint()));

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/HtmlDependencyReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/HtmlDependencyReporter.java
@@ -19,6 +19,7 @@ package org.gradle.api.reporting.dependencies.internal;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.reporting.HtmlReportBuilder;
 import org.gradle.reporting.HtmlReportRenderer;
@@ -46,8 +47,8 @@ public class HtmlDependencyReporter extends ReportRenderer<Set<Project>, File> {
     private File outputDirectory;
     private final JsonProjectDependencyRenderer renderer;
 
-    public HtmlDependencyReporter(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
-        renderer = new JsonProjectDependencyRenderer(versionSelectorScheme, versionComparator);
+    public HtmlDependencyReporter(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser) {
+        renderer = new JsonProjectDependencyRenderer(versionSelectorScheme, versionComparator, versionParser);
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
@@ -110,9 +111,10 @@ import java.util.Set;
  * </pre>
  */
 public class JsonProjectDependencyRenderer {
-    public JsonProjectDependencyRenderer(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
+    public JsonProjectDependencyRenderer(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser) {
         this.versionSelectorScheme = versionSelectorScheme;
         this.versionComparator = versionComparator;
+        this.versionParser = versionParser;
     }
 
     /**
@@ -262,7 +264,7 @@ public class JsonProjectDependencyRenderer {
             }
         });
 
-        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter().prepare(selectedDependencies, versionSelectorScheme, versionComparator);
+        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter().prepare(selectedDependencies, versionSelectorScheme, versionComparator, versionParser);
         return CollectionUtils.collect(sortedDeps, new Transformer<Object, RenderableDependency>() {
             @Override
             public Object transform(RenderableDependency dependency) {
@@ -311,4 +313,5 @@ public class JsonProjectDependencyRenderer {
 
     private final VersionSelectorScheme versionSelectorScheme;
     private final VersionComparator versionComparator;
+    private final VersionParser versionParser;
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
@@ -52,7 +53,11 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Description;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Failure;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Identifier;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Info;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.UserInput;
 
 /**
  * Generates a report that attempts to answer questions like:
@@ -160,6 +165,11 @@ public class DependencyInsightReportTask extends DefaultTask {
         throw new UnsupportedOperationException();
     }
 
+    @Inject
+    protected VersionParser getVersionParser() {
+        throw new UnsupportedOperationException();
+    }
+
     @TaskAction
     public void report() {
         final Configuration configuration = getConfiguration();
@@ -194,7 +204,7 @@ public class DependencyInsightReportTask extends DefaultTask {
             return;
         }
 
-        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter().prepare(selectedDependencies, getVersionSelectorScheme(), getVersionComparator());
+        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter().prepare(selectedDependencies, getVersionSelectorScheme(), getVersionComparator(), getVersionParser());
 
         NodeRenderer nodeRenderer = new NodeRenderer() {
             public void renderNode(StyledTextOutput target, RenderableDependency node, boolean alreadyRendered) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyEdge;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyReportHeader;
@@ -41,7 +42,7 @@ import static org.gradle.api.tasks.diagnostics.internal.graph.nodes.SelectionRea
 
 public class DependencyInsightReporter {
 
-    public Collection<RenderableDependency> prepare(Collection<DependencyResult> input, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator) {
+    public Collection<RenderableDependency> prepare(Collection<DependencyResult> input, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser) {
         LinkedList<RenderableDependency> out = new LinkedList<RenderableDependency>();
         List<DependencyEdge> dependencies = CollectionUtils.collect(input, new Transformer<DependencyEdge, DependencyResult>() {
             @Override
@@ -53,7 +54,7 @@ public class DependencyInsightReporter {
                 }
             }
         });
-        Collection<DependencyEdge> sorted = DependencyResultSorter.sort(dependencies, versionSelectorScheme, versionComparator);
+        Collection<DependencyEdge> sorted = DependencyResultSorter.sort(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         //remember if module id was annotated
         HashSet<ComponentIdentifier> annotated = new HashSet<ComponentIdentifier>();

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult
 import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult
@@ -34,14 +35,15 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.FORCED
 
 class DependencyInsightReporterSpec extends Specification {
-    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    def versionParser = new VersionParser()
+    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
     def versionComparator = new DefaultVersionComparator()
 
     def "sorts dependencies"() {
         def dependencies = [dep("a", "x", "1.0", "2.0"), dep("a", "x", "1.5", "2.0"), dep("b", "a", "5.0"), dep("a", "z", "1.0"), dep("a", "x", "2.0")]
 
         when:
-        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator);
+        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
         sorted.size() == 5
@@ -66,7 +68,7 @@ class DependencyInsightReporterSpec extends Specification {
         def dependencies = [dep("a", "x", "1.0", "2.0", forced()), dep("a", "x", "1.5", "2.0", forced()), dep("b", "a", "5.0")]
 
         when:
-        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator);
+        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
         sorted.size() == 4
@@ -88,7 +90,7 @@ class DependencyInsightReporterSpec extends Specification {
         def dependencies = [dep("a", "x", "1.0", "2.0", conflict()), dep("a", "x", "2.0", "2.0", conflict()), dep("b", "a", "5.0", "5.0", forced())]
 
         when:
-        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator);
+        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
         sorted.size() == 3

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorterSpec.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyEdge
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -32,7 +33,8 @@ import spock.lang.Unroll
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 
 class DependencyResultSorterSpec extends Specification {
-    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    def versionParser = new VersionParser()
+    def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
     def versionComparator = new DefaultVersionComparator()
 
     static VersionConstraint v(String version) {
@@ -42,7 +44,7 @@ class DependencyResultSorterSpec extends Specification {
     @Unroll
     def "throws exception if dependencyt or requested component selector is null (#d1, #d2)"() {
         when:
-        DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         Throwable t = thrown(IllegalArgumentException)
@@ -62,7 +64,7 @@ class DependencyResultSorterSpec extends Specification {
         def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2]
@@ -73,7 +75,7 @@ class DependencyResultSorterSpec extends Specification {
         def d2 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d2, d1]
@@ -92,7 +94,7 @@ class DependencyResultSorterSpec extends Specification {
         def d7 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "zzzz", v("2.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d5, d3, d6, d1, d2, d7, d4], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d5, d3, d6, d1, d2, d7, d4], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2, d3, d4, d5, d6, d7]
@@ -106,7 +108,7 @@ class DependencyResultSorterSpec extends Specification {
         def d5 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("3.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.2"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d3, d1, d5, d2, d4], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d3, d1, d5, d2, d4], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2, d3, d4, d5]
@@ -123,7 +125,7 @@ class DependencyResultSorterSpec extends Specification {
         def d8 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("2")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d4, d7, d1, d6, d8, d5, d3, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d4, d7, d1, d6, d8, d5, d3, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2, d3, d4, d5, d6, d7, d8]
@@ -141,7 +143,7 @@ class DependencyResultSorterSpec extends Specification {
         def d9 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("latest.zzz")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d4, d7, d1, d6, d8, d5, d3, d9, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d4, d7, d1, d6, d8, d5, d3, d9, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2, d3, d4, d5, d6, d7, d8, d9]
@@ -158,7 +160,7 @@ class DependencyResultSorterSpec extends Specification {
         def d8 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "other", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "other", "1.0"), DefaultModuleComponentIdentifier.newId("org.b", "a", "0.9.1"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d7, d8, d1, d3, d5, d2, d4, d6], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d7, d8, d1, d3, d5, d2, d4, d6], versionSelectorScheme, versionComparator, versionParser)
 
 
         then:
@@ -178,7 +180,7 @@ class DependencyResultSorterSpec extends Specification {
         def d7 = newDependency(TestComponentIdentifiers.newSelector(":project5"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d5, d3, d6, d1, d2, d7, d4], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d5, d3, d6, d1, d2, d7, d4], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2, d3, d4, d5, d6, d7]
@@ -189,7 +191,7 @@ class DependencyResultSorterSpec extends Specification {
         def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d2, d1]
@@ -200,7 +202,7 @@ class DependencyResultSorterSpec extends Specification {
         def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d2, d1]
@@ -211,7 +213,7 @@ class DependencyResultSorterSpec extends Specification {
         def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d1, d2]
@@ -222,7 +224,7 @@ class DependencyResultSorterSpec extends Specification {
         def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
 
         when:
-        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator)
+        def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
 
         then:
         sorted == [d2, d1]

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -12,6 +12,16 @@
             "type": "org.gradle.nativeplatform.OperatingSystemFamily",
             "member": "Constructor org.gradle.nativeplatform.OperatingSystemFamily()",
             "acceptation": "OperatingSystemFamily is now an abstract class"
+        },
+        {
+            "type": "org.gradle.api.reporting.dependencies.HtmlDependencyReportTask",
+            "member": "Method org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.getVersionParser()",
+            "acceptation": "Injected service"
+        },
+        {
+            "type": "org.gradle.api.tasks.diagnostics.DependencyInsightReportTask",
+            "member": "Method org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.getVersionParser()",
+            "acceptation": "Injected service"
         }
     ]
 }

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -78,12 +78,14 @@ public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
     private final VcsResolver vcsResolver;
     private final VersionSelectorScheme versionSelectorScheme;
     private final ProjectDependencyPublicationResolver publicationResolver;
+    private final VersionParser versionParser;
 
     @Inject
-    public SwiftPackageManagerExportPlugin(VcsResolver vcsResolver, VersionSelectorScheme versionSelectorScheme, ProjectDependencyPublicationResolver publicationResolver) {
+    public SwiftPackageManagerExportPlugin(VcsResolver vcsResolver, VersionSelectorScheme versionSelectorScheme, ProjectDependencyPublicationResolver publicationResolver, VersionParser versionParser) {
         this.vcsResolver = vcsResolver;
         this.versionSelectorScheme = versionSelectorScheme;
         this.publicationResolver = publicationResolver;
+        this.versionParser = versionParser;
     }
 
     @Override
@@ -247,7 +249,7 @@ public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
                 // TODO - take care of this in the selector parser
                 if (prefix.endsWith(".")) {
                     String versionString = prefix.substring(0, prefix.length() - 1);
-                    Version version = VersionParser.INSTANCE.transform(versionString);
+                    Version version = versionParser.transform(versionString);
                     if (version.getNumericParts().length == 1) {
                         Long part1 = version.getNumericParts()[0];
                         return new VersionDependency(gitSpec.getUrl(), part1 + ".0.0");

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.plugin.use.resolve.internal
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.plugin.management.internal.DefaultPluginRequest
@@ -30,7 +32,7 @@ import spock.lang.Specification
 import static org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver.SOURCE_NAME
 
 class ArtifactRepositoriesPluginResolverTest extends Specification {
-    def versionSelectorScheme = new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme())
+    def versionSelectorScheme = new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser()))
     def repository = Mock(ArtifactRepositoryInternal) {
         getDisplayName() >> "maven(url)"
     }


### PR DESCRIPTION
### Context

The version parser is the largest contributor to garbage created during the
resolution of a large dependency graph. This commit creates a build scope version
parser which is shared and caches the result of parsing, avoiding the creation of
a significant number of arrays.
