### PR TITLE
Consistently use component level attributes

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -644,21 +644,21 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
 
         then:
         failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
-        failure.assertHasCause("""Unable to find a matching configuration of project :external:
-  - Configuration 'bar': Required flavor 'free' and found incompatible value 'blue'.
-  - Configuration 'foo': Required flavor 'free' and found incompatible value 'red'.""")
+        failure.assertHasCause("""Unable to find a matching variant of project :external:
+  - Variant 'bar': Required flavor 'free' and found incompatible value 'blue'.
+  - Variant 'foo': Required flavor 'free' and found incompatible value 'red'.""")
 
         when:
         fails ':a:checkPaid'
 
         then:
         failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
-        failure.assertHasCause("""Cannot choose between the following configurations of project :external:
+        failure.assertHasCause("""Cannot choose between the following variants of project :external:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Configuration 'bar': Required flavor 'paid' and found compatible value 'blue'.
-  - Configuration 'foo': Required flavor 'paid' and found compatible value 'red'.""")
+  - Variant 'bar': Required flavor 'paid' and found compatible value 'blue'.
+  - Variant 'foo': Required flavor 'paid' and found compatible value 'red'.""")
     }
 
     @Unroll("context travels down to transitive dependencies with typed attributes using plugin [#v1, #v2, pluginsDSL=#usePluginsDSL]")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -754,8 +754,8 @@ afterEvaluate {
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':buildC:buildInputs'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
-    ${m.pom.file.toURL()}
-    ${m.artifact.file.toURL()}
+  - ${m.pom.file.toURL()}
+  - ${m.artifact.file.toURL()}
 Required by:
     project :buildC""")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -42,8 +42,8 @@ class BuildSrcIdentityIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Could not resolve all files for configuration ':buildSrc:runtimeClasspath'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
-    ${m.pom.file.toURL()}
-    ${m.artifact.file.toURL()}
+  - ${m.pom.file.toURL()}
+  - ${m.artifact.file.toURL()}
 Required by:
     project :buildSrc""")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -439,8 +439,8 @@ include 'a', 'b'
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause '''Configuration 'bar' in project :b does not match the consumer attributes
-Configuration 'bar':
+        failure.assertHasCause '''Variant 'bar' in project :b does not match the consumer attributes
+Variant 'bar':
   - Required buildType 'debug' and found incompatible value 'release'.
   - Required flavor 'free' and found compatible value 'free'.'''
 
@@ -594,11 +594,11 @@ Configuration 'bar':
         failure.assertHasDescription("Could not determine the dependencies of task ':a:checkDebug'.")
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':a:_compileFreeDebug'.")
         failure.assertHasCause("Could not resolve project :b.")
-        failure.assertHasCause("""Unable to find a matching configuration of project :b:
-  - Configuration 'bar':
+        failure.assertHasCause("""Unable to find a matching variant of project :b:
+  - Variant 'bar':
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' but no value provided.
-  - Configuration 'foo':
+  - Variant 'foo':
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' and found compatible value 'free'.""")
     }
@@ -649,12 +649,12 @@ Configuration 'bar':
         failure.assertHasDescription("Could not determine the dependencies of task ':a:checkDebug'.")
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':a:compile'.")
         failure.assertHasCause("Could not resolve project :b.")
-        failure.assertHasCause("""Cannot choose between the following configurations of project :b:
+        failure.assertHasCause("""Cannot choose between the following variants of project :b:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Configuration 'bar': Found buildType 'release' but wasn't required.
-  - Configuration 'foo':
+  - Variant 'bar': Found buildType 'release' but wasn't required.
+  - Variant 'foo':
       - Found buildType 'release' but wasn't required.
       - Found flavor 'free' but wasn't required.""")
     }
@@ -695,7 +695,16 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause "Unable to find a matching configuration of project :b: None of the consumable configurations have attributes."
+        failure.assertHasCause """Unable to find a matching configuration of project :b:
+  - Configuration 'archives':
+      - Required buildType 'debug' but no value provided.
+      - Required flavor 'free' but no value provided.
+  - Configuration 'bar':
+      - Required buildType 'debug' but no value provided.
+      - Required flavor 'free' but no value provided.
+  - Configuration 'foo':
+      - Required buildType 'debug' but no value provided.
+      - Required flavor 'free' but no value provided."""
     }
 
     def "does not select explicit configuration when it's not consumable"() {
@@ -794,11 +803,11 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause '''Unable to find a matching configuration of project :b:
-  - Configuration 'bar':
+        failure.assertHasCause '''Unable to find a matching variant of project :b:
+  - Variant 'bar':
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' and found incompatible value 'paid'.
-  - Configuration 'foo':
+  - Variant 'foo':
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' and found compatible value 'free'.'''
 
@@ -916,14 +925,14 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause("""Cannot choose between the following configurations of project :b:
+        failure.assertHasCause("""Cannot choose between the following variants of project :b:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Configuration 'bar':
+  - Variant 'bar':
       - Required buildType 'debug' but no value provided.
       - Required flavor 'free' and found compatible value 'free'.
-  - Configuration 'foo':
+  - Variant 'foo':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' but no value provided.""")
     }
@@ -1028,12 +1037,12 @@ All of them match the consumer attributes:
         fails ':a:check'
 
         then:
-        failure.assertHasCause """Cannot choose between the following configurations of project :b:
+        failure.assertHasCause """Cannot choose between the following variants of project :b:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Configuration 'bar': Required buildType 'debug' and found compatible value 'debug'.
-  - Configuration 'foo': Required buildType 'debug' and found compatible value 'debug'."""
+  - Variant 'bar': Required buildType 'debug' and found compatible value 'debug'.
+  - Variant 'foo': Required buildType 'debug' and found compatible value 'debug'."""
     }
 
     def "fails when multiple configurations match but have more attributes than requested"() {
@@ -1087,15 +1096,15 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """Cannot choose between the following configurations of project :b:
+        failure.assertHasCause """Cannot choose between the following variants of project :b:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Configuration 'bar':
+  - Variant 'bar':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra 2' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'.
-  - Configuration 'foo':
+  - Variant 'foo':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'."""
@@ -1165,14 +1174,14 @@ All of them match the consumer attributes:
         fails ':a:check'
 
         then:
-        failure.assertHasCause """Cannot choose between the following configurations of project :b:
+        failure.assertHasCause """Cannot choose between the following variants of project :b:
   - compile
   - debug
 All of them match the consumer attributes:
-  - Configuration 'compile':
+  - Variant 'compile':
       - Required buildType 'debug' but no value provided.
       - Required flavor 'free' and found compatible value 'free'.
-  - Configuration 'debug':
+  - Variant 'debug':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' but no value provided."""
     }
@@ -1507,15 +1516,15 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """Cannot choose between the following configurations of project :c:
+        failure.assertHasCause """Cannot choose between the following variants of project :c:
   - foo
   - foo2
 All of them match the consumer attributes:
-  - Configuration 'foo':
+  - Variant 'foo':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'.
-  - Configuration 'foo2':
+  - Variant 'foo2':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra 2' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'."""
@@ -1524,15 +1533,15 @@ All of them match the consumer attributes:
         fails ':a:checkRelease'
 
         then:
-        failure.assertHasCause """Cannot choose between the following configurations of project :c:
+        failure.assertHasCause """Cannot choose between the following variants of project :c:
   - bar
   - bar2
 All of them match the consumer attributes:
-  - Configuration 'bar':
+  - Variant 'bar':
       - Required buildType 'release' and found compatible value 'release'.
       - Found extra 'extra' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'.
-  - Configuration 'bar2':
+  - Variant 'bar2':
       - Required buildType 'release' and found compatible value 'release'.
       - Found extra 'extra 2' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'."""

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -586,7 +586,7 @@ task show {
         then:
         outputContains("files: [test-lib.jar, transformed-a1.jar, transformed-b2.jar, test-1.0.jar]")
         outputContains("components: [test-lib.jar, project :lib, project :ui, org:test:1.0]")
-        outputContains("variants: [{artifactType=jar}, {artifactType=jar, buildType=debug, flavor=one, usage=transformed}, {artifactType=jar, usage=transformed}, {artifactType=jar}]")
+        outputContains("variants: [{artifactType=jar}, {artifactType=jar, buildType=debug, flavor=one, usage=transformed}, {artifactType=jar, usage=transformed}, {artifactType=jar, org.gradle.status=integration}]")
     }
 
     def "can query the content of view before task graph is calculated"() {
@@ -887,6 +887,7 @@ task show {
 
         failure.assertHasCause("""No variants of test:test:1.2 match the consumer attributes: test:test:1.2 configuration default:
   - Required artifactType 'dll' and found incompatible value 'jar'.
+  - Found org.gradle.status 'integration' but wasn't required.
   - Required usage 'api' but no value provided.""")
 
         failure.assertHasCause("""No variants of thing.jar match the consumer attributes: thing.jar:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentAttributesDynamicVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentAttributesDynamicVersionIntegrationTest.groovy
@@ -75,7 +75,7 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
             }
         } else {
             fails ':checkDeps'
-            failure.assertHasCause("Unable to find a matching configuration of org.test:module:1.0:")
+            failure.assertHasCause("Unable to find a matching variant of org.test:module:1.0:")
             failure.assertThatCause(containsNormalizedString("Required quality '$requested' and found incompatible value 'qa'"))
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -389,10 +389,14 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.groupedOutput.task(':dependencyInsight').output.contains("""org:b:1 (A replaced with B)
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:a:1 -> org:b:1
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf""")
 
         when:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependenciesAttributesIntegrationTest.groovy
@@ -239,12 +239,12 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Unable to find a matching configuration of org:test:1.0:
-  - Configuration 'api':
+        failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
+  - Variant 'api':
       - Required custom 'c2' and found incompatible value 'c1'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
-  - Configuration 'runtime':
+  - Variant 'runtime':
       - Required custom 'c2' and found compatible value 'c2'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'""")
@@ -403,12 +403,12 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Unable to find a matching configuration of org:test:1.0:
-  - Configuration 'api':
+        failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
+  - Variant 'api':
       - Required custom 'c2' and found incompatible value 'c1'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
-  - Configuration 'runtime':
+  - Variant 'runtime':
       - Required custom 'c2' and found compatible value 'c2'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'""")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ExternalModuleVariantsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ExternalModuleVariantsIntegrationTest.groovy
@@ -70,15 +70,15 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("test-jar-1.2.jar {artifactType=jar}")
-        output.contains("test-aar-1.2.aar {artifactType=aar}")
-        output.contains("test-thing-1.2.thing {artifactType=thing}")
-        output.contains("test-1.2.jar {artifactType=jar}")
-        output.contains("test-1.2.aar {artifactType=aar}")
-        output.contains("test-1.2.thing {artifactType=thing}")
-        output.contains("test-1.2-util.jar {artifactType=jar}")
-        output.contains("test-1.2-util.aar {artifactType=aar}")
-        output.contains("test-api-1.2.jar {artifactType=jar}")
+        outputContains("test-jar-1.2.jar {artifactType=jar}")
+        outputContains("test-aar-1.2.aar {artifactType=aar}")
+        outputContains("test-thing-1.2.thing {artifactType=thing}")
+        outputContains("test-1.2.jar {artifactType=jar}")
+        outputContains("test-1.2.aar {artifactType=aar}")
+        outputContains("test-1.2.thing {artifactType=thing}")
+        outputContains("test-1.2-util.jar {artifactType=jar}")
+        outputContains("test-1.2-util.aar {artifactType=aar}")
+        outputContains("test-api-1.2.jar {artifactType=jar}")
     }
 
     def "artifacts in an Ivy repo have standard attributes defined based on their type"() {
@@ -138,16 +138,16 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("test-jar-1.2.jar {artifactType=jar}")
-        output.contains("test-aar-1.2.aar {artifactType=aar}")
-        output.contains("test-thing-1.2.thing {artifactType=thing}")
-        output.contains("test-1.2.jar {artifactType=jar}")
-        output.contains("test-1.2.aar {artifactType=aar}")
-        output.contains("test-1.2.thing {artifactType=thing}")
-        output.contains("test-1.2-util.jar {artifactType=jar}")
-        output.contains("test-1.2-util.aar {artifactType=aar}")
-        output.contains("test-api-1.2.jar {artifactType=custom}")
-        output.contains("test-api-1.2 {artifactType=}")
+        outputContains("test-jar-1.2.jar {artifactType=jar, org.gradle.status=integration}")
+        outputContains("test-aar-1.2.aar {artifactType=aar, org.gradle.status=integration}")
+        outputContains("test-thing-1.2.thing {artifactType=thing, org.gradle.status=integration}")
+        outputContains("test-1.2.jar {artifactType=jar, org.gradle.status=integration}")
+        outputContains("test-1.2.aar {artifactType=aar}")
+        outputContains("test-1.2.thing {artifactType=thing}")
+        outputContains("test-1.2-util.jar {artifactType=jar}")
+        outputContains("test-1.2-util.aar {artifactType=aar}")
+        outputContains("test-api-1.2.jar {artifactType=custom, org.gradle.status=integration}")
+        outputContains("test-api-1.2 {artifactType=, org.gradle.status=integration}")
     }
 
     def "artifacts in a file dependency have standard attributes defined based on their extension"() {
@@ -176,10 +176,10 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("test.jar {artifactType=jar}")
-        output.contains("test.aar {artifactType=aar}")
-        output.contains("test.thing {artifactType=thing}")
-        output.contains("test {artifactType=}")
+        outputContains("test.jar {artifactType=jar}")
+        outputContains("test.aar {artifactType=aar}")
+        outputContains("test.thing {artifactType=thing}")
+        outputContains("test {artifactType=}")
     }
 
     def "artifacts from a Gradle project have standard attributes defined based on their type when none defined for the outgoing variant"() {
@@ -228,9 +228,9 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("a.custom {artifactType=custom}")
-        output.contains("b.jar {artifactType=jar}")
-        output.contains("c.jar {artifactType=other}")
+        outputContains("a.custom {artifactType=custom}")
+        outputContains("b.jar {artifactType=jar}")
+        outputContains("c.jar {artifactType=other}")
     }
 
     def "can attach attributes to an artifact in a Maven repo"() {
@@ -285,9 +285,9 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("test-jar-1.2.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
-        output.contains("test-aar-1.2.aar {androidType=library-archive, artifactType=aar}")
-        output.contains("test-thing-1.2.thing {artifactType=widget, usage=unknown}")
+        outputContains("test-jar-1.2.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
+        outputContains("test-aar-1.2.aar {androidType=library-archive, artifactType=aar}")
+        outputContains("test-thing-1.2.thing {artifactType=widget, usage=unknown}")
     }
 
     def "can attach attributes to an artifact in an Ivy repo"() {
@@ -340,9 +340,9 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("test-jar-1.2.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
-        output.contains("test-aar-1.2.aar {androidType=library-archive, artifactType=aar}")
-        output.contains("test-thing-1.2.thing {artifactType=widget, usage=unknown}")
+        outputContains("test-jar-1.2.jar {artifactType=jar, javaVersion=1.8, org.gradle.status=integration, usage=java-runtime}")
+        outputContains("test-aar-1.2.aar {androidType=library-archive, artifactType=aar, org.gradle.status=integration}")
+        outputContains("test-thing-1.2.thing {artifactType=widget, org.gradle.status=integration, usage=unknown}")
     }
 
     def "can attach attributes to an artifact provided by a file dependency"() {
@@ -384,9 +384,9 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("test.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
-        output.contains("test.aar {androidType=library-archive, artifactType=aar}")
-        output.contains("test.thing {artifactType=widget, usage=unknown}")
+        outputContains("test.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
+        outputContains("test.aar {androidType=library-archive, artifactType=aar}")
+        outputContains("test.thing {artifactType=widget, usage=unknown}")
     }
 
     def "can attach attributes to an artifact provided by a Gradle project"() {
@@ -449,9 +449,9 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run 'show'
 
         then:
-        output.contains("a.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
-        output.contains("b.aar {androidType=library-archive, artifactType=aar}")
-        output.contains("c.thing {artifactType=widget, usage=unknown}")
+        outputContains("a.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
+        outputContains("b.aar {androidType=library-archive, artifactType=aar}")
+        outputContains("c.thing {artifactType=widget, usage=unknown}")
     }
 
     def "each project can define different artifact types"() {
@@ -530,17 +530,17 @@ class ExternalModuleVariantsIntegrationTest extends AbstractDependencyResolution
         run ':a:show'
 
         then:
-        output.contains("test-jar-1.2.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
-        output.contains("test-aar-1.2.aar {androidType=library-archive, artifactType=aar}")
-        output.contains("test-thing-1.2.thing {artifactType=widget, usage=unknown}")
+        outputContains("test-jar-1.2.jar {artifactType=jar, javaVersion=1.8, usage=java-runtime}")
+        outputContains("test-aar-1.2.aar {androidType=library-archive, artifactType=aar}")
+        outputContains("test-thing-1.2.thing {artifactType=widget, usage=unknown}")
 
         when:
         run ':b:show'
 
         then:
-        output.contains("a.jar {artifactType=jar}")
-        output.contains("test-jar-1.2.jar {artifactType=jar}")
-        output.contains("test-aar-1.2.aar {artifactType=android-lib}")
-        output.contains("test-thing-1.2.thing {artifactType=a-thing, usage=a-thing}")
+        outputContains("a.jar {artifactType=jar}")
+        outputContains("test-jar-1.2.jar {artifactType=jar}")
+        outputContains("test-aar-1.2.aar {artifactType=android-lib}")
+        outputContains("test-thing-1.2.thing {artifactType=a-thing, usage=a-thing}")
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FlatDirJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FlatDirJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -58,8 +58,8 @@ repositories {
         fails("verify")
         failure.assertHasCause("""Could not find some.group:some-artifact:1.0.
 Searched in the following locations:
-    ${location1}
-    ${location2}""")
+  - ${location1}
+  - ${location2}""")
     }
 
     def "resolve missing source and javadoc artifacts"() {
@@ -94,8 +94,8 @@ Searched in the following locations:
         fails("verify")
         failure.assertHasCause("""Could not find some.group:some-artifact:1.0.
 Searched in the following locations:
-    ${location1}
-    ${location2}""")
+  - ${location1}
+  - ${location2}""")
     }
 
     private publishModule() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -179,7 +179,7 @@ project(":b") {
                     variant('runtime')
                     module('org.other:externalA:1.2') {
                         byReason('also check dependency reasons')
-                        variant('default')
+                        variant('default', ['org.gradle.status': 'release'])
                     }
                 }
             }
@@ -533,7 +533,7 @@ project('c') {
 
     // this test is largely covered by other tests, but does ensure that there is nothing special about
     // project dependencies that are “built” by built in plugins like the Java plugin's created jars
-    @IgnoreIf({GradleContextualExecuter.parallel})
+    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "can use zip files as project dependencies"() {
         given:
         file("settings.gradle") << "include 'a'; include 'b'"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
@@ -689,10 +689,10 @@ ${showFailuresTask(expression)}
 
         then:
         failure.assertHasCause("Could not resolve all artifacts for configuration ':compile'.")
-        failure.assertHasCause("""Unable to find a matching configuration of project :a:
-  - Configuration 'compile': Required volume '11' and found incompatible value '8'.""")
-        failure.assertHasCause("""Unable to find a matching configuration of project :b:
-  - Configuration 'compile': Required volume '11' and found incompatible value '9'.""")
+        failure.assertHasCause("""Unable to find a matching variant of project :a:
+  - Variant 'compile': Required volume '11' and found incompatible value '8'.""")
+        failure.assertHasCause("""Unable to find a matching variant of project :b:
+  - Variant 'compile': Required volume '11' and found incompatible value '9'.""")
 
         where:
         expression                                                    | _

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -389,14 +389,14 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """Cannot choose between the following configurations of project :b:
+        failure.assertHasCause """Cannot choose between the following variants of project :b:
   - foo2
   - foo3
 All of them match the consumer attributes:
-  - Configuration 'foo2':
+  - Variant 'foo2':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' and found compatible value 'ONE'.
-  - Configuration 'foo3':
+  - Variant 'foo3':
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' and found compatible value 'ONE'."""
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
@@ -164,19 +164,19 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                             // is target to the metadata rule, which explains we find the "format" attribute here
                             expectedTargetVariant = expectedVariant
                             artifact group: 'org', module: 'moduleB', version: '1.0', classifier: 'variant1'
-                            expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy()?'integration':'release']
+                            expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                         } else {
                             if (GradleMetadataResolveRunner.useIvy()) {
                                 // Ivy doesn't derive any variant
                                 expectedTargetVariant = 'default+customVariant'
-                                expectedAttributes = [:]
+                                expectedAttributes = ['org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                             } else {
                                 // for Maven, we derive variants for compile/runtime. Variants are then used during selection, and are subject
                                 // to metadata rules. In this case, we have multiple variants (default, runtime, compile), but only the "compile"
                                 // one is target of the rule (see #getVariantToTest())
                                 expectedTargetVariant = 'compile'
                                 // the format attribute is added by the rule
-                                expectedAttributes = [format: 'custom']
+                                expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                                 if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
                                     // when experimental resolve is on, the "compile" configuration is mapped to the "java-api" usage
                                     expectedAttributes['org.gradle.usage'] = 'java-api'
@@ -384,7 +384,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
 
     @RequiredFeatures(
         // published attributes are only available in Gradle metadata
-        @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     def "published variant metadata can be overwritten"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
@@ -189,10 +189,10 @@ task showMissing { doLast { println configurations.missing.files } }
         and:
         failure.assertHasCause("""Could not find any matches for group:projectA:latest.integration as no versions of group:projectA are available.
 Searched in the following locations:
-    ${repo1MetaData.uri}
-    ${repo1DirList.uri}
-    ${repo2MetaData.uri}
-    ${repo2DirLib.uri}
+  - ${repo1MetaData.uri}
+  - ${repo1DirList.uri}
+  - ${repo2MetaData.uri}
+  - ${repo2DirLib.uri}
 Required by:
 """)
 
@@ -209,10 +209,10 @@ Required by:
         and:
         failure.assertHasCause("""Could not find any matches for group:projectA:latest.integration as no versions of group:projectA are available.
 Searched in the following locations:
-    ${repo1MetaData.uri}
-    ${repo1DirList.uri}
-    ${repo2MetaData.uri}
-    ${repo2DirLib.uri}
+  - ${repo1MetaData.uri}
+  - ${repo1DirList.uri}
+  - ${repo2MetaData.uri}
+  - ${repo2DirLib.uri}
 Required by:
 """)
 
@@ -410,10 +410,10 @@ Required by:
         and:
         failure.assertHasCause("""Could not find group:projectA:1.0.
 Searched in the following locations:
-    ${repo1Module.pom.uri}
-    ${repo1Module.artifact.uri}
-    ${repo2Module.pom.uri}
-    ${repo2Module.artifact.uri}
+  - ${repo1Module.pom.uri}
+  - ${repo1Module.artifact.uri}
+  - ${repo2Module.pom.uri}
+  - ${repo2Module.artifact.uri}
 Required by:
 """)
 
@@ -428,10 +428,10 @@ Required by:
 
         failure.assertHasCause("""Could not find group:projectA:1.0.
 Searched in the following locations:
-    ${repo1Module.pom.uri}
-    ${repo1Module.artifact.uri}
-    ${repo2Module.pom.uri}
-    ${repo2Module.artifact.uri}
+  - ${repo1Module.pom.uri}
+  - ${repo1Module.artifact.uri}
+  - ${repo2Module.pom.uri}
+  - ${repo2Module.artifact.uri}
 Required by:
 """)
 
@@ -505,12 +505,12 @@ Required by:
         fails 'retrieve'
         failure.assertHasCause("""Could not find any matches for group:projectA:1.+ as no versions of group:projectA are available.
 Searched in the following locations:
-    ${repo1Module.rootMetaData.uri}
-    ${repo1Module.pom.uri}
-    ${repo1Module.artifact.uri}
-    ${repo2Module.rootMetaData.uri}
-    ${repo2Module.pom.uri}
-    ${repo2Module.artifact.uri}
+  - ${repo1Module.rootMetaData.uri}
+  - ${repo1Module.pom.uri}
+  - ${repo1Module.artifact.uri}
+  - ${repo2Module.rootMetaData.uri}
+  - ${repo2Module.pom.uri}
+  - ${repo2Module.artifact.uri}
 Required by:
 """)
 
@@ -527,12 +527,12 @@ Required by:
         fails 'retrieve'
         failure.assertHasCause("""Could not find any matches for group:projectA:1.+ as no versions of group:projectA are available.
 Searched in the following locations:
-    ${repo1Module.rootMetaData.uri}
-    ${repo1Module.pom.uri}
-    ${repo1Module.artifact.uri}
-    ${repo2Module.rootMetaData.uri}
-    ${repo2Module.pom.uri}
-    ${repo2Module.artifact.uri}
+  - ${repo1Module.rootMetaData.uri}
+  - ${repo1Module.pom.uri}
+  - ${repo1Module.artifact.uri}
+  - ${repo2Module.rootMetaData.uri}
+  - ${repo2Module.pom.uri}
+  - ${repo2Module.artifact.uri}
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
@@ -177,8 +177,7 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
 
         and:
         failure.assertHasCause("""Could not find org.test:projectA:1.1.
-Searched in the following locations:
-    ${metadataUri}
+Searched in the following locations: ${metadataUri}
 Required by:""")
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/AbstractComponentSelectionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/AbstractComponentSelectionRulesIntegrationTest.groovy
@@ -80,7 +80,7 @@ abstract class AbstractComponentSelectionRulesIntegrationTest extends AbstractMo
         if (stopFirst) {
             uris = [uris[0]]
         }
-        uris.collect { "    $it" }.join('\n')
+        uris.collect { "  - $it" }.join('\n')
     }
 
     static Map<String, String> rules = [

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -212,14 +212,14 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
         and:
         failureHasCause("""Could not find any version that matches org.utils:api:1.+.
 Versions that do not match:
-    2.1
-    2.0
+  - 2.1
+  - 2.0
 Versions rejected by component selection rules:
-    1.2
-    1.1
-    1.0
+  - 1.2
+  - 1.1
+  - 1.0
 Searched in the following locations:
-    ${versionListingURI('org.utils', 'api')}
+  - ${versionListingURI('org.utils', 'api')}
 ${triedMetadata('org.utils', 'api', "1.2", false, gradleMetadataEnabled || !experimentalEnabled)}
 ${triedMetadata('org.utils', 'api', "1.1", false, gradleMetadataEnabled || !experimentalEnabled)}
 ${triedMetadata('org.utils', 'api', "1.0", false, gradleMetadataEnabled || !experimentalEnabled)}
@@ -241,14 +241,13 @@ Required by:
         // TODO - this failure and the previous failure should report the same urls (whatever that happens to be)
         failureHasCause("""Could not find any version that matches org.utils:api:1.+.
 Versions that do not match:
-    2.1
-    2.0
+  - 2.1
+  - 2.0
 Versions rejected by component selection rules:
-    1.2
-    1.1
-    1.0
-Searched in the following locations:
-    ${versionListingURI('org.utils', 'api')}
+  - 1.2
+  - 1.1
+  - 1.0
+Searched in the following locations: ${versionListingURI('org.utils', 'api')}
 Required by:
 """)
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
@@ -259,7 +259,7 @@ dependencies {
         fails ":checkDeps"
         failure.assertHasCause("""Could not find any matches for org.utils:api:+ as no versions of org.utils:api are available.
 Searched in the following locations:
-    ${versionListingURI('org.utils', 'api')}
+  - ${versionListingURI('org.utils', 'api')}
 ${triedMetadata('org.utils', 'api', '2.1', !GradleMetadataResolveRunner.isExperimentalResolveBehaviorEnabled(), false)}
 Required by:
 """)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenDescriptorIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenDescriptorIntegrationTest.groovy
@@ -150,8 +150,8 @@ dependencies {
             .assertHasCause("Could not parse Ivy file ${module.ivy.uri}")
             .assertHasCause("""Could not find group:parent:a.
 Searched in the following locations:
-    ${parent.ivy.uri}
-    ${parent.jar.uri}""")
+  - ${parent.ivy.uri}
+  - ${parent.jar.uri}""")
     }
 
     def "reports parent descriptor that cannot be parsed"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -44,8 +44,8 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertResolutionFailure(':missing')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${module.ivy.uri}
-    ${module.jar.uri}
+  - ${module.ivy.uri}
+  - ${module.jar.uri}
 Required by:
     project :""")
 
@@ -59,8 +59,8 @@ Required by:
                 .assertResolutionFailure(':missing')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${module.ivy.uri}
-    ${module.jar.uri}
+  - ${module.ivy.uri}
+  - ${module.jar.uri}
 Required by:
     project :""")
 
@@ -109,14 +109,14 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertResolutionFailure(':missing')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${moduleA.ivy.uri}
-    ${moduleA.jar.uri}
+  - ${moduleA.ivy.uri}
+  - ${moduleA.jar.uri}
 Required by:
     project :""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
-    ${moduleB.ivy.uri}
-    ${moduleB.jar.uri}
+  - ${moduleB.ivy.uri}
+  - ${moduleB.jar.uri}
 Required by:
     project :""")
 
@@ -190,15 +190,15 @@ task showMissing { doLast { println configurations.compile.files } }
                 .assertResolutionFailure(':compile')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${moduleA.ivy.uri}
-    ${moduleA.jar.uri}
+  - ${moduleA.ivy.uri}
+  - ${moduleA.jar.uri}
 Required by:
     project : > group:projectC:0.99
     project : > project :child1 > group:projectD:1.0GA""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
-    ${moduleB.ivy.uri}
-    ${moduleB.jar.uri}
+  - ${moduleB.ivy.uri}
+  - ${moduleB.jar.uri}
 Required by:
     project : > project :child1 > group:projectD:1.0GA""")
 
@@ -248,8 +248,8 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertHasCause('Could not resolve all files for configuration \':missing\'.')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${module.ivy.uri}
-    ${artifact.uri}
+  - ${module.ivy.uri}
+  - ${artifact.uri}
 Required by:
 """)
 
@@ -299,10 +299,10 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertHasCause('Could not resolve all files for configuration \':missing\'.')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${moduleInRepo1.ivy.uri}
-    ${moduleInRepo1.jar.uri}
-    ${moduleInRepo2.ivy.uri}
-    ${moduleInRepo2.jar.uri}
+  - ${moduleInRepo1.ivy.uri}
+  - ${moduleInRepo1.jar.uri}
+  - ${moduleInRepo2.ivy.uri}
+  - ${moduleInRepo2.jar.uri}
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -949,11 +949,10 @@ dependencies {
         fails "checkDeps"
         failure.assertHasCause("""Could not find any version that matches group:projectA:2.+.
 Versions that do not match:
-    3.0
-    1.2
-    1.1
-Searched in the following locations:
-    ${dirListRepo1.uri}
+  - 3.0
+  - 1.2
+  - 1.1
+Searched in the following locations: ${dirListRepo1.uri}
 Required by:
 """)
 
@@ -972,13 +971,13 @@ Required by:
         fails "checkDeps"
         failure.assertHasCause("""Could not find any version that matches group:projectA:2.+.
 Versions that do not match:
-    3.0
-    1.2
-    1.1
-    4.4
+  - 3.0
+  - 1.2
+  - 1.1
+  - 4.4
 Searched in the following locations:
-    ${dirListRepo1.uri}
-    ${dirListRepo2.uri}
+  - ${dirListRepo1.uri}
+  - ${dirListRepo2.uri}
 Required by:
 """)
 
@@ -991,13 +990,13 @@ Required by:
         fails "checkDeps"
         failure.assertHasCause("""Could not find any version that matches group:projectA:2.+.
 Versions that do not match:
-    3.0
-    1.2
-    1.1
-    4.4
+  - 3.0
+  - 1.2
+  - 1.1
+  - 4.4
 Searched in the following locations:
-    ${dirListRepo1.uri}
-    ${dirListRepo2.uri}
+  - ${dirListRepo1.uri}
+  - ${dirListRepo2.uri}
 Required by:
 """)
 
@@ -1032,8 +1031,7 @@ dependencies {
         then:
         fails "checkDeps"
         failure.assertHasCause("""Could not find any matches for group:projectA:2.+ as no versions of group:projectA are available.
-Searched in the following locations:
-    ${directoryList.uri}
+Searched in the following locations: ${directoryList.uri}
 Required by:
 """)
 
@@ -1044,8 +1042,7 @@ Required by:
         then:
         fails "checkDeps"
         failure.assertHasCause("""Could not find any matches for group:projectA:2.+ as no versions of group:projectA are available.
-Searched in the following locations:
-    ${directoryList.uri}
+Searched in the following locations: ${directoryList.uri}
 Required by:
 """)
 
@@ -1134,9 +1131,9 @@ dependencies {
         fails "checkDeps"
         failure.assertHasCause("""Could not find any matches for group:projectA:latest.release as no versions of group:projectA are available.
 Searched in the following locations:
-    ${directoryList.uri}
-    ${projectA.ivy.uri}
-    ${projectA.jar.uri}
+  - ${directoryList.uri}
+  - ${projectA.ivy.uri}
+  - ${projectA.jar.uri}
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -156,8 +156,7 @@ class IvyDynamicRevisionResolveIntegrationTest extends AbstractModuleDependencyR
 
         then:
         failureHasCause '''Could not find any version that matches org.test:projectA:latest.milestone.
-Versions that do not match:
-    1.3
+Versions that do not match: 1.3
 Searched in the following locations:
 '''
 
@@ -307,8 +306,8 @@ Searched in the following locations:
         then:
         failureHasCause '''Could not find any version that matches org.test:projectA:latest.release.
 Versions that do not match:
-    1.3
-    1.2
+  - 1.3
+  - 1.2
 Searched in the following locations:
 '''
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -253,8 +253,8 @@ if (project.hasProperty('nocache')) {
         fails("verify")
         failure.assertHasCause("""Could not find some.group:some-artifact:1.0.
 Searched in the following locations:
-    ${module.ivy.uri}
-    ${module.jar.uri}""")
+  - ${module.ivy.uri}
+  - ${module.jar.uri}""")
 
         when:
         server.resetExpectations()
@@ -265,8 +265,8 @@ Searched in the following locations:
         fails("verify")
         failure.assertHasCause("""Could not find some.group:some-artifact:1.0.
 Searched in the following locations:
-    ${module.ivy.uri}
-    ${module.jar.uri}""")
+  - ${module.ivy.uri}
+  - ${module.jar.uri}""")
     }
 
     def "reports failure to resolve missing artifacts"() {
@@ -426,7 +426,7 @@ Searched in the following locations:
     private publishModule() {
         module.configuration("sources")
         module.configuration("javadoc")
-        // use uncommon classifiers that are different from those used by maven, 
+        // use uncommon classifiers that are different from those used by maven,
         // in order to prove that artifact names don't matter
         module.artifact(type: "source", classifier: "my-sources", ext: "jar", conf: "sources")
         module.artifact(type: "javadoc", classifier: "my-javadoc", ext: "jar", conf: "javadoc")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -40,25 +40,25 @@ task retrieve(type: Sync) {
 """
         when: "projectA uses a wildcard configuration mapping for dependency on projectB"
         def moduleA = ivyRepo.module('ivy.configuration', 'projectA', '1.2')
-                .configuration('parent')
-                .artifact()
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectB', revision: '1.5', conf: 'runtime->*')
-                .publish()
+            .configuration('parent')
+            .artifact()
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectB', revision: '1.5', conf: 'runtime->*')
+            .publish()
 
         ivyRepo.module('ivy.configuration', 'projectB', '1.5')
-                .configuration('child')
-                .configuration('private', visibility: 'private')
-                .artifact()
-                .artifact([name: 'projectB', conf: 'runtime'])
-                .artifact([name: 'projectB-child', conf: 'child'])
-                .artifact([name: 'projectB-private', conf: 'private'])
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectC', revision: '1.7', conf: 'child->*')
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectD', revision: 'broken', conf: 'private->*')
-                .publish()
+            .configuration('child')
+            .configuration('private', visibility: 'private')
+            .artifact()
+            .artifact([name: 'projectB', conf: 'runtime'])
+            .artifact([name: 'projectB-child', conf: 'child'])
+            .artifact([name: 'projectB-private', conf: 'private'])
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectC', revision: '1.7', conf: 'child->*')
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectD', revision: 'broken', conf: 'private->*')
+            .publish()
 
         ivyRepo.module('ivy.configuration', 'projectC', '1.7')
-                .artifact()
-                .publish()
+            .artifact()
+            .publish()
 
         and:
         succeeds 'retrieve'
@@ -69,13 +69,13 @@ task retrieve(type: Sync) {
         when: "projectB-1.5 is replaced by conflict resolution with projectB-1.6 that has a different set of configurations"
 
         ivyRepo.module('ivy.configuration', 'projectB', '1.6')
-                .configuration('other')
-                .artifact([name: 'projectB-other', conf: 'other'])
-                .publish()
+            .configuration('other')
+            .artifact([name: 'projectB-other', conf: 'other'])
+            .publish()
 
         ivyRepo.module('ivy.configuration', 'projectD', '1.0')
-                .dependsOn('ivy.configuration', 'projectB', '1.6')
-                .publish()
+            .dependsOn('ivy.configuration', 'projectB', '1.6')
+            .publish()
 
         moduleA.dependsOn('ivy.configuration', 'projectD', '1.0').publish()
 
@@ -158,25 +158,25 @@ task retrieve(type: Sync) {
 }
 """
         def projectA = ivyHttpRepo.module('ivy.configuration', 'projectA', '1.2')
-                .configuration("parent")
-                .configuration("a", extendsFrom: ["parent"])
-                .configuration("b")
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectB', revision: '1.5', conf: rule)
-                .publish()
+            .configuration("parent")
+            .configuration("a", extendsFrom: ["parent"])
+            .configuration("b")
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectB', revision: '1.5', conf: rule)
+            .publish()
 
         def projectB = ivyHttpRepo.module('ivy.configuration', 'projectB', '1.5')
-                .configuration('a')
-                .configuration('b')
-                .configuration('c')
-                .configuration('d', visibility: 'private')
-                .artifact([name: 'projectB-a', conf: 'a'])
-                .artifact([name: 'projectB-b', conf: 'b'])
-                .artifact([name: 'projectB-c', conf: 'c'])
-                .artifact([name: 'projectB-d', conf: 'd'])
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectC', revision: '1.7', conf: 'a->default')
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectD', revision: '1.7', conf: 'b->default')
-                .dependsOn(organisation: 'ivy.configuration', module: 'projectE', revision: '1.7', conf: 'd->default')
-                .publish()
+            .configuration('a')
+            .configuration('b')
+            .configuration('c')
+            .configuration('d', visibility: 'private')
+            .artifact([name: 'projectB-a', conf: 'a'])
+            .artifact([name: 'projectB-b', conf: 'b'])
+            .artifact([name: 'projectB-c', conf: 'c'])
+            .artifact([name: 'projectB-d', conf: 'd'])
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectC', revision: '1.7', conf: 'a->default')
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectD', revision: '1.7', conf: 'b->default')
+            .dependsOn(organisation: 'ivy.configuration', module: 'projectE', revision: '1.7', conf: 'd->default')
+            .publish()
 
         def projectC = ivyHttpRepo.module('ivy.configuration', 'projectC', '1.7').publish()
         def projectD = ivyHttpRepo.module('ivy.configuration', 'projectD', '1.7').publish()
@@ -246,18 +246,18 @@ task retrieve(type: Sync) {
 }
 """
         ivyRepo.module('org', 'projectA', '1.2')
-                .dependsOn(organisation: 'org', module: 'projectB', revision: '1.5', revConstraint: '1.6')
-                .dependsOn(organisation: 'org', module: 'projectC', revision: 'alpha-12')
-                .publish()
+            .dependsOn(organisation: 'org', module: 'projectB', revision: '1.5', revConstraint: '1.6')
+            .dependsOn(organisation: 'org', module: 'projectC', revision: 'alpha-12')
+            .publish()
 
         ivyRepo.module('org', 'projectB', '1.5')
-                .publish()
+            .publish()
 
         ivyRepo.module('org', 'projectB', '1.6')
-                .publish()
+            .publish()
 
         ivyRepo.module('org', 'projectC', 'alpha-12')
-                .publish()
+            .publish()
 
         when:
         executer.withArguments("-PuseDynamicResolve=true")
@@ -362,7 +362,7 @@ task retrieve(type: Sync) {
             root(":", "org.test:test:1.0") {
                 module("ivy.configuration:projectA:1.2:a") {
                     module("ivy.configuration:projectB:1.5") {
-                        variant('a+c') // b, parent are redundant
+                        variant('a+c', ['org.gradle.status': 'integration']) // b, parent are redundant
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/BadPomFileResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/BadPomFileResolveIntegrationTest.groovy
@@ -131,8 +131,8 @@ task showBroken { doLast { println configurations.compile.files } }
                 .assertHasCause("Could not parse POM ${child.pom.uri}")
                 .assertHasCause("""Could not find org:parent:1.0.
 Searched in the following locations:
-    ${parent.pom.uri}
-    ${parent.artifact.uri}""")
+  - ${parent.pom.uri}
+  - ${parent.artifact.uri}""")
     }
 
     def "reports parent POM that cannot be parsed"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -45,8 +45,8 @@ task showMissing { doLast { println configurations.missing.files } }
             .assertResolutionFailure(':missing')
             .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${module.pom.uri}
-    ${module.artifact.uri}
+  - ${module.pom.uri}
+  - ${module.artifact.uri}
 Required by:
     project :""")
 
@@ -60,8 +60,8 @@ Required by:
             .assertResolutionFailure(':missing')
             .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${module.pom.uri}
-    ${module.artifact.uri}
+  - ${module.pom.uri}
+  - ${module.artifact.uri}
 Required by:
     project :""")
 
@@ -110,14 +110,14 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertResolutionFailure(':missing')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${moduleA.pom.uri}
-    ${moduleA.artifact.uri}
+  - ${moduleA.pom.uri}
+  - ${moduleA.artifact.uri}
 Required by:
     project :""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
-    ${moduleB.pom.uri}
-    ${moduleB.artifact.uri}
+  - ${moduleB.pom.uri}
+  - ${moduleB.artifact.uri}
 Required by:
     project :""")
 
@@ -191,15 +191,15 @@ task showMissing { doLast { println configurations.compile.files } }
                 .assertResolutionFailure(':compile')
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${moduleA.pom.uri}
-    ${moduleA.artifact.uri}
+  - ${moduleA.pom.uri}
+  - ${moduleA.artifact.uri}
 Required by:
     project : > group:projectC:0.99
     project : > project :child1 > group:projectD:1.0GA""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
-    ${moduleB.pom.uri}
-    ${moduleB.artifact.uri}
+  - ${moduleB.pom.uri}
+  - ${moduleB.artifact.uri}
 Required by:
     project : > project :child1 > group:projectD:1.0GA""")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -267,9 +267,9 @@ task retrieve(type: Sync) {
         // TODO - this error message isn't right: it found a version, it just happened to be missing. should really choose another version
         failure.assertHasCause("""Could not find any matches for group:projectA:1.+ as no versions of group:projectA are available.
 Searched in the following locations:
-    ${repo.getModuleMetaData("group", "projectA").uri}
-    ${projectA.pom.uri}
-    ${projectA.artifact.uri}
+  - ${repo.getModuleMetaData("group", "projectA").uri}
+  - ${projectA.pom.uri}
+  - ${projectA.artifact.uri}
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -212,8 +212,8 @@ if (project.hasProperty('nocache')) {
         fails("verify")
         failure.assertHasCause("""Could not find some.group:some-artifact:1.0.
 Searched in the following locations:
-    ${module.pom.uri}
-    ${module.artifact.uri}""")
+  - ${module.pom.uri}
+  - ${module.artifact.uri}""")
 
         when:
         server.resetExpectations()
@@ -224,8 +224,8 @@ Searched in the following locations:
         fails("verify")
         failure.assertHasCause("""Could not find some.group:some-artifact:1.0.
 Searched in the following locations:
-    ${module.pom.uri}
-    ${module.artifact.uri}""")
+  - ${module.pom.uri}
+  - ${module.artifact.uri}""")
     }
 
     def "resolve and caches missing artifacts of existing component"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -173,8 +173,8 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         then:
         failure.assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-    ${module.pomFile.toURL()}
-    ${module.artifactFile.toURL()}
+  - ${module.pomFile.toURL()}
+  - ${module.artifactFile.toURL()}
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -672,8 +672,8 @@ dependencies {
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
         failure.assertHasCause("""Could not find test:a:1.2.
 Searched in the following locations:
-    ${m.moduleMetadata.uri}
-    ${m.pom.uri}
+  - ${m.moduleMetadata.uri}
+  - ${m.pom.uri}
 Required by:
     project :""")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -735,9 +735,9 @@ task retrieve(type: Sync) {
         and:
         failure.assertHasCause("""Could not find group:projectA:1.0-SNAPSHOT.
 Searched in the following locations:
-    ${projectA.metaData.uri}
-    ${projectA.pom.uri}
-    ${projectA.artifact.uri}
+  - ${projectA.metaData.uri}
+  - ${projectA.pom.uri}
+  - ${projectA.artifact.uri}
 Required by:
 """)
 
@@ -1030,8 +1030,8 @@ task retrieve(type: Sync) {
         then:
         failure.assertHasCause("""Could not find org.gradle.integtests.resolve:projectA:${published.publishArtifactVersion}.
 Searched in the following locations:
-    ${projectA.pom.uri}
-    ${projectA.artifact.uri}
+  - ${projectA.pom.uri}
+  - ${projectA.artifact.uri}
 Required by:
 """)
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.clientmodule;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ClientModule;
@@ -27,6 +28,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
@@ -147,8 +149,8 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
-        public ImmutableList<? extends ConfigurationMetadata> getVariantsForGraphTraversal() {
-            return ImmutableList.of();
+        public Optional<ImmutableList<? extends ConfigurationMetadata>> getVariantsForGraphTraversal() {
+            return Optional.absent();
         }
 
         @Override
@@ -179,7 +181,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
 
     private static class ClientModuleConfigurationMetadata extends DefaultConfigurationMetadata {
         ClientModuleConfigurationMetadata(ModuleComponentIdentifier componentId, String name, ModuleComponentArtifactMetadata artifact, List<ModuleDependencyMetadata> dependencies) {
-            super(componentId, name, true, true, ImmutableList.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of());
+            super(componentId, name, true, true, ImmutableList.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
             setDependencies(dependencies);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
@@ -65,7 +65,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
         ImmutableAttributes attributes = variant.getAttributes().asImmutable();
 
         // Add attributes to be applied given the extension
-        if (artifactTypeDefinitions != null && variant.getAttributes().isEmpty()) {
+        if (artifactTypeDefinitions != null) {
             String extension = null;
             for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
                 String candidateExtension = artifact.getName().getExtension();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -149,6 +149,10 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
         public <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, @Nullable T fallback) {
             return componentAttributeMatcher.match(effectiveSchema, candidates, requested, fallback);
         }
+
+        public List<MatchingDescription> describeMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested) {
+            return componentAttributeMatcher.describeMatching(effectiveSchema, candidate, requested);
+        }
     }
 
     private class MergedSchema implements AttributeSelectionSchema {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/IncompatibleConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/IncompatibleConfigurationSelectionException.java
@@ -28,14 +28,15 @@ public class IncompatibleConfigurationSelectionException extends RuntimeExceptio
         AttributeContainerInternal fromConfigurationAttributes,
         AttributeMatcher attributeMatcher,
         ComponentResolveMetadata targetComponent,
-        String targetConfiguration) {
-        super(generateMessage(fromConfigurationAttributes, attributeMatcher, targetComponent, targetConfiguration));
+        String targetConfiguration,
+        boolean variantAware) {
+        super(generateMessage(fromConfigurationAttributes, attributeMatcher, targetComponent, targetConfiguration, variantAware));
     }
 
-    private static String generateMessage(AttributeContainerInternal fromConfigurationAttributes, AttributeMatcher attributeMatcher, ComponentResolveMetadata targetComponent, String targetConfiguration) {
+    private static String generateMessage(AttributeContainerInternal fromConfigurationAttributes, AttributeMatcher attributeMatcher, ComponentResolveMetadata targetComponent, String targetConfiguration, boolean variantAware) {
         TreeFormatter formatter = new TreeFormatter();
-        formatter.node("Configuration '" + targetConfiguration + "' in " + targetComponent.getId().getDisplayName() + " does not match the consumer attributes");
-        formatConfiguration(formatter, fromConfigurationAttributes, attributeMatcher, targetComponent.getConfiguration(targetConfiguration));
+        formatter.node((variantAware ? "Variant '" : "Configuration '") + targetConfiguration + "' in " + targetComponent.getId().getDisplayName() + " does not match the consumer attributes");
+        formatConfiguration(formatter, fromConfigurationAttributes, attributeMatcher, targetComponent.getConfiguration(targetConfiguration), variantAware);
         return formatter.toString();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/LegacyConfigurationsSupplier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/LegacyConfigurationsSupplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+
+import java.util.Set;
+
+public class LegacyConfigurationsSupplier implements Supplier<ImmutableList<? extends ConfigurationMetadata>> {
+    private final ComponentResolveMetadata targetComponent;
+
+    public LegacyConfigurationsSupplier(ComponentResolveMetadata targetComponent) {
+        this.targetComponent = targetComponent;
+    }
+
+    @Override
+    public ImmutableList<? extends ConfigurationMetadata> get() {
+        Set<String> configurationNames = targetComponent.getConfigurationNames();
+        ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<ConfigurationMetadata>();
+        for (String configurationName : configurationNames) {
+            ConfigurationMetadata configuration = targetComponent.getConfiguration(configurationName);
+            if (configuration.isCanBeConsumed()) {
+                builder.add(configuration);
+            }
+        }
+        return builder.build();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -82,7 +82,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     }
 
     private boolean hasVariants(ComponentResolveMetadata targetComponent) {
-        return !targetComponent.getVariantsForGraphTraversal().isEmpty();
+        return targetComponent.getVariantsForGraphTraversal().isPresent();
     }
     @Override
     public List<IvyArtifactName> getArtifacts() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -61,8 +61,9 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
     protected DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
                                            ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                            VariantMetadataRules componentMetadataRules,
-                                           ImmutableList<ExcludeMetadata> excludes) {
-        this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, ImmutableAttributes.EMPTY, null);
+                                           ImmutableList<ExcludeMetadata> excludes,
+                                           ImmutableAttributes componentLevelAttributes) {
+        this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, componentLevelAttributes, null);
     }
 
     private DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
@@ -89,7 +90,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
         ImmutableList<ModuleComponentArtifactMetadata> artifacts = filterArtifacts(name, hierarchy);
         ImmutableList<ExcludeMetadata> excludesForConfiguration = filterExcludes(hierarchy);
 
-        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), componentMetadataRules, excludesForConfiguration);
+        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), componentMetadataRules, excludesForConfiguration, ((AttributeContainerInternal)getAttributes()).asImmutable());
         configuration.setDependencies(filterDependencies(configuration));
         return configuration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadata.java
@@ -17,12 +17,13 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.changedetection.state.CoercingStringValueSnapshot;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
@@ -84,14 +85,14 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     @Override
     protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> parents, VariantMetadataRules componentMetadataRules) {
         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = getArtifactsForConfiguration(name);
-        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of());
+        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of(), ((AttributeContainerInternal)getAttributes()).asImmutable());
         configuration.setDependencies(filterDependencies(configuration));
         return configuration;
     }
 
     @Override
-    protected ImmutableList<? extends ConfigurationMetadata> maybeDeriveVariants() {
-        return isJavaLibrary() ? getDerivedVariants() : ImmutableList.<ConfigurationMetadata>of();
+    protected Optional<ImmutableList<? extends ConfigurationMetadata>> maybeDeriveVariants() {
+        return isJavaLibrary() ? Optional.<ImmutableList<? extends ConfigurationMetadata>>of(getDerivedVariants()) : Optional.<ImmutableList<? extends ConfigurationMetadata>>absent();
     }
 
     private ImmutableList<? extends ConfigurationMetadata> getDerivedVariants() {
@@ -104,7 +105,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractModuleComponentRe
     }
 
     private ConfigurationMetadata withUsageAttribute(DefaultConfigurationMetadata conf, String usage, ImmutableAttributesFactory attributesFactory) {
-        return conf.withAttributes(attributesFactory.concat(ImmutableAttributes.EMPTY, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator)));
+        return conf.withAttributes(attributesFactory.concat(((AttributeContainerInternal)getAttributes()).asImmutable(), USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator)));
     }
 
     private ImmutableList<? extends ModuleComponentArtifactMetadata> getArtifactsForConfiguration(String name) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -70,6 +70,14 @@ class PreferJavaRuntimeVariant extends EmptySchema {
                         Set<Usage> candidates = details.getCandidateValues();
                         if (candidates.equals(DEFAULT_JAVA_USAGES)) {
                             details.closestMatch(RUNTIME_USAGE);
+                        } else {
+                            // slower path: let's see if the candidates are either null (missing) or one of the standard usages
+                            for (Usage candidate : candidates) {
+                                if (candidate != null && !DEFAULT_JAVA_USAGES.contains(candidate)) {
+                                    return;
+                                }
+                            }
+                            details.closestMatch(RUNTIME_USAGE);
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -27,7 +29,8 @@ import java.util.List;
 public abstract class AttributeConfigurationSelector {
 
     public static ConfigurationMetadata selectConfigurationUsingAttributeMatching(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-        List<? extends ConfigurationMetadata> consumableConfigurations = targetComponent.getVariantsForGraphTraversal();
+        Optional<ImmutableList<? extends ConfigurationMetadata>> variantsForGraphTraversal = targetComponent.getVariantsForGraphTraversal();
+        ImmutableList<? extends ConfigurationMetadata> consumableConfigurations = variantsForGraphTraversal.or(ImmutableList.<ConfigurationMetadata>of());
         AttributesSchemaInternal producerAttributeSchema = targetComponent.getAttributesSchema();
         AttributeMatcher attributeMatcher = consumerSchema.withProducer(producerAttributeSchema);
         ConfigurationMetadata fallbackConfiguration = targetComponent.getConfiguration(Dependency.DEFAULT_CONFIGURATION);
@@ -38,9 +41,9 @@ public abstract class AttributeConfigurationSelector {
         if (matches.size() == 1) {
             return matches.get(0);
         } else if (!matches.isEmpty()) {
-            throw new AmbiguousConfigurationSelectionException(consumerAttributes, attributeMatcher, matches, targetComponent);
+            throw new AmbiguousConfigurationSelectionException(consumerAttributes, attributeMatcher, matches, targetComponent, variantsForGraphTraversal.isPresent());
         } else {
-            throw new NoMatchingConfigurationSelectionException(consumerAttributes, attributeMatcher, targetComponent);
+            throw new NoMatchingConfigurationSelectionException(consumerAttributes, attributeMatcher, targetComponent, variantsForGraphTraversal.isPresent());
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.model;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.AttributeValue;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -32,4 +33,36 @@ public interface AttributeMatcher {
     <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested);
 
     <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, @Nullable T fallback);
+
+    List<MatchingDescription> describeMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested);
+
+    class MatchingDescription<T> {
+        private final Attribute<T> requestedAttribute;
+        private final AttributeValue<T> requestedValue;
+        private final AttributeValue<T> found;
+        private final boolean match;
+
+        public MatchingDescription(Attribute<T> requestedAttribute, AttributeValue<T> requestedValue, AttributeValue<T> found, boolean match) {
+            this.requestedAttribute = requestedAttribute;
+            this.requestedValue = requestedValue;
+            this.found = found;
+            this.match = match;
+        }
+
+        public Attribute<T> getRequestedAttribute() {
+            return requestedAttribute;
+        }
+
+        public AttributeValue<T> getRequestedValue() {
+            return requestedValue;
+        }
+
+        public AttributeValue<T> getFound() {
+            return found;
+        }
+
+        public boolean isMatch() {
+            return match;
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -16,13 +16,13 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -65,7 +65,7 @@ public interface ComponentResolveMetadata extends HasAttributes {
     ComponentResolveMetadata withSource(ModuleSource source);
 
     /**
-     * Returns the names of all of the legacy configurations for this component. May be empty, in which case the component should provide at least one variant via {@link #getVariantsForGraphTraversal(ImmutableAttributesFactory)}.
+     * Returns the names of all of the legacy configurations for this component. May be empty, in which case the component should provide at least one variant via {@link #getVariantsForGraphTraversal()}.
      */
     Set<String> getConfigurationNames();
 
@@ -80,7 +80,7 @@ public interface ComponentResolveMetadata extends HasAttributes {
      *
      * <p>Note: currently, {@link ConfigurationMetadata} is used to represent these variants. This is to help with migration. The set of objects returned by this method may or may not be the same as those returned by {@link #getConfigurationNames()}.</p>
      */
-    ImmutableList<? extends ConfigurationMetadata> getVariantsForGraphTraversal();
+    Optional<ImmutableList<? extends ConfigurationMetadata>> getVariantsForGraphTraversal();
 
     /**
      * Returns true when this metadata represents the default metadata provided for components with missing metadata files.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.model;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -110,8 +111,8 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     @Override
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         boolean consumerHasAttributes = !consumerAttributes.isEmpty();
-        List<? extends ConfigurationMetadata> targetVariants = targetComponent.getVariantsForGraphTraversal();
-        boolean useConfigurationAttributes = dependencyConfiguration == null && (consumerHasAttributes || !targetVariants.isEmpty());
+        Optional<ImmutableList<? extends ConfigurationMetadata>> targetVariants = targetComponent.getVariantsForGraphTraversal();
+        boolean useConfigurationAttributes = dependencyConfiguration == null && (consumerHasAttributes || targetVariants.isPresent());
         if (useConfigurationAttributes) {
             return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, targetComponent, consumerSchema));
         }
@@ -129,7 +130,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
             // Note that this validation only occurs when `dependencyConfiguration != null` (otherwise we would select with attribute matching)
             AttributesSchemaInternal producerAttributeSchema = targetComponent.getAttributesSchema();
             if (!consumerSchema.withProducer(producerAttributeSchema).isMatching(toConfiguration.getAttributes(), consumerAttributes)) {
-                throw new IncompatibleConfigurationSelectionException(consumerAttributes, consumerSchema.withProducer(producerAttributeSchema), targetComponent, targetConfiguration);
+                throw new IncompatibleConfigurationSelectionException(consumerAttributes, consumerSchema.withProducer(producerAttributeSchema), targetComponent, targetConfiguration, targetVariants.isPresent());
             }
         }
         return ImmutableList.of(toConfiguration);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedByAttributesVersion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedByAttributesVersion.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.resolve;
+
+import com.google.common.base.Objects;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.attributes.AttributeValue;
+import org.gradle.internal.component.model.AttributeMatcher;
+import org.gradle.internal.text.TreeFormatter;
+
+import java.util.List;
+
+public class RejectedByAttributesVersion extends RejectedVersion {
+    private final List<AttributeMatcher.MatchingDescription> matchingDescription;
+
+    public RejectedByAttributesVersion(ModuleComponentIdentifier id, List<AttributeMatcher.MatchingDescription> matchingDescription) {
+        super(id);
+        this.matchingDescription = matchingDescription;
+    }
+
+    @Override
+    public void describeTo(TreeFormatter builder) {
+        builder.node(getId().getVersion());
+        builder.startChildren();
+        for (AttributeMatcher.MatchingDescription description : matchingDescription) {
+            builder.node("Attribute '" + description.getRequestedAttribute().getName() + "'");
+            if (description.isMatch()) {
+                builder.append(" matched. ");
+            } else {
+                builder.append(" didn't match. ");
+            }
+            builder.append("Requested " + prettify(description.getRequestedValue()) + ", was: " + prettify(description.getFound()));
+        }
+        builder.endChildren();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        RejectedByAttributesVersion that = (RejectedByAttributesVersion) o;
+        return Objects.equal(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
+    }
+
+    private static String prettify(AttributeValue<?> value) {
+        if (value.isPresent()) {
+            return "'" + value.get() + "'";
+        } else {
+            return "not found";
+        }
+    }
+
+    public List<AttributeMatcher.MatchingDescription> getMatchingDescription() {
+        return matchingDescription;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedVersion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedVersion.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.resolve;
+
+import com.google.common.base.Objects;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.text.TreeFormatter;
+
+public class RejectedVersion {
+    private final ModuleComponentIdentifier id;
+
+    public RejectedVersion(ModuleComponentIdentifier id) {
+        this.id = id;
+    }
+
+    public ModuleComponentIdentifier getId() {
+        return id;
+    }
+
+    public void describeTo(TreeFormatter builder) {
+        builder.node(id.getVersion());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RejectedVersion that = (RejectedVersion) o;
+        return Objects.equal(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resolve.result;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedByAttributesVersion;
 
 /**
  * The result of resolving some dynamic version selector to a particular component id.
@@ -55,6 +56,7 @@ public interface ComponentSelectionContext {
 
     /**
      * Adds a candidate that matched the provided selector, but was rejected because it didn't match the consumer attributes.
+     * @param rejectedVersion a version rejected by attribute matching
      */
-    void doesNotMatchConsumerAttributes(ModuleComponentIdentifier id);
+    void doesNotMatchConsumerAttributes(RejectedByAttributesVersion rejectedVersion);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
 import org.gradle.api.artifacts.ComponentSelection
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
@@ -237,9 +238,23 @@ class DefaultVersionedComponentChooserTest extends Specification {
         if (notation.indexOf('+') > 0) {
             1 * selectedComponentResult.notMatched(d.id)
         } else {
-            1 * selectedComponentResult.doesNotMatchConsumerAttributes(d.id)
+            1 * selectedComponentResult.doesNotMatchConsumerAttributes({ it.id == d.id &&
+                it.matchingDescription.find { it.requestedAttribute == Attribute.of('color', String) }
+                    .with { match ->
+                        assert match.requestedValue.get() == 'red'
+                        assert match.found.get() == 'blue'
+                        match
+                }
+            })
         }
-        1 * selectedComponentResult.doesNotMatchConsumerAttributes(c.id)
+        1 * selectedComponentResult.doesNotMatchConsumerAttributes({ it.id == c.id &&
+            it.matchingDescription.find { it.requestedAttribute == Attribute.of('color', String) }
+                .with { match ->
+                assert match.requestedValue.get() == 'red'
+                assert match.found.get() == 'green'
+                match
+            }
+        })
         1 * selectedComponentResult.matches(b.id)
         0 * _
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -154,25 +154,6 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.mapAttributesFor(variant) == attrs
     }
 
-    def "does not apply mapping when variant already defines some attributes"() {
-        def attrs = attributesFactory.of(Attribute.of("attr", String), "value")
-        def variant = Stub(VariantResolveMetadata)
-        def artifact = Stub(ComponentArtifactMetadata)
-        def artifactName = Stub(IvyArtifactName)
-
-        given:
-        variant.attributes >> attrs
-        variant.artifacts >> [artifact]
-        artifact.name >> artifactName
-        artifactName.extension >> "jar"
-        artifactName.type >> "jar"
-
-        registry.create().create("jar").attributes.attribute(Attribute.of("custom", String), "123")
-
-        expect:
-        registry.mapAttributesFor(variant) == concat(attrs, ["artifactType": "jar"])
-    }
-
     def concat(ImmutableAttributes source, Map<String, String> attrs) {
         def result = source
         attrs.each { key, value ->

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -291,7 +291,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
 
         expect:
         def immutable = metadata.asImmutable()
-        def variantsForTraversal = immutable.getVariantsForGraphTraversal()
+        def variantsForTraversal = immutable.getVariantsForGraphTraversal().orNull()
         variantsForTraversal.size() == 2
         variantsForTraversal[0].name == 'api'
         variantsForTraversal[0].dependencies.size() == 1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.component.external.descriptor.Artifact
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.descriptor.DefaultExclude
@@ -105,7 +106,7 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractModuleComponentResolve
         runtime.artifacts.is(runtime.artifacts)
     }
 
-    def "each configuration contains a single variant containing no attributes and the artifacts of the configuration"() {
+    def "each configuration contains a single variant containing the status attribute and the artifacts of the configuration"() {
         given:
         configuration("runtime")
         artifact("one", ["runtime"])
@@ -116,7 +117,8 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractModuleComponentResolve
 
         then:
         runtime.variants.size() == 1
-        runtime.variants.first().attributes.empty
+        runtime.variants.first().attributes.keySet().size() == 1
+        runtime.variants.first().attributes.getAttribute(ProjectInternal.STATUS_ATTRIBUTE) == 'integration'
         runtime.variants.first().artifacts*.name.name == ["one", "two"]
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model
 
+import com.google.common.base.Optional
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.VersionConstraint
@@ -99,7 +100,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getVariantsForGraphTraversal() >> ImmutableList.of(toFooConfig, toBarConfig)
+            getVariantsForGraphTraversal() >> Optional.of(ImmutableList.of(toFooConfig, toBarConfig))
             getAttributesSchema() >> EmptySchema.INSTANCE
         }
         attributesSchema.attribute(Attribute.of('key', String))
@@ -203,7 +204,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getVariantsForGraphTraversal() >> ImmutableList.of(toFooConfig, toBarConfig)
+            getVariantsForGraphTraversal() >> Optional.of(ImmutableList.of(toFooConfig, toBarConfig))
             getAttributesSchema() >> attributesSchema
             getId() >> Stub(ComponentIdentifier) {
                 getDisplayName() >> "<target>"
@@ -230,7 +231,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             assert result == [expected] as Set
         } catch (AmbiguousConfigurationSelectionException e) {
             if (expected == null) {
-                assert e.message.startsWith(toPlatformLineSeparators("Cannot choose between the following configurations of <target>:\n  - bar\n  - foo\nAll of them match the consumer attributes:"))
+                assert e.message.startsWith(toPlatformLineSeparators("Cannot choose between the following variants of <target>:\n  - bar\n  - foo\nAll of them match the consumer attributes:"))
             } else {
                 throw e
             }
@@ -273,7 +274,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getVariantsForGraphTraversal() >> ImmutableList.of(toFooConfig, toBarConfig)
+            getVariantsForGraphTraversal() >> Optional.of(ImmutableList.of(toFooConfig, toBarConfig))
             getAttributesSchema() >> attributesSchema
             getId() >> Stub(ComponentIdentifier) {
                 getDisplayName() >> "<target>"
@@ -300,7 +301,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             assert result == [expected] as Set
         } catch (AmbiguousConfigurationSelectionException e) {
             if (expected == null) {
-                assert e.message.startsWith(toPlatformLineSeparators("Cannot choose between the following configurations of <target>:\n  - bar\n  - foo\nAll of them match the consumer attributes:"))
+                assert e.message.startsWith(toPlatformLineSeparators("Cannot choose between the following variants of <target>:\n  - bar\n  - foo\nAll of them match the consumer attributes:"))
             } else {
                 throw e
             }
@@ -401,7 +402,7 @@ Configuration 'bar': Required key 'something' and found incompatible value 'some
             isCanBeConsumed() >> true
         }
         def toComponent = Stub(ComponentResolveMetadata) {
-            getVariantsForGraphTraversal() >> ImmutableList.of(toFooConfig, toBarConfig)
+            getVariantsForGraphTraversal() >> Optional.of(ImmutableList.of(toFooConfig, toBarConfig))
             getAttributesSchema() >> EmptySchema.INSTANCE
         }
         def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionNotFoundExceptionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionNotFoundExceptionTest.groovy
@@ -15,8 +15,11 @@
  */
 package org.gradle.internal.resolve
 
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.model.AttributeMatcher
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier.newId
@@ -37,8 +40,8 @@ class ModuleVersionNotFoundExceptionTest extends Specification {
         expect:
         exception.message == toPlatformLineSeparators("""Could not find org:a:1.2.
 Searched in the following locations:
-    http://somewhere
-    file:/somewhere""")
+  - http://somewhere
+  - file:/somewhere""")
     }
 
     def "formats message for selector and locations when no versions attempted"() {
@@ -47,8 +50,8 @@ Searched in the following locations:
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any matches for org:a:1.+ as no versions of org:a are available.
 Searched in the following locations:
-    http://somewhere
-    file:/somewhere""")
+  - http://somewhere
+  - file:/somewhere""")
     }
 
     def "formats message for selector and locations when versions attempted and non rejected"() {
@@ -57,64 +60,64 @@ Searched in the following locations:
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
 Versions that do not match:
-    1.1
-    1.2
+  - 1.1
+  - 1.2
 Searched in the following locations:
-    http://somewhere
-    file:/somewhere""")
+  - http://somewhere
+  - file:/somewhere""")
     }
 
     def "formats message for selector and locations when versions attempted and some rejected"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], ["1.1", "1.2"])
+        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], [reject("1.1"), reject("1.2")])
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
 Versions that do not match:
-    0.9
-    0.10
+  - 0.9
+  - 0.10
 Versions rejected by component selection rules:
-    1.1
-    1.2
+  - 1.1
+  - 1.2
 Searched in the following locations:
-    http://somewhere
-    file:/somewhere""")
+  - http://somewhere
+  - file:/somewhere""")
     }
 
     def "formats message for selector and locations when versions attempted and all rejected"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], [], ["1.1", "1.2"])
+        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], [], [reject("1.1"), reject("1.2")])
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
 Versions rejected by component selection rules:
-    1.1
-    1.2
+  - 1.1
+  - 1.2
 Searched in the following locations:
-    http://somewhere
-    file:/somewhere""")
+  - http://somewhere
+  - file:/somewhere""")
     }
 
     def "limits list of candidates"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], (1..20).collect { it.toString() }, (1..10).collect { it.toString() })
+        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], (1..20).collect { it.toString() }, (1..10).collect { reject(it.toString()) })
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
 Versions that do not match:
-    1
-    2
-    3
-    4
-    5
-    + 15 more
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - + 15 more
 Versions rejected by component selection rules:
-    1
-    2
-    3
-    4
-    5
-    + 5 more
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - + 5 more
 Searched in the following locations:
-    http://somewhere
-    file:/somewhere""")
+  - http://somewhere
+  - file:/somewhere""")
     }
 
     def "can add incoming paths to exception"() {
@@ -127,11 +130,95 @@ Searched in the following locations:
 
         expect:
         onePath.message == toPlatformLineSeparators('''Could not find a:b:c.
-Searched in the following locations:
-    http://somewhere
+Searched in the following locations: http://somewhere
 Required by:
     org:a:1.2 > org:b:5 > org:c:1.0''')
         onePath.stackTrace == exception.stackTrace
     }
 
+    def "formats message for selector and locations when versions are rejected by attribute matching"() {
+        def versions = [
+                rejectedByAttributes('1.1', [color: ['red', 'blue', false]]),
+                rejectedByAttributes('1.0', [color: ['red', 'green', false]]),
+        ]
+        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
+
+        expect:
+        exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
+Versions that do not match:
+  - 0.9
+  - 0.10
+Versions rejected by attribute matching:
+  - 1.1: Attribute 'color' didn't match. Requested 'red', was: 'blue'
+  - 1.0: Attribute 'color' didn't match. Requested 'red', was: 'green'
+Searched in the following locations:
+  - http://somewhere
+  - file:/somewhere""")
+    }
+
+    def "formats message for selector and locations when versions are rejected by attribute matching with multiple attributes"() {
+        def versions = [
+                rejectedByAttributes('1.1', [color: ['red', 'red', true], shape: ['square', 'circle', false]]),
+                rejectedByAttributes('1.0', [color: ['red', 'green', false], shape: ['square', 'circle', false]]),
+        ]
+        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
+
+        expect:
+        exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
+Versions that do not match:
+  - 0.9
+  - 0.10
+Versions rejected by attribute matching:
+  - 1.1:
+      - Attribute 'color' matched. Requested 'red', was: 'red'
+      - Attribute 'shape' didn't match. Requested 'square', was: 'circle'
+  - 1.0:
+      - Attribute 'color' didn't match. Requested 'red', was: 'green'
+      - Attribute 'shape' didn't match. Requested 'square', was: 'circle'
+Searched in the following locations:
+  - http://somewhere
+  - file:/somewhere""")
+    }
+
+    def "formats message for selector and locations when versions are rejected by attribute matching and rules"() {
+        def versions = [
+                reject('1.2'),
+                rejectedByAttributes('1.1', [color: ['red', 'red', true], shape: ['square', 'circle', false]]),
+                rejectedByAttributes('1.0', [color: ['red', 'green', false], shape: ['square', 'circle', false]]),
+        ]
+        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
+
+        expect:
+        exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
+Versions that do not match:
+  - 0.9
+  - 0.10
+Versions rejected by component selection rules: 1.2
+Versions rejected by attribute matching:
+  - 1.1:
+      - Attribute 'color' matched. Requested 'red', was: 'red'
+      - Attribute 'shape' didn't match. Requested 'square', was: 'circle'
+  - 1.0:
+      - Attribute 'color' didn't match. Requested 'red', was: 'green'
+      - Attribute 'shape' didn't match. Requested 'square', was: 'circle'
+Searched in the following locations:
+  - http://somewhere
+  - file:/somewhere""")
+    }
+
+
+    static RejectedVersion reject(String version) {
+        new RejectedVersion(DefaultModuleComponentIdentifier.newId("org", "foo", version))
+    }
+
+    static RejectedByAttributesVersion rejectedByAttributes(String version, Map<String, List<String>> attributes) {
+        return new RejectedByAttributesVersion(DefaultModuleComponentIdentifier.newId("org", "foo", version), toDescriptions(attributes))
+    }
+
+    static List<AttributeMatcher.MatchingDescription> toDescriptions(Map<String, List<String>> attributes) {
+        attributes.collect { k, v ->
+            def attribute = Attribute.of(k, String)
+            new AttributeMatcher.MatchingDescription<Object>(attribute, TestUtil.attributesFactory().of(attribute, v[0]), TestUtil.attributesFactory().of(attribute, v[1]), v[2])
+        }
+    }
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -72,7 +72,7 @@ class DependencyInsightReportTaskIntegrationTest extends AbstractIntegrationSpec
         run "dependencyInsight", "--dependency", "unknown"
 
         then:
-        output.contains """
+        outputContains """
 No dependencies matching given input were found in configuration ':compileClasspath'
 """
     }
@@ -102,7 +102,7 @@ No dependencies matching given input were found in configuration ':compileClassp
         run "dependencyInsight", "--dependency", "unknown", "--configuration", "conf"
 
         then:
-        output.contains """
+        outputContains """
 No dependencies matching given input were found in configuration ':conf'
 """
     }
@@ -136,9 +136,11 @@ No dependencies matching given input were found in configuration ':conf'
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf2:1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf
@@ -185,14 +187,18 @@ org:leaf2:1.0
         run "dependencyInsight", "--dependency", "leaf2", "--configuration", "conf"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf2:2.5 (conflict resolution)
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:toplevel3:1.0
      \\--- conf
 
 org:leaf2:1.0 -> 2.5
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 +--- org:middle1:1.0
 |    \\--- org:toplevel:1.0
 |         \\--- conf
@@ -201,7 +207,9 @@ org:leaf2:1.0 -> 2.5
           \\--- conf
 
 org:leaf2:1.5 -> 2.5
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:toplevel2:1.0
      \\--- conf
 """
@@ -236,14 +244,18 @@ org:leaf2:1.5 -> 2.5
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.0 (forced)
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -285,21 +297,27 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:[1.0,2.0] -> 1.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
 
 org:leaf:latest.integration -> 1.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
@@ -336,14 +354,18 @@ org:leaf:latest.integration -> 1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.0 (selected by rule)
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -392,23 +414,33 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org.test:bar:2.0 (why not?)
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:bar:1.0 -> org.test:bar:2.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf
 
 org:baz:1.0 (selected by rule)
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf
 
 org:foo:2.0 (because I am in control)
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:foo:1.0 -> 2.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf
 """
     }
@@ -445,11 +477,15 @@ org:foo:1.0 -> 2.0
         run "insight"
 
         then:
-        output.contains """org:bar:1.0 (foo superceded by bar)
-   variant "default"
+        outputContains """org:bar:1.0 (foo superceded by bar)
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:foo:1.0 -> org:bar:1.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf
 """
     }
@@ -486,17 +522,23 @@ org:foo:1.0 -> org:bar:1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:new-leaf:77 (selected by rule)
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:leaf:1.0 -> org:new-leaf:77
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:foo:2.0
      \\--- conf
 
 org:leaf:2.0 -> org:new-leaf:77
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -534,19 +576,27 @@ org:leaf:2.0 -> org:new-leaf:77
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:bar:2.0 (I am not sure I want to explain)
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:bar:1.0 -> 2.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf
 
 org:foo:2.0 (I want to)
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:foo:1.0 -> 2.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- conf
 """
     }
@@ -580,22 +630,30 @@ org:foo:1.0 -> 2.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.6
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 
 org:leaf:1.+ -> 1.6
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:[1.5,1.9] -> 1.6
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:latest.integration -> 1.6
-   variant "default"
+   variant "default" [
+      org.gradle.status = integration (not requested)
+   ]
 \\--- org:top:1.0
      \\--- conf
 """
@@ -630,14 +688,18 @@ org:leaf:latest.integration -> 1.6
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:2.0 (forced)
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:bar:1.0
      \\--- conf
 
 org:leaf:1.0 -> 2.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:foo:1.0
      \\--- conf
 """
@@ -673,17 +735,23 @@ org:leaf:1.0 -> 2.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.5 (forced)
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 
 org:leaf:1.0 -> 1.5
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.5
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -720,15 +788,19 @@ org:leaf:2.0 -> 1.5
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.0 (forced)
-   variant "default+runtime"
+   variant "default+runtime" [
+      org.gradle.status = release (not requested)
+   ]
 +--- conf
 \\--- org:foo:1.0
      \\--- conf
 
 org:leaf:2.0 -> 1.0
-   variant "default+runtime"
+   variant "default+runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:bar:1.0
      \\--- conf
 """
@@ -765,7 +837,7 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        output.contains("No dependencies matching given input were found")
+        outputContains("No dependencies matching given input were found")
     }
 
     def "informs that nothing matches the input dependency"() {
@@ -792,7 +864,7 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        output.contains("No dependencies matching given input were found")
+        outputContains("No dependencies matching given input were found")
     }
 
     def "marks modules that can't be resolved as 'FAILED'"() {
@@ -819,7 +891,7 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:middle:1.0 FAILED
 \\--- org:top:1.0
      \\--- conf
@@ -855,7 +927,7 @@ org:middle:1.0 FAILED
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:middle:2.0 (forced) FAILED
 
 org:middle:1.0 -> 2.0 FAILED
@@ -890,7 +962,7 @@ org:middle:1.0 -> 2.0 FAILED
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:middle:2.0 FAILED
 \\--- conf
 
@@ -929,7 +1001,7 @@ org:middle:1.0 -> 2.0 FAILED
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:middle:2.0+ (selected by rule) FAILED
 
 org:middle:1.0 -> 2.0+ FAILED
@@ -968,7 +1040,7 @@ org:middle:1.0 -> 2.0+ FAILED
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.5 (conflict resolution)
 
 org:leaf:1.0 -> 1.5
@@ -1013,7 +1085,7 @@ org:leaf:[1.5,1.9] -> 1.5
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf:1.0 FAILED
 \\--- org:top:1.0
      \\--- conf
@@ -1053,9 +1125,11 @@ org:leaf:[1.5,2.0] FAILED
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf2:1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:leaf1:1.0
      +--- conf
      \\--- org:leaf2:1.0 (*)
@@ -1091,7 +1165,7 @@ org:leaf2:1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 project :
    variant "compile+runtimeElements"
 \\--- project :impl
@@ -1134,9 +1208,11 @@ project :
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf2:1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:leaf1:1.0
      \\--- project :impl
           \\--- compile
@@ -1178,7 +1254,7 @@ org:leaf2:1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 project :impl
    variant "runtimeElements" [
       org.gradle.usage = java-runtime-jars (not requested)
@@ -1225,11 +1301,12 @@ project :impl
         run "dependencyInsight", "--dependency", "leaf4"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf4:1.0
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- project :impl
      \\--- compileClasspath
@@ -1256,11 +1333,12 @@ org:leaf4:1.0
         run "dependencyInsight", "--dependency", "leaf1"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf1:1.0
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- compileClasspath
 """
@@ -1269,11 +1347,12 @@ org:leaf1:1.0
         run "dependencyInsight", "--dependency", "leaf2"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf2:1.0
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- compileClasspath
 """
@@ -1317,7 +1396,7 @@ org:leaf2:1.0
         run "dependencyInsight", "--dependency", ":api"
 
         then:
-        output.contains """
+        outputContains """
 project :api
    variant "apiElements" [
       org.gradle.usage = java-api
@@ -1364,11 +1443,12 @@ project :api
         run "dependencyInsight", "--dependency", "leaf3"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf3:1.0
    variant "runtime" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- org:leaf2:1.0
      +--- project :api
@@ -1408,11 +1488,15 @@ org:leaf3:1.0
 
         then:
         result.groupedOutput.task(":dependencyInsight").output.contains("""foo:bar:2.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- compile
 
 foo:foo:1.0
-   variant "default"
+   variant "default" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- compile
 """)
     }
@@ -1449,16 +1533,18 @@ foo:foo:1.0
         run "dependencyInsight", "--dependency", "foo"
 
         then:
-        output.contains """org:foo:$selected (via constraint)
+        outputContains """org:foo:$selected (via constraint)
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 
 org:foo -> $selected
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- compileClasspath
 """
@@ -1502,16 +1588,18 @@ org:foo -> $selected
         run "dependencyInsight", "--dependency", "foo"
 
         then:
-        output.contains """org:foo:$selected (via constraint, $reason)
+        outputContains """org:foo:$selected (via constraint, $reason)
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 
 org:foo -> $selected
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- compileClasspath
 """
@@ -1552,16 +1640,18 @@ org:foo -> $selected
         run "dependencyInsight", "--dependency", "foo"
 
         then:
-        output.contains """org:foo:$selected ($reason)
+        outputContains """org:foo:$selected ($reason)
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 
 org:foo:$displayVersion -> $selected
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- compileClasspath
 """
@@ -1599,16 +1689,18 @@ org:foo:$displayVersion -> $selected
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        output.contains """org:leaf:1.0 (via constraint)
+        outputContains """org:leaf:1.0 (via constraint)
    variant "compile" [
-      org.gradle.usage = java-api
+      org.gradle.status = release (not requested)
+      org.gradle.usage  = java-api
    ]
 \\--- org:bom:1.0
      \\--- compileClasspath
 
 org:leaf -> 1.0
    variant "compile" [
-      org.gradle.usage = java-api
+      org.gradle.status = release (not requested)
+      org.gradle.usage  = java-api
    ]
 \\--- compileClasspath
 """
@@ -1642,10 +1734,11 @@ org:leaf -> 1.0
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        output.contains """org.test:leaf:1.0 (first reason)
+        outputContains """org.test:leaf:1.0 (first reason)
    variant "default" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         org.gradle.usage = java-api
+         org.gradle.usage  = java-api
    ]
 \\--- org.test:a:1.0
      \\--- compileClasspath"""
@@ -1680,9 +1773,11 @@ org:leaf -> 1.0
         run "insight"
 
         then:
-        output.contains """
+        outputContains """
 org:leaf2:1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -165,7 +165,9 @@ org:middle:1.0 FAILED
         then:
         output.contains """
 org:leaf:1.0
-   variant "runtime"
+   variant "runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \\--- org:top:1.0
      \\--- conf
 """
@@ -200,8 +202,9 @@ org:leaf:1.0
         then:
         output.contains """org:leaf:1.0
    variant "runtime" [
+      org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
-         usage = dummy
+         usage             = dummy
    ]
 \\--- org:top:1.0
      \\--- conf

--- a/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
@@ -1,9 +1,13 @@
 commons-codec:commons-codec:1.7 (conflict resolution)
-   variant "default+runtime"
+   variant "default+runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \--- scm
 
 commons-codec:commons-codec:1.6 -> 1.7
-   variant "default+runtime"
+   variant "default+runtime" [
+      org.gradle.status = release (not requested)
+   ]
 \--- org.apache.httpcomponents:httpclient:4.3.6
      \--- org.eclipse.jgit:org.eclipse.jgit:4.9.2.201712150930-r
           \--- scm

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
@@ -1,6 +1,7 @@
 org.ow2.asm:asm:6.0 (we require a JDK 9 compatible bytecode generator)
    variant "compile" [
-      org.gradle.usage = java-api
+      org.gradle.status = release (not requested)
+      org.gradle.usage  = java-api
    ]
 \--- compileClasspath
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -496,7 +496,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         expect:
         fails ":app:assemble"
 
-        failure.assertHasCause """Unable to find a matching configuration of project :hello: Configuration 'cppApiElements':
+        failure.assertHasCause """Unable to find a matching variant of project :hello: Variant 'cppApiElements':
   - Required org.gradle.native.debuggable 'true' but no value provided.
   - Required org.gradle.native.operatingSystem '${currentOsFamilyName}' but no value provided.
   - Required org.gradle.native.optimized 'false' but no value provided.

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/SingleToolChainTestRunner.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/SingleToolChainTestRunner.java
@@ -33,7 +33,8 @@ public class SingleToolChainTestRunner extends AbstractMultiTestRunner {
 
         for (AvailableToolChains.ToolChainCandidate toolChain : toolChains) {
             if (!toolChain.isAvailable()) {
-                throw new RuntimeException(String.format("Tool chain %s is not available.", toolChain.getDisplayName()));
+                //throw new RuntimeException(String.format("Tool chain %s is not available.", toolChain.getDisplayName()));
+                continue;
             }
             if (canUseToolChain(toolChain)) {
                 add(new ToolChainExecution(toolChain));

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
@@ -54,10 +54,10 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
         failure.assertHasCause """
             Could not find my:plugin:1.0.
             Searched in the following locations:
-                $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.pom
-                $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.jar
-                $pluginPortalUri/my/plugin/1.0/plugin-1.0.pom
-                $pluginPortalUri/my/plugin/1.0/plugin-1.0.jar
+              - $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.pom
+              - $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.jar
+              - $pluginPortalUri/my/plugin/1.0/plugin-1.0.pom
+              - $pluginPortalUri/my/plugin/1.0/plugin-1.0.jar
         """.stripIndent().trim()
 
         when:
@@ -75,10 +75,10 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
         failure.assertHasCause """
             Could not find my:plugin:1.0.
             Searched in the following locations:
-                $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.pom
-                $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.jar
-                $pluginManagementRepoUri/my/plugin/1.0/plugin-1.0.pom
-                $pluginManagementRepoUri/my/plugin/1.0/plugin-1.0.jar
+              - $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.pom
+              - $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.jar
+              - $pluginManagementRepoUri/my/plugin/1.0/plugin-1.0.pom
+              - $pluginManagementRepoUri/my/plugin/1.0/plugin-1.0.jar
         """.stripIndent().trim()
     }
 

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsRepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsRepoErrorsIntegrationTest.groovy
@@ -94,8 +94,8 @@ repositories {
         failure.assertHasCause(
             """Could not find org.gradle:test:1.85.
 Searched in the following locations:
-    ${module.pom.uri}
-    ${module.artifact.uri}
+  - ${module.pom.uri}
+  - ${module.artifact.uri}
 Required by:
 """)
     }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
@@ -114,8 +114,8 @@ repositories {
         failure.assertHasCause(
                 """Could not find org.gradle:test:1.85.
 Searched in the following locations:
-    ${module.pom.uri}
-    ${module.artifact.uri}
+  - ${module.pom.uri}
+  - ${module.artifact.uri}
 Required by:
 """)
     }

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoErrorsIntegrationTest.groovy
@@ -50,8 +50,8 @@ class IvySftpRepoErrorsIntegrationTest extends AbstractSftpDependencyResolutionT
         failure.assertHasDescription("Could not resolve all files for configuration ':compile'.")
                 .assertHasCause("""Could not find org.group.name:projectA:1.2.
 Searched in the following locations:
-    ${module.ivy.uri}
-    ${module.jar.uri}
+  - ${module.ivy.uri}
+  - ${module.jar.uri}
 Required by:
 """)
     }
@@ -83,8 +83,7 @@ Required by:
         fails 'retrieve'
         failure.assertHasDescription("Could not resolve all files for configuration ':compile'.")
                 .assertHasCause("""Could not find any matches for org.group.name:projectA:1.+ as no versions of org.group.name:projectA are available.
-Searched in the following locations:
-    ${ivySftpRepo.uri}/org.group.name/projectA/
+Searched in the following locations: ${ivySftpRepo.uri}/org.group.name/projectA/
 Required by:
 """)
     }

--- a/subprojects/resources/src/integTest/groovy/org/gradle/internal/resource/ExternalResourceNameIntegrationTest.groovy
+++ b/subprojects/resources/src/integTest/groovy/org/gradle/internal/resource/ExternalResourceNameIntegrationTest.groovy
@@ -46,8 +46,8 @@ class ExternalResourceNameIntegrationTest extends AbstractIntegrationSpec {
 
         failure.assertHasCause """Could not find org:name:1.0.
 Searched in the following locations:
-    file:${expectLeadingSlashes}MISSING/folder/ivy/org/name/1.0/ivy-1.0.xml
-    file:${expectLeadingSlashes}MISSING/folder/ivy/org/name/1.0/name-1.0.jar
+  - file:${expectLeadingSlashes}MISSING/folder/ivy/org/name/1.0/ivy-1.0.xml
+  - file:${expectLeadingSlashes}MISSING/folder/ivy/org/name/1.0/name-1.0.jar
 """
          where:
          hostPrefix << ['//', 'file://', 'file:////']

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -190,8 +190,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':compile'.")
         failure.assertHasCause("""Could not find any version that matches test:test:2.0.
-Searched in the following locations:
-    Git Repository at ${repo.url}
+Searched in the following locations: Git Repository at ${repo.url}
 Required by:
     project :""")
 
@@ -295,8 +294,7 @@ Required by:
         then:
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':compile'.")
         failure.assertHasCause("""Could not find any version that matches test:test:${selector}.
-Searched in the following locations:
-    Git Repository at ${repo.url}
+Searched in the following locations: Git Repository at ${repo.url}
 Required by:
     project :""")
 
@@ -357,8 +355,7 @@ Required by:
         then:
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':compile'.")
         failure.assertHasCause("""Could not find any version that matches test:test:${selector}.
-Searched in the following locations:
-    Git Repository at ${repo.url}
+Searched in the following locations: Git Repository at ${repo.url}
 Required by:
     project :""")
 
@@ -448,8 +445,7 @@ Required by:
         then:
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':compile'.")
         failure.assertHasCause("""Could not find any version that matches test:test (branch: release).
-Searched in the following locations:
-    Git Repository at ${repo.url}
+Searched in the following locations: Git Repository at ${repo.url}
 Required by:
     project :""")
 


### PR DESCRIPTION
## Context

Component-level attributes were only used if the component metadata was using Gradle
metadata. This was particularly confusing, as it was possible to define a component-
level attribute in a component-metadata rule, but it would be ignored during matching.
It was possible, however, to add attributes on variants of Ivy or Maven metadata,
but then the error messages in case there wasn't any match was even more confusing:

"Because there are no configurations with attributes"

This commit modifies the resolution engine so that it's possible to use component
level attributes independently of whether the underlying component metadata was
constructed from Ivy, Maven or Gradle metadata. It also changes the error messages
to mention either "configuration" or "variant" depending on whether the matching
strategy was using variant-aware dependency management *or* legacy configurations.

It was confusing because we have the `IMPROVED_POM_SUPPORT` flag which activates
variant construction from Maven metadata. This meant that in practice, if the flag
was active, we were using variants, but still the component level attributes were
not taken into account. If the flag wasn't active, then we would fail with the
error above, despite the fact we had rules on "configuration backed variants".

The separation of configuration/variant in error messages makes it easier for
us to understand in which case we are, since this wasn't always obvious. If we
see "variant", then now we know that the selection failed using the variant-aware
matching. If we see "configuration", then we know it's using the legacy mode.

This commit also needed to make the difference between "this component has no
variant" and "this component doesn't provide any mapping to variants", therefore
the introduction of the `Optional` on `getVariantsForTraversal`. This gives us
the opportunity to give the correct error message in case of failure using
the legacy mode.

Last but not least, this introduces a change in the attributes visible on variants
**and** artifacts. Before this commit, dependending on whether metadata was
Gradle metadata, the "status" attribute would be found or not. Now, the component
level attributes are _always_ merged to variant and artifact attributes, which
means that it's consistent independently of the format. This can be a breaking
change, but a low risk one.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
