### PR TITLE
Bug fixes for dependency locking

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -62,4 +62,34 @@ dependencies {
         outputDoesNotContain('foo')
 
     }
+
+    def 'does not lock dependencies missing a version'() {
+        def flatRepo = testDirectory.file('repo')
+        flatRepo.createFile('my-dep-1.0.jar')
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    flatDir {
+        dirs 'repo'
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf name: 'my-dep-1.0'
+}
+"""
+        when:
+        succeeds 'dependencies', '--write-locks'
+
+        then:
+        outputContains('my-dep-1.0')
+        lockfileFixture.verifyLockfile('lockedConf', [])
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.locking
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+
+class LockingInteractionsIntegrationTest extends AbstractDependencyResolutionTest {
+
+    def lockfileFixture = new LockfileFixture(testDirectory: testDirectory)
+
+    def setup() {
+        settingsFile << "rootProject.name = 'locking-interactions'"
+    }
+
+    def 'locking constraints do not bring back excluded modules'() {
+        def foo = mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'bar', '1.0').dependsOn(foo).publish()
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf('org:bar:1.+') {
+        exclude module: 'foo'
+    }
+}
+"""
+
+        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0'])
+
+        when:
+        succeeds 'dependencies'
+
+        then:
+        outputContains('org:bar:1.0')
+        outputDoesNotContain('foo')
+
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -80,7 +80,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
                         dependencyConstraint.getGroup(), dependencyConstraint.getName(), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
                     result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
-                        Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, true, dependencyConstraint.getReason()));
+                        Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, false, true, dependencyConstraint.getReason()));
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -75,10 +75,12 @@ public class DependencyLockingArtifactVisitor implements DependencyArtifactsVisi
         ComponentIdentifier identifier = node.getOwner().getComponentId();
         if (identifier instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier id = (ModuleComponentIdentifier) identifier;
-            if (allResolvedModules.add(id) && dependencyLockingState.mustValidateLockState()) {
-                String displayName = id.getDisplayName();
-                if (!lockingConstraints.remove(displayName)) {
-                    extraModules.add(displayName);
+            if (!id.getVersion().isEmpty()) {
+                if (allResolvedModules.add(id) && dependencyLockingState.mustValidateLockState()) {
+                    String displayName = id.getDisplayName();
+                    if (!lockingConstraints.remove(displayName)) {
+                        extraModules.add(displayName);
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -44,6 +44,22 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
         child.dependencies.size() == 0
     }
 
+    def 'locking constraints are not transitive'() {
+        given:
+        def constraint = new DefaultDependencyConstraint('org', 'foo', '1.1')
+        dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(false, [constraint] as Set)
+        addConfiguration('conf').enableLocking()
+
+        when:
+        def conf = metadata.getConfiguration('conf')
+
+        then:
+        conf.dependencies.size() == 1
+        conf.dependencies.each {
+            assert !it.transitive
+        }
+    }
+
     private addConfiguration(String name, Collection<String> extendsFrom = [], ImmutableAttributes attributes = ImmutableAttributes.EMPTY) {
         metadata.addConfiguration(name, "", extendsFrom as Set, (extendsFrom + [name]) as Set, true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -64,7 +64,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         0 * _
     }
 
-    def 'process node having a ModuleComponentIdentifier'() {
+    def 'processes node having a ModuleComponentIdentifier'() {
         given:
         startWithState([])
 
@@ -78,8 +78,26 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         then:
         1 * node.owner >> component
         1 * component.componentId >> identifier
+        1 * identifier.version >> '1.0'
         1 * identifier.displayName >> 'org:foo:1.0'
+    }
 
+    def 'ignores node having a ModuleComponentIdentifier but an empty version'() {
+        given:
+        startWithState([])
+
+        DependencyGraphNode node = Mock()
+        DependencyGraphComponent component = Mock()
+        ModuleComponentIdentifier identifier = Mock()
+
+        when:
+        visitor.visitNode(node)
+
+        then:
+        1 * node.owner >> component
+        1 * component.componentId >> identifier
+        1 * identifier.version >> ''
+        0 * _
     }
 
     def 'ignores node not having a ModuleComponentIdentifier'() {
@@ -156,6 +174,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         ModuleComponentIdentifier identifier = Mock()
         node.owner >> component
         component.componentId >> identifier
+        identifier.version >> module.substring(module.lastIndexOf(':') + 1)
         identifier.displayName >> module
 
         visitor.visitNode(node)


### PR DESCRIPTION
* Locking generated dependency graph elements cannot be transitive
* Ignore dependency notations from `flatDir` style repositories when they have no version defined.