### PR TITLE
Remove download message in play tests to avoid flakiness

### DIFF
--- a/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/components/AbstractComponentReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/components/AbstractComponentReportIntegrationTest.groovy
@@ -33,8 +33,12 @@ abstract class AbstractComponentReportIntegrationTest extends AbstractIntegratio
 
     boolean outputMatches(String expectedOutput) {
         def actualOutput = result.groupedOutput.task(":components").output
-        assert actualOutput == expected(expectedOutput)
+        assert removeDownloadMessageAndEmptyLines(actualOutput) == expected(expectedOutput)
         return true
+    }
+
+    String removeDownloadMessageAndEmptyLines(String output) {
+        return output.readLines().findAll { !it.isEmpty() && !(it ==~ /^Download http.*$/) }.join('\n')
     }
 
     String expected(String normalised) {
@@ -43,7 +47,7 @@ Root project
 ------------------------------------------------------------
 """ + normalised + """
 Note: currently not all plugins register their components, so some components may not be visible here."""
-        return formatter.transform(raw)
+        return formatter.transform(raw).readLines().findAll { !it.isEmpty() }.join('\n')
     }
 
     AvailableToolChains.InstalledToolChain getToolChain() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.logging;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.integtests.fixtures.executer.LogContent;
 
 import java.util.HashMap;
@@ -72,7 +73,7 @@ public class GroupedOutputFixture {
         while (matcher.find()) {
             String taskName = matcher.group(1);
             String taskOutcome = matcher.group(2);
-            String taskOutput = trimEmptyLines(matcher.group(3));
+            String taskOutput = StringUtils.strip(matcher.group(3), "\n");
 
             GroupedTaskFixture task = tasks.get(taskName);
             if (task == null) {
@@ -85,19 +86,6 @@ public class GroupedOutputFixture {
         }
 
         return strippedOutput;
-    }
-
-    private String trimEmptyLines(String s) {
-        int end = s.length();
-        int start = 0;
-
-        while ((start < end) && (s.charAt(start) == '\n')) {
-            start++;
-        }
-        while ((start < end) && (s.charAt(end - 1) == '\n')) {
-            end--;
-        }
-        return s.substring(start, end);
     }
 
     public int getTaskCount() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -72,7 +72,7 @@ public class GroupedOutputFixture {
         while (matcher.find()) {
             String taskName = matcher.group(1);
             String taskOutcome = matcher.group(2);
-            String taskOutput = matcher.group(3).trim();
+            String taskOutput = matcher.group(3);
 
             GroupedTaskFixture task = tasks.get(taskName);
             if (task == null) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -72,7 +72,7 @@ public class GroupedOutputFixture {
         while (matcher.find()) {
             String taskName = matcher.group(1);
             String taskOutcome = matcher.group(2);
-            String taskOutput = matcher.group(3);
+            String taskOutput = trimEmptyLines(matcher.group(3));
 
             GroupedTaskFixture task = tasks.get(taskName);
             if (task == null) {
@@ -85,6 +85,19 @@ public class GroupedOutputFixture {
         }
 
         return strippedOutput;
+    }
+
+    private String trimEmptyLines(String s) {
+        int end = s.length();
+        int start = 0;
+
+        while ((start < end) && (s.charAt(start) == '\n')) {
+            start++;
+        }
+        while ((start < end) && (s.charAt(end - 1) == '\n')) {
+            end--;
+        }
+        return s.substring(start, end);
     }
 
     public int getTaskCount() {


### PR DESCRIPTION
### Context

This is an attempt to fix https://github.com/gradle/gradle-private/issues/1238.

This flaky test can be reproduced by removing `<projectDir>/intTestHomeDir/worker-1/caches`.

If caches is empty when executing this test, extra `Downloading http://xxx.jar` will appear in test log, failing the test with unmatched log failure.

This PR removes the downloading message from test log.

In addition, this PR fixes an issue in `GroupedOutputFixture.java`: previously, if the test output is `\n\t\tOutput\n`,  it will be trimmed to `Output` - this is not right. Only empty lines should be trimmed, so the correct trimmed output should be `\t\tOutput`.