### PR TITLE
Fix NullPointerException on QEMU

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddresses.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddresses.java
@@ -46,8 +46,10 @@ class InetAddresses {
 
     private void analyzeNetworkInterfaces() throws SocketException {
         Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-        while (interfaces.hasMoreElements()) {
-            analyzeNetworkInterface(interfaces.nextElement());
+        if (interfaces != null) {
+            while (interfaces.hasMoreElements()) {
+                analyzeNetworkInterface(interfaces.nextElement());
+            }   
         }
     }
 
@@ -102,8 +104,10 @@ class InetAddresses {
     private void useMulticastFallback() throws SocketException {
         logger.debug("No multicast interfaces, using fallbacks");
         Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        while (networkInterfaces.hasMoreElements()) {
-            multicastInterfaces.add(networkInterfaces.nextElement());
+        if (networkInterfaces != null) {
+            while (networkInterfaces.hasMoreElements()) {
+                multicastInterfaces.add(networkInterfaces.nextElement());
+            }
         }
     }
 


### PR DESCRIPTION
Iterate only if Enumeration is not null

### Context
I'm working on a cross plateform CI using Docker and QEMU.
And when I tried to run a gradle build it fail with that error caused by a NPE  : 

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine a usable local IP for this machine.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
/go/src/github.com/kuzzleio/sdk-go
```

This is due to the fact that my container runs inside a ARMV7 QEMU VM.

After applying this little fix and rebuild gradle,  I was able to build and run tests for my project inside .

### Step to reproduce bug 

* Have docker installed on a AMD64 desktop.
* Run `docker run --rm --privileged multiarch/qemu-user-static:register` to enable Docker QEMU support.
* Download [Kuzzle SDK Go](https://github.com/kuzzleio/sdk-go)
* Checkout to branch `test-automation` 
* Then run `docker run --rm --name build-machine --privileged --mount type=bind,source="$(pwd)",target=/go/src/github.com/kuzzleio/sdk-go kuzzleio/sdk-cross:armv7 /build.sh`

