### PR TITLE
Mitigate dependency management performance regressions

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -19,6 +19,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
@@ -120,11 +121,11 @@ public abstract class CollectionUtils {
     }
 
     public static <T> List<T> filter(List<? extends T> list, Spec<? super T> filter) {
-        return filter(list, new LinkedList<T>(), filter);
+        return filter(list, Lists.<T>newArrayListWithCapacity(list.size()), filter);
     }
 
     public static <T> List<T> filter(T[] array, Spec<? super T> filter) {
-        return filter(Arrays.asList(array), new LinkedList<T>(), filter);
+        return filter(Arrays.asList(array), Lists.<T>newArrayListWithCapacity(array.length), filter);
     }
 
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
@@ -31,8 +31,6 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
         assert version != null : "version cannot be null";
         this.id = DefaultModuleIdentifier.newId(group, name);
         this.version = version;
-        // pre-compule the hashcode as it's going to be used anyway, and this object
-        // is used as a key in several hash maps
         this.hashCode = 31 * id.hashCode() ^ version.hashCode();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
@@ -23,6 +23,7 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
 
     private final ModuleIdentifier id;
     private final String version;
+    private final int hashCode;
 
     public DefaultModuleVersionIdentifier(String group, String name, String version) {
         assert group != null : "group cannot be null";
@@ -30,12 +31,18 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
         assert version != null : "version cannot be null";
         this.id = DefaultModuleIdentifier.newId(group, name);
         this.version = version;
+        // pre-compule the hashcode as it's going to be used anyway, and this object
+        // is used as a key in several hash maps
+        this.hashCode = 31 * id.hashCode() ^ version.hashCode();
     }
 
     public DefaultModuleVersionIdentifier(ModuleIdentifier id, String version) {
         assert version != null : "version cannot be null";
         this.id = id;
         this.version = version;
+        // pre-compule the hashcode as it's going to be used anyway, and this object
+        // is used as a key in several hash maps
+        this.hashCode = 31 * id.hashCode() ^ version.hashCode();
     }
 
     public String getGroup() {
@@ -77,7 +84,7 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
 
     @Override
     public int hashCode() {
-        return 31 * id.hashCode() ^ version.hashCode();
+        return hashCode;
     }
 
     public ModuleIdentifier getModule() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -30,6 +30,8 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
     @Nullable
     private final String requiredBranch;
 
+    private final int hashCode;
+
     public DefaultImmutableVersionConstraint(String preferredVersion,
                                              List<String> rejectedVersions) {
         this(preferredVersion, rejectedVersions, null);
@@ -53,6 +55,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         this.preferredVersion = preferredVersion;
         this.rejectedVersions = ImmutableList.copyOf(rejectedVersions);
         this.requiredBranch = requiredBranch;
+        this.hashCode = super.hashCode();
     }
 
     public DefaultImmutableVersionConstraint(String preferredVersion) {
@@ -62,6 +65,12 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         this.preferredVersion = preferredVersion;
         this.rejectedVersions = ImmutableList.of();
         this.requiredBranch = null;
+        this.hashCode = super.hashCode();
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -53,6 +53,7 @@ class EdgeState implements DependencyGraphEdge {
     private final ResolveState resolveState;
     private final ModuleExclusion transitiveExclusions;
     private final List<NodeState> targetNodes = Lists.newLinkedList();
+    private final boolean isTransitive;
 
     private ModuleVersionResolveException targetNodeSelectionFailure;
 
@@ -64,6 +65,7 @@ class EdgeState implements DependencyGraphEdge {
         this.transitiveExclusions = transitiveExclusions;
         this.resolveState = resolveState;
         this.selector = resolveState.getSelector(dependencyState, dependencyState.getModuleIdentifier());
+        this.isTransitive = from.isTransitive() && dependencyMetadata.isTransitive();
     }
 
     @Override
@@ -98,7 +100,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     public boolean isTransitive() {
-        return from.isTransitive() && dependencyMetadata.isTransitive();
+        return isTransitive;
     }
 
     public void attachToTargetConfigurations() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -55,8 +55,8 @@ class NodeState implements DependencyGraphNode {
 
     private final Long resultId;
     private final ComponentState component;
-    private final List<EdgeState> incomingEdges = Lists.newLinkedList();
-    private final List<EdgeState> outgoingEdges = Lists.newLinkedList();
+    private final List<EdgeState> incomingEdges = Lists.newArrayList();
+    private final List<EdgeState> outgoingEdges = Lists.newArrayList();
     private final ResolvedConfigurationIdentifier id;
 
     private final ConfigurationMetadata metaData;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -61,6 +61,7 @@ class NodeState implements DependencyGraphNode {
 
     private final ConfigurationMetadata metaData;
     private final ResolveState resolveState;
+    private final boolean isTransitive;
     private ModuleExclusion previousTraversalExclusions;
 
     NodeState(Long resultId, ResolvedConfigurationIdentifier id, ComponentState component, ResolveState resolveState, ConfigurationMetadata md) {
@@ -69,6 +70,7 @@ class NodeState implements DependencyGraphNode {
         this.component = component;
         this.resolveState = resolveState;
         this.metaData = md;
+        this.isTransitive = metaData.isTransitive();
         component.addConfiguration(this);
     }
 
@@ -130,7 +132,7 @@ class NodeState implements DependencyGraphNode {
     }
 
     public boolean isTransitive() {
-        return metaData.isTransitive();
+        return isTransitive;
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifier.java
@@ -23,15 +23,18 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentIdenti
  */
 public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleComponentIdentifier {
     private final String timestamp;
+    private final int hashCode;
 
     public MavenUniqueSnapshotComponentIdentifier(String group, String module, String version, String timestamp) {
         super(group, module, version);
         this.timestamp = timestamp;
+        this.hashCode = super.hashCode() + timestamp.hashCode();
     }
 
     public MavenUniqueSnapshotComponentIdentifier(ModuleComponentIdentifier baseIdentifier, String timestamp) {
         super(baseIdentifier.getGroup(), baseIdentifier.getModule(), baseIdentifier.getVersion());
         this.timestamp = timestamp;
+        this.hashCode = super.hashCode() + timestamp.hashCode();
     }
 
     @Override
@@ -41,7 +44,7 @@ public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleCompone
 
     @Override
     public int hashCode() {
-        return super.hashCode() + timestamp.hashCode();
+        return hashCode;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -44,6 +44,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private final ModuleComponentIdentifier componentId;
     private final ExternalDependencyDescriptor dependencyDescriptor;
     private final String reason;
+    private final boolean isTransitive;
 
     private boolean alwaysUseAttributeMatching;
 
@@ -52,6 +53,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         this.componentId = componentId;
         this.dependencyDescriptor = dependencyDescriptor;
         this.reason = reason;
+        this.isTransitive = dependencyDescriptor.isTransitive();
     }
 
     public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {
@@ -144,7 +146,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
 
     @Override
     public boolean isTransitive() {
-        return dependencyDescriptor.isTransitive();
+        return isTransitive;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.external.model;
 
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.DisplayName;
@@ -23,6 +24,7 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
     private final String group;
     private final String module;
     private final String version;
+    private final int hashCode;
 
     public DefaultModuleComponentIdentifier(String group, String module, String version) {
         assert group != null : "group cannot be null";
@@ -31,6 +33,9 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
         this.group = group;
         this.module = module;
         this.version = version;
+        // Cache hashcode because it's being used several times, in particular
+        // in in-memory component metadata cache
+        this.hashCode = Objects.hashCode(version, module, group);
     }
 
     public String getDisplayName() {
@@ -86,10 +91,7 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
 
     @Override
     public int hashCode() {
-        int result = group.hashCode();
-        result = 31 * result + module.hashCode();
-        result = 31 * result + version.hashCode();
-        return result;
+        return hashCode;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
@@ -33,8 +33,8 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
         this.group = group;
         this.module = module;
         this.version = version;
-        // Cache hashcode because it's being used several times, in particular
-        // in in-memory component metadata cache
+        // Do NOT change the order of members used in hash code here, it's been empirically
+        // tested to reduce the number of collisions on a large dependency graph (performance test)
         this.hashCode = Objects.hashCode(version, module, group);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -43,10 +43,8 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         this.module = module;
         this.versionConstraint = version;
         this.attributes = attributes;
-        // Pre-compute the hashcode for this selector as it's going to be used anyway
-        // and computed several times because it's used as a key in a hash map
-        // see CachingDependencySubstitutionApplicator
-        // order of members here matter and tries to reduce collisions
+        // Do NOT change the order of members used in hash code here, it's been empirically
+        // tested to reduce the number of collisions on a large dependency graph (performance test)
         this.hashCode = Objects.hashCode(version, module, attributes, group);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.external.model;
 
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -31,6 +32,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     private final String module;
     private final ImmutableVersionConstraint versionConstraint;
     private final ImmutableAttributes attributes;
+    private final int hashCode;
 
     private DefaultModuleComponentSelector(String group, String module, ImmutableVersionConstraint version, ImmutableAttributes attributes) {
         assert group != null : "group cannot be null";
@@ -41,6 +43,11 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         this.module = module;
         this.versionConstraint = version;
         this.attributes = attributes;
+        // Pre-compute the hashcode for this selector as it's going to be used anyway
+        // and computed several times because it's used as a key in a hash map
+        // see CachingDependencySubstitutionApplicator
+        // order of members here matter and tries to reduce collisions
+        this.hashCode = Objects.hashCode(version, module, attributes, group);
     }
 
     public String getDisplayName() {
@@ -124,11 +131,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
 
     @Override
     public int hashCode() {
-        int result = group.hashCode();
-        result = 31 * result + module.hashCode();
-        result = 31 * result + versionConstraint.hashCode();
-        result = 31 * result + attributes.hashCode();
-        return result;
+        return hashCode;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -30,7 +30,8 @@ public class ImmutableCapability implements CapabilityInternal {
         this.name = name;
         this.version = version;
 
-        // Pre-compute and cache hashCode, which is going to be computed in any case
+        // Do NOT change the order of members used in hash code here, it's been empirically
+        // tested to reduce the number of collisions on a large dependency graph (performance test)
         this.hashCode = Objects.hashCode(version, name, group);
 
         // Using a string instead of a plain ID here might look strange, but this turned out to be

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -31,7 +31,7 @@ public class ImmutableCapability implements CapabilityInternal {
         this.version = version;
 
         // Pre-compute and cache hashCode, which is going to be computed in any case
-        this.hashCode = Objects.hashCode(group, name, version);
+        this.hashCode = Objects.hashCode(version, name, group);
 
         // Using a string instead of a plain ID here might look strange, but this turned out to be
         // the fastest of several experiments, including:

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -30,9 +30,11 @@ import java.util.List;
 
 public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata {
     private final DependencyMetadata delegate;
+    private final boolean isTransitive;
 
     public ModuleDependencyMetadataWrapper(DependencyMetadata delegate) {
         this.delegate = delegate;
+        this.isTransitive = delegate.isTransitive();
     }
 
     @Override
@@ -79,7 +81,7 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
 
     @Override
     public boolean isTransitive() {
-        return delegate.isTransitive();
+        return isTransitive;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -32,10 +32,12 @@ import java.util.List;
 public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     private final ProjectComponentSelector selector;
     private final DependencyMetadata delegate;
+    private final boolean isTransitive;
 
     public DefaultProjectDependencyMetadata(ProjectComponentSelector selector, DependencyMetadata delegate) {
         this.selector = selector;
         this.delegate = delegate;
+        this.isTransitive = delegate.isTransitive();
     }
 
     @Override
@@ -73,7 +75,7 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
 
     @Override
     public boolean isTransitive() {
-        return delegate.isTransitive();
+        return isTransitive;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -32,10 +32,12 @@ import java.util.List;
 public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMetadata, LocalOriginDependencyMetadata {
     private final LocalOriginDependencyMetadata delegate;
     private final Dependency source;
+    private final boolean isTransitive;
 
     public DslOriginDependencyMetadataWrapper(LocalOriginDependencyMetadata delegate, Dependency source) {
         this.delegate = delegate;
         this.source = source;
+        this.isTransitive = delegate.isTransitive();
     }
 
     @Override
@@ -75,7 +77,7 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
 
     @Override
     public boolean isTransitive() {
-        return delegate.isTransitive();
+        return isTransitive;
     }
 
     @Override

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -23,6 +23,8 @@ import spock.lang.Unroll
 class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 
     private final static TEST_PROJECT_NAME = 'excludeRuleMergingBuild'
+    public static final String MIN_MEMORY = "-Xms512m"
+    public static final String MAX_MEMORY = "-Xmx512m"
 
     def setup() {
         runner.minimumVersion = '4.6'
@@ -34,7 +36,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
 
         given:
         runner.tasksToRun = ['resolveDependencies']
-        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
+        runner.gradleOpts = [MIN_MEMORY, MAX_MEMORY]
         runner.args = ["-PnoExcludes"]
 
         when:
@@ -51,7 +53,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
 
         given:
         runner.tasksToRun = ['resolveDependencies']
-        runner.gradleOpts = ["-Xms256m", "-Xmx256m"]
+        runner.gradleOpts = [MIN_MEMORY, MAX_MEMORY]
         runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", '-PnoExcludes']
         if (parallel) {
             runner.args += '--parallel'


### PR DESCRIPTION
### Context

This pull request supercedes #4258 and focuses on implementing some simple performance improvements during dependency resolution. It focuses on:

- pre-computing hashes for objects which are keys to hash maps (very common)
- inlining `isTransitive` which shows up as a "tower" in all profiling data, because the JIT cannot inline the calls
- replacing the use of linked lists with array lists to take advantage of memory collocation

Depending on runs, this PR improves the "resolve large dependency graph" peformance between 1.5 and 3% : https://builds.gradle.org/viewLog.html?buildId=12474670&tab=buildResultsDiv&buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux

Profiling data shows that we now resize hashmaps faster (because rehashing doesn't need to recompute hashes) and that comparisons also got faster thanks to re-ordering the fields in hash computation.