### PR TITLE
Avoid realizing test task for Java and Groovy plugins

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -104,6 +104,14 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 `Signature.getToSignArtifact()` should have been an internal API and is now deprecated without a replacement.
 
+### Use of single test selection system property
+
+The [use of a system property](userguide/java_testing.html#sec:single_test_execution_via_system_properties) to select which tests to execute is deprecated.  The built-in `--tests` filter has long replaced this functionality.
+
+### Use of remote debugging test system property
+
+The use of a system property (`-Dtest.debug`) to enable remote debugging of test processes is deprecated.  The built-in `--debug-jvm` flag has long replaced this functionality.
+
 ## Potential breaking changes
 
 ### Changed behaviour for missing init scripts

--- a/subprojects/docs/src/docs/userguide/javaTesting.adoc
+++ b/subprojects/docs/src/docs/userguide/javaTesting.adoc
@@ -70,9 +70,9 @@ When debugging for tests is enabled, Gradle will start the test process suspende
 It's a common requirement to run subsets of a test suite, such as when you're fixing a bug or developing a new test case. Gradle provides two mechanisms to do this:
 
  * Filtering (the preferred option)
- * Test inclusion/exclusion (based on `-Dtest.single`, `test.include` and friends)
- 
-Filtering supersedes the inclusion/exclusionmechanism, but you may still come across the latter in the wild.
+ * Test inclusion/exclusion
+
+Filtering supersedes the inclusion/exclusion mechanism, but you may still come across the latter in the wild.
 
 With Gradle's test filtering you can select tests to run based on:
 
@@ -80,7 +80,7 @@ With Gradle's test filtering you can select tests to run based on:
  * A simple class name or method name if the pattern starts with an upper-case letter, e.g. `SomeTest`, `SomeTest.someMethod` (since Gradle 4.7)
  * '*' wildcard matching
 
-You can enable filtering either in the build or via the `--tests` command line option. Here's an example of some filters that are applied every time the build runs:
+You can enable filtering either in the build script or via the `--tests` command-line option. Here's an example of some filters that are applied every time the build runs:
 
 ++++
 <sample xmlns:xi="http://www.w3.org/2001/XInclude" id="testfiltering" dir="testing/filtering" title="Filtering tests in the build script">
@@ -90,7 +90,7 @@ You can enable filtering either in the build or via the `--tests` command line o
 
 For more details and examples of declaring filters in the build script, please see the api:org.gradle.api.tasks.testing.TestFilter[] reference.
 
-The command line option is especially useful for the classic single test method execution use case. When you use `--tests`, be aware that the inclusions declared in the build script are still honored. Also note that it is possible to supply multiple `--tests` options, all of whose patterns will take effect. The following sections have several examples of using the command line option.
+The command-line option is especially useful to execute a single test method. When you use `--tests`, be aware that the inclusions declared in the build script are still honored. It is also possible to supply multiple `--tests` options, all of whose patterns will take effect. The following sections have several examples of using the command-line option.
 
 NOTE: Not all test frameworks play well with filtering. Some advanced, synthetic tests may not be fully compatible. However, the vast majority of tests and use cases work perfectly well with Gradle's filtering mechanism.
 
@@ -171,7 +171,7 @@ The `Test` task generates the following results by default:
 
 In most cases, you'll work with the standard HTML report, which automatically includes the results from _all_ your `Test` tasks, even the ones you explicitly add to the build yourself. For example, if you add a `Test` task for integration tests, the report will include the results of both the unit tests and the integration tests if both tasks are run.
 
-Unlike with many of the testing configuration options, there are several project-level <<sec:java_convention_properties,convention properties that affect the test reports>>. For example, you can change the destination of the test results and reports like so: 
+Unlike with many of the testing configuration options, there are several project-level <<sec:java_convention_properties,convention properties that affect the test reports>>. For example, you can change the destination of the test results and reports like so:
 
 ++++
 <sample id="javaCustomReportDirs" dir="userguide/java/customDirs" title="Changing the default test report and results directories">

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -122,16 +122,13 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
                     return
                 }
                 
-                assert configuredTasks.size() == 3
+                assert configuredTasks.size() == 2
 
                 // This should be the only task configured
                 assert ":help" in configuredTaskPaths
                 
                 // This task needs to be able to register publications lazily
                 assert ":jar" in configuredTaskPaths
-                
-                // This task is eagerly configured with configureEachLater
-                assert ":test" in configuredTaskPaths
             }
         """
         expect:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
@@ -105,7 +105,7 @@ public class BarTest {
         """
 
         when:
-        succeeds("test", "-Dtest.single=Foo")
+        succeeds("test", "--tests", "Foo*")
 
         then:
         //asserting on output because test results are kept in between invocations
@@ -113,14 +113,14 @@ public class BarTest {
         outputContains("executed Test test(FooTest)")
 
         when:
-        succeeds("test", "-Dtest.single=Bar")
+        succeeds("test", "--tests", "Bar*")
 
         then:
         outputContains("executed Test test(BarTest)")
         outputDoesNotContain("executed Test test(FooTest)")
 
         when:
-        succeeds("test", "-Dtest.single=Bar")
+        succeeds("test", "--tests", "Bar*")
 
         then:
         result.assertTaskSkipped(":test")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -78,33 +78,30 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         """
 
         when:
-        executer.withArgument("-Dtest.debug")
-
+        executer.withArgument("-Dtest.debug").expectDeprecationWarning()
         then:
         succeeds("test")
+        output.contains("System property 'test.debug' has been deprecated and is scheduled to be removed in Gradle 5.0. Use --debug-jvm to enable remote debugging of tests.")
+
+        when:
+        executer.withArgument("-D:test.debug").expectDeprecationWarning()
+        then:
+        succeeds("test")
+        output.contains("System property ':test.debug' has been deprecated and is scheduled to be removed in Gradle 5.0. Use --debug-jvm to enable remote debugging of tests.")
+
+        expect:
+        succeeds("test", "--debug-jvm")
     }
 
     def "configures test task when test.single property is set"() {
         given:
         buildFile << """
-            import org.gradle.api.internal.tasks.properties.PropertyVisitor
-            import org.gradle.api.internal.tasks.properties.PropertyWalker
-            import org.gradle.api.internal.tasks.TaskInputFilePropertySpec
-            import org.gradle.api.internal.tasks.TaskPropertyUtils
-
             apply plugin: 'java'
 
             task validate() {
                 doFirst {
+                    assert test.candidateClassFiles.empty
                     assert test.includes  == ['**/pattern*.class'] as Set
-                    boolean hasSourceFiles = false
-                    TaskPropertyUtils.visitProperties(project.services.get(PropertyWalker), it, new PropertyVisitor.Adapter() {
-                        @Override
-                        void visitInputFileProperty(TaskInputFilePropertySpec inputFileProperty) {
-                            hasSourceFiles |= inputFileProperty.isSkipWhenEmpty() && !inputFileProperty.propertyFiles.empty
-                        }
-                    })
-                    assert !hasSourceFiles
                 }
             }
             test.include 'ignoreme'
@@ -113,10 +110,17 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         """
 
         when:
-        executer.withArgument("-Dtest.single=pattern")
-
+        executer.withArgument("-Dtest.single=pattern").expectDeprecationWarning()
         then:
         succeeds("test")
+        output.contains("System property 'test.single' has been deprecated and is scheduled to be removed in Gradle 5.0. Use --tests to filter which tests to run instead.")
+
+
+        when:
+        executer.withArgument("-D:test.single=pattern").expectDeprecationWarning()
+        then:
+        succeeds("test")
+        output.contains("System property ':test.single' has been deprecated and is scheduled to be removed in Gradle 5.0. Use --tests to filter which tests to run instead.")
     }
 
     def "fails cleanly even if an exception is thrown that doesn't serialize cleanly"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -146,29 +146,28 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
     def canRunSingleTests() {
         when:
-        executer.withTasks('test').withArguments('-Dtest.single=Ok2').run()
+        succeeds("test", "--tests=Ok2*")
 
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted('Ok2')
+        def testResult = new DefaultTestExecutionResult(testDirectory)
+        testResult.assertTestClassesExecuted('Ok2')
 
         when:
-        executer.withTasks('cleanTest', 'test').withArguments('-Dtest.single=Ok').run()
+        succeeds("cleanTest", "test", "--tests=Ok*")
 
         then:
-        result.assertTestClassesExecuted('Ok', 'Ok2')
+        testResult.assertTestClassesExecuted('Ok', 'Ok2')
 
         when:
-        def failure = executer.withTasks('test').withArguments('-Dtest.single=DoesNotMatchAClass').runWithFailure()
+        fails("test", "--tests=DoesNotMatchAClass*")
 
         then:
-        failure.assertHasCause('Could not find matching test for pattern: DoesNotMatchAClass')
+        result.assertHasCause('No tests found for given includes: [DoesNotMatchAClass*](--tests filter)')
 
         when:
-        failure = executer.withTasks('test').withArguments('-Dtest.single=NotATest').runWithFailure()
-
+        fails("test", "--tests=NotATest*")
         then:
-        failure.assertHasCause('Could not find matching test for pattern: NotATest')
+        result.assertHasCause('No tests found for given includes: [NotATest*](--tests filter)')
     }
 
     def canUseTestSuperClassesFromAnotherProject() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -168,6 +168,12 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         fails("test", "--tests=NotATest*")
         then:
         result.assertHasCause('No tests found for given includes: [NotATest*](--tests filter)')
+
+        when:
+        executer.expectDeprecationWarning()
+        fails("test", "-Dtest.single=DoesNotMatchAClass", "-i")
+        then:
+        result.assertHasCause('Could not find matching test for pattern: DoesNotMatchAClass')
     }
 
     def canUseTestSuperClassesFromAnotherProject() {


### PR DESCRIPTION
- Deprecate test.single and test.debug system properties
   - test.single can be replaced by --tests
   - test.debug can be replaced by --debug-jvm
- System properties are now checked in the Test task
