### PR TITLE
Polish chapters on Signing and Ivy/Maven Publish Plugins

### DIFF
--- a/subprojects/docs/src/docs/userguide/publishingIvy.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingIvy.adoc
@@ -19,7 +19,7 @@
 [NOTE]
 ====
 
-This chapter describes the new <<feature_lifecycle,incubating>> Ivy publishing support provided by the “`ivy-publish`” plugin. Eventually this new publishing support will replace publishing via the `Upload` task.
+This chapter describes the new <<feature_lifecycle,incubating>> Ivy publishing support provided by the Ivy Publish Plugin. Eventually this new publishing support will replace publishing via the `Upload` task.
 
 If you are looking for documentation on the original Ivy publishing support using the `Upload` task please see <<artifact_management>>.
 
@@ -31,23 +31,20 @@ A published Ivy module can be consumed by Gradle (see <<declaring_dependencies>>
 
 
 [[publishing_ivy:plugin]]
-=== The “`ivy-publish`” Plugin
+=== The Ivy Publish Plugin
 
-The ability to publish in the Ivy format is provided by the “`ivy-publish`” plugin.
-
-The “`publishing`” plugin creates an extension on the project named “`publishing`” of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The “`ivy-publish`” plugin works with api:org.gradle.api.publish.ivy.IvyPublication[] publications and api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] repositories.
+The ability to publish in the Ivy format is provided by the Ivy Publish Plugin. It uses an extension on the project named `publishing` of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The Ivy Publish Plugin works with api:org.gradle.api.publish.ivy.IvyPublication[] publications and api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] repositories.
 
 ++++
-<sample id="publishing_ivy:apply-plugin-snippet" dir="ivy-publish/quickstart" title="Applying the “ivy-publish” plugin">
+<sample id="publishing_ivy:apply-plugin-snippet" dir="ivy-publish/quickstart" title="Applying the Ivy Publish Plugin">
             <sourcefile file="build.gradle" snippet="use-plugin"/>
         </sample>
 ++++
 
-Applying the “`ivy-publish`” plugin does the following:
+Applying the Ivy Publish Plugin does the following:
 
-* Applies the “`publishing`” plugin
-* Establishes a rule to automatically create a api:org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor[] task for each api:org.gradle.api.publish.ivy.IvyPublication[] added (see <<publishing_ivy:publications>>).
-* Establishes a rule to automatically create a api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[] task for the combination of each api:org.gradle.api.publish.ivy.IvyPublication[] added (see <<publishing_ivy:publications>>), with each api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] added (see <<publishing_ivy:repositories>>).
+* Automatically creates a api:org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor[] task for each api:org.gradle.api.publish.ivy.IvyPublication[] added (see <<publishing_ivy:publications>>).
+* Automatically creates a api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[] task for the combination of each api:org.gradle.api.publish.ivy.IvyPublication[] added (see <<publishing_ivy:publications>>), with each api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] added (see <<publishing_ivy:repositories>>).
 
 
 [[publishing_ivy:publications]]
@@ -56,12 +53,12 @@ Applying the “`ivy-publish`” plugin does the following:
 
 [NOTE]
 ====
-If you are not familiar with project artifacts and configurations, you should read <<artifact_management>>, which introduces these concepts. This chapter also describes “publishing artifacts” using a different mechanism than what is described in this chapter. The publishing functionality described here will eventually supersede that functionality.
+If you are not familiar with project artifacts and configurations, you should read <<artifact_management>>, which introduces these concepts. That chapter also describes publishing artifacts using a different mechanism than the one described in this chapter. The publishing functionality described here will eventually supersede that functionality.
 ====
 
 Publication objects describe the structure/configuration of a publication to be created. Publications are published to repositories via tasks, and the configuration of the publication object determines exactly what is published. All of the publications of a project are defined in the api:org.gradle.api.publish.PublishingExtension#getPublications()[] container. Each publication has a unique name within the project.
 
-For the “`ivy-publish`” plugin to have any effect, an api:org.gradle.api.publish.ivy.IvyPublication[] must be added to the set of publications. This publication determines which artifacts are actually published as well as the details included in the associated Ivy module descriptor file. A publication can be configured by adding components, customizing artifacts, and by modifying the generated module descriptor file directly.
+For the Ivy Publish Plugin to have any effect, an api:org.gradle.api.publish.ivy.IvyPublication[] must be added to the set of publications. This publication determines which artifacts are actually published as well as the details included in the associated Ivy module descriptor file. A publication can be configured by adding components, customizing artifacts, and by modifying the generated module descriptor file directly.
 
 
 [[sec:publishing_component_to_ivy]]
@@ -69,26 +66,13 @@ For the “`ivy-publish`” plugin to have any effect, an api:org.gradle.api.pub
 
 The simplest way to publish a Gradle project to an Ivy repository is to specify a api:org.gradle.api.component.SoftwareComponent[] to publish. The components presently available for publication are:
 
-.Software Components
-[cols="a,a,a,a", options="header"]
-|===
-| Name
-| Provided By
-| Artifacts
-| Dependencies
+`java` — provider: <<java_plugin,Java Plugin>>::
+Generated JAR file, dependencies from `runtime` configuration
 
-| `java`
-| <<java_plugin,Java Plugin>>
-| Generated jar file
-| Dependencies from 'runtime' configuration
+`web` — provider: <<war_plugin,War Plugin>>::
+Generated WAR file, no dependencies
 
-| `web`
-| <<war_plugin,War Plugin>>
-| Generated war file
-| No dependencies
-|===
-
-In the following example, artifacts and runtime dependencies are taken from the `java` component, which is added by the `Java Plugin`.
+In the following example, artifacts and runtime dependencies are taken from the `java` component, which is added by the <<java_plugin,Java Plugin>>.
 
 ++++
 <sample dir="ivy-publish/quickstart" id="publishing_ivy:publish-component-snippet" title="Publishing a Java module to Ivy">
@@ -100,7 +84,7 @@ In the following example, artifacts and runtime dependencies are taken from the 
 [[sec:publishing_custom_artifacts_to_ivy]]
 ==== Publishing custom artifacts
 
-It is also possible to explicitly configure artifacts to be included in the publication. Artifacts are commonly supplied as raw files, or as instances of api:org.gradle.api.tasks.bundling.AbstractArchiveTask[] (e.g. Jar, Zip).
+It is also possible to explicitly configure artifacts to be included in the publication. Artifacts are commonly supplied as raw files, or as instances of api:org.gradle.api.tasks.bundling.AbstractArchiveTask[] (e.g. api:org.gradle.api.tasks.bundling.Jar[] or api:org.gradle.api.tasks.bundling.Zip[]).
 
 For each custom artifact, it is possible to specify the `name`, `extension`, `type`, `classifier` and `conf` values to use for publication. Note that each artifacts must have a unique name/classifier/extension combination.
 
@@ -133,25 +117,25 @@ The generated Ivy module descriptor file contains an `&lt;info&gt;` element that
 * `status` - api:org.gradle.api.Project#getStatus()[]
 * `branch` - (not set)
 
-Overriding the default identity values is easy: simply specify the `organisation`, `module` or `revision` attributes when configuring the `IvyPublication`. The `status` and `branch` attributes can be set via the `descriptor` property (see api:org.gradle.api.publish.ivy.IvyModuleDescriptorSpec[]). The `descriptor` property can also be used to add additional custom elements as children of the `&lt;info&gt;` element.
+Overriding the default identity values is easy: simply specify the `organisation`, `module` or `revision` attributes when configuring the api:org.gradle.api.publish.ivy.IvyPublication[]. The `status` and `branch` attributes can be set via the `descriptor` property (see api:org.gradle.api.publish.ivy.IvyModuleDescriptorSpec[]). The `descriptor` property can also be used to add additional custom elements as children of the `&lt;info&gt;` element.
 
 ++++
 <sample dir="ivy-publish/multiple-publications" id="publishing_ivy:publish-customize-identity" title="customizing the publication identity">
-                <sourcefile file="build.gradle" snippet="customize-identity"/>
-            </sample>
+    <sourcefile file="build.gradle" snippet="customize-identity"/>
+</sample>
 ++++
 
 [TIP]
 ====
-Certain repositories are not able to handle all supported characters. For example, the ':' character cannot be used as an identifier when publishing to a filesystem-backed repository on Windows.
+Certain repositories are not able to handle all supported characters. For example, the `:` character cannot be used as an identifier when publishing to a filesystem-backed repository on Windows.
 ====
 
-Gradle will handle any valid Unicode character for organisation, module and revision (as well as artifact name, extension and classifier). The only values that are explicitly prohibited are '```\```', '```/```' and any ISO control character. The supplied values are validated early during publication.
+Gradle will handle any valid Unicode character for organisation, module and revision (as well as artifact name, extension and classifier). The only values that are explicitly prohibited are `\`, `/` and any ISO control character. The supplied values are validated early during publication.
 
 [[sec:modifying_the_generated_module_descriptor]]
 ==== Modifying the generated module descriptor
 
-At times, the module descriptor file generated from the project information will need to be tweaked before publishing. The “`ivy-publish`” plugin provides a hook to allow such modification.
+At times, the module descriptor file generated from the project information will need to be tweaked before publishing. The Ivy Publish Plugin provides a hook to allow such modification.
 
 ++++
 <sample dir="ivy-publish/descriptor-customization" id="publishing_ivy:descriptor-customization-snippet" title="Customizing the module descriptor file">
@@ -170,7 +154,7 @@ The identifier (organisation, module, revision) of the published module is an ex
 [[sec:publishing_multiple_modules_to_ivy]]
 ==== Publishing multiple modules
 
-Sometimes it's useful to publish multiple modules from your Gradle build, without creating a separate Gradle subproject. An example is publishing a separate API and implementation jar for your library. With Gradle this is simple:
+Sometimes it's useful to publish multiple modules from your Gradle build, without creating a separate Gradle subproject. An example is publishing a separate API and implementation JAR for your library. With Gradle this is simple:
 
 ++++
 <sample dir="ivy-publish/multiple-publications" id="publishing_ivy:publish-multiple-publications" title="Publishing multiple modules from a single project">
@@ -191,14 +175,14 @@ Publications are published to repositories. The repositories to publish to are d
 </sample>
 ++++
 
-The DSL used to declare repositories for publishing is the same DSL that is used to declare repositories for dependencies (api:org.gradle.api.artifacts.dsl.RepositoryHandler[]). However, in the context of Ivy publication only the repositories created by the `ivy()` methods can be used as publication destinations. You cannot publish an `IvyPublication` to a Maven repository for example.
+The DSL used to declare repositories for publishing is the same DSL that is used to declare repositories for dependencies (api:org.gradle.api.artifacts.dsl.RepositoryHandler[]). However, in the context of Ivy publication only the repositories created by the `ivy()` methods can be used as publication destinations. You cannot publish an api:org.gradle.api.publish.ivy.IvyPublication[] to a Maven repository for example.
 
 [[publishing_ivy:publishing]]
 === Performing a publish
 
-The “`ivy-publish`” plugin automatically creates a api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[] task for each api:org.gradle.api.publish.ivy.IvyPublication[] and api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] combination in the `publishing.publications` and `publishing.repositories` containers respectively.
+The Ivy Publish Plugin automatically creates a api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[] task for each api:org.gradle.api.publish.ivy.IvyPublication[] and api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] combination in the `publishing.publications` and `publishing.repositories` containers respectively.
 
-The created task is named “`publish«_PUBNAME_»PublicationTo«_REPONAME_»Repository`”, which is “`publishIvyJavaPublicationToIvyRepository`” for this example. This task is of type api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[].
+The created task is named `publish«_PUBNAME_»PublicationTo«_REPONAME_»Repository`, which is `publishIvyJavaPublicationToIvyRepository` for this example. This task is of type api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[].
 
 ++++
 <sample dir="ivy-publish/quickstart" id="publishingIvyPublishSingle" title="Choosing a particular publication to publish">
@@ -209,14 +193,12 @@ The created task is named “`publish«_PUBNAME_»PublicationTo«_REPONAME_»Rep
 
 
 [[sec:the_publish_lifecycle_task]]
-==== The “`publish`” lifecycle task
+==== The `publish` lifecycle task
 
-The “`publish`” plugin (that the “`ivy-publish`” plugin implicitly applies) adds a lifecycle task that can be used to publish all publications to all applicable repositories named “`publish`”.
-
-In more concrete terms, executing this task will execute all api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[] tasks in the project. This is usually the most convenient way to perform a publish.
+The `publish` lifecycle task can be used to publish all publications to all applicable repositories. In more concrete terms, executing this task will execute all api:org.gradle.api.publish.ivy.tasks.PublishToIvyRepository[] tasks in the project. This is usually the most convenient way to perform a publish.
 
 ++++
-<sample dir="ivy-publish/quickstart" id="publishingIvyPublishLifecycle" title="Publishing all publications via the “publish” lifecycle task">
+<sample dir="ivy-publish/quickstart" id="publishingIvyPublishLifecycle" title="Publishing all publications via the `publish` lifecycle task">
     <output args="publish"/>
 </sample>
 ++++
@@ -235,7 +217,7 @@ When you have defined multiple publications or repositories, you often want to c
 
 You may not want build users publishing both types of publications to both repositories, but the plugin automatically generates tasks for all possible combinations. So how do you stop someone from publishing the `binaryAndSources` publication to the `external` repository?
 
-You can configure the tasks generated by the “`ivy-publish`” plugin to be skipped based on certain criteria. The following sample demonstrates how to restrict the `binary` publication to the `external` repository and the `binaryAndSources` publication to the `internal` repository.
+You can configure the tasks generated by the Ivy Publish Plugin to be skipped based on certain criteria. The following sample demonstrates how to restrict the `binary` publication to the `external` repository and the `binaryAndSources` publication to the `internal` repository.
 
 ++++
 <sample dir="ivy-publish/conditional-publishing" id="publishingIvyConditionally" title="Configuring which artifacts should be published to which repositories">
@@ -258,9 +240,9 @@ Moreover, you may want to define your own shorthand tasks to fit your workflow. 
 
 At times it is useful to generate the Ivy module descriptor file (normally `ivy.xml`) without publishing your module to an Ivy repository. Since descriptor file generation is performed by a separate task, this is very easy to do.
 
-The “`ivy-publish`” plugin creates one api:org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor[] task for each registered api:org.gradle.api.publish.ivy.IvyPublication[], named “`generateDescriptorFileFor«_PUBNAME_»Publication`”, which will be “`generateDescriptorFileForIvyJavaPublication`” for the previous example of the “`ivyJava`” publication.
+The Ivy Publish Plugin creates one api:org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor[] task for each registered api:org.gradle.api.publish.ivy.IvyPublication[], named `generateDescriptorFileFor«_PUBNAME_»Publication`, which will be `generateDescriptorFileForIvyJavaPublication` for the previous example of the `ivyJava` publication.
 
-You can specify where the generated Ivy file will be located by setting the `destination` property on the generated task. By default this file is written to “`build/publications/«_PUBNAME_»/ivy.xml`”.
+You can specify where the generated Ivy file will be located by setting the `destination` property on the generated task. By default this file is written to `build/publications/«_PUBNAME_»/ivy.xml`.
 
 ++++
 <sample dir="ivy-publish/descriptor-customization" id="publishingIvyGenerateDescriptor" title="Generating the Ivy module descriptor file">
@@ -283,9 +265,9 @@ The following example demonstrates publishing with a multi-project build. Each p
 
 The result is that the following artifacts will be published for each project:
 
-* The Ivy module descriptor file: “`ivy-1.0.xml`”.
-* The primary “jar” artifact for the Java component: “`project1-1.0.jar`”.
-* The source “jar” artifact that has been explicitly configured: “`project1-1.0-source.jar`”.
+* The Ivy module descriptor file: `ivy-1.0.xml`.
+* The primary JAR artifact for the Java component: `project1-1.0.jar`.
+* The source JAR artifact that has been explicitly configured: `project1-1.0-source.jar`.
 
 When `project1` is published, the module descriptor (i.e. the `ivy.xml` file) that is produced will look like:
 
@@ -304,7 +286,7 @@ Note that `«PUBLICATION-TIME-STAMP»` in this example Ivy module descriptor wil
 [[publishing_ivy:future]]
 === Future features
 
-The “`ivy-publish`” plugin functionality as described above is incomplete, as the feature is still <<feature_lifecycle,incubating>>. In upcoming Gradle releases, the functionality will be expanded to include (but not limited to):
+The Ivy Publish Plugin functionality as described above is incomplete, as the feature is still <<feature_lifecycle,incubating>>. In upcoming Gradle releases, the functionality will be expanded to include (but not limited to):
 
 * Convenient customization of module attributes (`module`, `organisation` etc.)
 * Convenient customization of dependencies reported in `module descriptor`.

--- a/subprojects/docs/src/docs/userguide/publishingMaven.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingMaven.adoc
@@ -18,33 +18,30 @@
 
 [NOTE]
 ====
-This chapter describes the new <<feature_lifecycle,incubating>> Maven publishing support provided by the “`maven-publish`” plugin. Eventually this new publishing support will replace publishing via the `Upload` task.
+This chapter describes the new <<feature_lifecycle,incubating>> Maven publishing support provided by the Maven Publish Plugin. Eventually this new publishing support will replace publishing via the `Upload` task.
 
 If you are looking for documentation on the original Maven publishing support using the `Upload` task please see <<artifact_management>>.
 ====
 
-This chapter describes how to publish build artifacts to an http://maven.apache.org/[Apache Maven] Repository. A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies>>) and other tools that understand the Maven repository format.
+This chapter describes how to publish build artifacts to an http://maven.apache.org/[Apache Maven] repository. A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies>>) and other tools that understand the Maven repository format.
 
 
 [[sec:the_mavenpublish_plugin]]
-=== The “`maven-publish`” Plugin
+=== The Maven Publish Plugin
 
-The ability to publish in the Maven format is provided by the “`maven-publish`” plugin.
-
-The “`publishing`” plugin creates an extension on the project named “`publishing`” of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The “`maven-publish`” plugin works with api:org.gradle.api.publish.maven.MavenPublication[] publications and api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] repositories.
+The ability to publish in the Maven format is provided by the Maven Publish Plugin. It uses an extension on the project named `publishing` of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The Maven Publish Plugin works with api:org.gradle.api.publish.maven.MavenPublication[] publications and api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] repositories.
 
 ++++
-<sample id="publishing_maven:apply_plugin" dir="maven-publish/quickstart" title="Applying the 'maven-publish' plugin">
+<sample id="publishing_maven:apply_plugin" dir="maven-publish/quickstart" title="Applying the Maven Publish Plugin">
     <sourcefile file="build.gradle" snippet="use-plugin"/>
 </sample>
 ++++
 
-Applying the “`maven-publish`” plugin does the following:
+Applying the Maven Publish Plugin does the following:
 
-* Applies the “`publishing`” plugin
-* Establishes a rule to automatically create a api:org.gradle.api.publish.maven.tasks.GenerateMavenPom[] task for each api:org.gradle.api.publish.maven.MavenPublication[] added (see <<publishing_maven:publications>>).
-* Establishes a rule to automatically create a api:org.gradle.api.publish.maven.tasks.PublishToMavenRepository[] task for the combination of each api:org.gradle.api.publish.maven.MavenPublication[] added (see <<publishing_maven:publications>>), with each api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] added (see <<publishing_maven:repositories>>).
-* Establishes a rule to automatically create a api:org.gradle.api.publish.maven.tasks.PublishToMavenLocal[] task for each api:org.gradle.api.publish.maven.MavenPublication[] added (see<<publishing_maven:publications>>).
+* Automatically creates a api:org.gradle.api.publish.maven.tasks.GenerateMavenPom[] task for each api:org.gradle.api.publish.maven.MavenPublication[] added (see <<publishing_maven:publications>>).
+* Automatically creates a api:org.gradle.api.publish.maven.tasks.PublishToMavenRepository[] task for the combination of each api:org.gradle.api.publish.maven.MavenPublication[] added (see <<publishing_maven:publications>>), with each api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] added (see <<publishing_maven:repositories>>).
+* Automatically creates a api:org.gradle.api.publish.maven.tasks.PublishToMavenLocal[] task for each api:org.gradle.api.publish.maven.MavenPublication[] added (see <<publishing_maven:publications>>).
 
 
 [[publishing_maven:publications]]
@@ -53,12 +50,12 @@ Applying the “`maven-publish`” plugin does the following:
 
 [NOTE]
 ====
-If you are not familiar with project artifacts and configurations, you should read the <<artifact_management>> that introduces these concepts. This chapter also describes “publishing artifacts” using a different mechanism than what is described in this chapter. The publishing functionality described here will eventually supersede that functionality.
+If you are not familiar with project artifacts and configurations, you should read <<artifact_management>>, which introduces these concepts. That chapter also describes publishing artifacts using a different mechanism than the one described in this chapter. The publishing functionality described here will eventually supersede that functionality.
 ====
 
 Publication objects describe the structure/configuration of a publication to be created. Publications are published to repositories via tasks, and the configuration of the publication object determines exactly what is published. All of the publications of a project are defined in the api:org.gradle.api.publish.PublishingExtension#getPublications()[] container. Each publication has a unique name within the project.
 
-For the “`maven-publish`” plugin to have any effect, a api:org.gradle.api.publish.maven.MavenPublication[] must be added to the set of publications. This publication determines which artifacts are actually published as well as the details included in the associated POM file. A publication can be configured by adding components, customizing artifacts, and by modifying the generated POM file directly.
+For the Maven Publish Plugin to have any effect, a api:org.gradle.api.publish.maven.MavenPublication[] must be added to the set of publications. This publication determines which artifacts are actually published as well as the details included in the associated POM file. A publication can be configured by adding components, customizing artifacts, and by modifying the generated POM file directly.
 
 
 [[sec:publishing_component_to_maven]]
@@ -66,26 +63,13 @@ For the “`maven-publish`” plugin to have any effect, a api:org.gradle.api.pu
 
 The simplest way to publish a Gradle project to a Maven repository is to specify a api:org.gradle.api.component.SoftwareComponent[] to publish. The components presently available for publication are:
 
-.Software Components
-[cols="a,a,a,a", options="header"]
-|===
-| Name
-| Provided By
-| Artifacts
-| Dependencies
+`java` — provider: <<java_plugin,Java Plugin>>::
+Generated JAR file, dependencies from `runtime` configuration
 
-| `java`
-| <<java_plugin>>
-| Generated jar file
-| Dependencies from 'runtime' configuration
+`web` — provider: <<war_plugin,War Plugin>>::
+Generated WAR file, no dependencies
 
-| `web`
-| <<war_plugin>>
-| Generated war file
-| No dependencies
-|===
-
-In the following example, artifacts and runtime dependencies are taken from the `java` component, which is added by the `Java Plugin`.
+In the following example, artifacts and runtime dependencies are taken from the `java` component, which is added by the <<java_plugin,Java Plugin>>.
 
 ++++
 <sample dir="maven-publish/quickstart" id="publishing_maven:publish-component" title="Adding a MavenPublication for a Java component">
@@ -97,7 +81,7 @@ In the following example, artifacts and runtime dependencies are taken from the 
 [[sec:publishing_custom_artifacts_to_maven]]
 ==== Publishing custom artifacts
 
-It is also possible to explicitly configure artifacts to be included in the publication. Artifacts are commonly supplied as raw files, or as instances of api:org.gradle.api.tasks.bundling.AbstractArchiveTask[] (e.g. Jar, Zip).
+It is also possible to explicitly configure artifacts to be included in the publication. Artifacts are commonly supplied as raw files, or as instances of api:org.gradle.api.tasks.bundling.AbstractArchiveTask[] (e.g. api:org.gradle.api.tasks.bundling.Jar[] or api:org.gradle.api.tasks.bundling.Zip[]).
 
 For each custom artifact, it is possible to specify the `extension` and `classifier` values to use for publication. Note that only one of the published artifacts can have an empty classifier, and all other artifacts must have a unique classifier/extension combination.
 
@@ -122,13 +106,13 @@ See the api:org.gradle.api.publish.maven.MavenPublication[] class in the API doc
 [[sec:identity_values_in_the_generated_pom]]
 ==== Identity values in the generated POM
 
-The attributes of the generated `POM` file will contain identity values derived from the following project properties:
+The attributes of the generated POM file will contain identity values derived from the following project properties:
 
 * `groupId` - api:org.gradle.api.Project#getGroup()[]
 * `artifactId` - api:org.gradle.api.Project#getName()[]
 * `version` - api:org.gradle.api.Project#getVersion()[]
 
-Overriding the default identity values is easy: simply specify the `groupId`, `artifactId` or `version` attributes when configuring the `MavenPublication`.
+Overriding the default identity values is easy: simply specify the `groupId`, `artifactId` or `version` attributes when configuring the api:org.gradle.api.publish.maven.MavenPublication[].
 
 ++++
 <sample dir="maven-publish/multiple-publications" id="publishing_maven:publish-customize-identity" title="customizing the publication identity">
@@ -138,17 +122,17 @@ Overriding the default identity values is easy: simply specify the `groupId`, `a
 
 [TIP]
 ====
-Certain repositories will not be able to handle all supported characters. For example, the ':' character cannot be used as an identifier when publishing to a filesystem-backed repository on Windows.
+Certain repositories will not be able to handle all supported characters. For example, the `:` character cannot be used as an identifier when publishing to a filesystem-backed repository on Windows.
 ====
 
 Maven restricts 'groupId' and 'artifactId' to a limited character set (`[A-Za-z0-9_\\-.]+`) and Gradle enforces this restriction. For 'version' (as well as artifact 'extension' and 'classifier'), Gradle will handle any valid Unicode character.
 
-The only Unicode values that are explicitly prohibited are '```\```', '```/```' and any ISO control character. Supplied values are validated early in publication.
+The only Unicode values that are explicitly prohibited are `\`, `/` and any ISO control character. Supplied values are validated early in publication.
 
 [[sec:customizing_the_generated_pom]]
 ==== Customizing the generated POM
 
-The generated POM file can be customized before publishing. For example, when publishing a library to Maven Central you will need to set certain metadata. The “`maven-publish`” plugin provides a DSL for that purpose. Please see api:org.gradle.api.publish.maven.MavenPom[] in the DSL Reference for the complete documentation of available properties and methods. The following sample shows how to use the most common ones:
+The generated POM file can be customized before publishing. For example, when publishing a library to Maven Central you will need to set certain metadata. The Maven Publish Plugin provides a DSL for that purpose. Please see api:org.gradle.api.publish.maven.MavenPom[] in the DSL Reference for the complete documentation of available properties and methods. The following sample shows how to use the most common ones:
 
 ++++
 <sample dir="signing/maven-publish" id="publishing_maven:pom_customization" title="Customizing the POM file">
@@ -159,7 +143,7 @@ The generated POM file can be customized before publishing. For example, when pu
 [[sec:publishing_multiple_modules_to_maven]]
 ==== Publishing multiple modules
 
-Sometimes it's useful to publish multiple modules from your Gradle build, without creating a separate Gradle subproject. An example is publishing a separate API and implementation jar for your library. With Gradle this is simple:
+Sometimes it's useful to publish multiple modules from your Gradle build, without creating a separate Gradle subproject. An example is publishing a separate API and implementation JAR for your library. With Gradle this is simple:
 
 ++++
 <sample dir="maven-publish/multiple-publications" id="publishing_maven:publish-multiple-publications" title="Publishing multiple modules from a single project">
@@ -204,9 +188,9 @@ Similarly, you can use a <<build_environment, project or system property>> to de
 [[publishing_maven:publishing]]
 === Performing a publish
 
-The “`maven-publish`” plugin automatically creates a api:org.gradle.api.publish.maven.tasks.PublishToMavenRepository[] task for each api:org.gradle.api.publish.maven.MavenPublication[] and api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] combination in the `publishing.publications` and `publishing.repositories` containers respectively.
+The Maven Publish Plugin automatically creates a api:org.gradle.api.publish.maven.tasks.PublishToMavenRepository[] task for each api:org.gradle.api.publish.maven.MavenPublication[] and api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] combination in the `publishing.publications` and `publishing.repositories` containers respectively.
 
-The created task is named “`publish«_PUBNAME_»PublicationTo«_REPONAME_»Repository`”.
+The created task is named `publish«_PUBNAME_»PublicationTo«_REPONAME_»Repository`.
 
 ++++
 <sample dir="maven-publish/quickstart" id="publishingMavenPublishMinimal" title="Publishing a project to a Maven repository">
@@ -215,14 +199,14 @@ The created task is named “`publish«_PUBNAME_»PublicationTo«_REPONAME_»Rep
 </sample>
 ++++
 
-In this example, a task named “`publishMavenJavaPublicationToMavenRepository`” is created, which is of type api:org.gradle.api.publish.maven.tasks.PublishToMavenRepository[]. This task is wired into the `publish` lifecycle task. Executing “`gradle publish`” builds the POM file and all of the artifacts to be published, and transfers them to the repository.
+In this example, a task named `publishMavenJavaPublicationToMavenRepository` is created, which is of type api:org.gradle.api.publish.maven.tasks.PublishToMavenRepository[]. This task is wired into the `publish` lifecycle task. Executing `gradle publish` builds the POM file and all of the artifacts to be published, and transfers them to the repository.
 
 [[publishing_maven:install]]
 === Publishing to Maven Local
 
-For integration with a local Maven installation, it is sometimes useful to publish the module into the local .m2 repository. In Maven parlance, this is referred to as 'installing' the module. The “`maven-publish`” plugin makes this easy to do by automatically creating a api:org.gradle.api.publish.maven.tasks.PublishToMavenLocal[] task for each api:org.gradle.api.publish.maven.MavenPublication[] in the `publishing.publications` container. Each of these tasks is wired into the `publishToMavenLocal` lifecycle task. You do not need to have `mavenLocal` in your `publishing.repositories` section.
+For integration with a local Maven installation, it is sometimes useful to publish the module into the local .m2 repository. In Maven parlance, this is referred to as 'installing' the module. The Maven Publish Plugin makes this easy to do by automatically creating a api:org.gradle.api.publish.maven.tasks.PublishToMavenLocal[] task for each api:org.gradle.api.publish.maven.MavenPublication[] in the `publishing.publications` container. Each of these tasks is wired into the `publishToMavenLocal` lifecycle task. You do not need to have `mavenLocal` in your `publishing.repositories` section.
 
-The created task is named “`publish«_PUBNAME_»PublicationToMavenLocal`”.
+The created task is named `publish«_PUBNAME_»PublicationToMavenLocal`.
 
 ++++
 <sample dir="maven-publish/quickstart" id="publishingMavenPublishLocal" title="Publish a project to the Maven local repository">
@@ -230,7 +214,7 @@ The created task is named “`publish«_PUBNAME_»PublicationToMavenLocal`”.
 </sample>
 ++++
 
-The resulting task in this example is named “`publishMavenJavaPublicationToMavenLocal`”. This task is wired into the `publishToMavenLocal` lifecycle task. Executing “`gradle publishToMavenLocal`” builds the POM file and all of the artifacts to be published, and installs them into the local Maven repository.
+The resulting task in this example is named `publishMavenJavaPublicationToMavenLocal`. This task is wired into the `publishToMavenLocal` lifecycle task. Executing `gradle publishToMavenLocal` builds the POM file and all of the artifacts to be published, and installs them into the local Maven repository.
 
 [[publishing_maven:conditional_publishing]]
 === Conditional publishing
@@ -245,7 +229,7 @@ When you have defined multiple publications or repositories, you often want to c
 
 You may not want build users publishing both types of publications to both repositories, but the plugin automatically generates tasks for all possible combinations. So how do you stop someone from publishing the `binaryAndSources` publication to the `external` repository?
 
-You can configure the tasks generated by the “`maven-publish`” plugin to be skipped based on certain criteria. The following sample demonstrates how to restrict the `binary` publication to the `external` repository and the `binaryAndSources` publication to the `internal` repository. In addition, it configures only `binaryAndSources` to be published to the local Maven repository.
+You can configure the tasks generated by the Maven Publish Plugin to be skipped based on certain criteria. The following sample demonstrates how to restrict the `binary` publication to the `external` repository and the `binaryAndSources` publication to the `internal` repository. In addition, it configures only `binaryAndSources` to be published to the local Maven repository.
 
 ++++
 <sample dir="maven-publish/conditional-publishing" id="publishingMavenConditionally" title="Configuring which artifacts should be published to which repositories">
@@ -273,7 +257,7 @@ The <<signing_plugin, Signing Plugin>> can be used to sign all artifacts, includ
 </sample>
 ++++
 
-For each specified publication, this will create a `Sign` task and wire all “`publish«_PUBNAME_»PublicationTo«_REPONAME_»Repository`” tasks to depend on it. Thus, you can simply execute “`gradle publish`” to sign and publish.
+For each specified publication, this will create a `Sign` task and wire all `publish«_PUBNAME_»PublicationTo«_REPONAME_»Repository` tasks to depend on it. Thus, you can simply execute `gradle publish` to sign and publish.
 
 ++++
 <sample dir="signing/maven-publish" id="publishingMavenSignAndPublish" title="Sign and publish a project">
@@ -286,7 +270,7 @@ For each specified publication, this will create a `Sign` task and wire all “`
 
 At times it is useful to generate a Maven POM file for a module without actually publishing. Since POM generation is performed by a separate task, it is very easy to do so.
 
-The task for generating the POM file is of type api:org.gradle.api.publish.maven.tasks.GenerateMavenPom[], and it is given a name based on the name of the publication: “`generatePomFileFor«_PUBNAME_»Publication`”. So in the example below, where the publication is named “`mavenCustom`”, the task will be named “`generatePomFileForMavenCustomPublication`”.
+The task for generating the POM file is of type api:org.gradle.api.publish.maven.tasks.GenerateMavenPom[], and it is given a name based on the name of the publication: `generatePomFileFor«_PUBNAME_»Publication`. So in the example below, where the publication is named `mavenCustom`, the task will be named `generatePomFileForMavenCustomPublication`.
 
 ++++
 <sample dir="maven-publish/pomGeneration" id="publishingMavenGeneratePom" title="Generate a POM file without publishing">

--- a/subprojects/docs/src/docs/userguide/signingPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/signingPlugin.adoc
@@ -15,17 +15,17 @@
 [[signing_plugin]]
 == The Signing Plugin
 
-The signing plugin adds the ability to digitally sign built files and artifacts. These digital signatures can then be used to prove who built the artifact the signature is attached to as well as other information such as when the signature was generated.
+The Signing Plugin adds the ability to digitally sign built files and artifacts. These digital signatures can then be used to prove who built the artifact the signature is attached to as well as other information such as when the signature was generated.
 
-The signing plugin currently only provides support for generating https://en.wikipedia.org/wiki/Pretty_Good_Privacy#OpenPGP[OpenPGP signatures] (which is the signature format http://central.sonatype.org/pages/requirements.html#sign-files-with-gpgpgp[required for publication to the Maven Central Repository]).
+The Signing Plugin currently only provides support for generating https://en.wikipedia.org/wiki/Pretty_Good_Privacy#OpenPGP[OpenPGP signatures] (which is the signature format http://central.sonatype.org/pages/requirements.html#sign-files-with-gpgpgp[required for publication to the Maven Central Repository]).
 
 [[sec:signing_usage]]
 === Usage
 
-To use the Signing plugin, include the following in your build script:
+To use the Signing Plugin, include the following in your build script:
 
 ++++
-<sample id="useSigningPlugin" dir="signing/maven" title="Using the Signing plugin">
+<sample id="useSigningPlugin" dir="signing/maven" title="Using the Signing Plugin">
     <sourcefile file="build.gradle" snippet="use-plugin"/>
 </sample>
 ++++
@@ -33,7 +33,7 @@ To use the Signing plugin, include the following in your build script:
 [[sec:signatory_credentials]]
 === Signatory credentials
 
-In order to create OpenPGP signatures, you will need a key pair (instructions on creating a key pair using the https://www.gnupg.org/[GnuPG tools] can be found in the https://www.gnupg.org/documentation/howtos.html[GnuPG HOWTOs]). You need to provide the signing plugin with your key information, which means three things:
+In order to create OpenPGP signatures, you will need a key pair (instructions on creating a key pair using the https://www.gnupg.org/[GnuPG tools] can be found in the https://www.gnupg.org/documentation/howtos.html[GnuPG HOWTOs]). You need to provide the Signing Plugin with your key information, which means three things:
 
 * The public key ID (The last 8 symbols of the keyId. You can use `gpg -K` to get it).
 * The absolute path to the secret key ring file containing your private key. (Since gpg 2.1, you need to export the keys with command `gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg`).
@@ -84,12 +84,12 @@ Note that the presence of a null value for any these three properties will cause
 
 OpenPGP supports subkeys, which are like the normal keys, except they're bound to a master key pair. One feature of OpenPGP subkeys is that they can be revoked independently of the master keys which makes key management easier. A practical case study of how subkeys can be leveraged in software development can be read on the https://wiki.debian.org/Subkeys[Debian wiki].
 
-The signing plugin supports OpenPGP subkeys out of the box. Just specify a subkey ID as the value in the `signing.keyId` property.
+The Signing Plugin supports OpenPGP subkeys out of the box. Just specify a subkey ID as the value in the `signing.keyId` property.
 
 [[sec:using_gpg_agent]]
 === Using gpg-agent
 
-By default the signing plugin uses a Java-based implementation of PGP for signing. This implementation cannot use the gpg-agent program for managing private keys, though. If you want to use the gpg-agent, you can change the signatory implementation used by the signing plugin:
+By default the Signing Plugin uses a Java-based implementation of PGP for signing. This implementation cannot use the gpg-agent program for managing private keys, though. If you want to use the gpg-agent, you can change the signatory implementation used by the Signing Plugin:
 
 ++++
 <sample id="useGnupg" dir="signing/gnupg-signatory" title="Sign with GnuPG">
@@ -97,7 +97,7 @@ By default the signing plugin uses a Java-based implementation of PGP for signin
 </sample>
 ++++
 
-This tells the signing plugin to use the `GnupgSignatory` instead of the default api:org.gradle.plugins.signing.signatory.pgp.PgpSignatory[]. The `GnupgSignatory` relies on the gpg2 program to sign the artifacts. Of course, this requires that GnuPG is installed.
+This tells the Signing Plugin to use the `GnupgSignatory` instead of the default api:org.gradle.plugins.signing.signatory.pgp.PgpSignatory[]. The `GnupgSignatory` relies on the gpg2 program to sign the artifacts. Of course, this requires that GnuPG is installed.
 
 Without any further configuration the `gpg2` (on Windows: `gpg2.exe`) executable found on the `PATH` will be used. The password is supplied by the `gpg-agent` and the default key is used for signing.
 
@@ -131,12 +131,12 @@ All configuration properties are optional.
 [[sec:specifying_what_to_sign]]
 === Specifying what to sign
 
-As well as configuring how things are to be signed (i.e. the signatory configuration), you must also specify what is to be signed. The Signing plugin provides a DSL that allows you to specify the tasks and/or configurations that should be signed.
+As well as configuring how things are to be signed (i.e. the signatory configuration), you must also specify what is to be signed. The Signing Plugin provides a DSL that allows you to specify the tasks and/or configurations that should be signed.
 
 [[sec:signing_publications]]
 ==== Signing Publications
 
-When publishing artifacts, you often want to sign them so the consumer of your artifacts can verify their signature. For example, the <<java_plugin,Java plugin>> defines a component that you can use to define a publication to a Maven (or Ivy) repository. Using the Signing DSL, you can specify that all of the artifacts of this publication should be signed.
+When publishing artifacts, you often want to sign them so the consumer of your artifacts can verify their signature. For example, the <<java_plugin,Java plugin>> defines a component that you can use to define a publication to a Maven (or Ivy) repository using the <<publishing_maven, Maven Publish Plugin>> (or the <<publishing_ivy, Ivy Publish Plugin>>, respectively). Using the Signing DSL, you can specify that all of the artifacts of this publication should be signed.
 
 ++++
 <sample id="signingPublication" dir="signing/maven-publish" title="Signing a publication">
@@ -144,7 +144,7 @@ When publishing artifacts, you often want to sign them so the consumer of your a
 </sample>
 ++++
 
-This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your project named “`signMavenJavaPublication`” that will build all artifacts that are part of the publication (if needed) and then generate signatures for them. The signature files will be placed alongside the artifacts being signed.
+This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your project named `signMavenJavaPublication` that will build all artifacts that are part of the publication (if needed) and then generate signatures for them. The signature files will be placed alongside the artifacts being signed.
 
 ++++
 <sample id="signingPluginSignPublication" dir="signing/maven-publish" title="Signing a publication output">
@@ -165,7 +165,7 @@ It is common to want to sign the artifacts of a configuration. For example, the 
 </sample>
 ++++
 
-This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your project named “`signArchives`”, that will build any `archives` artifacts (if needed) and then generate signatures for them. The signature files will be placed alongside the artifacts being signed.
+This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your project named `signArchives`, that will build any `archives` artifacts (if needed) and then generate signatures for them. The signature files will be placed alongside the artifacts being signed.
 
 ++++
 <sample id="signingArchivesOutput" dir="signing/maven" title="Signing a configuration output">
@@ -184,7 +184,7 @@ In some cases the artifact that you need to sign may not be part of a configurat
 </sample>
 ++++
 
-This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your project named “`signStuffZip`”, that will build the input task's archive (if needed) and then sign it. The signature file will be placed alongside the artifact being signed.
+This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your project named `signStuffZip`, that will build the input task's archive (if needed) and then sign it. The signature file will be placed alongside the artifact being signed.
 
 ++++
 <sample id="signingTaskOutput" dir="signing/tasks" title="Signing a task output">
@@ -192,7 +192,7 @@ This will create a task (of type api:org.gradle.plugins.signing.Sign[]) in your 
 </sample>
 ++++
 
-For a task to be “signable”, it must produce an archive of some type. Tasks that do this are the api:org.gradle.api.tasks.bundling.Tar[], api:org.gradle.api.tasks.bundling.Zip[], api:org.gradle.api.tasks.bundling.Jar[], api:org.gradle.api.tasks.bundling.War[] and api:org.gradle.plugins.ear.Ear[] tasks.
+For a task to be _signable_, it must produce an archive of some type, i.e. it must extend api:org.gradle.api.tasks.bundling.AbstractArchiveTask[]. Tasks that do this are the api:org.gradle.api.tasks.bundling.Tar[], api:org.gradle.api.tasks.bundling.Zip[], api:org.gradle.api.tasks.bundling.Jar[], api:org.gradle.api.tasks.bundling.War[] and api:org.gradle.plugins.ear.Ear[] tasks.
 
 [[sec:conditional_signing]]
 ==== Conditional Signing
@@ -207,7 +207,7 @@ A common usage pattern is to require the signing of build artifacts only under c
 
 In this example, we only want to require signing if we are building a release version and we are going to publish it. Because we are inspecting the task graph to determine if we are going to be publishing, we must set the `signing.required` property to a closure to defer the evaluation. See api:org.gradle.plugins.signing.SigningExtension#setRequired(java.lang.Object)[] for more information.
 
-If the `required` condition does not hold true, artifacts will only be signed if signatory credentials are configured. Alternatively, you may want to skip signing entirely whether or not signatory credentials are available. If so, you can configure the `Sign` tasks to be skipped, for example by attaching a predicate using the `onlyIf()` method shown in the following example:
+If the `required` condition does not hold true, artifacts will only be signed if signatory credentials are configured. Alternatively, you may want to skip signing entirely whether or not signatory credentials are available. If so, you can configure the api:org.gradle.plugins.signing.Sign[] tasks to be skipped, for example by attaching a predicate using the `onlyIf()` method shown in the following example:
 
 ++++
 <sample id="conditionalSigning" dir="signing/conditional" title="Specifying when signing is skipped">
@@ -231,7 +231,7 @@ This section covers signing POM files for the _original_ publishing mechanism av
 The POM file generated by the _new_ Maven publishing support provided by the <<publishing_maven,Maven Publishing plugin>> is automatically signed if the corresponding publication is <<sec:signing_publications,specified to be signed>>.
 ====
 
-When deploying signatures for your artifacts to a Maven repository, you will also want to sign the published POM file. The signing plugin adds a `signing.signPom()` (see: api:org.gradle.plugins.signing.SigningExtension#signPom(org.gradle.api.artifacts.maven.MavenDeployment,groovy.lang.Closure)[]) method that can be used in the `beforeDeployment()` block in your upload task configuration.
+When deploying signatures for your artifacts to a Maven repository, you will also want to sign the published POM file. The Signing Plugin adds a `signing.signPom()` (see: api:org.gradle.plugins.signing.SigningExtension#signPom(org.gradle.api.artifacts.maven.MavenDeployment,groovy.lang.Closure)[]) method that can be used in the `beforeDeployment()` block in your upload task configuration.
 
 ++++
 <sample id="signingMavenPom" dir="signing/maven" title="Signing a POM for deployment">


### PR DESCRIPTION
- Apply naming and style conventions
  - Consistently name plugins, e.g. "Maven Publish Plugin" instead of "“`maven-publish`” plugin"
  - Replace quotes around inline code blocks, e.g. `signArchives` instead of “`signArchives`”
  - Remove superfluous quotes around terms
  - Use JAR and WAR consistently
  - Always link tasks from paragraphs
  - Use inline code blocks (only) where appropriate
- Add reference to `AbstractArchiveTask` and Publish Plugins to Signing Plugin documentation
- Remove rule terminology from Publish Plugins chapters

Resolves #5149.