### PR TITLE
Add configureLater(name, action) to TaskContainer

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -72,7 +72,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      */
     @Incubating
     <T extends Task> TaskProvider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException;
-    
+
     /**
      * <p>Creates a {@link Task} and adds it to this container. A map of creation options can be passed to this method
      * to control how the task is created. The following options are available:</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -74,6 +74,18 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
     <T extends Task> Provider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException;
 
     /**
+     * Configures the named element in this collection using the given action. Actions are run in the order added.
+     *
+     * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
+     *
+     * @param name Name of the element to be configured
+     * @param action A {@link Action} that can configure the element when required.
+     * @since 4.8
+     */
+    @Incubating
+    void configureLater(String name, Action<? super Task> action);
+
+    /**
      * <p>Creates a {@link Task} and adds it to this container. A map of creation options can be passed to this method
      * to control how the task is created. The following options are available:</p>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -71,20 +71,8 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    <T extends Task> Provider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException;
-
-    /**
-     * Configures the named element in this collection using the given action. Actions are run in the order added.
-     *
-     * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
-     *
-     * @param name Name of the element to be configured
-     * @param action A {@link Action} that can configure the element when required.
-     * @since 4.8
-     */
-    @Incubating
-    void configureLater(String name, Action<? super Task> action);
-
+    <T extends Task> TaskProvider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException;
+    
     /**
      * <p>Creates a {@link Task} and adds it to this container. A map of creation options can be passed to this method
      * to control how the task is created. The following options are available:</p>
@@ -233,7 +221,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    Provider<Task> createLater(String name, Action<? super Task> configurationAction);
+    TaskProvider<Task> createLater(String name, Action<? super Task> configurationAction);
 
     /**
      * Defines a new task, which will be created and configured when it is required. A task is 'required' when the task is located using query methods such as {@link #getByName(String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.
@@ -251,7 +239,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    <T extends Task> Provider<T> createLater(String name, Class<T> type, Action<? super T> configurationAction);
+    <T extends Task> TaskProvider<T> createLater(String name, Class<T> type, Action<? super T> configurationAction);
 
     /**
      * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link #getByName(String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.
@@ -268,7 +256,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    <T extends Task> Provider<T> createLater(String name, Class<T> type);
+    <T extends Task> TaskProvider<T> createLater(String name, Class<T> type);
 
     /**
      * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link #getByName(String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.
@@ -284,7 +272,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @since 4.8
      */
     @Incubating
-    <T extends Task> Provider<T> createLater(String name);
+    <T extends Task> TaskProvider<T> createLater(String name);
 
     /**
      * <p>Creates a {@link Task} with the given name and adds it to this container, replacing any existing task with the

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
@@ -22,7 +22,8 @@ import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 
 /**
- * TODO: Docs
+ * Providers a task of the given type.
+ * 
  * @param <T> Task type
  * @since 4.8
  */

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
+
+/**
+ * TODO: Docs
+ * @param <T> Task type
+ * @since 4.8
+ */
+@Incubating
+public interface TaskProvider<T extends Task> extends Provider<T> {
+    /**
+     * Configures the task with the given action. Actions are run in the order added.
+     *
+     * @param action A {@link Action} that can configure the task when required.
+     * @since 4.8
+     */
+    void configure(Action<? super Task> action);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -35,8 +35,8 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.provider.AbstractProvider;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.Cast;
@@ -270,16 +270,16 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
-    public Provider<Task> createLater(String name, Action<? super Task> configurationAction) {
+    public TaskProvider<Task> createLater(String name, Action<? super Task> configurationAction) {
         return Cast.uncheckedCast(createLater(name, DefaultTask.class, configurationAction));
     }
 
     @Override
-    public <T extends Task> Provider<T> createLater(final String name, final Class<T> type, @Nullable  Action<? super T> configurationAction) {
+    public <T extends Task> TaskProvider<T> createLater(final String name, final Class<T> type, @Nullable  Action<? super T> configurationAction) {
         if (hasWithName(name)) {
             duplicateTask(name);
         }
-        TaskProvider<T> provider = new TaskCreatingProvider<T>(type, name, configurationAction);
+        DefaultTaskProvider<T> provider = new TaskCreatingProvider<T>(type, name, configurationAction);
         addLater(provider);
         if (eagerlyCreateLazyTasks) {
             provider.get();
@@ -288,12 +288,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
-    public <T extends Task> Provider<T> createLater(String name, Class<T> type) {
+    public <T extends Task> TaskProvider<T> createLater(String name, Class<T> type) {
         return createLater(name, type, null);
     }
 
     @Override
-    public <T extends Task> Provider<T> createLater(String name) {
+    public <T extends Task> TaskProvider<T> createLater(String name) {
         return Cast.uncheckedCast(createLater(name, DefaultTask.class));
     }
 
@@ -321,11 +321,10 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
-    public <T extends Task> Provider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException {
+    public <T extends Task> TaskProvider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException {
         return new TaskLookupProvider<T>(type, name);
     }
 
-    @Override
     public void configureLater(final String name, final Action<? super Task> action) {
         configureEachLater(new Action<Task>() {
             @Override
@@ -486,11 +485,11 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return new RealizableTaskCollection<S>(type, super.withType(type), modelNode);
     }
 
-    private abstract class TaskProvider<T extends Task> extends AbstractProvider<T> implements Named {
+    private abstract class DefaultTaskProvider<T extends Task> extends AbstractProvider<T> implements Named, TaskProvider<T> {
         final Class<T> type;
         final String name;
 
-        TaskProvider(Class<T> type, String name) {
+        DefaultTaskProvider(Class<T> type, String name) {
             this.type = type;
             this.name = name;
         }
@@ -509,9 +508,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         public boolean isPresent() {
             return findByNameWithoutRules(name) != null;
         }
+
+        @Override
+        public void configure(final Action<? super Task> action) {
+            configureLater(name, action);
+        }
     }
 
-    private class TaskCreatingProvider<T extends Task> extends TaskProvider<T> {
+    private class TaskCreatingProvider<T extends Task> extends DefaultTaskProvider<T> {
         Action<? super T> configureAction;
         T task;
 
@@ -539,7 +543,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         }
     }
 
-    private class TaskLookupProvider<T extends Task> extends TaskProvider<T> {
+    private class TaskLookupProvider<T extends Task> extends DefaultTaskProvider<T> {
         T task;
 
         public TaskLookupProvider(Class<T> type, String name) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -325,6 +325,18 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return new TaskLookupProvider<T>(type, name);
     }
 
+    @Override
+    public void configureLater(final String name, final Action<? super Task> action) {
+        configureEachLater(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                if (task.getName().equals(name)) {
+                    action.execute(task);
+                }
+            }
+        });
+    }
+
     public Task resolveTask(String path) {
         if (Strings.isNullOrEmpty(path)) {
             throw new InvalidUserDataException("A path must be specified!");

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -591,6 +591,39 @@ class DefaultTaskContainerTest extends Specification {
         0 * action._
     }
 
+    void "can configure a task by type and name without triggering creation or configuration"() {
+        def action = Mock(Action)
+        def deferredAction = Mock(Action)
+        def task = task("task")
+
+        given:
+        container.createLater("task", DefaultTask, action)
+
+        when:
+        def provider = container.getByNameLater(Task, "task")
+        and:
+        provider.configure(deferredAction)
+        then:
+        !provider.present
+
+        and:
+        0 * _
+
+        when:
+        def result = provider.get()
+
+        then:
+        result == task
+        1 * taskFactory.create("task", DefaultTask) >> task
+        then:
+        1 * deferredAction.execute(task)
+        then:
+        1 * action.execute(task)
+        then:
+        0 * action._
+        0 * deferredAction._
+    }
+
     void "can locate task that already exists by type and name without triggering creation or configuration"() {
         def task = task("task")
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -89,15 +89,10 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
             }
             
             gradle.buildFinished {
-                assert configuredTasks.size() == 7
+                assert configuredTasks.size() == 3
                 def configuredTaskPaths = configuredTasks*.path
                 // This should be the only task configured
                 assert ":help" in configuredTaskPaths
-                // These tasks are referenced directly by name
-                assert ":assemble" in configuredTaskPaths
-                assert ":buildDependents" in configuredTaskPaths
-                assert ":buildNeeded" in configuredTaskPaths
-                assert ":check" in configuredTaskPaths
                 
                 // This task needs to be able to register publications lazily
                 assert ":jar" in configuredTaskPaths

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -174,7 +174,7 @@ public class BasePlugin implements Plugin<Project> {
     }
 
     private void configureAssemble(final ProjectInternal project) {
-        project.getTasks().configureLater(ASSEMBLE_TASK_NAME, new Action<Task>() {
+        project.getTasks().getByNameLater(Task.class, ASSEMBLE_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 task.dependsOn(project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getAllArtifacts().getBuildDependencies());

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
@@ -173,6 +174,11 @@ public class BasePlugin implements Plugin<Project> {
     }
 
     private void configureAssemble(final ProjectInternal project) {
-        project.getTasks().getByName(ASSEMBLE_TASK_NAME).dependsOn(project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getAllArtifacts().getBuildDependencies());
+        project.getTasks().configureLater(ASSEMBLE_TASK_NAME, new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                task.dependsOn(project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getAllArtifacts().getBuildDependencies());
+            }
+        });
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -364,10 +364,20 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     }
 
     private void configureBuild(Project project) {
-        addDependsOnTaskInOtherProjects(project.getTasks().getByName(JavaBasePlugin.BUILD_NEEDED_TASK_NAME), true,
-            JavaBasePlugin.BUILD_NEEDED_TASK_NAME, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
-        addDependsOnTaskInOtherProjects(project.getTasks().getByName(JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME), false,
-            JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        project.getTasks().configureLater(JavaBasePlugin.BUILD_NEEDED_TASK_NAME, new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                addDependsOnTaskInOtherProjects(task, true,
+                    JavaBasePlugin.BUILD_NEEDED_TASK_NAME, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            }
+        });
+        project.getTasks().configureLater(JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME, new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                addDependsOnTaskInOtherProjects(task, false,
+                    JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            }
+        });
     }
 
     private void configureTest(final Project project, final JavaPluginConvention pluginConvention) {
@@ -386,15 +396,19 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
             }
         });
 
-        Provider<Test> test = project.getTasks().createLater(TEST_TASK_NAME, Test.class, new Action<Test>() {
+        final Provider<Test> test = project.getTasks().createLater(TEST_TASK_NAME, Test.class, new Action<Test>() {
             @Override
             public void execute(Test test) {
                 test.setDescription("Runs the unit tests.");
                 test.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             }
         });
-        project.getTasks().getByName(JavaBasePlugin.CHECK_TASK_NAME).dependsOn(test);
-
+        project.getTasks().configureLater(JavaBasePlugin.CHECK_TASK_NAME, new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                task.dependsOn(test);
+            }
+        });
     }
 
     private void configureConfigurations(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -364,14 +364,14 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     }
 
     private void configureBuild(Project project) {
-        project.getTasks().configureLater(JavaBasePlugin.BUILD_NEEDED_TASK_NAME, new Action<Task>() {
+        project.getTasks().getByNameLater(Task.class, JavaBasePlugin.BUILD_NEEDED_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 addDependsOnTaskInOtherProjects(task, true,
                     JavaBasePlugin.BUILD_NEEDED_TASK_NAME, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             }
         });
-        project.getTasks().configureLater(JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME, new Action<Task>() {
+        project.getTasks().getByNameLater(Task.class, JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 addDependsOnTaskInOtherProjects(task, false,
@@ -403,7 +403,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
                 test.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             }
         });
-        project.getTasks().configureLater(JavaBasePlugin.CHECK_TASK_NAME, new Action<Task>() {
+        project.getTasks().getByNameLater(Task.class, JavaBasePlugin.CHECK_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 task.dependsOn(test);


### PR DESCRIPTION
- Replace direct references to lifecycle tasks with configureLater
- This reduces the number of realized tasks to two for simple Java projects (jar, test)

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
