### PR TITLE
Honor nested `afterEvaluate` requests

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
@@ -24,6 +24,25 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << "rootProject.name='root'"
     }
 
+    def "nested afterEvaluate is honored asynchronously"() {
+        given:
+        buildFile << """
+            afterEvaluate {
+                println "> Outer"
+                afterEvaluate {
+                    println "Inner"
+                }
+                println "< Outer"
+            }
+        """
+
+        when:
+        succeeds 'help'
+
+        then:
+        output =~ /> Outer\s+< Outer\s+Inner/
+    }
+
     def "if two exceptions occur, prints an info about both without stacktrace"() {
         given:
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.project;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.UnknownProjectException;
@@ -41,6 +42,8 @@ import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.model.internal.registry.ModelRegistryScope;
 import org.gradle.util.Path;
+
+import javax.annotation.Nullable;
 
 @UsedByScanPlugin
 public interface ProjectInternal extends Project, ProjectIdentifier, FileOperations, ProcessOperations, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
@@ -120,5 +123,14 @@ public interface ProjectInternal extends Project, ProjectIdentifier, FileOperati
      */
     Path getIdentityPath();
 
-
+    /**
+     * Executes the given action against the given listener collecting any new listener registrations in a separate
+     * {@link ProjectEvaluationListener} instance which is returned at the end if not empty.
+     *
+     * @param listener the current listener
+     * @param action the listener action
+     * @return null if no listeners were added during evaluation or the {@link ProjectEvaluationListener} instance representing the new batch of registered listeners
+     */
+    @Nullable
+    ProjectEvaluationListener stepEvaluationListener(ProjectEvaluationListener listener, Action<ProjectEvaluationListener> action);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
@@ -46,6 +46,10 @@ class LifecycleProjectEvaluatorTest extends Specification {
         project.projectPath >> Path.path(":project1")
         project.path >> project.projectPath.toString()
         project.identityPath >> Path.path(":project1")
+        project.stepEvaluationListener(listener, _) >> { listener, step ->
+            step.execute(listener)
+            null
+        }
     }
 
     void "nothing happens if project was already configured"() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -84,6 +84,41 @@ The following are the features that have been promoted in this Gradle release.
 
 ## Fixed issues
 
+### Nested `afterEvaluate` requests are no longer silently ignored
+
+Before this release, `afterEvaluate` requests happening during the execution of an `afterEvaluate` callback were silently ignored.
+
+Consider the following code:
+
+```gradle
+afterEvaluate {
+    println "> Outer"
+    afterEvaluate {
+        println "Inner"
+    }
+    println "< Outer"
+}
+```
+
+In Gradle 4.7 and below, it would print:
+
+```text
+> Outer
+< Outer
+```
+
+With the `Inner` part being silently ignored.
+
+Starting with Gradle 4.8, nested `afterEvaluate` requests will be honoured asynchronously in order to preserve the callback _execute later_ semantics, in other words, the same code will now print:
+
+```text
+> Outer
+< Outer
+Inner
+```
+
+Please note that `beforeEvaluate` and other similar hooks have *not* been changed and will still silently ignore nested requests, that behaviour is subject to change in a future Gradle release (gradle/gradle#5262).
+
 ## Deprecations
 
 Features that have become superseded or irrelevant due to the natural evolution of Gradle become *deprecated*, and scheduled to be removed


### PR DESCRIPTION
By doing a sort of fixed-point iteration on `notifyAfterEvaluate` until no more `afterEvaluate` listeners are registered.

See #3411