### PR TITLE
Add support for URI-backed text resources

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/resources/TextResourceFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/resources/TextResourceFactory.java
@@ -37,6 +37,8 @@ import org.gradle.api.Incubating;
  * configurations { someConfig } // assumption: contains a single archive
  * def sourcedFromConfiguration =
  *   resources.text.fromArchiveEntry(configurations.someConfig, "path/to/archive/entry.txt")
+ *
+ * def sourceFromUri = resources.text.fromUri("https://path/to/the/resource")
  * </pre>
  *
  * File based factory methods optionally accept a character encoding. If no encoding is specified,
@@ -85,4 +87,15 @@ public interface TextResourceFactory {
      * Same as {@code fromArchiveEntry(archive, path, Charset.defaultCharset().name())}.
      */
     TextResource fromArchiveEntry(Object archive, String path);
+
+    /**
+     * Creates a text resource backed by the given uri.
+     *
+     * @param uri a URI as evaluated by {@link org.gradle.api.Project#uri(Object)}
+     *
+     * @return a text resource backed by the given uri
+     * @since 4.8
+     */
+    @Incubating
+    TextResource fromUri(Object uri);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
@@ -17,8 +17,13 @@
 package org.gradle.api.resource
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.junit.Rule
 
 class BrokenTextResourceIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    public final HttpServer server = new HttpServer()
+
     def setup() {
         buildFile << """
 class TextTask extends DefaultTask {
@@ -71,5 +76,18 @@ task text(type: TextTask)
         expect:
         fails("text")
         failure.assertHasCause("Expected entry 'config.txt' in archive file collection to contain exactly one file, however, it contains no files.")
+    }
+
+    def "reports read of missing uri resource"() {
+        given:
+        server.expectGetMissing("/myConfig.txt")
+        server.start()
+        buildFile << """
+            text.text = resources.text.fromUri("http://localhost:$server.port/myConfig.txt")
+"""
+
+        expect:
+        fails("text")
+        failure.assertHasCause("Could not read 'http://localhost:$server.port/myConfig.txt' as it does not exist.")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
@@ -18,12 +18,16 @@ package org.gradle.api.resource
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
+import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
 
 @TestReproducibleArchives
 class TextResourceIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     TestResources resource = new TestResources(temporaryFolder)
+
+    @Rule
+    public final HttpServer server = new HttpServer()
 
     def "string backed text resource"() {
         when:
@@ -85,4 +89,32 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
         then:
         skippedTasks == [":generateConfigFile", ":generateConfigZip", ":archiveEntryText"] as Set
     }
+
+    def "uri backed text resource"() {
+
+        given:
+        def resourceFile = file("web-file.txt")
+        server.expectGet("/myConfig.txt", resourceFile)
+        server.start()
+
+        buildFile << """
+            task uriText(type: MyTask) {
+                config = resources.text.fromUri("http://localhost:$server.port/myConfig.txt")
+                output = project.file("output.txt")
+            }
+"""
+        when:
+        run("uriText")
+
+        then:
+        executedTasks == [":uriText"]
+        file("output.txt").text == "my config\n"
+
+        when:
+        run("uriText")
+
+        then:
+        skippedTasks == [":uriText"] as Set
+    }
+
 }

--- a/subprojects/core/src/integTest/resources/org/gradle/api/resource/TextResourceIntegrationTest/shared/web-file.txt
+++ b/subprojects/core/src/integTest/resources/org/gradle/api/resource/TextResourceIntegrationTest/shared/web-file.txt
@@ -1,0 +1,1 @@
+my config

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -43,6 +43,7 @@ import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.resource.local.LocalFileStandInExternalResource;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
@@ -73,13 +74,18 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
     private final FileSystem fileSystem;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
+    @Deprecated //used by the Kotlin DSL
     public DefaultFileOperations(FileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory) {
+        this(fileResolver, taskResolver, temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory, null);
+    }
+
+    public DefaultFileOperations(FileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory, TextResourceLoader textResourceLoader) {
         this.fileResolver = fileResolver;
         this.taskResolver = taskResolver;
         this.temporaryFileProvider = temporaryFileProvider;
         this.instantiator = instantiator;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
-        this.resourceHandler = new DefaultResourceHandler(this, temporaryFileProvider);
+        this.resourceHandler = new DefaultResourceHandler(this, temporaryFileProvider, textResourceLoader);
         this.streamHasher = streamHasher;
         this.fileHasher = fileHasher;
         this.execFactory = execFactory;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/ApiTextResourceAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/ApiTextResourceAdapter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.resources;
+
+import com.google.common.io.Files;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.api.internal.tasks.TaskDependencies;
+import org.gradle.api.resources.ResourceException;
+import org.gradle.api.resources.internal.TextResourceInternal;
+import org.gradle.api.tasks.TaskDependency;
+import org.gradle.internal.resource.ResourceExceptions;
+import org.gradle.internal.resource.TextResource;
+import org.gradle.internal.resource.TextResourceLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URI;
+import java.nio.charset.Charset;
+
+/**
+ * A {@link org.gradle.api.resources.TextResource} that adapts a {@link TextResource}.
+ */
+public class ApiTextResourceAdapter implements TextResourceInternal {
+    private final URI uri;
+    private final TextResourceLoader textResourceLoader;
+    private final TemporaryFileProvider tempFileProvider;
+    private TextResource textResource;
+
+    public ApiTextResourceAdapter(TextResourceLoader textResourceLoader, TemporaryFileProvider tempFileProvider, URI uri) {
+        this.uri = uri;
+        this.textResourceLoader = textResourceLoader;
+        this.tempFileProvider = tempFileProvider;
+    }
+
+    @Override
+    public String asString() {
+        return getWrappedTextResource().getText();
+    }
+
+    @Override
+    public Reader asReader() {
+        return getWrappedTextResource().getAsReader();
+    }
+
+    @Override
+    public File asFile(String targetCharset) {
+        try {
+            File file = getWrappedTextResource().getFile();
+            if (file == null) {
+                file = tempFileProvider.createTemporaryFile("wrappedInternalText", ".txt", "resource");
+                Files.write(getWrappedTextResource().getText(), file, Charset.forName(targetCharset));
+                return file;
+            }
+            Charset sourceCharset = getWrappedTextResource().getCharset();
+            Charset targetCharsetObj = Charset.forName(targetCharset);
+            if (targetCharsetObj.equals(sourceCharset)) {
+                return file;
+            }
+
+            File targetFile = tempFileProvider.createTemporaryFile("uriTextResource", ".txt", "resource");
+            try {
+                Files.asCharSource(file, sourceCharset).copyTo(Files.asCharSink(targetFile, targetCharsetObj));
+                return targetFile;
+            } catch (IOException e) {
+                throw new ResourceException("Could not write " + getDisplayName() + " content to " + targetFile + ".", e);
+            }
+        } catch (Exception e) {
+            throw ResourceExceptions.readFailed(getDisplayName(), e);
+        }
+    }
+
+    @Override
+    public File asFile() {
+        return asFile(Charset.defaultCharset().name());
+    }
+
+    @Override
+    public Object getInputProperties() {
+        return uri;
+    }
+
+    @Override
+    public FileCollection getInputFiles() {
+        return null;
+    }
+
+    @Override
+    public TaskDependency getBuildDependencies() {
+        return TaskDependencies.EMPTY;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return getWrappedTextResource().getDisplayName();
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+    private TextResource getWrappedTextResource() {
+        if (textResource == null) {
+            textResource = textResourceLoader.loadUri("textResource", uri);
+        }
+        return textResource;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultResourceHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultResourceHandler.java
@@ -23,14 +23,15 @@ import org.gradle.api.internal.file.archive.compression.GzipArchiver;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.resources.TextResourceFactory;
 import org.gradle.api.resources.internal.ReadableResourceInternal;
+import org.gradle.internal.resource.TextResourceLoader;
 
 public class DefaultResourceHandler implements ResourceHandler {
     private final FileOperations fileOperations;
     private final TextResourceFactory textResourceFactory;
 
-    public DefaultResourceHandler(FileOperations fileOperations, TemporaryFileProvider tempFileProvider) {
+    public DefaultResourceHandler(FileOperations fileOperations, TemporaryFileProvider tempFileProvider, TextResourceLoader textResourceLoader) {
         this.fileOperations = fileOperations;
-        textResourceFactory = new DefaultTextResourceFactory(fileOperations, tempFileProvider);
+        textResourceFactory = new DefaultTextResourceFactory(fileOperations, tempFileProvider, textResourceLoader);
     }
 
     public ReadableResourceInternal gzip(Object path) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
@@ -20,16 +20,19 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.resources.TextResourceFactory;
+import org.gradle.internal.resource.TextResourceLoader;
 
 import java.nio.charset.Charset;
 
 public class DefaultTextResourceFactory implements TextResourceFactory {
     private final FileOperations fileOperations;
     private final TemporaryFileProvider tempFileProvider;
+    private final TextResourceLoader textResourceLoader;
 
-    public DefaultTextResourceFactory(FileOperations fileOperations, TemporaryFileProvider tempFileProvider) {
+    public DefaultTextResourceFactory(FileOperations fileOperations, TemporaryFileProvider tempFileProvider, TextResourceLoader textResourceLoader) {
         this.fileOperations = fileOperations;
         this.tempFileProvider = tempFileProvider;
+        this.textResourceLoader = textResourceLoader;
     }
 
     public TextResource fromString(String string) {
@@ -51,5 +54,10 @@ public class DefaultTextResourceFactory implements TextResourceFactory {
 
     public TextResource fromArchiveEntry(Object archive, String entryPath) {
         return fromArchiveEntry(archive, entryPath, Charset.defaultCharset().name());
+    }
+
+    @Override
+    public TextResource fromUri(Object uri) {
+        return new ApiTextResourceAdapter(textResourceLoader, tempFileProvider, fileOperations.uri(uri));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -82,14 +82,15 @@ public abstract class DefaultScript extends BasicScript {
         DirectoryFileTreeFactory directoryFileTreeFactory = services.get(DirectoryFileTreeFactory.class);
         StreamHasher streamHasher = services.get(StreamHasher.class);
         FileHasher fileHasher = services.get(FileHasher.class);
+        TextResourceLoader textResourceLoader = services.get(TextResourceLoader.class);
         if (target instanceof FileOperations) {
             fileOperations = (FileOperations) target;
         } else {
             File sourceFile = getScriptSource().getResource().getLocation().getFile();
             if (sourceFile != null) {
-                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(sourceFile.getParentFile()), null, null, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory);
+                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(sourceFile.getParentFile()), null, null, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory, textResourceLoader);
             } else {
-                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(), null, null, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory);
+                fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(), null, null, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory, textResourceLoader);
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -71,6 +71,7 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
@@ -143,8 +144,8 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultProjectConfigurationActionContainer();
     }
 
-    protected DefaultFileOperations createFileOperations(FileResolver fileResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory) {
-        return new DefaultFileOperations(fileResolver, project.getTasks(), temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory);
+    protected DefaultFileOperations createFileOperations(FileResolver fileResolver, TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory, TextResourceLoader textResourceLoader) {
+        return new DefaultFileOperations(fileResolver, project.getTasks(), temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory, textResourceLoader);
     }
 
     protected ExecFactory decorateExecFactory(ExecFactory execFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -33,6 +33,7 @@ import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.resource.TextResourceLoader
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecException
 import org.gradle.process.internal.ExecFactory
@@ -58,10 +59,11 @@ class DefaultFileOperationsTest extends Specification {
     private final StreamHasher streamHasher = Mock()
     private final FileHasher fileHasher = Mock()
     private final ExecFactory execFactory = TestFiles.execFactory()
+    private final TextResourceLoader textResourceLoader = Mock()
     private DefaultFileOperations fileOperations = instance()
 
     private DefaultFileOperations instance(FileResolver resolver = resolver) {
-        instantiator.newInstance(DefaultFileOperations, resolver, taskResolver, temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory)
+        instantiator.newInstance(DefaultFileOperations, resolver, taskResolver, temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory, textResourceLoader)
     }
 
     @Rule

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -38,6 +38,7 @@ import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.resource.TextResourceLoader
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.model.internal.registry.ModelRegistry
@@ -165,7 +166,8 @@ class DefaultProjectSpec extends Specification {
         def directoryFileTreeFactory = Mock(DefaultDirectoryFileTreeFactory)
         def streamHasher = Mock(StreamHasher)
         def fileHasher = Mock(FileHasher)
-        def fileOperations = instantiator.newInstance(DefaultFileOperations, fileResolver, taskResolver, tempFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, TestFiles.execFactory())
+        def textResourceLoader = Mock(TextResourceLoader)
+        def fileOperations = instantiator.newInstance(DefaultFileOperations, fileResolver, taskResolver, tempFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, TestFiles.execFactory(), textResourceLoader)
         def projectDir = new File("project")
         def layout = instantiator.newInstance(DefaultProjectLayout, projectDir, fileResolver, taskResolver)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/ApiTextResourceAdapterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/ApiTextResourceAdapterTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.resources
+
+import org.gradle.api.internal.file.TemporaryFileProvider
+import org.gradle.api.internal.tasks.TaskDependencies
+import org.gradle.internal.resource.TextResource
+import org.gradle.internal.resource.TextResourceLoader
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+class ApiTextResourceAdapterTest extends AbstractTextResourceTest {
+
+    TextResource textResource = Mock(TextResource)
+    TextResourceLoader textResourceLoader = Mock(TextResourceLoader)
+    Reader reader
+
+    def setup() {
+        def file = project.file("file.txt")
+        file.text = "contents"
+        reader = new InputStreamReader(new FileInputStream(file), Charset.defaultCharset())
+
+        textResourceLoader.loadUri("textResource", new URI("http://www.gradle.org/unknown.txt")) >> textResource
+        textResource.getFile() >>> [file, null]
+        textResource.getDisplayName() >> "Text resource display name"
+        textResource.getText() >>> ["contents", "more contents"]
+        textResource.getCharset() >> StandardCharsets.UTF_8
+        textResource.getAsReader() >> reader
+
+        resource = new ApiTextResourceAdapter(textResourceLoader, project.services.get(TemporaryFileProvider), new URI("http://www.gradle.org/unknown.txt"),)
+    }
+
+    def cleanup() {
+        reader.close()
+    }
+
+    def "get display name"() {
+        expect:
+        resource.getDisplayName() == "Text resource display name"
+    }
+
+    def "to string"() {
+        expect:
+        resource.toString() == "Text resource display name"
+    }
+
+    def "get build dependencies"() {
+        expect:
+        resource.getBuildDependencies() == TaskDependencies.EMPTY
+    }
+
+    def "get input Files"() {
+        expect:
+        resource.getInputFiles() == null
+    }
+
+    def "get input properties"() {
+        expect:
+        resource.getInputProperties() == new URI("http://www.gradle.org/unknown.txt")
+    }
+
+    def "read as file when file in depending resource is null"() {
+        expect:
+        resource.asString() == "contents"
+        resource.asFile().text == "contents"
+        resource.asFile().text == "more contents"
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.logging.StandardOutputCapture
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.resource.TextResourceLoader
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.process.internal.ExecFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -70,6 +71,8 @@ class DefaultScriptTest {
             will(returnValue(context.mock(FileHasher)))
             allowing(serviceRegistryMock).get(ExecFactory)
             will(returnValue(context.mock(ExecFactory)))
+            allowing(serviceRegistryMock).get(TextResourceLoader)
+            will(returnValue(context.mock(TextResourceLoader)))
         }
 
         DefaultScript script = new GroovyShell(createBaseCompilerConfiguration()).parse(testScriptText)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -57,6 +57,7 @@ import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.resource.TextResourceLoader
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.model.internal.inspect.ModelRuleExtractor
@@ -116,6 +117,7 @@ class ProjectScopeServicesTest extends Specification {
         parent.get(StreamHasher) >> Mock(StreamHasher)
         parent.get(FileHasher) >> Mock(FileHasher)
         parent.get(TaskStatistics) >> new TaskStatistics()
+        parent.get(TextResourceLoader) >> Mock(TextResourceLoader)
         registry = new ProjectScopeServices(parent, project, loggingManagerInternalFactory)
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -25,6 +25,8 @@ import org.gradle.internal.hash.DefaultFileHasher;
 import org.gradle.internal.hash.DefaultStreamHasher;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.reflect.DirectInstantiator;
+import org.gradle.internal.resource.BasicTextResourceLoader;
+import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.resource.local.FileResourceConnector;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.process.internal.DefaultExecActionFactory;
@@ -72,7 +74,11 @@ public class TestFiles {
     }
 
     public static FileOperations fileOperations(File basedDir) {
-        return new DefaultFileOperations(resolver(basedDir), null, null, DirectInstantiator.INSTANCE, fileLookup(), directoryFileTreeFactory(), streamHasher(), fileHasher(), execFactory());
+        return new DefaultFileOperations(resolver(basedDir), null, null, DirectInstantiator.INSTANCE, fileLookup(), directoryFileTreeFactory(), streamHasher(), fileHasher(), execFactory(), textResourceLoader());
+    }
+
+    public static TextResourceLoader textResourceLoader() {
+        return new BasicTextResourceLoader();
     }
 
     public static DefaultStreamHasher streamHasher() {

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.resources.TextResourceFactory.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.resources.TextResourceFactory.xml
@@ -42,6 +42,10 @@
             <tr>
                 <td>fromArchiveEntry</td>
             </tr>
+
+            <tr>
+                <td>fromUri</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -56,6 +56,14 @@ in the next major Gradle version (Gradle 5.0). See the User guide section on the
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
 
+### TextResources can now be fetched from a URI
+
+Text resources like a common checkstyle configuration file can now be fetched directly from a URI. Gradle will apply the same caching that it does for remote build scripts.
+
+    checkstyle {
+        config = resources.text.fromUri("http://company.com/checkstyle-config.xml)"
+    }
+
 <!--
 ### Example deprecation
 -->
@@ -96,11 +104,12 @@ This is no longer the case and thus may cause modules to be excluded from a depe
 
 We would like to thank the following community members for making contributions to this release of Gradle.
 
+- [Lucas Smaira](https://github.com/lsmaira) Introduce support for running phased actions (gradle/gradle#4533)
+- [Filip Hrisafov](filiphr) Add support for URI backed TextResource (gradle/gradle#2760)
 - [Florian Nègre](https://github.com/fnegre) Fix distribution plugin documentation (gradle/gradle#4880)
 - [Andrew Potter](https://github.com/apottere) Update pluginManagement documentation to mention global configuration options (gradle/gradle#4999)
 - [Patrik Erdes](https://github.com/patrikerdes) Fail the build if a referenced init script does not exist (gradle/gradle#4845)
 - [Emmanuel Debanne](https://github.com/debanne) Upgrade CodeNarc to version 1.1 (gradle/gradle#4917)
-- [Lucas Smaira](https://github.com/lsmaira) Introduce support for running phased actions (gradle/gradle#4533)
 - [Alexandre Bouthinon](https://github.com/alexandrebouthinon) Fix NullPointerException (gradle/gradle#5199)
 - [Paul Eddie](https://github.com/paul-eeoc) Fix typo (gradle/gradle#5180)
 <!--

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/DownloadedUriTextResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/DownloadedUriTextResource.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URI;
+import java.nio.charset.Charset;
 
 /**
  * A {@link TextResource} implementation backed by a {@link UriTextResource}. This helps hide the internal details about file caching.
@@ -43,5 +44,10 @@ public class DownloadedUriTextResource extends UriTextResource {
         String charset = extractCharacterEncoding(contentType, DEFAULT_ENCODING);
         InputStream inputStream = new FileInputStream(downloadedResource);
         return new InputStreamReader(inputStream, charset);
+    }
+
+    @Override
+    public Charset getCharset() {
+        return Charset.forName(extractCharacterEncoding(contentType, DEFAULT_ENCODING));
     }
 }

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/DownloadedUriTextResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/DownloadedUriTextResourceTest.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class DownloadedUriTextResourceTest extends Specification {
+
+    private TestFile testDir
+    private File downloadedFile
+    private URI sourceUri
+
+    private TextResource underTest
+
+    @Rule
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+
+    def setup() {
+        testDir = tmpDir.createDir('dir')
+        downloadedFile = tmpDir.file("dummy.txt")
+        sourceUri = "http://www.gradle.org/unknown.txt".toURI()
+
+    }
+
+    def "should return passed description as display name"() {
+        when:
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        underTest.getDisplayName() == "Test description '$sourceUri'"
+    }
+
+    def "content should not be cached"() {
+        when:
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        !underTest.isContentCached()
+    }
+
+    def "should have no content when downloaded file has no content"() {
+        when:
+        downloadedFile.text = ""
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        underTest.getHasEmptyContent()
+    }
+
+    def "should have content when downloaded file has content"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        !underTest.getHasEmptyContent()
+    }
+
+    def "should return text from downloaded file"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        underTest.getText() == "Some content"
+    }
+
+    def "should return reader from downloaded file"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        underTest.getAsReader().text == "Some content"
+    }
+
+    def "should not exists when downloaded file is not initialized"() {
+        when:
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        !underTest.getExists()
+    }
+
+    def "should exists when downloaded file is initialized"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        underTest.getExists()
+    }
+
+    def "should not return downloaded file"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+
+        then:
+        underTest.getFile() == null
+    }
+
+    def "should return charset of content type"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "text/html; charset=ISO-8859-1", downloadedFile)
+
+        then:
+        underTest.getCharset() == Charset.forName("ISO-8859-1")
+    }
+
+    def "should return default charset when charset is missing in content type"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "text/html", downloadedFile)
+
+        then:
+        underTest.getCharset() == Charset.forName("UTF-8")
+    }
+
+    def "should return default charset when content type is missing"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, null, downloadedFile)
+
+        then:
+        underTest.getCharset() == Charset.forName("UTF-8")
+    }
+
+    def "should return correct ResourceLocation"() {
+        when:
+        downloadedFile.text = "Some content"
+        underTest = new DownloadedUriTextResource("Test description", sourceUri, "", downloadedFile)
+        def resourceLocation = underTest.getLocation()
+
+        then:
+        resourceLocation.getDisplayName() == "Test description '$sourceUri'"
+        resourceLocation.getURI() == sourceUri
+        resourceLocation.getFile() == null
+    }
+}

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/LocalFileStandInExternalResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/LocalFileStandInExternalResourceTest.groovy
@@ -27,10 +27,6 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-import java.nio.file.Files
-import java.nio.file.LinkOption
-import java.nio.file.attribute.BasicFileAttributeView
-
 class LocalFileStandInExternalResourceTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -383,7 +379,7 @@ class LocalFileStandInExternalResourceTest extends Specification {
     }
 
     def lastModified(File file) {
-        return Files.getFileAttributeView(file.toPath(), BasicFileAttributeView, LinkOption.NOFOLLOW_LINKS).readAttributes().lastModifiedTime().toMillis()
+        TestFiles.fileSystem().stat(file).lastModified
     }
 
 }


### PR DESCRIPTION
This can be used to point tasks like Checkstyle
to a remote, shared configuration file without
having to package it into an archive and using
dependency resolution.

The implementation reuses the same caching logic
we have for remote build scripts.

Supersedes https://github.com/gradle/gradle/pull/2760