### PR TITLE
Fix typed attributes on dependencies triggering an assertion error

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.Cast;
+
+import java.util.Set;
+
+abstract class AttributeDesugaring {
+    /**
+     * Desugars attributes so that what we're going to serialize consists only of String or Boolean attributes,
+     * and not their original types.
+     * @return desugared attributes
+     */
+    static ImmutableAttributes desugar(ImmutableAttributes attributes, ImmutableAttributesFactory attributesFactory) {
+        if (attributes.isEmpty()) {
+            return attributes;
+        }
+        AttributeContainerInternal mutable = attributesFactory.mutable();
+        Set<Attribute<?>> keySet = attributes.keySet();
+        for (Attribute<?> attribute : keySet) {
+            Object value = attributes.getAttribute(attribute);
+            Attribute<Object> desugared = Cast.uncheckedCast(attribute);
+            if (attribute.getType() == Boolean.class || attribute.getType() == String.class) {
+                mutable.attribute(desugared, value);
+            } else {
+                desugared = Cast.uncheckedCast(Attribute.of(attribute.getName(), String.class));
+                mutable.attribute(desugared, value.toString());
+            }
+        }
+        return mutable.asImmutable();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
@@ -15,11 +15,15 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Cast;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 
 import java.util.Set;
 
@@ -46,5 +50,17 @@ abstract class AttributeDesugaring {
             }
         }
         return mutable.asImmutable();
+    }
+
+    static ComponentSelector desugarSelector(ComponentSelector selector, ImmutableAttributesFactory attributesFactory) {
+        if (selector instanceof ModuleComponentSelector) {
+            ModuleComponentSelector module = (ModuleComponentSelector) selector;
+            AttributeContainer moduleAttributes = module.getAttributes();
+            if (!moduleAttributes.isEmpty()) {
+                ImmutableAttributes attributes = ((AttributeContainerInternal) moduleAttributes).asImmutable();
+                return DefaultModuleComponentSelector.newSelector(module.getGroup(), module.getModule(), module.getVersionConstraint(), desugar(attributes, attributesFactory));
+            }
+        }
+        return selector;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -178,7 +178,7 @@ class EdgeState implements DependencyGraphEdge {
 
     @Override
     public ComponentSelector getRequested() {
-        return dependencyState.getRequested();
+        return AttributeDesugaring.desugarSelector(dependencyState.getRequested(), from.getAttributesFactory());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
@@ -29,10 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -41,7 +37,6 @@ import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult;
 
-import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.AttributeDesugaring.desugar;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.CONSTRAINT;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.REQUESTED;
 
@@ -218,14 +213,6 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     private ComponentSelector selectorWithDesugaredAttributes(ComponentSelector selector) {
-        if (selector instanceof ModuleComponentSelector) {
-            ModuleComponentSelector module = (ModuleComponentSelector) selector;
-            AttributeContainer moduleAttributes = module.getAttributes();
-            if (!moduleAttributes.isEmpty()) {
-                ImmutableAttributes attributes = ((AttributeContainerInternal) moduleAttributes).asImmutable();
-                return DefaultModuleComponentSelector.newSelector(module.getGroup(), module.getModule(), module.getVersionConstraint(), desugar(attributes, attributesFactory));
-            }
-        }
-        return selector;
+        return AttributeDesugaring.desugarSelector(selector, attributesFactory);
     }
 }


### PR DESCRIPTION
### Context

The attributes that we write in the serialized graph must be desugared, similar as if
they were read from an external module descriptor (Gradle metadata). This was done for
variant attributes, but now that we can set attributes on dependencies too, they must
be desugared too. Without this fix, attempting to use a dependency attribute with a
strongly typed attribute would result in an assertion error in the serializer.
