### PR TITLE
Wait for async processes to configure the `buildScan` extension

### DIFF
--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -101,7 +101,7 @@ open class BuildScanPlugin : Plugin<Project> {
     private
     fun Project.extractVcsData() {
 
-        fun async(action: () -> Unit) = thread {
+        fun fork(action: () -> Unit) = thread {
             try {
                 action()
             } catch (e: Exception) {
@@ -111,13 +111,13 @@ open class BuildScanPlugin : Plugin<Project> {
 
         val threads = listOf(
 
-            async {
+            fork {
                 system("git", "rev-parse", "--verify", "HEAD").let { commitId ->
                     setCommitId(commitId)
                 }
             },
 
-            async {
+            fork {
                 system("git", "status", "--porcelain").let { status ->
                     if (status.isNotEmpty()) {
                         buildScan {
@@ -128,7 +128,7 @@ open class BuildScanPlugin : Plugin<Project> {
                 }
             },
 
-            async {
+            fork {
                 system("git", "rev-parse", "--abbrev-ref", "HEAD").let { branchName ->
                     if (branchName.isNotEmpty() && branchName != "HEAD") {
                         buildScan {


### PR DESCRIPTION
In `buildScan.buildFinished` to guarantee everything has finished before
transmitting the event stream.
 
- [x] Verify test coverage and [CI build status](https://builds.gradle.org/viewQueued.html?itemId=12558087)
