### PR TITLE
Revert unnecessary change to support folders to be included to Xcode IDE

### DIFF
--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -308,7 +308,7 @@ public class XcodePlugin extends IdePlugin {
                 xcodeProject.getGroups().getSources().from(sources);
 
                 FileCollection headers = component.getHeaderFiles();
-                xcodeProject.getGroups().getHeaders().from(headers.getAsFileTree());
+                xcodeProject.getGroups().getHeaders().from(headers);
 
                 // TODO - should use the _install_ task for an executable
                 final String targetName = StringUtils.capitalize(component.getBaseName().get());


### PR DESCRIPTION
### Context
Following the code review on https://github.com/gradle/gradle/pull/5114, this PR revert unnecessary changes to the Xcode plugin.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fxcode)
- [x] Verify documentation
- [x] Recognize contributor in release notes
