### PR TITLE
Fix flaky test stopScheduledExecutorThrowsExceptionOnTimeout

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
@@ -301,7 +301,9 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
     }
 
     def stopScheduledExecutorThrowsExceptionOnTimeout() {
+        def latch = new CountDownLatch(1)
         def action = {
+            latch.countDown()
             thread.block()
         }
 
@@ -309,6 +311,7 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
         def executor = factory.createScheduled('<display-name>', 1)
         executor.schedule(action, 0, TimeUnit.SECONDS)
         operation.stop {
+            latch.await()
             executor.stop(200, TimeUnit.MILLISECONDS)
         }
 


### PR DESCRIPTION
### Context

This is an attempt to fix https://github.com/gradle/gradle-private/issues/750

This flaky test's intention is:

- Submit a thread which blocks 750ms to the executor
- Close the executor with 200ms timeout
- Assert an exception to be thrown

The problem is, when the executor start closing, the block thread might not start running. Therefore, the executor can close without any exceptions.

This PR adds a `CountdownLatch` to coordinate these actions. The executor will not be closed until block thread starts running.

@eskatos Seems you're the original author of this test, could you take a look at it?
