### PR TITLE
Improve performance of incremental compilation filtering

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.8-20180417000132+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.8-20180420000014+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -167,7 +167,7 @@ public class PmdExtension extends CodeQualityExtension {
      * Example: ruleSetFiles = files("config/pmd/myRuleSet.xml")
      */
     public void setRuleSetFiles(FileCollection ruleSetFiles) {
-        this.ruleSetFiles = project.files(ruleSetFiles);
+        this.ruleSetFiles = project.getLayout().configurableFiles(ruleSetFiles);
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -66,7 +66,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         extension = project.getExtensions().create("pmd", PmdExtension.class, project);
         extension.setToolVersion(DEFAULT_PMD_VERSION);
         extension.setRuleSets(new ArrayList<String>(Arrays.asList("java-basic")));
-        extension.setRuleSetFiles(project.files());
+        extension.setRuleSetFiles(project.getLayout().files());
         conventionMappingOf(extension).map("targetJdk", new Callable<Object>() {
             @Override
             public Object call() {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -150,7 +150,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             sourceSets = [project.sourceSets.main]
             ruleSets = ["java-braces", "java-unusedcode"]
             ruleSetConfig = project.resources.text.fromString("ruleset contents")
-            ruleSetFiles = project.files("my-ruleset.xml")
+            ruleSetFiles = project.getLayout().files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
             rulePriority = 3
@@ -186,7 +186,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         project.pmd {
             ruleSets = ["java-braces", "java-unusedcode"]
             ruleSetConfig = project.resources.text.fromString("ruleset contents")
-            ruleSetFiles = project.files("my-ruleset.xml")
+            ruleSetFiles = project.getLayout().files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
             rulePriority = 3

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -36,17 +36,17 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
 
         buildScript << """
-def baseDir = new File("${escapeString(baseDir)}")
-def file = new File(baseDir, "file")
-def symlink = new File(baseDir, "symlink")
-def symlinked = new File(baseDir, "symlinked")
-def fileCollection = $code
+            def baseDir = new File("${escapeString(baseDir)}")
+            def file = new File(baseDir, "file")
+            def symlink = new File(baseDir, "symlink")
+            def symlinked = new File(baseDir, "symlinked")
+            def fileCollection = $code
 
-assert fileCollection.contains(file)
-assert fileCollection.contains(symlink)
-assert fileCollection.contains(symlinked)
-assert fileCollection.files == [file, symlink, symlinked] as Set
-assert (fileCollection - project.files(symlink)).files == [file, symlinked] as Set
+            assert fileCollection.contains(file)
+            assert fileCollection.contains(symlink)
+            assert fileCollection.contains(symlinked)
+            assert fileCollection.files == [file, symlink, symlinked] as Set
+            assert (fileCollection - project.layout.files(symlink)).files == [file, symlinked] as Set
         """
 
         when:
@@ -56,8 +56,10 @@ assert (fileCollection - project.files(symlink)).files == [file, symlinked] as S
         noExceptionThrown()
 
         where:
-        desc                 | code
-        "project.files()"    | "project.files(file, symlink, symlinked)"
-        "project.fileTree()" | "project.fileTree(baseDir)"
+        desc                                  | code
+        "project.files()"                     | "project.files(file, symlink, symlinked)"
+        "project.layout.files()"              | "project.layout.files(file, symlink, symlinked)"
+        "project.layout.configurableFiles()"  | "project.layout.configurableFiles(file, symlink, symlinked)"
+        "project.fileTree()"                  | "project.fileTree(baseDir)"
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileProvidersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileProvidersIntegrationTest.groovy
@@ -305,7 +305,7 @@ task useDirProvider {
                 @InputFile
                 final RegularFileProperty inputFile = newInputFile()
                 @InputFiles
-                final ConfigurableFileCollection inputFiles = project.files()
+                final ConfigurableFileCollection inputFiles = project.layout.configurableFiles()
                 @OutputFile
                 final RegularFileProperty outputFile = newOutputFile()
                 
@@ -594,7 +594,7 @@ class SomeTask extends DefaultTask {
             class ConsumerTask extends DefaultTask {
             
                 @InputFiles
-                FileCollection inputFiles = project.files()
+                ConfigurableFileCollection inputFiles = project.layout.configurableFiles()
                 
                 @Optional
                 @OutputFile

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.file
 
+import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.TextUtil
 import spock.lang.Unroll
@@ -217,7 +218,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         'FileCollection'             | 'Closure'        | 'project.layout.files({ "%s/src/resource/file.txt" })'
         'FileCollection'             | 'List'           | 'project.layout.files([ "%s/src/resource/file.txt" ])'
         'FileCollection'             | 'array'          | 'project.layout.files([ "%s/src/resource/file.txt" ] as Object[])'
-        'FileCollection'             | 'FileCollection' | 'project.layout.files(new org.gradle.api.internal.file.collections.SimpleFileCollection(new File("%s/src/resource/file.txt")))'
+        'FileCollection'             | 'FileCollection' | "project.layout.files(${ImmutableFileCollection.name}.of(new File('%s/src/resource/file.txt')))"
         'FileCollection'             | 'Callable'       | "project.layout.files($STRING_CALLABLE)"
         'FileCollection'             | 'Provider'       | "project.layout.files(provider($STRING_CALLABLE))"
         'FileCollection'             | 'nested objects' | "project.layout.files({[{$STRING_CALLABLE}]})"
@@ -232,7 +233,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         'ConfigurableFileCollection' | 'Closure'        | 'project.layout.configurableFiles({ "%s/src/resource/file.txt" })'
         'ConfigurableFileCollection' | 'List'           | 'project.layout.configurableFiles([ "%s/src/resource/file.txt" ])'
         'ConfigurableFileCollection' | 'array'          | 'project.layout.configurableFiles([ "%s/src/resource/file.txt" ] as Object[])'
-        'ConfigurableFileCollection' | 'FileCollection' | 'project.layout.configurableFiles(new org.gradle.api.internal.file.collections.SimpleFileCollection(new File("%s/src/resource/file.txt")))'
+        'ConfigurableFileCollection' | 'FileCollection' | "project.layout.configurableFiles(${ImmutableFileCollection.name}.of(new File('%s/src/resource/file.txt')))"
         'ConfigurableFileCollection' | 'Callable'       | "project.layout.configurableFiles($STRING_CALLABLE)"
         'ConfigurableFileCollection' | 'Provider'       | "project.layout.configurableFiles(provider($STRING_CALLABLE))"
         'ConfigurableFileCollection' | 'nested objects' | "project.layout.configurableFiles({[{$STRING_CALLABLE}]})"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/collections/SimpleFileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/collections/SimpleFileCollectionIntegrationTest.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class SimpleFileCollectionIntegrationTest extends AbstractIntegrationSpec {
+    def 'creating SimpleFileCollection produces deprecation warning'() {
+        buildFile << '''
+            new org.gradle.api.internal.file.collections.SimpleFileCollection()
+        '''
+
+        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
+
+        expect:
+        succeeds "help"
+        output.contains "The SimpleFileCollection type has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Project.files() instead."
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -218,7 +218,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
             class NoSources extends NotCacheable {
                 @InputFiles
                 @SkipWhenEmpty
-                FileCollection empty = project.files()
+                FileCollection empty = project.layout.files()
             }
             
             task cacheable(type: NoSources) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinScriptIntegrationTest.groovy
@@ -44,7 +44,7 @@ class PropertyKotlinScriptIntegrationTest extends KotlinScriptIntegrationTest {
 
             open class MyTask : DefaultTask() {
                 val enabled: PropertyState<Boolean> = project.property(Boolean::class.java)
-                val outputFiles: ConfigurableFileCollection = project.files()
+                val outputFiles: ConfigurableFileCollection = project.layout.configurableFiles()
 
                 init {
                     enabled.set(false)
@@ -88,7 +88,7 @@ class PropertyKotlinScriptIntegrationTest extends KotlinScriptIntegrationTest {
         when:
         buildFile << """
             myTask.setEnabled(true)
-            myTask.setOutputFiles(project.files("${normaliseFileSeparators(projectUnderTest.customOutputFile.canonicalPath)}"))
+            myTask.setOutputFiles(project.layout.files("${normaliseFileSeparators(projectUnderTest.customOutputFile.canonicalPath)}"))
         """
         succeeds('myTask')
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyStateProjectUnderTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/provider/PropertyStateProjectUnderTest.groovy
@@ -81,7 +81,7 @@ class PropertyStateProjectUnderTest {
 
             class MyTask extends DefaultTask {
                 private final Property<Boolean> enabled = project.objects.property(Boolean)
-                private final ConfigurableFileCollection outputFiles = project.files()
+                private final ConfigurableFileCollection outputFiles = project.layout.configurableFiles()
 
                 @Input
                 boolean getEnabled() {
@@ -219,7 +219,7 @@ class PropertyStateProjectUnderTest {
 
                 MyExtension(Project project) {
                     enabled = project.objects.property(Boolean)
-                    outputFiles = project.files()
+                    outputFiles = project.layout.configurableFiles()
                 }
 
                 Boolean getEnabled() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MonkeyPatchRelocationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MonkeyPatchRelocationIntegrationTest.groovy
@@ -47,7 +47,7 @@ class MonkeyPatchRelocationIntegrationTest extends AbstractIntegrationSpec imple
         dir.file("build.gradle") << """
             @CacheableTask
             class Broken extends DefaultTask {
-                FileCollection processorListFile = project.files("input.txt")
+                FileCollection processorListFile = project.layout.files("input.txt")
 
                 @InputFiles
                 FileCollection getProcessorListFile() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -135,7 +135,7 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.api.tasks.*
 
             class TaskWithTwoOutputDirectoriesProperties extends DefaultTask {
-                @InputFiles def inputFiles = project.files()
+                @InputFiles def inputFiles = project.layout.files()
 
                 @OutputDirectory File outputs1
                 @OutputDirectory File outputs2
@@ -193,7 +193,7 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.api.tasks.*
 
             class TaskWithValidOutputFilesAndOutputDirectoriesProperty extends DefaultTask {
-                @InputFiles def inputFiles = project.files()
+                @InputFiles def inputFiles = project.layout.files()
                 @OutputFiles Map<String, File> outputFiles = [:]
                 @OutputDirectories Map<String, File> outputDirs = [:]
                 @TaskAction void action() {}

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -174,7 +174,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
                 return """
                     class CustomTask extends DefaultTask {
                         @OutputFile File outputFile = new File(temporaryDir, "output.txt")
-                        @Classpath FileCollection classpath = project.files("classpath/dirEntry", "library.jar")
+                        @Classpath FileCollection classpath = project.layout.files("classpath/dirEntry", "library.jar")
     
                         @TaskAction void generate() {
                             outputFile.text = "done"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -28,7 +28,7 @@ import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.cache.internal.ProducerGuard;
@@ -112,7 +112,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
             public Snapshot create() {
                 Snapshot snapshot = fileSystemMirror.getContent(path);
                 if (snapshot == null) {
-                    FileCollectionSnapshot fileCollectionSnapshot = snapshotter.snapshot(new SimpleFileCollection(file), InputPathNormalizationStrategy.ABSOLUTE, InputNormalizationStrategy.NOT_CONFIGURED);
+                    FileCollectionSnapshot fileCollectionSnapshot = snapshotter.snapshot(ImmutableFileCollection.of(file), InputPathNormalizationStrategy.ABSOLUTE, InputNormalizationStrategy.NOT_CONFIGURED);
                     DefaultBuildCacheHasher hasher = new DefaultBuildCacheHasher();
                     fileCollectionSnapshot.appendToHasher(hasher);
                     HashCode hashCode = hasher.hash();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.file.collections;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -38,11 +39,22 @@ public abstract class ImmutableFileCollection extends AbstractFileCollection {
         }
     };
 
+    public static ImmutableFileCollection of() {
+        return EMPTY;
+    }
+
     public static ImmutableFileCollection of(File... files) {
         if (files.length == 0) {
             return EMPTY;
         }
-        return new FileOnlyImmutableFileCollection(files);
+        return new FileOnlyImmutableFileCollection(ImmutableSet.copyOf(files));
+    }
+
+    public static ImmutableFileCollection of(Iterable<File> files) {
+        if (Iterables.isEmpty(files)) {
+            return EMPTY;
+        }
+        return new FileOnlyImmutableFileCollection(ImmutableSet.copyOf(files));
     }
 
     public static ImmutableFileCollection usingResolver(FileResolver fileResolver, Object... paths) {
@@ -68,8 +80,8 @@ public abstract class ImmutableFileCollection extends AbstractFileCollection {
     private static class FileOnlyImmutableFileCollection extends ImmutableFileCollection {
         private final ImmutableSet<File> files;
 
-        FileOnlyImmutableFileCollection(File... files) {
-            this.files = ImmutableSet.copyOf(files);
+        FileOnlyImmutableFileCollection(ImmutableSet<File> files) {
+            this.files = files;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/SimpleFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/SimpleFileCollection.java
@@ -15,16 +15,27 @@
  */
 package org.gradle.api.internal.file.collections;
 
+import org.gradle.util.DeprecationLogger;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
 
+/**
+ * @deprecated Use {@link org.gradle.api.file.ProjectLayout#files(Object...)} or {@link org.gradle.api.file.ProjectLayout#configurableFiles(Object...)}
+ */
+@Deprecated
 public class SimpleFileCollection extends FileCollectionAdapter implements Serializable {
     public SimpleFileCollection(File... files) {
-        super(new ListBackedFileSet(files));
+        this(new ListBackedFileSet(files));
     }
 
     public SimpleFileCollection(Collection<File> files) {
-        super(new ListBackedFileSet(files));
+        this(new ListBackedFileSet(files));
+    }
+
+    private SimpleFileCollection(MinimalFileSet fileSet) {
+        super(fileSet);
+        DeprecationLogger.nagUserOfDiscontinuedApi("SimpleFileCollection type", "Please use Project.files() instead.");
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClasspathHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClasspathHasher.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.initialization.loadercache;
 
 import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.caching.internal.BuildCacheHasher;
 import org.gradle.caching.internal.DefaultBuildCacheHasher;
 import org.gradle.internal.classloader.ClasspathHasher;
@@ -36,7 +36,7 @@ public class DefaultClasspathHasher implements ClasspathHasher {
 
     @Override
     public HashCode hash(ClassPath classpath) {
-        FileCollectionSnapshot snapshot = snapshotter.snapshot(new SimpleFileCollection(classpath.getAsFiles()), null, InputNormalizationStrategy.NOT_CONFIGURED);
+        FileCollectionSnapshot snapshot = snapshotter.snapshot(ImmutableFileCollection.of(classpath.getAsFiles()), null, InputNormalizationStrategy.NOT_CONFIGURED);
         BuildCacheHasher hasher = new DefaultBuildCacheHasher();
         snapshot.appendToHasher(hasher);
         return hasher.hash();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CacheableTaskOutputCompositeFilePropertyElementSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CacheableTaskOutputCompositeFilePropertyElementSpec.java
@@ -18,11 +18,10 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.PathNormalizationStrategy;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.tasks.FileNormalizer;
 
 import java.io.File;
-import java.util.Collections;
 
 class CacheableTaskOutputCompositeFilePropertyElementSpec implements CacheableTaskOutputFilePropertySpec {
     private final CompositeTaskOutputPropertySpec parentProperty;
@@ -33,7 +32,7 @@ class CacheableTaskOutputCompositeFilePropertyElementSpec implements CacheableTa
     public CacheableTaskOutputCompositeFilePropertyElementSpec(CompositeTaskOutputPropertySpec parentProperty, String propertySuffix, File file) {
         this.parentProperty = parentProperty;
         this.propertySuffix = propertySuffix;
-        this.files = new SimpleFileCollection(Collections.singleton(file));
+        this.files = ImmutableFileCollection.of(file);
         this.file = file;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/file/FileCollectionSymlinkTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/file/FileCollectionSymlinkTest.groovy
@@ -51,11 +51,13 @@ class FileCollectionSymlinkTest extends Specification {
         fileCollection.contains(symlinked)
         fileCollection.files == [file, symlink, symlinked] as Set
 
-        (fileCollection - project.files(symlink)).files == [file, symlinked] as Set
+        (fileCollection - project.getLayout().files(symlink)).files == [file, symlinked] as Set
 
         where:
-        desc                 | fileCollection
-        "project.files()"    | project.files(file, symlink, symlinked)
-        "project.fileTree()" | project.fileTree(baseDir)
+        desc                                    | fileCollection
+        "project.files()"                       | project.files(file, symlink, symlinked)
+        "project.layout.files()"                | project.getLayout().files(file, symlink, symlinked)
+        "project.layout.configurableFilesFor()" | project.getLayout().configurableFiles(file, symlink, symlinked)
+        "project.fileTree()"                    | project.fileTree(baseDir)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/AbstractPathNormalizationStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/AbstractPathNormalizationStrategyTest.groovy
@@ -40,7 +40,7 @@ class AbstractPathNormalizationStrategyTest extends AbstractProjectBuilderSpec {
         createFile("dir/resources/b/input-2.txt") << "input #2"
         file("empty-dir").mkdirs()
 
-        files = project.files("dir/libs/library-a.jar", "dir/libs/library-b.jar", "dir/resources", "missing-file", "empty-dir")
+        files = project.getLayout().files("dir/libs/library-a.jar", "dir/libs/library-b.jar", "dir/resources", "missing-file", "empty-dir")
     }
 
     private def createFile(String path) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/ImmutableFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/ImmutableFileCollectionTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.api.internal.file.collections
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.Transformer
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
+import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.provider.Provider
 import org.gradle.util.UsesNativeServices
@@ -32,18 +34,22 @@ import java.util.concurrent.Callable
 @UsesNativeServices
 class ImmutableFileCollectionTest extends Specification {
     def 'can create empty collection'() {
-        ImmutableFileCollection files = ImmutableFileCollection.of()
+        ImmutableFileCollection collection1 = ImmutableFileCollection.of()
+        ImmutableFileCollection collection2 = ImmutableFileCollection.of(new File[0])
 
         expect:
-        files.files.size() == 0
+        collection1.files.size() == 0
+        collection2.files.size() == 0
     }
 
     def 'empty collections are fixed instance'() {
         ImmutableFileCollection collection1 = ImmutableFileCollection.of()
         ImmutableFileCollection collection2 = ImmutableFileCollection.of()
+        ImmutableFileCollection collection3 = ImmutableFileCollection.of(new File[0])
 
         expect:
         collection1.is(collection2)
+        collection1.is(collection3)
     }
 
     def 'resolves specified files using FileResolver'() {
@@ -155,10 +161,24 @@ class ImmutableFileCollectionTest extends Specification {
         'closure'          | ({ [ 'abc', 'def' ] } as Object[])
         'collection(list)' | [ 'abc', 'def' ]
         'array'            | ([ 'abc', 'def' ] as Object[])
-        'FileCollection'   | new SimpleFileCollection(new File('1'), new File('2'))
+        'FileCollection'   | fileCollectionOf(new File('1'), new File('2'))
         'Callable'         | (({ [ 'abc', 'def' ] } as Callable<Object>) as Object[])
         'Provider'         | providerReturning(['abc', 'def'])
         'nested objects'   | ({[{['abc', { ['def'] as String[] }]}]} as Object[])
+    }
+
+    private FileCollection fileCollectionOf(final File... files) {
+        return new AbstractFileCollection() {
+            @Override
+            String getDisplayName() {
+                return 'test file collection'
+            }
+
+            @Override
+            Set<File> getFiles() {
+                return ImmutableSet.copyOf(files)
+            }
+        }
     }
 
     private Provider<Object> providerReturning(Object result) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
@@ -242,7 +242,7 @@ class DefaultAntBuilderTest extends AbstractProjectBuilderSpec {
         project.file(dirname).mkdir()
         File fileWithDollars = project.file(dirAndFile)
         fileWithDollars << "Some Text"
-        FileCollection files = project.files(dirAndFile)
+        FileCollection files = project.getLayout().files(dirAndFile)
 
         when:
         ant.property(name: "my.property", value: "doesNotExist")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/FileCollectionBackedTarArchiveTextResourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/FileCollectionBackedTarArchiveTextResourceTest.groovy
@@ -28,6 +28,6 @@ class FileCollectionBackedTarArchiveTextResourceTest extends AbstractTextResourc
         archiveEntry.text = "contents"
         project.ant.tar(basedir: project.file("archive"), destfile: archive, compression: "gzip")
         resource = new FileCollectionBackedArchiveTextResource(project.services.get(FileOperations),
-                project.services.get(TemporaryFileProvider), project.files(archive), "path/to/text", Charsets.UTF_8)
+                project.services.get(TemporaryFileProvider), project.layout.files(archive), "path/to/text", Charsets.UTF_8)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/FileCollectionBackedTextResourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/FileCollectionBackedTextResourceTest.groovy
@@ -23,6 +23,6 @@ class FileCollectionBackedTextResourceTest extends AbstractTextResourceTest {
     def setup() {
         def file = project.file("file.txt")
         file.text = "contents"
-        resource = new FileCollectionBackedTextResource(project.services.get(TemporaryFileProvider), project.files(file), Charsets.UTF_8)
+        resource = new FileCollectionBackedTextResource(project.services.get(TemporaryFileProvider), project.layout.files(file), Charsets.UTF_8)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/FileCollectionBackedZipArchiveTextResourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/resources/FileCollectionBackedZipArchiveTextResourceTest.groovy
@@ -28,6 +28,6 @@ class FileCollectionBackedZipArchiveTextResourceTest extends AbstractTextResourc
         archiveEntry.text = "contents"
         project.ant.zip(basedir: project.file("archive"), destfile: archive)
         resource = new FileCollectionBackedArchiveTextResource(project.services.get(FileOperations),
-                project.services.get(TemporaryFileProvider), project.files(archive), "path/to/text", Charsets.UTF_8)
+                project.services.get(TemporaryFileProvider), project.layout.files(archive), "path/to/text", Charsets.UTF_8)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
@@ -35,7 +35,7 @@ class SourceTaskTest extends AbstractTaskTest {
         file2.createNewFile()
 
         task.source = file1
-        task.source = task.source + project.files(file2)
+        task.source = task.source + project.layout.files(file2)
 
         expect:
         task.source.asList() == [file1, file2]

--- a/subprojects/distributions/binary-compatibility.gradle
+++ b/subprojects/distributions/binary-compatibility.gradle
@@ -16,13 +16,13 @@
 
 
 
+
 import japicmp.model.JApiChangeStatus
 import me.champeau.gradle.japicmp.JapicmpTask
-import org.gradle.api.attributes.Attribute
-import org.gradle.binarycompatibility.rules.*
-import org.gradle.binarycompatibility.transforms.*
 import org.gradle.binarycompatibility.AcceptedApiChanges
 import org.gradle.binarycompatibility.CleanAcceptedApiChanges
+import org.gradle.binarycompatibility.rules.*
+import org.gradle.binarycompatibility.transforms.*
 import org.gradle.gradlebuild.ProjectGroups
 import org.gradle.gradlebuild.PublicApi
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -69,6 +69,11 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 `Signature.getToSignArtifact()` should have been an internal API and is now deprecated without a replacement.
 
+### `SimpleFileCollection`
+
+The internal `SimpleFileCollection` implementation of `FileCollection` has been deprecated.
+You should use `Project.files()` instead.
+
 ## Potential breaking changes
 
 ### Changed behaviour for missing init scripts

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/AbstractCppBinaryVisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/AbstractCppBinaryVisualStudioTargetBinary.java
@@ -18,7 +18,7 @@ package org.gradle.ide.visualstudio.internal;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.internal.DefaultCppBinary;
@@ -121,7 +121,7 @@ abstract public class AbstractCppBinaryVisualStudioTargetBinary implements Visua
 
     @Override
     public FileCollection getResourceFiles() {
-        return new SimpleFileCollection();
+        return ImmutableFileCollection.of();
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -225,7 +225,7 @@ public class EclipseWtpPlugin extends IdePlugin {
                         convention.map("sourceDirs", new Callable<Set<File>>() {
                             @Override
                             public Set<File> call() throws Exception {
-                                return project.files(project.getConvention().getPlugin(EarPluginConvention.class).getAppDirName()).getFiles();
+                                return project.getLayout().files(project.getConvention().getPlugin(EarPluginConvention.class).getAppDirName()).getFiles();
                             }
                         });
                         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaScalaConfigurer.java
@@ -137,7 +137,7 @@ public class IdeaScalaConfigurer {
             return createScalaSdkFromPlatform(scalaPlatform, scalaClasspath, useScalaSdk);
         } else if (ideaModule.getScalaPlatform() != null) {
             // TODO: Wrong, using the full classpath of the application
-            return createScalaSdkFromPlatform(ideaModule.getScalaPlatform(), scalaProject.files(files), useScalaSdk);
+            return createScalaSdkFromPlatform(ideaModule.getScalaPlatform(), scalaProject.getLayout().files(files), useScalaSdk);
         } else {
             // One of the Scala plugins is applied, but ScalaRuntime extension is missing or the ScalaPlatform is undefined.
             // we can't create a Scala SDK without either one

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -222,7 +222,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
             checkEclipseWtpComponentForEar(project.sourceSets.main.allSource.srcDirs)
         } else {
             checkEclipseClasspath([])
-            checkEclipseWtpComponentForEar(project.files(project.appDirName) as Set)
+            checkEclipseWtpComponentForEar(project.layout.files(project.appDirName) as Set)
         }
         checkEclipseWtpFacet([
                 new Facet(FacetType.fixed, "jst.ear", null),

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -58,8 +58,8 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compile', project.files('lib/guava.jar'))
-        project.dependencies.add('testCompile', project.files('lib/mockito.jar'))
+        project.dependencies.add('compile', project.layout.files('lib/guava.jar'))
+        project.dependencies.add('testCompile', project.layout.files('lib/mockito.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:
@@ -77,8 +77,8 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('testRuntime', project.files('lib/guava.jar'))
-        project.dependencies.add('excluded', project.files('lib/guava.jar'))
+        project.dependencies.add('testRuntime', project.layout.files('lib/guava.jar'))
+        project.dependencies.add('excluded', project.layout.files('lib/guava.jar'))
         module.scopes.TEST.minus << project.configurations.getByName('excluded')
         def result = dependenciesProvider.provide(module)
 
@@ -96,10 +96,10 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('testRuntime', project.files('lib/guava.jar'))
-        project.dependencies.add('testRuntime', project.files('lib/slf4j-api.jar'))
-        project.dependencies.add('excluded1', project.files('lib/guava.jar'))
-        project.dependencies.add('excluded2', project.files('lib/slf4j-api.jar'))
+        project.dependencies.add('testRuntime', project.layout.files('lib/guava.jar'))
+        project.dependencies.add('testRuntime', project.layout.files('lib/slf4j-api.jar'))
+        project.dependencies.add('excluded1', project.layout.files('lib/guava.jar'))
+        project.dependencies.add('excluded2', project.layout.files('lib/slf4j-api.jar'))
         module.scopes.TEST.minus << project.configurations.getByName('excluded1')
         module.scopes.TEST.minus << project.configurations.getByName('excluded2')
         def result = dependenciesProvider.provide(module)
@@ -113,7 +113,7 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'java')
 
         def module = project.ideaModule.module
-        def extraDependency = project.dependencies.create(project.files('lib/guava.jar'))
+        def extraDependency = project.dependencies.create(project.layout.files('lib/guava.jar'))
         def detachedCfg = project.configurations.detachedConfiguration(extraDependency)
         module.offline = true
 
@@ -167,8 +167,8 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('testCompile', project.files('lib/foo-impl.jar'))
-        project.dependencies.add('runtime', project.files('lib/foo-impl.jar'))
+        project.dependencies.add('testCompile', project.layout.files('lib/foo-impl.jar'))
+        project.dependencies.add('runtime', project.layout.files('lib/foo-impl.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:
@@ -185,8 +185,8 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compileOnly', project.files('lib/foo-api.jar'))
-        project.dependencies.add('testRuntime', project.files('lib/foo-impl.jar'))
+        project.dependencies.add('compileOnly', project.layout.files('lib/foo-api.jar'))
+        project.dependencies.add('testRuntime', project.layout.files('lib/foo-impl.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:
@@ -203,10 +203,10 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         module.offline = true
 
         when:
-        project.dependencies.add('compileOnly', project.files('lib/foo-runtime.jar'))
-        project.dependencies.add('compileOnly', project.files('lib/foo-testRuntime.jar'))
-        project.dependencies.add('runtime', project.files('lib/foo-runtime.jar'))
-        project.dependencies.add('testRuntime', project.files('lib/foo-testRuntime.jar'))
+        project.dependencies.add('compileOnly', project.layout.files('lib/foo-runtime.jar'))
+        project.dependencies.add('compileOnly', project.layout.files('lib/foo-testRuntime.jar'))
+        project.dependencies.add('runtime', project.layout.files('lib/foo-runtime.jar'))
+        project.dependencies.add('testRuntime', project.layout.files('lib/foo-testRuntime.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:
@@ -225,7 +225,7 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         def extraConfiguration = project.configurations.create('extraConfiguration')
 
         when:
-        project.dependencies.add('testCompile', project.files('lib/mockito.jar'))
+        project.dependencies.add('testCompile', project.layout.files('lib/mockito.jar'))
         def result = dependenciesProvider.provide(module)
 
         then:

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/tasks/PublishToIvyRepositoryTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/tasks/PublishToIvyRepositoryTest.groovy
@@ -58,7 +58,7 @@ class PublishToIvyRepositoryTest extends AbstractProjectBuilderSpec {
 
     def "the publishableFiles of the publication are inputs of the task"() {
         given:
-        def publishableFiles = project.files("a", "b", "c")
+        def publishableFiles = project.layout.files("a", "b", "c")
 
         publication.getPublishableArtifacts() >> Mock(PublicationArtifactSet) {
             getFiles() >> publishableFiles

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -55,7 +55,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert project.test.extensions.getByType(JacocoTaskExtension) != null
                     assert project.jacocoTestReport instanceof JacocoReport
-                    assert project.jacocoTestReport.sourceDirectories*.absolutePath == project.files("src/main/java")*.absolutePath
+                    assert project.jacocoTestReport.sourceDirectories*.absolutePath == project.layout.files("src/main/java")*.absolutePath
                     assert project.jacocoTestReport.classDirectories == project.sourceSets.main.output
                 }
             }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -16,7 +16,10 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
@@ -32,8 +35,7 @@ import org.codehaus.groovy.tools.javac.JavaCompilerFactory;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.classloading.GroovySystemLoader;
 import org.gradle.api.internal.classloading.GroovySystemLoaderFactory;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
-import org.gradle.api.specs.Spec;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.internal.classloader.ClassLoaderUtils;
@@ -50,6 +52,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.gradle.internal.FileUtils.hasExtension;
 
@@ -132,7 +135,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         }
 
         // Sort source files to work around https://issues.apache.org/jira/browse/GROOVY-7966
-        File[] sortedSourceFiles = Iterables.toArray(spec.getSource(), File.class);
+        File[] sortedSourceFiles = Iterables.toArray(spec.getSourceFiles(), File.class);
         Arrays.sort(sortedSourceFiles);
         unit.addSources(sortedSourceFiles);
 
@@ -143,7 +146,11 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                         if (shouldProcessAnnotations) {
                             // In order for the Groovy stubs to have annotation processors invoked against them, they must be compiled as source.
                             // Classes compiled as a result of being on the -sourcepath do not have the annotation processor run against them
-                            spec.setSource(spec.getSource().plus(new SimpleFileCollection(stubDir).getAsFileTree()));
+                            Set<File> newSource = ImmutableSet.<File>builder()
+                                .addAll(spec.getSourceFiles())
+                                .add(stubDir)
+                                .build();
+                            spec.setSourceFiles(ImmutableFileCollection.of(newSource).getAsFileTree().getFiles());
                         } else {
                             // When annotation processing isn't required, it's better to add the Groovy stubs as part of the source path.
                             // This allows compilations to complete faster, because only the Groovy stubs that are needed by the java source are compiled.
@@ -155,8 +162,9 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                             spec.getCompileOptions().setSourcepath(sourcepathBuilder.build());
                         }
 
-                        spec.setSource(spec.getSource().filter(new Spec<File>() {
-                            public boolean isSatisfiedBy(File file) {
+                        spec.setSourceFiles(Collections2.filter(spec.getSourceFiles(), new Predicate<File>() {
+                            @Override
+                            public boolean apply(File file) {
                                 return hasExtension(file, ".java");
                             }
                         }));

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.compile;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
@@ -52,7 +51,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.gradle.internal.FileUtils.hasExtension;
 
@@ -140,17 +138,15 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         unit.addSources(sortedSourceFiles);
 
         unit.setCompilerFactory(new JavaCompilerFactory() {
+            @Override
             public JavaCompiler createCompiler(final CompilerConfiguration config) {
                 return new JavaCompiler() {
+                    @Override
                     public void compile(List<String> files, CompilationUnit cu) {
                         if (shouldProcessAnnotations) {
                             // In order for the Groovy stubs to have annotation processors invoked against them, they must be compiled as source.
                             // Classes compiled as a result of being on the -sourcepath do not have the annotation processor run against them
-                            Set<File> newSource = ImmutableSet.<File>builder()
-                                .addAll(spec.getSourceFiles())
-                                .add(stubDir)
-                                .build();
-                            spec.setSourceFiles(ImmutableFileCollection.of(newSource).getAsFileTree().getFiles());
+                            spec.setSourceFiles(Iterables.concat(spec.getSourceFiles(), ImmutableFileCollection.of(stubDir).getAsFileTree()));
                         } else {
                             // When annotation processing isn't required, it's better to add the Groovy stubs as part of the source path.
                             // This allows compilations to complete faster, because only the Groovy stubs that are needed by the java source are compiled.

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -16,19 +16,19 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import org.gradle.api.Transformer;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 
 import static org.gradle.internal.FileUtils.hasExtension;
@@ -61,8 +61,9 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                 return '.' + extension;
             }
         });
-        FileCollection filtered = spec.getSource().filter(new Spec<File>() {
-            public boolean isSatisfiedBy(File element) {
+        Collection<File> filtered = Collections2.filter(spec.getSourceFiles(), new Predicate<File>() {
+            @Override
+            public boolean apply(File element) {
                 for (String fileExtension : fileExtensions) {
                     if (hasExtension(element, fileExtension)) {
                         return true;
@@ -72,7 +73,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
             }
         });
 
-        spec.setSource(new SimpleFileCollection(filtered.getFiles()));
+        spec.setSourceFiles(filtered);
     }
 
     private void resolveClasspath(GroovyJavaJointCompileSpec spec) {
@@ -98,7 +99,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
 
         StringBuilder builder = new StringBuilder();
         builder.append("Source files to be compiled:");
-        for (File file : spec.getSource()) {
+        for (File file : spec.getSourceFiles()) {
             builder.append('\n');
             builder.append(file);
         }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -93,7 +93,7 @@ public class GroovyCompile extends AbstractCompile {
 
     private DefaultGroovyJavaJointCompileSpec createSpec() {
         DefaultGroovyJavaJointCompileSpec spec = new DefaultGroovyJavaJointCompileSpecFactory(compileOptions).create();
-        spec.setSource(getSource());
+        spec.setSourceFiles(getSource().getFiles());
         spec.setDestinationDir(getDestinationDir());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.tasks.compile
 
-import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.api.tasks.compile.GroovyCompileOptions
 import org.gradle.util.TestUtil
@@ -30,7 +29,7 @@ class NormalizingGroovyCompilerTest extends Specification {
     def setup() {
         spec.compileClasspath = [new File('Dep1.jar'), new File('Dep2.jar'), new File('Dep3.jar')]
         spec.groovyClasspath = spec.compileClasspath
-        spec.source = files('House.scala', 'Person1.java', 'package.html', 'Person2.groovy')
+        spec.sourceFiles = files('House.scala', 'Person1.java', 'package.html', 'Person2.groovy')
         spec.destinationDir = new File("destinationDir")
         spec.compileOptions = new CompileOptions(TestUtil.objectFactory())
         spec.groovyCompileOptions = new GroovyCompileOptions()
@@ -42,7 +41,7 @@ class NormalizingGroovyCompilerTest extends Specification {
 
         then:
         1 * target.execute(spec) >> {
-            assert spec.source.files == files('Person1.java', 'Person2.groovy').files
+            assert spec.sourceFiles == files('Person1.java', 'Person2.groovy')
         }
     }
 
@@ -54,7 +53,7 @@ class NormalizingGroovyCompilerTest extends Specification {
 
         then:
         1 * target.execute(spec) >> {
-            assert spec.source.files == files('package.html').files
+            assert spec.sourceFiles == files('package.html')
         }
     }
 
@@ -91,6 +90,6 @@ class NormalizingGroovyCompilerTest extends Specification {
     }
 
     private files(String... paths) {
-        ImmutableFileCollection.of(paths.collect { new File(it) } as File[])
+        paths.collect { new File(it) } as Set
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CleaningJavaCompilerSupport.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CleaningJavaCompilerSupport.java
@@ -28,7 +28,7 @@ public abstract class CleaningJavaCompilerSupport<T extends JavaCompileSpec> imp
         StaleClassCleaner cleaner = createCleaner(spec);
 
         cleaner.setDestinationDir(spec.getDestinationDir());
-        cleaner.setSource(spec.getSource());
+        cleaner.setSource(spec.getSourceFiles());
         cleaner.execute();
 
         Compiler<? super T> compiler = getCompiler();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -259,7 +259,7 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
 
-        for (File file : spec.getSource()) {
+        for (File file : spec.getSourceFiles()) {
             args.add(file.getPath());
         }
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -59,7 +59,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         JavaCompiler compiler = javaHomeBasedJavaCompilerFactory.create();
         MinimalJavaCompileOptions compileOptions = spec.getCompileOptions();
         StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, compileOptions.getEncoding() != null ? Charset.forName(compileOptions.getEncoding()) : null);
-        Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSource());
+        Iterable<? extends JavaFileObject> compilationUnits = standardFileManager.getJavaFileObjectsFromFiles(spec.getSourceFiles());
         StandardJavaFileManager fileManager = standardFileManager;
         if (JavaVersion.current().isJava9Compatible() && emptySourcepathIn(options)) {
             fileManager = (StandardJavaFileManager) SourcepathIgnoringProxy.proxy(standardFileManager, StandardJavaFileManager.class);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -16,17 +16,18 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Joiner;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 
 import static org.gradle.internal.FileUtils.hasExtension;
@@ -54,13 +55,14 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
     private void resolveAndFilterSourceFiles(JavaCompileSpec spec) {
         // this mimics the behavior of the Ant javac task (and therefore AntJavaCompiler),
         // which silently excludes files not ending in .java
-        FileCollection javaOnly = spec.getSource().filter(new Spec<File>() {
-            public boolean isSatisfiedBy(File element) {
-                return hasExtension(element, ".java");
+        Collection<File> javaOnly = Collections2.filter(spec.getSourceFiles(), new Predicate<File>() {
+            @Override
+            public boolean apply(@Nullable File input) {
+                return hasExtension(input, ".java");
             }
         });
 
-        spec.setSource(new SimpleFileCollection(javaOnly.getFiles()));
+        spec.setSourceFiles(javaOnly);
     }
 
     private void resolveNonStringsInCompilerArgs(JavaCompileSpec spec) {
@@ -75,7 +77,7 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
 
         StringBuilder builder = new StringBuilder();
         builder.append("Source files to be compiled:");
-        for (File file : spec.getSource()) {
+        for (File file : spec.getSourceFiles()) {
             builder.append('\n');
             builder.append(file);
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
@@ -16,12 +16,13 @@
 
 package org.gradle.api.internal.tasks.compile.incremental;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
 import org.gradle.api.tasks.util.PatternSet;
@@ -35,9 +36,11 @@ import java.util.Set;
 
 class IncrementalCompilationInitializer {
     private final FileOperations fileOperations;
+    private final SourceToNameConverter sourceToNameConverter;
 
-    public IncrementalCompilationInitializer(FileOperations fileOperations) {
+    public IncrementalCompilationInitializer(FileOperations fileOperations, SourceToNameConverter sourceToNameConverter) {
         this.fileOperations = fileOperations;
+        this.sourceToNameConverter = sourceToNameConverter;
     }
 
     public void initializeCompilation(JavaCompileSpec spec, RecompilationSpec recompilationSpec) {
@@ -48,18 +51,31 @@ class IncrementalCompilationInitializer {
         }
         Factory<PatternSet> patternSetFactory = fileOperations.getFileResolver().getPatternSetFactory();
         PatternSet classesToDelete = patternSetFactory.create();
-        PatternSet sourceToCompile = patternSetFactory.create();
 
-        preparePatterns(recompilationSpec.getClassesToCompile(), classesToDelete, sourceToCompile);
-        narrowDownSourcesToCompile(spec, sourceToCompile);
+        prepareDeletePatterns(recompilationSpec.getClassesToCompile(), classesToDelete);
+        narrowDownSourcesToCompile(spec, recompilationSpec.getClassesToCompile());
         includePreviousCompilationOutputOnClasspath(spec);
         addClassesToProcess(spec, recompilationSpec);
         deleteStaleFilesIn(classesToDelete, spec.getDestinationDir());
         deleteStaleFilesIn(classesToDelete, spec.getCompileOptions().getAnnotationProcessorGeneratedSourcesDirectory());
     }
 
-    private void narrowDownSourcesToCompile(JavaCompileSpec spec, PatternSet sourceToCompile) {
-        spec.setSourceFiles(ImmutableFileCollection.of(spec.getSourceFiles()).getAsFileTree().matching(sourceToCompile).getFiles());
+    private void narrowDownSourcesToCompile(JavaCompileSpec spec, Collection<String> sourceToCompile) {
+        ImmutableList.Builder<File> builder = ImmutableList.builder();
+        Set<String> classesToCompileSet = ImmutableSet.copyOf(sourceToCompile);
+        for (File sourceFile : spec.getSourceFiles()) {
+            String className = sourceToNameConverter.getClassName(sourceFile);
+            if (classesToCompileSet.contains(normalizedClassName(className))) {
+                builder.add(sourceFile);
+            }
+        }
+
+        spec.setSourceFiles(builder.build());
+    }
+
+    private String normalizedClassName(String className) {
+        int dollarPosition = className.indexOf('$');
+        return dollarPosition == -1 ? className : className.substring(0, dollarPosition);
     }
 
     private void includePreviousCompilationOutputOnClasspath(JavaCompileSpec spec) {
@@ -69,7 +85,8 @@ class IncrementalCompilationInitializer {
         spec.setCompileClasspath(classpath);
     }
 
-    private void addClassesToProcess(JavaCompileSpec spec, RecompilationSpec recompilationSpec) {
+    @VisibleForTesting
+    void addClassesToProcess(JavaCompileSpec spec, RecompilationSpec recompilationSpec) {
         Set<String> classesToProcess = Sets.newHashSet(recompilationSpec.getClassesToProcess());
         classesToProcess.removeAll(recompilationSpec.getClassesToCompile());
         spec.setClasses(classesToProcess);
@@ -83,16 +100,14 @@ class IncrementalCompilationInitializer {
         fileOperations.delete(deleteMe);
     }
 
-    void preparePatterns(Collection<String> staleClasses, PatternSet filesToDelete, PatternSet sourceToCompile) {
+    @VisibleForTesting
+    void prepareDeletePatterns(Collection<String> staleClasses, PatternSet filesToDelete) {
         for (String staleClass : staleClasses) {
             String path = staleClass.replaceAll("\\.", "/");
             filesToDelete.include(path.concat(".class"));
             filesToDelete.include(path.concat(".java"));
             filesToDelete.include(path.concat("$*.class"));
             filesToDelete.include(path.concat("$*.java"));
-
-            sourceToCompile.include(path.concat(".java"));
-            sourceToCompile.include(path.concat("$*.java"));
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.internal.tasks.compile.incremental;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
 import org.gradle.api.tasks.util.PatternSet;
@@ -41,7 +42,7 @@ class IncrementalCompilationInitializer {
 
     public void initializeCompilation(JavaCompileSpec spec, RecompilationSpec recompilationSpec) {
         if (!recompilationSpec.isBuildNeeded()) {
-            spec.setSource(new SimpleFileCollection());
+            spec.setSourceFiles(ImmutableSet.<File>of());
             spec.setClasses(Collections.<String>emptySet());
             return;
         }
@@ -58,7 +59,7 @@ class IncrementalCompilationInitializer {
     }
 
     private void narrowDownSourcesToCompile(JavaCompileSpec spec, PatternSet sourceToCompile) {
-        spec.setSource(spec.getSource().getAsFileTree().matching(sourceToCompile));
+        spec.setSourceFiles(ImmutableFileCollection.of(spec.getSourceFiles()).getAsFileTree().matching(sourceToCompile).getFiles());
     }
 
     private void includePreviousCompilationOutputOnClasspath(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
@@ -65,17 +65,12 @@ class IncrementalCompilationInitializer {
         Set<String> classesToCompileSet = ImmutableSet.copyOf(sourceToCompile);
         for (File sourceFile : spec.getSourceFiles()) {
             String className = sourceToNameConverter.getClassName(sourceFile);
-            if (classesToCompileSet.contains(normalizedClassName(className))) {
+            if (classesToCompileSet.contains(className)) {
                 builder.add(sourceFile);
             }
         }
 
         spec.setSourceFiles(builder.build());
-    }
-
-    private String normalizedClassName(String className) {
-        int dollarPosition = className.indexOf('$');
-        return dollarPosition == -1 ? className : className.substring(0, dollarPosition);
     }
 
     private void includePreviousCompilationOutputOnClasspath(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
@@ -68,7 +68,7 @@ public class IncrementalCompilerFactory {
         SourceToNameConverter sourceToNameConverter = new SourceToNameConverter(sourceDirs);
         RecompilationSpecProvider recompilationSpecProvider = new RecompilationSpecProvider(sourceToNameConverter, fileOperations);
         ClassSetAnalysisUpdater classSetAnalysisUpdater = new ClassSetAnalysisUpdater(compileCaches.getLocalClassSetAnalysisStore(), fileOperations, analyzer, fileHasher);
-        IncrementalCompilationInitializer compilationInitializer = new IncrementalCompilationInitializer(fileOperations);
+        IncrementalCompilationInitializer compilationInitializer = new IncrementalCompilationInitializer(fileOperations, sourceToNameConverter);
         IncrementalCompilerDecorator incrementalSupport = new IncrementalCompilerDecorator(jarClasspathSnapshotMaker, compileCaches, compilationInitializer, cleaningJavaCompiler, compileDisplayName, recompilationSpecProvider, classSetAnalysisUpdater, sourceDirs, annotationProcessorClasspath, annotationProcessorDetector);
         return incrementalSupport.prepareCompiler(inputs);
     }
@@ -78,18 +78,22 @@ public class IncrementalCompilerFactory {
         final LocalJarClasspathSnapshotStore localJarClasspathSnapshotStore = generalCompileCaches.createLocalJarClasspathSnapshotStore(path);
         final AnnotationProcessorPathStore annotationProcessorPathStore = generalCompileCaches.createAnnotationProcessorPathStore(path);
         return new CompileCaches() {
+            @Override
             public ClassAnalysisCache getClassAnalysisCache() {
                 return generalCompileCaches.getClassAnalysisCache();
             }
 
+            @Override
             public JarSnapshotCache getJarSnapshotCache() {
                 return generalCompileCaches.getJarSnapshotCache();
             }
 
+            @Override
             public LocalJarClasspathSnapshotStore getLocalJarClasspathSnapshotStore() {
                 return localJarClasspathSnapshotStore;
             }
 
+            @Override
             public LocalClassSetAnalysisStore getLocalClassSetAnalysisStore() {
                 return localClassSetAnalysisStore;
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
@@ -63,7 +63,7 @@ class SelectiveCompiler implements org.gradle.language.base.internal.compile.Com
 
         incrementalCompilationInitilizer.initializeCompilation(spec, recompilationSpec);
 
-        if (spec.getSource().isEmpty() && spec.getClasses().isEmpty()) {
+        if (spec.getSourceFiles().isEmpty() && spec.getClasses().isEmpty()) {
             LOG.info("None of the classes needs to be compiled! Analysis took {}. ", clock.getElapsed());
             return new RecompilationNotNecessary();
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
@@ -18,10 +18,13 @@ package org.gradle.api.internal.tasks.compile.incremental;
 
 import java.io.File;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
 public class SourceToNameConverter {
+
+    private static final Pattern SOURCE_EXTENSION = Pattern.compile("\\.java$");
 
     private CompilationSourceDirs sourceDirs;
 
@@ -32,11 +35,11 @@ public class SourceToNameConverter {
     public String getClassName(File javaSourceClass) {
         List<File> dirs = sourceDirs.getSourceRoots();
         for (File sourceDir : dirs) {
-            if (javaSourceClass.getAbsolutePath().startsWith(sourceDir.getAbsolutePath())) { //perf tweak only
-                String relativePath = javaSourceClass.getAbsolutePath().substring(sourceDir.getAbsolutePath().length() + 1);
-                if (!relativePath.startsWith("..")) {
-                    return relativePath.replaceAll("/", ".").replaceAll("\\.java$", "");
-                }
+            String javaSourceClassAbsolutePath = javaSourceClass.getAbsolutePath();
+            String sourceDirAbsolutePath = sourceDir.getAbsolutePath();
+            if (javaSourceClassAbsolutePath.startsWith(sourceDirAbsolutePath)) {
+                String relativePath = javaSourceClassAbsolutePath.substring(sourceDirAbsolutePath.length() + 1);
+                return SOURCE_EXTENSION.matcher(relativePath).replaceFirst("").replace(File.separatorChar, '.');
             }
         }
         throw new IllegalArgumentException(format("Unable to find source java class: '%s' because it does not belong to any of the source dirs: '%s'",

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
@@ -35,7 +35,9 @@ public class SourceToNameConverter {
             String javaSourceClassAbsolutePath = javaSourceClass.getAbsolutePath();
             if (javaSourceClassAbsolutePath.startsWith(sourceDirAbsolutePath)) {
                 int endIndex = javaSourceClassAbsolutePath.endsWith(".java") ? javaSourceClassAbsolutePath.length() - 5 : javaSourceClassAbsolutePath.length();
-                String relativePath = javaSourceClassAbsolutePath.substring(sourceDirAbsolutePath.length(), endIndex);
+                int startIndex = sourceDirAbsolutePath.length();
+                int dollarIndex = javaSourceClassAbsolutePath.indexOf('$', startIndex);
+                String relativePath = javaSourceClassAbsolutePath.substring(startIndex, dollarIndex == -1 ? endIndex : dollarIndex);
                 return relativePath.replace(File.separatorChar, '.');
             }
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile.incremental;
 
-import org.gradle.util.RelativePathUtil;
-
 import java.io.File;
 import java.util.List;
 
@@ -35,7 +33,7 @@ public class SourceToNameConverter {
         List<File> dirs = sourceDirs.getSourceRoots();
         for (File sourceDir : dirs) {
             if (javaSourceClass.getAbsolutePath().startsWith(sourceDir.getAbsolutePath())) { //perf tweak only
-                String relativePath = RelativePathUtil.relativePath(sourceDir, javaSourceClass);
+                String relativePath = javaSourceClass.getAbsolutePath().substring(sourceDir.getAbsolutePath().length() + 1);
                 if (!relativePath.startsWith("..")) {
                     return relativePath.replaceAll("/", ".").replaceAll("\\.java$", "");
                 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
@@ -18,13 +18,10 @@ package org.gradle.api.internal.tasks.compile.incremental;
 
 import java.io.File;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
 public class SourceToNameConverter {
-
-    private static final Pattern SOURCE_EXTENSION = Pattern.compile("\\.java$");
 
     private CompilationSourceDirs sourceDirs;
 
@@ -33,13 +30,13 @@ public class SourceToNameConverter {
     }
 
     public String getClassName(File javaSourceClass) {
-        List<File> dirs = sourceDirs.getSourceRoots();
-        for (File sourceDir : dirs) {
+        List<String> dirs = sourceDirs.getSourceRoots();
+        for (String sourceDirAbsolutePath : dirs) {
             String javaSourceClassAbsolutePath = javaSourceClass.getAbsolutePath();
-            String sourceDirAbsolutePath = sourceDir.getAbsolutePath();
             if (javaSourceClassAbsolutePath.startsWith(sourceDirAbsolutePath)) {
-                String relativePath = javaSourceClassAbsolutePath.substring(sourceDirAbsolutePath.length() + 1);
-                return SOURCE_EXTENSION.matcher(relativePath).replaceFirst("").replace(File.separatorChar, '.');
+                int endIndex = javaSourceClassAbsolutePath.endsWith(".java") ? javaSourceClassAbsolutePath.length() - 5 : javaSourceClassAbsolutePath.length();
+                String relativePath = javaSourceClassAbsolutePath.substring(sourceDirAbsolutePath.length(), endIndex);
+                return relativePath.replace(File.separatorChar, '.');
             }
         }
         throw new IllegalArgumentException(format("Unable to find source java class: '%s' because it does not belong to any of the source dirs: '%s'",

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -284,7 +284,7 @@ public class CompileOptions extends AbstractOptions {
             for (String path : paths) {
                 files.add(new File(path));
             }
-            this.bootstrapClasspath = new SimpleFileCollection(files);
+            this.bootstrapClasspath = ImmutableFileCollection.of(files);
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -159,7 +159,7 @@ public class JavaCompile extends AbstractCompile {
 
     private DefaultJavaCompileSpec createSpec() {
         final DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions).create();
-        spec.setSource(getSource());
+        spec.setSourceFiles(getSource().getFiles());
         spec.setDestinationDir(getDestinationDir());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -136,6 +136,7 @@ public class JavaCompile extends AbstractCompile {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     protected void compile() {
         DefaultJavaCompileSpec spec = createSpec();
         performCompilation(spec, createCompiler(spec));
@@ -159,7 +160,7 @@ public class JavaCompile extends AbstractCompile {
 
     private DefaultJavaCompileSpec createSpec() {
         final DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions).create();
-        spec.setSourceFiles(getSource().getFiles());
+        spec.setSourceFiles(getSource());
         spec.setDestinationDir(getDestinationDir());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CleaningJavaCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CleaningJavaCompilerTest.groovy
@@ -15,10 +15,9 @@
  */
 package org.gradle.api.internal.tasks.compile
 
+import org.gradle.api.tasks.WorkResult
 import org.gradle.language.base.internal.tasks.StaleClassCleaner
 import spock.lang.Specification
-import org.gradle.api.tasks.WorkResult
-import org.gradle.api.file.FileCollection
 
 class CleaningJavaCompilerTest extends Specification {
     private final org.gradle.language.base.internal.compile.Compiler<JavaCompileSpec> target = Mock()
@@ -34,13 +33,13 @@ class CleaningJavaCompilerTest extends Specification {
             return cleaner
         }
     }
-    
+
     def cleansStaleClassesAndThenInvokesCompiler() {
         WorkResult result = Mock()
         File destDir = new File('dest')
-        FileCollection source = Mock()
         _ * spec.destinationDir >> destDir
-        _ * spec.source >> source
+        def files = [new File('src')] as Set
+        _ * spec.sourceFiles >> files
 
         when:
         def r = compiler.execute(spec)
@@ -50,7 +49,7 @@ class CleaningJavaCompilerTest extends Specification {
 
         and:
         1 * cleaner.setDestinationDir(destDir)
-        1 * cleaner.setSource(source)
+        1 * cleaner.setSource(files)
 
         and:
         1 * cleaner.execute()

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CommandLineJavaCompilerArgumentsGeneratorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CommandLineJavaCompilerArgumentsGeneratorTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile
 
 import com.google.common.collect.Lists
-import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -44,7 +43,7 @@ class CommandLineJavaCompilerArgumentsGeneratorTest extends Specification {
         println argsFile.text
 
         and: "args file contains remaining arguments (one per line, quoted)"
-        argsFile.readLines() == ["-g", "-sourcepath", quote(""), "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", quote("${spec.compileClasspath.join(File.pathSeparator)}"), *(spec.source*.path.collect { quote(it) })]
+        argsFile.readLines() == ["-g", "-sourcepath", quote(""), "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", quote("${spec.compileClasspath.join(File.pathSeparator)}"), *(spec.sourceFiles*.path.collect { quote(it) })]
     }
 
     String defaultEmptySourcePathRefFolder() {
@@ -57,7 +56,7 @@ class CommandLineJavaCompilerArgumentsGeneratorTest extends Specification {
         def spec = new DefaultJavaCompileSpec()
         spec.compileOptions = new CompileOptions(TestUtil.objectFactory())
         spec.compileOptions.forkOptions.memoryMaximumSize = "256m"
-        spec.source = ImmutableFileCollection.of(sources as File[])
+        spec.sourceFiles = sources
         spec.compileClasspath = classpath
         spec.tempDir = tempDir.testDirectory
         spec

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -312,7 +312,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     def "can include/exclude source files"() {
         def file1 = new File("/src/Person.java")
         def file2 = new File("Computer.java")
-        spec.source = ImmutableFileCollection.of(file1, file2)
+        spec.sourceFiles = [file1, file2]
 
         when:
         builder.includeSourceFiles(true)
@@ -330,7 +330,7 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
     def "does not include source files by default"() {
         def file1 = new File("/src/Person.java")
         def file2 = new File("Computer.java")
-        spec.source = ImmutableFileCollection.of(file1, file2)
+        spec.sourceFiles = [file1, file2]
 
         expect:
         builder.build() == defaultOptions

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
@@ -27,10 +27,10 @@ class NormalizingJavaCompilerTest extends Specification {
     NormalizingJavaCompiler compiler = new NormalizingJavaCompiler(target)
 
     def setup() {
-        spec.source = files("Source1.java", "Source2.java", "Source3.java")
+        spec.sourceFiles = files("Source1.java", "Source2.java", "Source3.java")
         spec.compileClasspath = [new File("Dep1.jar"), new File("Dep2.jar"), new File("Dep3.jar")]
         def compileOptions = new CompileOptions(TestUtil.objectFactory())
-        compileOptions.annotationProcessorPath = files("processor.jar")
+        compileOptions.annotationProcessorPath = ImmutableFileCollection.of(new File("processor.jar"))
         spec.compileOptions = compileOptions
     }
 
@@ -42,21 +42,21 @@ class NormalizingJavaCompilerTest extends Specification {
 
         then:
         1 * target.execute(spec) >> {
-            assert spec.source.files == old(spec.source.files)
+            assert spec.sourceFiles == old(spec.sourceFiles)
             workResult
         }
         result == workResult
     }
 
     def "silently excludes source files not ending in .java"() {
-        spec.source = files("House.scala", "Person1.java", "package.html", "Person2.java")
+        spec.sourceFiles = files("House.scala", "Person1.java", "package.html", "Person2.java")
 
         when:
         compiler.execute(spec)
 
         then:
         1 * target.execute(spec) >> {
-            assert spec.source.files == files("Person1.java", "Person2.java").files
+            assert spec.sourceFiles == files("Person1.java", "Person2.java")
         }
     }
 
@@ -114,6 +114,6 @@ class NormalizingJavaCompilerTest extends Specification {
     }
 
     private files(String... paths) {
-        ImmutableFileCollection.of(paths.collect { new File(it) } as File[])
+        paths.collect { new File(it) } as Set
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
@@ -63,7 +63,7 @@ class IncrementalCompilationInitializerTest extends Specification {
         initializer.initializeCompilation(compileSpec, new RecompilationSpec())
 
         then:
-        1 * compileSpec.setSource { it.files.empty }
+        1 * compileSpec.setSourceFiles { it.files.empty }
     }
 
     def "configures empty classes when aggregated types empty"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
@@ -77,7 +77,7 @@ class IncrementalCompilationInitializerTest extends Specification {
         1 * fileOperations.fileResolver >> fileResolver
         1 * fileResolver.patternSetFactory >> patternSetFactory
         1 * patternSetFactory.create() >> patternSet
-        _ * compilationSourceDirs.sourceRoots >> [new File('/some/base/dir/source/main/java')]
+        _ * compilationSourceDirs.sourceRoots >> ['/some/base/dir/source/main/java/']
 
         narrowedSourceFiles == toSourceFiles(['com/Foo.java', 'com/Foo$Inner.java', 'Bar.java', 'Bar$Inner$Inner.java'])
     }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializerTest.groovy
@@ -19,7 +19,9 @@ package org.gradle.api.internal.tasks.compile.incremental
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec
+import org.gradle.api.internal.tasks.compile.MinimalJavaCompileOptions
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec
 import org.gradle.api.tasks.util.PatternSet
 import spock.lang.Specification
@@ -28,15 +30,16 @@ import spock.lang.Subject
 class IncrementalCompilationInitializerTest extends Specification {
 
     def fileOperations = Mock(FileOperations)
+    def compilationSourceDirs = Mock(CompilationSourceDirs)
+    def sourceToNameConverter = new SourceToNameConverter(compilationSourceDirs)
     @Subject
-        initializer = new IncrementalCompilationInitializer(fileOperations)
+    def initializer = new IncrementalCompilationInitializer(fileOperations, sourceToNameConverter)
 
     def "prepares patterns"() {
         PatternSet filesToDelete = Mock(PatternSet)
-        PatternSet sourceToCompile = Mock(PatternSet)
 
         when:
-        initializer.preparePatterns(["com.Foo", "Bar"], filesToDelete, sourceToCompile)
+        initializer.prepareDeletePatterns(["com.Foo", "Bar"], filesToDelete)
 
         then:
         1 * filesToDelete.include('com/Foo.class')
@@ -48,12 +51,39 @@ class IncrementalCompilationInitializerTest extends Specification {
         1 * filesToDelete.include('Bar$*.class')
         1 * filesToDelete.include('Bar$*.java')
 
-        1 * sourceToCompile.include('Bar.java')
-        1 * sourceToCompile.include('com/Foo.java')
-        1 * sourceToCompile.include('Bar$*.java')
-        1 * sourceToCompile.include('com/Foo$*.java')
-
         0 * _
+    }
+
+    def "narrows source files"() {
+        def compileSpec = Mock(JavaCompileSpec)
+        def spec = new RecompilationSpec()
+        spec.classesToCompile.addAll(["com.Foo", "Bar"])
+        def narrowedSourceFiles = []
+        def fileResolver = Mock(FileResolver)
+        org.gradle.internal.Factory<PatternSet> patternSetFactory = Mock()
+        def patternSet = Mock(PatternSet)
+        def compileOptions = Mock(MinimalJavaCompileOptions)
+
+        when:
+        initializer.initializeCompilation(compileSpec, spec)
+
+        then:
+        1 * compileSpec.getSourceFiles() >> toSourceFiles(['com/Foo.java', 'com/Foo$Inner.java', 'Bar.java', 'org/Bar.java', 'org/Bar$Inner.java', 'BarFoo.java', 'Bar$Inner$Inner.java', 'Bar2$Inner.java', 'Baz.java'])
+        1 * compileSpec.setSourceFiles(_) >> { args ->
+            narrowedSourceFiles.addAll(args[0])
+        }
+        1 * compileSpec.compileClasspath >> []
+        1 * compileSpec.getCompileOptions() >> compileOptions
+        1 * fileOperations.fileResolver >> fileResolver
+        1 * fileResolver.patternSetFactory >> patternSetFactory
+        1 * patternSetFactory.create() >> patternSet
+        _ * compilationSourceDirs.sourceRoots >> [new File('/some/base/dir/source/main/java')]
+
+        narrowedSourceFiles == toSourceFiles(['com/Foo.java', 'com/Foo$Inner.java', 'Bar.java', 'Bar$Inner$Inner.java'])
+    }
+
+    List<File> toSourceFiles(List<String> relativePaths) {
+        relativePaths.collect { new File("/some/base/dir/source/main/java/${it}")}
     }
 
     def "configures empty source when stale classes empty"() {

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -17,18 +17,22 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Serializable {
     private File workingDir;
     private File tempDir;
     private List<File> classpath;
     private File destinationDir;
-    private FileCollection source;
+    private Set<File> sourceFiles;
     private String sourceCompatibility;
     private String targetCompatibility;
 
@@ -61,14 +65,28 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
         this.tempDir = tempDir;
     }
 
+    // retained because ThirdPartyPluginsSmokeTest.'gosu plugin'()
+    @Deprecated
     @Override
     public FileCollection getSource() {
-        return source;
+        return ImmutableFileCollection.of(sourceFiles);
+    }
+
+    // retained because ThirdPartyPluginsSmokeTest.'gosu plugin'()
+    @Deprecated
+    @Override
+    public void setSource(FileCollection source) {
+        sourceFiles = ImmutableSet.copyOf(source.getFiles());
     }
 
     @Override
-    public void setSource(FileCollection source) {
-        this.source = source;
+    public Collection<File> getSourceFiles() {
+        return sourceFiles;
+    }
+
+    @Override
+    public void setSourceFiles(Collection<File> sourceFiles) {
+        this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
     }
 
     @Override

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 
@@ -25,14 +24,13 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Serializable {
     private File workingDir;
     private File tempDir;
     private List<File> classpath;
     private File destinationDir;
-    private Set<File> sourceFiles;
+    private List<File> sourceFiles;
     private String sourceCompatibility;
     private String targetCompatibility;
 
@@ -76,7 +74,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     @Deprecated
     @Override
     public void setSource(FileCollection source) {
-        sourceFiles = ImmutableSet.copyOf(source.getFiles());
+        sourceFiles = ImmutableList.copyOf(source.getFiles());
     }
 
     @Override
@@ -86,7 +84,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
 
     @Override
     public void setSourceFiles(Iterable<File> sourceFiles) {
-        this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
+        this.sourceFiles = ImmutableList.copyOf(sourceFiles);
     }
 
     @Override

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -85,7 +85,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     }
 
     @Override
-    public void setSourceFiles(Collection<File> sourceFiles) {
+    public void setSourceFiles(Iterable<File> sourceFiles) {
         this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
     }
 

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -20,6 +20,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.language.base.internal.compile.CompileSpec;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 
 public interface JvmLanguageCompileSpec extends CompileSpec {
@@ -35,9 +36,17 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
 
     void setDestinationDir(File destinationDir);
 
+    // retained because ThirdPartyPluginsSmokeTest.'gosu plugin'()
+    @Deprecated
     FileCollection getSource();
 
+    // retained because ThirdPartyPluginsSmokeTest.'gosu plugin'()
+    @Deprecated
     void setSource(FileCollection source);
+
+    Collection<File> getSourceFiles();
+
+    void setSourceFiles(Collection<File> sourceFiles);
 
     @Deprecated
     Iterable<File> getClasspath();

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -46,7 +46,7 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
 
     Collection<File> getSourceFiles();
 
-    void setSourceFiles(Collection<File> sourceFiles);
+    void setSourceFiles(Iterable<File> sourceFiles);
 
     @Deprecated
     Iterable<File> getClasspath();

--- a/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/internal/EmptyClasspath.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/internal/EmptyClasspath.java
@@ -17,7 +17,7 @@
 package org.gradle.language.jvm.internal;
 
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.tasks.TaskDependencies;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.jvm.Classpath;
@@ -26,7 +26,7 @@ import org.gradle.jvm.Classpath;
 public class EmptyClasspath implements Classpath {
     @Override
     public FileCollection getFiles() {
-        return new SimpleFileCollection();
+        return ImmutableFileCollection.of();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileFilesFactory.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileFilesFactory.java
@@ -55,7 +55,7 @@ public class IncrementalCompileFilesFactory {
         this.ignoreUnresolvedHeadersInDependencies = Boolean.getBoolean(IGNORE_UNRESOLVED_HEADERS_IN_DEPENDENCIES_PROPERTY_NAME);
     }
 
-    public IncementalCompileSourceProcessor filesFor(CompilationState previousCompileState) {
+    public IncementalCompileSourceProcessor files(CompilationState previousCompileState) {
         return new DefaultIncementalCompileSourceProcessor(previousCompileState);
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessor.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessor.java
@@ -40,7 +40,7 @@ public class IncrementalCompileProcessor {
             @Override
             public IncrementalCompilation call(BuildOperationContext context) {
                 CompilationState previousCompileState = previousCompileStateCache.get();
-                IncementalCompileSourceProcessor processor = incrementalCompileFilesFactory.filesFor(previousCompileState);
+                IncementalCompileSourceProcessor processor = incrementalCompileFilesFactory.files(previousCompileState);
                 for (File sourceFile : sourceFiles) {
                     processor.processSource(sourceFile);
                 }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.scala;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
 import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
@@ -44,16 +43,11 @@ public class NormalizingScalaCompiler implements Compiler<ScalaJavaJointCompileS
 
     @Override
     public WorkResult execute(ScalaJavaJointCompileSpec spec) {
-        resolveAndFilterSourceFiles(spec);
         resolveClasspath(spec);
         resolveNonStringsInCompilerArgs(spec);
         logSourceFiles(spec);
         logCompilerArguments(spec);
         return delegateAndHandleErrors(spec);
-    }
-
-    private void resolveAndFilterSourceFiles(final ScalaJavaJointCompileSpec spec) {
-        spec.setSource(new SimpleFileCollection(spec.getSource().getFiles()));
     }
 
     private void resolveClasspath(ScalaJavaJointCompileSpec spec) {
@@ -78,7 +72,7 @@ public class NormalizingScalaCompiler implements Compiler<ScalaJavaJointCompileS
 
         StringBuilder builder = new StringBuilder();
         builder.append("Source files to be compiled:");
-        for (File file : spec.getSource()) {
+        for (File file : spec.getSourceFiles()) {
             builder.append('\n');
             builder.append(file);
         }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -66,7 +66,7 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
 
             List<String> scalacOptions = new ZincScalaCompilerArgumentsGenerator().generate(spec);
             List<String> javacOptions = new JavaCompilerArgumentsBuilder(spec).includeClasspath(false).noEmptySourcePath().build();
-            Inputs inputs = Inputs.create(ImmutableList.copyOf(spec.getCompileClasspath()), ImmutableList.copyOf(spec.getSource()), spec.getDestinationDir(),
+            Inputs inputs = Inputs.create(ImmutableList.copyOf(spec.getCompileClasspath()), ImmutableList.copyOf(spec.getSourceFiles()), spec.getDestinationDir(),
                     scalacOptions, javacOptions, spec.getScalaCompileOptions().getIncrementalOptions().getAnalysisFile(), spec.getAnalysisMap(), "mixed", getIncOptions(), true);
             if (LOGGER.isDebugEnabled()) {
                 Inputs.debug(inputs, logger);

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -94,7 +94,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile {
 
     protected ScalaJavaJointCompileSpec createSpec() {
         DefaultScalaJavaJointCompileSpec spec = new DefaultScalaJavaJointCompileSpecFactory(compileOptions).create();
-        spec.setSource(getSource());
+        spec.setSourceFiles(getSource().getFiles());
         spec.setDestinationDir(getDestinationDir());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());

--- a/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/NormalizingScalaCompilerTest.groovy
+++ b/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/NormalizingScalaCompilerTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.tasks.scala
 
-import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.internal.tasks.compile.CompilationFailedException
 import org.gradle.api.tasks.WorkResult
 import org.gradle.api.tasks.compile.CompileOptions
@@ -32,7 +31,7 @@ class NormalizingScalaCompilerTest extends Specification {
 
     def setup() {
         spec.destinationDir = new File("dest")
-        spec.source = files("Source1.java", "Source2.java", "Source3.java")
+        spec.sourceFiles = files("Source1.java", "Source2.java", "Source3.java")
         spec.compileClasspath = [new File("Dep1.jar"), new File("Dep2.jar")]
         spec.zincClasspath = files("zinc.jar", "zinc-dep.jar")
         spec.compileOptions = new CompileOptions(TestUtil.objectFactory())
@@ -47,7 +46,7 @@ class NormalizingScalaCompilerTest extends Specification {
 
         then:
         1 * target.execute(spec) >> {
-            assert spec.source as List == old(spec.source as List)
+            assert spec.sourceFiles == old(spec.sourceFiles)
 
             workResult
         }
@@ -114,7 +113,7 @@ class NormalizingScalaCompilerTest extends Specification {
     }
 
     private files(String... paths) {
-        ImmutableFileCollection.of(paths.collect { new File(it) } as File[])
+        paths.collect { new File(it) } as Set
     }
 }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/BuildEnvironmentIntegrationTest.groovy
@@ -192,7 +192,7 @@ task check {
             apply plugin: "java"
 
             task echoDefaultEncoding(type: JavaExec) {
-                classpath = project.files(compileJava)
+                classpath = project.layout.files(compileJava)
                 main "echo.EchoEncoding"
             }
         """, expectedEncoding

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/tasks/StaleClassCleaner.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/tasks/StaleClassCleaner.java
@@ -15,22 +15,23 @@
  */
 package org.gradle.language.base.internal.tasks;
 
-import org.gradle.api.file.FileCollection;
+import com.google.common.collect.ImmutableSet;
 
 import java.io.File;
+import java.util.Collection;
 
 public abstract class StaleClassCleaner {
     private File destinationDir;
-    FileCollection source;
+    Collection<File> source;
 
     public abstract void execute();
 
-    public FileCollection getSource() {
+    public Collection<File> getSource() {
         return source;
     }
 
-    public void setSource(FileCollection source) {
-        this.source = source;
+    public void setSource(Collection<File> source) {
+        this.source = ImmutableSet.copyOf(source);
     }
 
     public void setDestinationDir(File destinationDir) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -22,7 +22,7 @@ import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.os.OperatingSystem;
@@ -35,7 +35,11 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.EnumMap;
 
 public class JavaInstallationProbe {
@@ -143,7 +147,7 @@ public class JavaInstallationProbe {
         exec.executable(javaExe(jdkPath, "java"));
         File workingDir = Files.createTempDir();
         exec.setWorkingDir(workingDir);
-        exec.setClasspath(new SimpleFileCollection(workingDir));
+        exec.setClasspath(ImmutableFileCollection.of(workingDir));
         try {
             writeProbe(workingDir);
             exec.setMain(JavaProbe.CLASSNAME);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/SourceSetNativeDependencyResolver.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/SourceSetNativeDependencyResolver.java
@@ -19,8 +19,8 @@ package org.gradle.nativeplatform.internal.resolve;
 import org.gradle.api.Buildable;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.nativeplatform.HeaderExportingSourceSet;
@@ -59,21 +59,17 @@ public class SourceSetNativeDependencyResolver implements NativeDependencyResolv
     private static class EmptyNativeDependencySet implements NativeDependencySet {
         @Override
         public FileCollection getIncludeRoots() {
-            return empty();
+            return ImmutableFileCollection.of();
         }
 
         @Override
         public FileCollection getLinkFiles() {
-            return empty();
+            return ImmutableFileCollection.of();
         }
 
         @Override
         public FileCollection getRuntimeFiles() {
-            return empty();
-        }
-
-        private FileCollection empty() {
-            return new SimpleFileCollection();
+            return ImmutableFileCollection.of();
         }
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunner.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayApplicationRunner.java
@@ -16,11 +16,11 @@
 
 package org.gradle.play.internal.run;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.changedetection.state.ClasspathSnapshotter;
 import org.gradle.api.internal.changedetection.state.InputPathNormalizationStrategy;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.deployment.internal.Deployment;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.normalization.internal.InputNormalizationStrategy;
@@ -30,7 +30,6 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 
 import java.io.File;
-import java.util.Set;
 
 public class PlayApplicationRunner {
     private final WorkerProcessFactory workerFactory;
@@ -68,9 +67,11 @@ public class PlayApplicationRunner {
         }
 
         private FileCollection collectApplicationClasspath(PlayRunSpec runSpec) {
-            Set<File> applicationClasspath = Sets.newLinkedHashSet(runSpec.getChangingClasspath());
-            applicationClasspath.add(runSpec.getApplicationJar());
-            return new SimpleFileCollection(applicationClasspath);
+            ImmutableSet<File> applicationClasspath = ImmutableSet.<File>builder()
+                .addAll(runSpec.getChangingClasspath())
+                .add(runSpec.getApplicationJar())
+                .build();
+            return ImmutableFileCollection.of(applicationClasspath);
         }
 
         @Override

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayPluginConfigurations.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayPluginConfigurations.java
@@ -18,13 +18,17 @@ package org.gradle.play.plugins;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Incubating;
-import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.collections.LazilyInitializedFileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.io.File;
@@ -132,7 +136,7 @@ public class PlayPluginConfigurations {
                     files.add(artifact.getFile());
                 }
             }
-            return new SimpleFileCollection(files.build());
+            return ImmutableFileCollection.of(files.build());
         }
 
         @Override

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayTestPlugin.java
@@ -22,7 +22,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.testing.Test;
@@ -54,7 +54,7 @@ public class PlayTestPlugin extends RuleSource {
 
             final String testCompileTaskName = binary.getTasks().taskName("compile", "tests");
             final File testSourceDir = fileResolver.resolve("test");
-            final FileCollection testSources = new SimpleFileCollection(testSourceDir).getAsFileTree().matching(new PatternSet().include("**/*.scala", "**/*.java"));
+            final FileCollection testSources = ImmutableFileCollection.of(testSourceDir).getAsFileTree().matching(new PatternSet().include("**/*.scala", "**/*.java"));
             final File testClassesDir = new File(buildDir, binary.getProjectScopedName() + "/testClasses");
             tasks.create(testCompileTaskName, PlatformScalaCompile.class, new Action<PlatformScalaCompile>() {
                 public void execute(PlatformScalaCompile scalaCompile) {
@@ -83,7 +83,7 @@ public class PlayTestPlugin extends RuleSource {
 
                     test.setClasspath(getRuntimeClasspath(testClassesDir, testCompileClasspath));
 
-                    test.setTestClassesDirs(new SimpleFileCollection(testClassesDir));
+                    test.setTestClassesDirs(ImmutableFileCollection.of(testClassesDir));
                     test.setBinResultsDir(new File(binaryBuildDir, "results/" + testTaskName + "/bin"));
                     test.getReports().getJunitXml().setDestination(new File(binaryBuildDir, "reports/test/xml"));
                     test.getReports().getHtml().setDestination(new File(binaryBuildDir, "reports/test"));
@@ -96,11 +96,11 @@ public class PlayTestPlugin extends RuleSource {
     }
 
     private FileCollection getTestCompileClasspath(PlayApplicationBinarySpec binary, PlayToolProvider playToolProvider, PlayPluginConfigurations configurations) {
-        return new SimpleFileCollection(binary.getJarFile()).plus(configurations.getPlayTest().getAllArtifacts());
+        return ImmutableFileCollection.of(binary.getJarFile()).plus(configurations.getPlayTest().getAllArtifacts());
     }
 
     private FileCollection getRuntimeClasspath(File testClassesDir, FileCollection testCompileClasspath) {
-        return new SimpleFileCollection(testClassesDir).plus(testCompileClasspath);
+        return ImmutableFileCollection.of(testClassesDir).plus(testCompileClasspath);
     }
 
     @Mutate

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayTestPluginTest.groovy
@@ -47,6 +47,7 @@ class PlayTestPluginTest extends Specification {
     def dependencyHandler = Mock(DependencyHandler)
 
     File buildDir = new File("tmp")
+    File jarFile = new File("file.jar")
 
     PlayTestPlugin plugin = new PlayTestPlugin()
 
@@ -57,9 +58,12 @@ class PlayTestPluginTest extends Specification {
             taskName(_, _) >> { String verb, String object -> "${verb}SomeBinary${object.capitalize()}"}
             taskName(_) >> { String verb -> "${verb}SomeBinary"}
         }
+        1 * binary.jarFile >> jarFile
 
         _ * configurations.create(_) >> configuration
         _ * configurations.maybeCreate(_) >> configuration
+        _ * configurations.getByName(_) >> configuration
+        0 * _
     }
 
     def "adds test related tasks per binary"() {
@@ -79,5 +83,6 @@ class PlayTestPluginTest extends Specification {
         1 * taskModelMap.create("testSomeBinary", Test, _)
         0 * taskModelMap.create(_)
         0 * taskModelMap.create(_, _, _)
+        1 * taskModelMap.get('testSomeBinary')
     }
 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -384,7 +384,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
                 String compileConfigurationName = testSourceSet.getCompileConfigurationName();
                 dependencies.add(compileConfigurationName, dependencies.gradleTestKit());
                 String runtimeConfigurationName = testSourceSet.getRuntimeConfigurationName();
-                dependencies.add(runtimeConfigurationName, project.files(pluginClasspathTask));
+                dependencies.add(runtimeConfigurationName, project.getLayout().files(pluginClasspathTask));
             }
         }
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -43,7 +43,7 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
             apply plugin: "java"
 
             task run(type: JavaExec) {
-                classpath = project.files(compileJava)
+                classpath = project.layout.files(compileJava)
                 main "driver.Driver"
                 args "1"
             }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
@@ -54,7 +54,7 @@ class DaemonJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
         goodCode()
         buildFile << """
             tasks.withType(JavaCompile) { 
-                options.sourcepath = project.files()
+                options.sourcepath = project.layout.files()
             }
         """
 
@@ -70,7 +70,7 @@ class DaemonJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
         goodCode()
         buildFile << """
             tasks.withType(JavaCompile) { 
-                options.bootstrapClasspath = project.files("$bootClasspath")
+                options.bootstrapClasspath = project.layout.files("$bootClasspath")
             }
         """
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -119,7 +119,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
                     public Object call() throws Exception {
                         FileCollection groovyClasspath = groovyRuntime.inferGroovyClasspath(groovydoc.getClasspath());
                         // Jansi is required to log errors when generating Groovydoc
-                        ConfigurableFileCollection jansi = project.files(moduleRegistry.getExternalModule("jansi").getImplementationClasspath().getAsFiles());
+                        ConfigurableFileCollection jansi = project.getLayout().configurableFiles(moduleRegistry.getExternalModule("jansi").getImplementationClasspath().getAsFiles());
                         return groovyClasspath.plus(jansi);
                     }
                 });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -272,8 +272,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         SourceSet main = pluginConvention.getSourceSets().create(SourceSet.MAIN_SOURCE_SET_NAME);
 
         SourceSet test = pluginConvention.getSourceSets().create(SourceSet.TEST_SOURCE_SET_NAME);
-        test.setCompileClasspath(project.files(main.getOutput(), project.getConfigurations().getByName(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME)));
-        test.setRuntimeClasspath(project.files(test.getOutput(), main.getOutput(), project.getConfigurations().getByName(TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
+        test.setCompileClasspath(project.getLayout().configurableFiles(main.getOutput(), project.getConfigurations().getByName(TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME)));
+        test.setRuntimeClasspath(project.getLayout().configurableFiles(test.getOutput(), main.getOutput(), project.getConfigurations().getByName(TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
 
         // Register the project's source set output directories
         pluginConvention.getSourceSets().all(new Action<SourceSet>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovyRuntime.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovyRuntime.java
@@ -73,7 +73,7 @@ public class GroovyRuntime {
      * @return a corresponding class path for executing Groovy tools such as the Groovy compiler and Groovydoc tool
      */
     public FileCollection inferGroovyClasspath(final Iterable<File> classpath) {
-        // alternatively, we could return project.files(Runnable)
+        // alternatively, we could return project.getLayout().files(Runnable)
         // would differ in at least the following ways: 1. live 2. no autowiring
         return new LazilyInitializedFileCollection() {
             @Override
@@ -89,7 +89,7 @@ public class GroovyRuntime {
                 }
 
                 if (groovyJar.isGroovyAll()) {
-                    return Cast.cast(FileCollectionInternal.class, project.files(groovyJar.getFile()));
+                    return Cast.cast(FileCollectionInternal.class, project.getLayout().files(groovyJar.getFile()));
                 }
 
                 if (project.getRepositories().isEmpty()) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -273,7 +273,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
                 resources {
                     srcDirs = [project.file("resrc1"), project.file("resrc2")]
                 }
-                compileClasspath = project.files("jar1.jar", "jar2.jar")
+                compileClasspath = project.layout.files("jar1.jar", "jar2.jar")
             }
         }
 
@@ -286,7 +286,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         and:
         def java = sources.withType(JavaSourceSet).iterator().next()
         java.source.srcDirs as Set == [project.file("src1"), project.file("src2")] as Set
-        java.compileClasspath.files as Set == project.files("jar1.jar", "jar2.jar") as Set
+        java.compileClasspath.files as Set == project.layout.files("jar1.jar", "jar2.jar") as Set
 
         and:
         def resources = sources.withType(JvmResourceSet).iterator().next()

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -384,7 +384,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task instanceof Javadoc
         task dependsOn(JavaPlugin.CLASSES_TASK_NAME)
         task.source.files == project.sourceSets.main.allJava.files
-        Assert.assertThat(task.classpath, sameCollection(project.files(project.sourceSets.main.output, project.sourceSets.main.compileClasspath)))
+        Assert.assertThat(task.classpath, sameCollection(project.layout.configurableFiles(project.sourceSets.main.output, project.sourceSets.main.compileClasspath)))
         task.destinationDir == project.file("$project.docsDir/javadoc")
         task.title == project.extensions.getByType(ReportingExtension).apiDocTitle
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -118,10 +118,10 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         project.dependencies {
-            providedCompile project.files(providedJar)
-            compile project.files(compileJar)
-            compileOnly project.files(compileOnlyJar)
-            runtime project.files(runtimeJar)
+            providedCompile project.layout.files(providedJar)
+            compile project.layout.files(compileJar)
+            compileOnly project.layout.files(compileOnlyJar)
+            runtime project.layout.files(runtimeJar)
         }
 
         then:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -43,7 +43,7 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         task.testReporter = Mock(TestReporter)
         task.binResultsDir = task.project.file('build/test-results')
         task.reports.junitXml.destination = task.project.file('build/test-results')
-        task.testClassesDirs = task.project.files()
+        task.testClassesDirs = task.project.layout.files()
         completion = task.project.services.get(WorkerLeaseRegistry).getWorkerLease().start()
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
@@ -54,7 +54,7 @@ public class ScalaPlugin implements Plugin<Project> {
                 scalaDoc.getConventionMapping().map("classpath", new Callable<FileCollection>() {
                     @Override
                     public FileCollection call() throws Exception {
-                        ConfigurableFileCollection files = project.files();
+                        ConfigurableFileCollection files = project.getLayout().configurableFiles();
                         files.from(main.getOutput());
                         files.from(main.getCompileClasspath());
                         return files;

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaRuntime.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaRuntime.java
@@ -71,7 +71,7 @@ public class ScalaRuntime {
      * @return a class path containing a corresponding 'scala-compiler' Jar and its dependencies
      */
     public FileCollection inferScalaClasspath(final Iterable<File> classpath) {
-        // alternatively, we could return project.files(Runnable)
+        // alternatively, we could return project.getLayout().files(Runnable)
         // would differ in the following ways: 1. live (not sure if we want live here) 2. no autowiring (probably want autowiring here)
         return new LazilyInitializedFileCollection() {
             @Override

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
@@ -102,7 +102,7 @@ class ScalaPluginTest {
         assertThat(task, dependsOn(JavaPlugin.CLASSES_TASK_NAME))
         assertThat(task.destinationDir, equalTo(project.file("$project.docsDir/scaladoc")))
         assertThat(task.source as List, equalTo(project.sourceSets.main.scala as List))
-        assertThat(task.classpath, FileCollectionMatchers.sameCollection(project.files(project.sourceSets.main.output, project.sourceSets.main.compileClasspath)))
+        assertThat(task.classpath, FileCollectionMatchers.sameCollection(project.layout.configurableFiles(project.sourceSets.main.output, project.sourceSets.main.compileClasspath)))
         assertThat(task.title, equalTo(project.extensions.getByType(ReportingExtension).apiDocTitle))
     }
 
@@ -111,6 +111,6 @@ class ScalaPluginTest {
 
         def task = project.task('otherScaladoc', type: ScalaDoc)
         assertThat(task, dependsOn(JavaPlugin.CLASSES_TASK_NAME))
-        assertThat(task.classpath, FileCollectionMatchers.sameCollection(project.files(project.sourceSets.main.output, project.sourceSets.main.compileClasspath)))
+        assertThat(task.classpath, FileCollectionMatchers.sameCollection(project.layout.configurableFiles(project.sourceSets.main.output, project.sourceSets.main.compileClasspath)))
     }
 }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
@@ -19,7 +19,7 @@ import com.google.common.base.Function;
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.type.SignatureType;
 import org.gradle.util.ConfigureUtil;
@@ -222,7 +222,7 @@ public class SignOperation implements SignatureSpec {
     }
 
     private FileCollection newSignatureFileCollection(Function<Signature, File> getFile) {
-        return new SimpleFileCollection(collectSignatureFiles(getFile));
+        return ImmutableFileCollection.of(collectSignatureFiles(getFile));
     }
 
     private ArrayList<File> collectSignatureFiles(Function<Signature, File> getFile) {

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/build.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/build.gradle
@@ -89,9 +89,9 @@ project.afterEvaluate {
                     "src/$productFlavorName/kotlin",
                     "src/$buildTypeName/kotlin"
                 ]
-                additionalSourceDirs = layout.files(coverageSourceDirs)
-                sourceDirectories = layout.files(coverageSourceDirs)
-                executionData = layout.files("${project.buildDir}/jacoco/${testTaskName}.exec")
+                additionalSourceDirs = files(coverageSourceDirs)
+                sourceDirectories = files(coverageSourceDirs)
+                executionData = files("${project.buildDir}/jacoco/${testTaskName}.exec")
                 reports {
                     xml.enabled = true
                     html.enabled = true

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerResultIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerResultIntegrationTest.groovy
@@ -56,7 +56,7 @@ class GradleRunnerResultIntegrationTest extends BaseGradleRunnerIntegrationTest 
         given:
         buildFile << """
            task empty {
-                inputs.files(project.files()).skipWhenEmpty()
+                inputs.files(project.layout.files()).skipWhenEmpty()
                 doLast{}
            }
         """

--- a/subprojects/testing-jvm/src/main/java/org/gradle/jvm/plugins/JvmTestSuiteBasePlugin.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/jvm/plugins/JvmTestSuiteBasePlugin.java
@@ -26,7 +26,7 @@ import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.file.collections.SimpleFileCollection;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.TestTaskReports;
 import org.gradle.initialization.BuildIdentity;
@@ -84,7 +84,7 @@ public class JvmTestSuiteBasePlugin extends RuleSource {
                 test.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
                 test.setDescription(String.format("Runs %s.", WordUtils.uncapitalize(binary.getDisplayName())));
                 test.dependsOn(jvmAssembly);
-                test.setTestClassesDirs(new SimpleFileCollection(binary.getClassesDir()));
+                test.setTestClassesDirs(ImmutableFileCollection.of(binary.getClassesDir()));
                 test.setClasspath(binary.getRuntimeClasspath());
                 configureReports(binary, test);
             }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
@@ -65,7 +65,7 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
                 def outputFileDirPath = "${outputFileDirPath}/\${name}"
                 def additionalForkOptions = {}
                 def runnableClass = TestRunnable.class
-                def additionalClasspath = project.files()
+                def additionalClasspath = project.layout.files()
                 def foo = new Foo()
                 def displayName = null
                 def isolationMode = IsolationMode.AUTO

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -815,7 +815,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 def isolationMode = IsolationMode.NONE
                 def additionalForkOptions = {}
                 def runnableClass = TestParallelRunnable.class
-                def additionalClasspath = project.files()
+                def additionalClasspath = project.layout.files()
 
                 @Inject
                 WorkerExecutor getWorkerExecutor() {


### PR DESCRIPTION
We try to filter the classes to compile without using `FileTree`.