### PR TITLE
Document how to publish custom artifacts using Maven and Ivy

### DIFF
--- a/subprojects/docs/src/docs/userguide/publishingIvy.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingIvy.adoc
@@ -107,8 +107,16 @@ For each custom artifact, it is possible to specify the `name`, `extension`, `ty
 Configure custom artifacts as follows:
 
 ++++
-<sample dir="ivy-publish/java-multi-project" id="publishing_ivy:publish-custom-artifact-snippet" title="Publishing additional artifact to Ivy">
+<sample dir="ivy-publish/java-multi-project" id="publishing_ivy:publish-custom-artifact-snippet" title="Adding an additional archive artifact to an IvyPublication">
     <sourcefile file="build.gradle" snippet="publish-custom-artifact"/>
+</sample>
+++++
+
+In addition, instances of api:org.gradle.api.artifacts.PublishArtifact[] can be added to a publication. For example, let's assume you have a custom `rpm` task that produces an RPM package of your application and writes it to `rpmFile`. The following sample demonstrates how to create a `PublishArtifact` using the `artifacts.add()` method and add it to a publication:
+
+++++
+<sample dir="ivy-publish/publish-artifact" id="publishing_maven:publish-artifact" title="Adding an additional custom artifact to an IvyPublication">
+    <sourcefile file="build.gradle" snippet="custom-artifact"/>
 </sample>
 ++++
 

--- a/subprojects/docs/src/docs/userguide/publishingMaven.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingMaven.adoc
@@ -104,8 +104,16 @@ For each custom artifact, it is possible to specify the `extension` and `classif
 Configure custom artifacts as follows:
 
 ++++
-<sample dir="maven-publish/javaProject" id="publishing_maven:publish-custom-artifact" title="Adding additional artifact to a MavenPublication">
+<sample dir="maven-publish/javaProject" id="publishing_maven:publish-custom-artifact" title="Adding an additional archive artifact to a MavenPublication">
     <sourcefile file="build.gradle" snippet="publish-custom-artifact"/>
+</sample>
+++++
+
+In addition, instances of api:org.gradle.api.artifacts.PublishArtifact[] can be added to a publication. For example, let's assume you have a custom `rpm` task that produces an RPM package of your application and writes it to `rpmFile`. The following sample demonstrates how to create a `PublishArtifact` using the `artifacts.add()` method and add it to a publication:
+
+++++
+<sample dir="maven-publish/publish-artifact" id="publishing_maven:publish-artifact" title="Adding an additional custom artifact to a MavenPublication">
+    <sourcefile file="build.gradle" snippet="custom-artifact"/>
 </sample>
 ++++
 

--- a/subprojects/docs/src/samples/ivy-publish/publish-artifact/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/publish-artifact/build.gradle
@@ -1,0 +1,39 @@
+apply plugin: "base"
+apply plugin: "ivy-publish"
+
+group = "org.gradle.sample"
+version = "1.0"
+
+// START SNIPPET custom-artifact
+def rpmFile = file("$buildDir/rpms/my-package.rpm")
+def rpmArtifact = artifacts.add("archives", rpmFile) {
+    type "rpm"
+    builtBy "rpm"
+}
+// END SNIPPET custom-artifact
+
+task rpm() {
+    outputs.file rpmFile
+    doLast {
+        // produce real RPM here
+        rpmFile << "file contents"
+    }
+}
+
+// START SNIPPET custom-artifact
+publishing {
+    publications {
+        ivy(IvyPublication) {
+            artifact rpmArtifact
+        }
+    }
+// END SNIPPET custom-artifact
+    repositories {
+        // change URLs to point to your repo, e.g. http://my.org/repo
+        ivy {
+            url "$buildDir/repo"
+        }
+    }
+// START SNIPPET custom-artifact
+}
+// END SNIPPET custom-artifact

--- a/subprojects/docs/src/samples/ivy-publish/publish-artifact/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/publish-artifact/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'publish-artifact'

--- a/subprojects/docs/src/samples/maven-publish/publish-artifact/build.gradle
+++ b/subprojects/docs/src/samples/maven-publish/publish-artifact/build.gradle
@@ -1,0 +1,39 @@
+apply plugin: "base"
+apply plugin: "maven-publish"
+
+group = "org.gradle.sample"
+version = "1.0"
+
+// START SNIPPET custom-artifact
+def rpmFile = file("$buildDir/rpms/my-package.rpm")
+def rpmArtifact = artifacts.add("archives", rpmFile) {
+    type "rpm"
+    builtBy "rpm"
+}
+// END SNIPPET custom-artifact
+
+task rpm() {
+    outputs.file rpmFile
+    doLast {
+        // produce real RPM here
+        rpmFile << "file contents"
+    }
+}
+
+// START SNIPPET custom-artifact
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact rpmArtifact
+        }
+    }
+// END SNIPPET custom-artifact
+    repositories {
+        // change URLs to point to your repo, e.g. http://my.org/repo
+        maven {
+            url "$buildDir/repo"
+        }
+    }
+// START SNIPPET custom-artifact
+}
+// END SNIPPET custom-artifact

--- a/subprojects/docs/src/samples/maven-publish/publish-artifact/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/publish-artifact/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'publish-artifact'

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
@@ -172,6 +172,26 @@ class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
         notExecuted ":publishBinaryPublicationToExternalRepository", ":publishBinaryAndSourcesPublicationToExternalRepository"
     }
 
+    @UsesSample("ivy-publish/publish-artifact")
+    def publishesRpmArtifact() {
+        given:
+        sample sampleProject
+        def artifactId = "publish-artifact"
+        def version = "1.0"
+        def repo = ivy(sampleProject.dir.file("build/repo"))
+        def module = repo.module("org.gradle.sample", artifactId, version)
+
+        when:
+        succeeds "publish"
+
+        then:
+        executed ":rpm", ":publish"
+
+        and:
+        module.assertPublished()
+        module.assertArtifactsPublished "${artifactId}-${version}.rpm", "ivy-${version}.xml"
+    }
+
     private void verifyIvyFile(IvyFileModule project1sample, String outputFileName) {
         def actualIvyXmlText = project1sample.ivyFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
         assert actualIvyXmlText == getExpectedIvyOutput(sampleProject.dir.file(outputFileName))

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -189,6 +189,26 @@ class SamplesMavenPublishIntegrationTest extends AbstractIntegrationSpec {
         notExecuted ":publishBinaryPublicationToExternalRepository", ":publishBinaryAndSourcesPublicationToExternalRepository"
     }
 
+    @UsesSample("maven-publish/publish-artifact")
+    def publishesRpmArtifact() {
+        given:
+        sample sampleProject
+        def artifactId = "publish-artifact"
+        def version = "1.0"
+        def repo = maven(sampleProject.dir.file("build/repo"))
+        def module = repo.module("org.gradle.sample", artifactId, version)
+
+        when:
+        succeeds "publish"
+
+        then:
+        executed ":rpm", ":publish"
+
+        and:
+        module.assertPublished()
+        module.assertArtifactsPublished "${artifactId}-${version}.rpm", "${artifactId}-${version}.pom"
+    }
+
     private void verifyPomFile(MavenFileModule module, String outputFileName) {
         def actualPomXmlText = module.pomFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
         assert actualPomXmlText == getExpectedPomOutput(sampleProject.dir.file(outputFileName))


### PR DESCRIPTION
This PR adds a sample that demonstrates how to publish a custom PublishArtifact as part of an IvyPublication or MavenPublication.

Resolves #3064.