### PR TITLE
Support setter generation for capitalization like `cCompiler`

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/PropertyAccessorTypeTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/PropertyAccessorTypeTest.groovy
@@ -225,10 +225,10 @@ class PropertyAccessorTypeTest extends Specification {
         }
 
         try {
-            bean.notString
+            bean.stillNotBoolean
             assert false
         } catch (MissingPropertyException e) {
-            assert e.property == "notString"
+            assert e.property == "stillNotBoolean"
         }
 
         PropertyAccessorType.fromName('isNotBoolean') == PropertyAccessorType.IS_GETTER

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/PropertyAccessorTypeTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/PropertyAccessorTypeTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.reflect
 
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -198,5 +200,43 @@ class PropertyAccessorTypeTest extends Specification {
         PropertyAccessorType.of(StaticMethods.getMethod("isStatic")) == null
         PropertyAccessorType.of(StaticMethods.getMethod("getStatic")) == null
         PropertyAccessorType.of(StaticMethods.getMethod("setStatic", int)) == null
+    }
+
+    static class DeviantProviderMethods {
+        Provider<Boolean> isNotBoolean() {
+            null
+        }
+
+        Property<Boolean> isStillNotBoolean() {
+            null
+        }
+    }
+
+    def "is methods with Provider/Property of Boolean return type are not considered as such by Gradle, Groovy and Java"() {
+        def bean = new DeviantProviderMethods()
+        def propertyNames = Introspector.getBeanInfo(DeviantProviderMethods).propertyDescriptors.collect { it.name }
+
+        expect:
+        try {
+            bean.notBoolean
+            assert false
+        } catch (MissingPropertyException e) {
+            assert e.property == "notBoolean"
+        }
+
+        try {
+            bean.notString
+            assert false
+        } catch (MissingPropertyException e) {
+            assert e.property == "notString"
+        }
+
+        PropertyAccessorType.fromName('isNotBoolean') == PropertyAccessorType.IS_GETTER
+        PropertyAccessorType.of(DeviantProviderMethods.class.getMethod("isNotBoolean")) == null
+        PropertyAccessorType.fromName('isStillNotBoolean') == PropertyAccessorType.IS_GETTER
+        PropertyAccessorType.of(DeviantProviderMethods.class.getMethod("isStillNotBoolean")) == null
+
+        !propertyNames.contains("notBoolean")
+        !propertyNames.contains("stillNotBoolean")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AsmBackedClassGenerator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AsmBackedClassGenerator.java
@@ -22,7 +22,6 @@ import groovy.lang.GroovyObject;
 import groovy.lang.GroovySystem;
 import groovy.lang.MetaClass;
 import groovy.lang.MetaClassRegistry;
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.provider.PropertyInternal;
@@ -59,7 +58,17 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.gradle.model.internal.asm.AsmClassGeneratorUtils.signature;
-import static org.objectweb.asm.Opcodes.*;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.PUTFIELD;
+import static org.objectweb.asm.Opcodes.PUTSTATIC;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_5;
 import static org.objectweb.asm.Type.VOID_TYPE;
 
 public class AsmBackedClassGenerator extends AbstractClassGenerator {
@@ -407,7 +416,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             //    ((PropertyInternal)<getter>()).setFromAnyValue(p);
             // }
 
-            MethodVisitor methodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, "set" + StringUtils.capitalize(getter.getName().substring(3)), RETURN_VOID_FROM_OBJECT, null, EMPTY_STRINGS);
+            MethodVisitor methodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, "set" + getter.getName().substring(3), RETURN_VOID_FROM_OBJECT, null, EMPTY_STRINGS);
             methodVisitor.visitCode();
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, generatedType.getInternalName(), getter.getName(), Type.getMethodDescriptor(getter), false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AsmBackedClassGenerator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AsmBackedClassGenerator.java
@@ -22,6 +22,7 @@ import groovy.lang.GroovyObject;
 import groovy.lang.GroovySystem;
 import groovy.lang.MetaClass;
 import groovy.lang.MetaClassRegistry;
+import groovy.lang.MetaProperty;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.provider.PropertyInternal;
@@ -416,7 +417,8 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             //    ((PropertyInternal)<getter>()).setFromAnyValue(p);
             // }
 
-            MethodVisitor methodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, "set" + getter.getName().substring(3), RETURN_VOID_FROM_OBJECT, null, EMPTY_STRINGS);
+
+            MethodVisitor methodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, MetaProperty.getSetterName(property.getName()), RETURN_VOID_FROM_OBJECT, null, EMPTY_STRINGS);
             methodVisitor.visitCode();
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, generatedType.getInternalName(), getter.getName(), Type.getMethodDescriptor(getter), false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AsmBackedClassGenerator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AsmBackedClassGenerator.java
@@ -407,7 +407,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             //    ((PropertyInternal)<getter>()).setFromAnyValue(p);
             // }
 
-            MethodVisitor methodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, "set" + StringUtils.capitalize(property.getName()), RETURN_VOID_FROM_OBJECT, null, EMPTY_STRINGS);
+            MethodVisitor methodVisitor = visitor.visitMethod(Opcodes.ACC_PUBLIC, "set" + StringUtils.capitalize(getter.getName().substring(3)), RETURN_VOID_FROM_OBJECT, null, EMPTY_STRINGS);
             methodVisitor.visitCode();
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, generatedType.getInternalName(), getter.getName(), Type.getMethodDescriptor(getter), false);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AsmBackedClassGeneratorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AsmBackedClassGeneratorTest.java
@@ -855,6 +855,27 @@ public class AsmBackedClassGeneratorTest {
     }
 
     @Test
+    public void addsSetterMethodsForPropertyWhoseTypeIsPropertyAndCapitalizedProperly() throws Exception {
+        DefaultProviderFactory providerFactory = new DefaultProviderFactory();
+        BeanWithProperty bean = generator.newInstance(BeanWithProperty.class, TestUtil.objectFactory());
+
+        DynamicObject dynamicObject = ((DynamicObjectAware) bean).getAsDynamicObject();
+
+        dynamicObject.setProperty("aProp", "value");
+        assertEquals("value", bean.getaProp().get());
+
+        dynamicObject.setProperty("aProp", providerFactory.provider(new Callable<String>() {
+            int count;
+            @Override
+            public String call() throws Exception {
+                return "[" + String.valueOf(++count) + "]";
+            }
+        }));
+        assertEquals("[1]", bean.getaProp().get());
+        assertEquals("[2]", bean.getaProp().get());
+    }
+
+    @Test
     public void doesNotAddSetterMethodsForPropertyWhoseTypeIsPropertyWhenTheSetterMethodsAlreadyExist() throws Exception {
         DefaultProviderFactory providerFactory = new DefaultProviderFactory();
         BeanWithProperty bean = generator.newInstance(BeanWithProperty.class, TestUtil.objectFactory());
@@ -1375,10 +1396,12 @@ public class AsmBackedClassGeneratorTest {
     public static class BeanWithProperty {
         private final Property<String> prop;
         private final Property<String> prop2;
+        private final Property<String> aProp;
 
         public BeanWithProperty(ObjectFactory factory) {
             this.prop = factory.property(String.class);
             this.prop2 = factory.property(String.class);
+            this.aProp = factory.property(String.class);
         }
 
         public Property<String> getProp() {
@@ -1395,6 +1418,10 @@ public class AsmBackedClassGeneratorTest {
 
         public void setProp2(int value) {
             prop2.set("[" + value + "]");
+        }
+
+        public Property<String> getaProp() {
+            return aProp;
         }
     }
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
The setter generation is created from the property name which is capitalized. However, for special cases like `cCompiler`-style the capitalization is wrong and causes unexpected weirdness in the build script.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fsupport-setter-generation-for-special-capitalization)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
