### PR TITLE
Validate destroyables with outputs/inputs sooner

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -653,6 +653,18 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
             taskMutationInfo.hasOutputs = taskProperties.hasDeclaredOutputs();
             taskMutationInfo.hasLocalState = !taskProperties.getLocalStateFiles().isEmpty();
             taskMutationInfo.resolved = true;
+
+            if (!taskMutationInfo.destroyablePaths.isEmpty()) {
+                if (taskMutationInfo.hasOutputs) {
+                    throw new IllegalStateException("Task " + taskInfo.getTask().getIdentityPath() + " has both outputs and destroyables defined.  A task can define either outputs or destroyables, but not both.");
+                }
+                if (taskMutationInfo.hasFileInputs) {
+                    throw new IllegalStateException("Task " + taskInfo.getTask().getIdentityPath() + " has both inputs and destroyables defined.  A task can define either inputs or destroyables, but not both.");
+                }
+                if (taskMutationInfo.hasLocalState) {
+                    throw new IllegalStateException("Task " + taskInfo.getTask().getIdentityPath() + " has both local state and destroyables defined.  A task can define either local state or destroyables, but not both.");
+                }
+            }
         }
         return taskMutationInfo;
     }
@@ -716,18 +728,6 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
 
     private boolean canRunWithCurrentlyExecutedTasks(TaskInfo taskInfo, TaskMutationInfo taskMutationInfo) {
         Set<String> candidateTaskDestroyables = taskMutationInfo.destroyablePaths;
-
-        if (!candidateTaskDestroyables.isEmpty()) {
-            if (taskMutationInfo.hasOutputs) {
-                throw new IllegalStateException("Task " + taskInfo.getTask().getIdentityPath() + " has both outputs and destroyables defined.  A task can define either outputs or destroyables, but not both.");
-            }
-            if (taskMutationInfo.hasFileInputs) {
-                throw new IllegalStateException("Task " + taskInfo.getTask().getIdentityPath() + " has both inputs and destroyables defined.  A task can define either inputs or destroyables, but not both.");
-            }
-            if (taskMutationInfo.hasLocalState) {
-                throw new IllegalStateException("Task " + taskInfo.getTask().getIdentityPath() + " has both local state and destroyables defined.  A task can define either local state or destroyables, but not both.");
-            }
-        }
 
         if (!runningTasks.isEmpty()) {
             Set<String> candidateTaskOutputs = taskMutationInfo.outputPaths;


### PR DESCRIPTION
We now validate if a task has destroyables and outputs/inputs as soon
as we calculate that information, so it doesn't have to be validated
every time we check for overlapping outputs.
