### PR TITLE
Add plugin registry for buildSrc plugins

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -116,7 +116,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     protected PluginRegistry createPluginRegistry(PluginRegistry rootRegistry) {
         PluginRegistry parentRegistry;
         if (project.getParent() == null) {
-            parentRegistry = rootRegistry;
+            parentRegistry = rootRegistry.createChild(project.getBaseClassLoaderScope());
         } else {
             parentRegistry = project.getParent().getServices().get(PluginRegistry.class);
         }


### PR DESCRIPTION
Plugins registries form a hierarchy and every scope
that can contain plugins should have a corresponding
plugin registry. A missing registry leads to slow
plugin lookups for plugins defined in that scope.

We were missing a plugin registry that caches the
plugins contained in `buildSrc`. Thus builds making
heavy use of `buildSrc` plugins were paying an
unnecessary price for every such plugin they apply.