### PR TITLE
Refactor lazy infrastructure in domain object collections

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -272,6 +272,26 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Create :task1")
     }
 
+    def "fails to get a task by name when it does not match the filtered type"() {
+        buildFile <<'''
+            tasks.createLater("task1", SomeTask) {
+                println "Configure ${path}"
+            }
+            
+            tasks.create("other") {
+                dependsOn tasks.withType(SomeOtherTask).getByName("task1")
+            }
+        '''
+
+        when:
+        fails "other"
+
+        then:
+        outputDoesNotContain("Create :task1")
+        outputDoesNotContain("Configure :task1")
+        failure.assertHasCause("Task with name 'task1' not found")
+    }
+
     def "fails to get a task by name when it does not match the collection filter"() {
         buildFile <<'''
             tasks.createLater("task1", SomeTask) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 
 
 class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
@@ -250,5 +251,24 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Configure :task1")
         outputContains("Received :task1")
         result.assertNotOutput("task2")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/5148")
+    def "can get a task by name with a filtered collection"() {
+        buildFile <<'''
+            tasks.createLater("task1", SomeTask) {
+                println "Configure ${path}"
+            }
+            
+            tasks.create("other") {
+                dependsOn tasks.withType(SomeTask).getByName("task1")
+            }
+        '''
+
+        when:
+        run "other"
+
+        then:
+        outputContains("Create :task1")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -271,4 +271,24 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains("Create :task1")
     }
+
+    def "fails to get a task by name when it does not match the collection filter"() {
+        buildFile <<'''
+            tasks.createLater("task1", SomeTask) {
+                println "Configure ${path}"
+            }
+            
+            tasks.create("other") {
+                dependsOn tasks.matching { it.name.contains("foo") }.getByName("task1")
+            }
+        '''
+
+        when:
+        fails "other"
+
+        then:
+        outputContains("Create :task1")
+        outputContains("Configure :task1")
+        failure.assertHasCause("Task with name 'task1' not found")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -253,12 +253,12 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
 
         @Override
-        public void flushPending() {
+        public void realizePending() {
 
         }
 
         @Override
-        public void flushPending(Class<?> type) {
+        public void realizePending(Class<?> type) {
 
         }
 
@@ -273,7 +273,7 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
 
         @Override
-        public void onFlush(Action<ProviderInternal<? extends T>> action) {
+        public void onRealize(Action<ProviderInternal<? extends T>> action) {
 
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -21,6 +21,8 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.internal.collections.ElementSource;
+import org.gradle.api.internal.collections.PendingSource;
+import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Actions;
 
@@ -135,6 +137,7 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
     }
 
+    // TODO Make this work with pending elements
     private final static class DomainObjectCompositeCollection<T> implements ElementSource<T> {
 
         private final List<DomainObjectCollection<? extends T>> store = Lists.newLinkedList();
@@ -243,6 +246,36 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
                 size += Estimates.estimateSizeOf(ts);
             }
             return size;
+        }
+
+        @Override
+        public Iterator<T> iteratorNoFlush() {
+            return iterator();
+        }
+
+        @Override
+        public void flushPending() {
+
+        }
+
+        @Override
+        public void flushPending(Class<?> type) {
+
+        }
+
+        @Override
+        public void addPending(ProviderInternal<? extends T> provider) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removePending(ProviderInternal<? extends T> provider) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void onFlush(Action<ProviderInternal<? extends T>> action) {
+
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.internal.collections.ElementSource;
-import org.gradle.api.internal.collections.PendingSource;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Actions;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -38,8 +38,6 @@ import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
 
 public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> implements DomainObjectCollection<T>, WithEstimatedSize {
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -54,7 +54,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         this.type = type;
         this.store = store;
         this.eventRegister = eventRegister;
-        this.store.onFlush(new Action<ProviderInternal<? extends T>>() {
+        this.store.onRealize(new Action<ProviderInternal<? extends T>>() {
             @Override
             public void execute(ProviderInternal<? extends T> provider) {
                 doAdd(provider.get());
@@ -410,7 +410,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         @Override
         public void registerEagerAddAction(Class<? extends S> type, Action<? super S> addAction) {
             // Any elements previously added should not be visible to the action
-            store.flushPending(filter.getType());
+            store.realizePending(filter.getType());
             delegate.registerEagerAddAction(filter.getType(), Actions.filter(addAction, filter));
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -262,7 +262,9 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             index.removePending(name);
             getStore().removePending(provider);
             // TODO - this isn't correct, assumes that a side effect is to add the element
-            return provider.get();
+            provider.get();
+            // Use the index here so we can apply any filters to the realized element
+            return index.get(name);
         }
         if (!applyRules(name)) {
             return null;
@@ -601,7 +603,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         @Override
         public Map<String, ProviderInternal<? extends T>> getPendingAsMap() {
-            // TODO not sure if we clean up the generics here and do less unchecked casting
+            // TODO not sure if we can clean up the generics here and do less unchecked casting
             Map<String, ProviderInternal<?>> delegateMap = (Map<String, ProviderInternal<?>>) delegate.getPendingAsMap();
             Map<String, ProviderInternal<? extends T>> filteredMap = Maps.newLinkedHashMap();
             for (Map.Entry<String, ProviderInternal<?>> entry : delegateMap.entrySet()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -467,7 +467,6 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         void putPending(String name, ProviderInternal<? extends T> provider);
 
-        @Nullable
         void removePending(String name);
 
         Map<String, ProviderInternal<? extends T>> getPendingAsMap();
@@ -595,7 +594,6 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             delegate.putPending(name, provider);
         }
 
-        @Nullable
         @Override
         public void removePending(String name) {
             delegate.removePending(name);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
+import org.gradle.internal.Cast;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
@@ -602,11 +603,12 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         @Override
         public Map<String, ProviderInternal<? extends T>> getPendingAsMap() {
             // TODO not sure if we can clean up the generics here and do less unchecked casting
-            Map<String, ProviderInternal<?>> delegateMap = (Map<String, ProviderInternal<?>>) delegate.getPendingAsMap();
+            Map<String, ProviderInternal<?>> delegateMap = Cast.uncheckedCast(delegate.getPendingAsMap());
             Map<String, ProviderInternal<? extends T>> filteredMap = Maps.newLinkedHashMap();
             for (Map.Entry<String, ProviderInternal<?>> entry : delegateMap.entrySet()) {
                 if (entry.getValue().getType() != null && filter.getType().isAssignableFrom(entry.getValue().getType())) {
-                    filteredMap.put(entry.getKey(), (ProviderInternal<? extends T>) entry.getValue());
+                    ProviderInternal<? extends T> typedValue = Cast.uncheckedCast(entry.getValue());
+                    filteredMap.put(entry.getKey(), typedValue);
                 }
             }
             return filteredMap;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal;
 import groovy.lang.Closure;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.Namer;
-import org.gradle.api.internal.collections.CollectionEventRegister;
 import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.collections.FilteredList;
@@ -37,10 +36,6 @@ import java.util.ListIterator;
 public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCollection<T> implements NamedDomainObjectList<T> {
     public DefaultNamedDomainObjectList(DefaultNamedDomainObjectList<? super T> objects, CollectionFilter<T> filter, Instantiator instantiator, Namer<? super T> namer) {
         super(objects, filter, instantiator, namer);
-    }
-
-    public DefaultNamedDomainObjectList(Class<T> type, CollectionEventRegister<T> collectionEventRegister, Instantiator instantiator, Namer<? super T> namer) {
-        super(type, new ListElementSource<T>(), collectionEventRegister, new UnfilteredIndex<T>(), instantiator, namer);
     }
 
     public DefaultNamedDomainObjectList(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.Action;
+import org.gradle.api.internal.provider.ProviderInternal;
+
+import java.util.List;
+import java.util.ListIterator;
+
+public class DefaultPendingSource<T> implements PendingSource<T> {
+    private final List<ProviderInternal<? extends T>> pending = Lists.newArrayList();
+    private Action<ProviderInternal<? extends T>> flushAction;
+
+    @Override
+    public void flushPending() {
+        for (ProviderInternal<? extends T> provider : pending) {
+            flushAction.execute(provider);
+        }
+        pending.clear();
+    }
+
+    @Override
+    public void flushPending(Class<?> type) {
+        ListIterator<ProviderInternal<? extends T>> iterator = pending.listIterator();
+        while (iterator.hasNext()) {
+            ProviderInternal<? extends T> provider = iterator.next();
+            if (provider.getType() == null || type.isAssignableFrom(provider.getType())) {
+                flushAction.execute(provider);
+                iterator.remove();
+            }
+        }
+    }
+
+    @Override
+    public void addPending(ProviderInternal<? extends T> provider) {
+        pending.add(provider);
+    }
+
+    @Override
+    public void removePending(ProviderInternal<? extends T> provider) {
+        pending.remove(provider);
+    }
+
+    @Override
+    public void onFlush(Action<ProviderInternal<? extends T>> action) {
+        this.flushAction = action;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return pending.isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return pending.size();
+    }
+
+    @Override
+    public void clear() {
+        pending.clear();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -28,7 +28,7 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
     private Action<ProviderInternal<? extends T>> flushAction;
 
     @Override
-    public void flushPending() {
+    public void realizePending() {
         for (ProviderInternal<? extends T> provider : pending) {
             flushAction.execute(provider);
         }
@@ -36,7 +36,7 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
     }
 
     @Override
-    public void flushPending(Class<?> type) {
+    public void realizePending(Class<?> type) {
         ListIterator<ProviderInternal<? extends T>> iterator = pending.listIterator();
         while (iterator.hasNext()) {
             ProviderInternal<? extends T> provider = iterator.next();
@@ -58,7 +58,7 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
     }
 
     @Override
-    public void onFlush(Action<ProviderInternal<? extends T>> action) {
+    public void onRealize(Action<ProviderInternal<? extends T>> action) {
         this.flushAction = action;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -30,7 +30,11 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
     @Override
     public void realizePending() {
         for (ProviderInternal<? extends T> provider : pending) {
-            flushAction.execute(provider);
+            if (flushAction != null) {
+                flushAction.execute(provider);
+            } else {
+                throw new IllegalStateException("Cannot realize pending elements when realize action is not set");
+            }
         }
         pending.clear();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/ElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/ElementSource.java
@@ -21,12 +21,17 @@ import org.gradle.api.internal.WithEstimatedSize;
 import java.util.Collection;
 import java.util.Iterator;
 
-public interface ElementSource<T> extends Iterable<T>, WithEstimatedSize {
+public interface ElementSource<T> extends Iterable<T>, WithEstimatedSize, PendingSource<T> {
     /**
      * Iterates over and realizes each of the elements of this source.
      */
     @Override
     Iterator<T> iterator();
+
+    /**
+     * Iterates over only the realized elements (without flushing any pending elements)
+     */
+    Iterator<T> iteratorNoFlush();
 
     /**
      * Returns false if this source is not empty or it is not fast to determine this.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -144,7 +144,7 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
 
     @Override
     public Iterator<S> iterator() {
-        collection.flushPending(filter.getType());
+        collection.realizePending(filter.getType());
         return new FilteringIterator<T, S>(collection, filter);
     }
 
@@ -171,13 +171,13 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     }
 
     @Override
-    public void flushPending() {
-        flushPending(filter.getType());
+    public void realizePending() {
+        realizePending(filter.getType());
     }
 
     @Override
-    public void flushPending(Class<?> type) {
-        collection.flushPending(type);
+    public void realizePending(Class<?> type) {
+        collection.realizePending(type);
     }
 
     @Override
@@ -191,5 +191,5 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     }
 
     @Override
-    public void onFlush(Action<ProviderInternal<? extends S>> action) { }
+    public void onRealize(Action<ProviderInternal<? extends S>> action) { }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -15,7 +15,9 @@
  */
 package org.gradle.api.internal.collections;
 
+import org.gradle.api.Action;
 import org.gradle.api.internal.WithEstimatedSize;
+import org.gradle.api.internal.provider.ProviderInternal;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -95,7 +97,7 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
         private S next;
 
         FilteringIterator(ElementSource<T> collection, CollectionFilter<S> filter) {
-            this.iterator = collection.iterator();
+            this.iterator = collection.iteratorNoFlush();
             this.filter = filter;
             this.estimatedSize = collection.estimatedSize();
             this.next = findNext();
@@ -142,6 +144,7 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
 
     @Override
     public Iterator<S> iterator() {
+        collection.flushPending(filter.getType());
         return new FilteringIterator<T, S>(collection, filter);
     }
 
@@ -153,6 +156,7 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     @Override
     public int size() {
         int i = 0;
+        // TODO this will realize all pending elements
         for (T o : collection) {
             if (accept(o)) {
                 ++i;
@@ -160,4 +164,32 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
         }
         return i;
     }
+
+    @Override
+    public Iterator<S> iteratorNoFlush() {
+        return new FilteringIterator<T, S>(collection, filter);
+    }
+
+    @Override
+    public void flushPending() {
+        collection.flushPending();
+    }
+
+    @Override
+    public void flushPending(Class<?> type) {
+        collection.flushPending(type);
+    }
+
+    @Override
+    public void addPending(ProviderInternal<? extends S> provider) {
+        collection.addPending(provider);
+    }
+
+    @Override
+    public void removePending(ProviderInternal<? extends S> provider) {
+        collection.removePending(provider);
+    }
+
+    @Override
+    public void onFlush(Action<ProviderInternal<? extends S>> action) { }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -172,7 +172,7 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
 
     @Override
     public void flushPending() {
-        collection.flushPending();
+        flushPending(filter.getType());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredList.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredList.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+// TODO make this work with pending elements
 public class FilteredList<T, S extends T> extends FilteredCollection<T, S> implements IndexedElementSource<S> {
     public FilteredList(ElementSource<T> collection, CollectionFilter<S> filter) {
         super(collection, filter);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
@@ -50,7 +50,7 @@ public class IterationOrderRetainingSetElementSource<T> implements ElementSource
 
     @Override
     public Iterator<T> iterator() {
-        pending.flushPending();
+        pending.realizePending();
         return values.iterator();
     }
 
@@ -61,13 +61,13 @@ public class IterationOrderRetainingSetElementSource<T> implements ElementSource
 
     @Override
     public boolean contains(Object element) {
-        pending.flushPending();
+        pending.realizePending();
         return values.contains(element);
     }
 
     @Override
     public boolean containsAll(Collection<?> elements) {
-        pending.flushPending();
+        pending.realizePending();
         return values.containsAll(elements);
     }
 
@@ -88,13 +88,13 @@ public class IterationOrderRetainingSetElementSource<T> implements ElementSource
     }
 
     @Override
-    public void flushPending() {
-        pending.flushPending();
+    public void realizePending() {
+        pending.realizePending();
     }
 
     @Override
-    public void flushPending(Class<?> type) {
-        pending.flushPending(type);
+    public void realizePending(Class<?> type) {
+        pending.realizePending(type);
     }
 
     @Override
@@ -108,7 +108,7 @@ public class IterationOrderRetainingSetElementSource<T> implements ElementSource
     }
 
     @Override
-    public void onFlush(Action<ProviderInternal<? extends T>> action) {
-        pending.onFlush(action);
+    public void onRealize(Action<ProviderInternal<? extends T>> action) {
+        pending.onRealize(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.collections;
 
+import org.gradle.api.Action;
+import org.gradle.api.internal.provider.ProviderInternal;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -23,39 +26,48 @@ import java.util.Set;
 
 public class IterationOrderRetainingSetElementSource<T> implements ElementSource<T> {
     private final Set<T> values = new LinkedHashSet<T>();
+    private final PendingSource<T> pending = new DefaultPendingSource<T>();
 
     @Override
     public boolean isEmpty() {
-        return values.isEmpty();
+        return values.isEmpty() && pending.isEmpty();
     }
 
     @Override
     public boolean constantTimeIsEmpty() {
-        return values.isEmpty();
+        return values.isEmpty() && pending.isEmpty();
     }
 
     @Override
     public int size() {
-        return values.size();
+        return values.size() + pending.size();
     }
 
     @Override
     public int estimatedSize() {
-        return values.size();
+        return values.size() + pending.size();
     }
 
     @Override
     public Iterator<T> iterator() {
+        pending.flushPending();
+        return values.iterator();
+    }
+
+    @Override
+    public Iterator<T> iteratorNoFlush() {
         return values.iterator();
     }
 
     @Override
     public boolean contains(Object element) {
+        pending.flushPending();
         return values.contains(element);
     }
 
     @Override
     public boolean containsAll(Collection<?> elements) {
+        pending.flushPending();
         return values.containsAll(elements);
     }
 
@@ -71,6 +83,32 @@ public class IterationOrderRetainingSetElementSource<T> implements ElementSource
 
     @Override
     public void clear() {
+        pending.clear();
         values.clear();
+    }
+
+    @Override
+    public void flushPending() {
+        pending.flushPending();
+    }
+
+    @Override
+    public void flushPending(Class<?> type) {
+        pending.flushPending(type);
+    }
+
+    @Override
+    public void addPending(ProviderInternal<? extends T> provider) {
+        pending.addPending(provider);
+    }
+
+    @Override
+    public void removePending(ProviderInternal<? extends T> provider) {
+        pending.removePending(provider);
+    }
+
+    @Override
+    public void onFlush(Action<ProviderInternal<? extends T>> action) {
+        pending.onFlush(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
@@ -51,7 +51,7 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
 
     @Override
     public Iterator<T> iterator() {
-        pending.flushPending();
+        pending.realizePending();
         return values.iterator();
     }
 
@@ -72,13 +72,13 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
 
     @Override
     public boolean contains(Object element) {
-        pending.flushPending();
+        pending.realizePending();
         return values.contains(element);
     }
 
     @Override
     public boolean containsAll(Collection<?> elements) {
-        pending.flushPending();
+        pending.realizePending();
         return values.containsAll(elements);
     }
 
@@ -134,13 +134,13 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
     }
 
     @Override
-    public void flushPending() {
-        pending.flushPending();
+    public void realizePending() {
+        pending.realizePending();
     }
 
     @Override
-    public void flushPending(Class<?> type) {
-        pending.flushPending(type);
+    public void realizePending(Class<?> type) {
+        pending.realizePending(type);
     }
 
     @Override
@@ -154,7 +154,7 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
     }
 
     @Override
-    public void onFlush(Action<ProviderInternal<? extends T>> action) {
-        pending.onFlush(action);
+    public void onRealize(Action<ProviderInternal<? extends T>> action) {
+        pending.onRealize(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.collections;
 
+import org.gradle.api.Action;
+import org.gradle.api.internal.provider.ProviderInternal;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -24,28 +27,36 @@ import java.util.ListIterator;
 
 public class ListElementSource<T> implements IndexedElementSource<T> {
     private final List<T> values = new ArrayList<T>();
+    private final PendingSource<T> pending = new DefaultPendingSource<T>();
+
     @Override
     public boolean isEmpty() {
-        return values.isEmpty();
+        return values.isEmpty() && pending.isEmpty();
     }
 
     @Override
     public boolean constantTimeIsEmpty() {
-        return values.isEmpty();
+        return values.isEmpty() && pending.isEmpty();
     }
 
     @Override
     public int size() {
-        return values.size();
+        return values.size() + pending.size();
     }
 
     @Override
     public int estimatedSize() {
-        return values.size();
+        return values.size() + pending.size();
     }
 
     @Override
     public Iterator<T> iterator() {
+        pending.flushPending();
+        return values.iterator();
+    }
+
+    @Override
+    public Iterator<T> iteratorNoFlush() {
         return values.iterator();
     }
 
@@ -61,11 +72,13 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
 
     @Override
     public boolean contains(Object element) {
+        pending.flushPending();
         return values.contains(element);
     }
 
     @Override
     public boolean containsAll(Collection<?> elements) {
+        pending.flushPending();
         return values.containsAll(elements);
     }
 
@@ -116,6 +129,32 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
 
     @Override
     public void clear() {
+        pending.clear();
         values.clear();
+    }
+
+    @Override
+    public void flushPending() {
+        pending.flushPending();
+    }
+
+    @Override
+    public void flushPending(Class<?> type) {
+        pending.flushPending(type);
+    }
+
+    @Override
+    public void addPending(ProviderInternal<? extends T> provider) {
+        pending.addPending(provider);
+    }
+
+    @Override
+    public void removePending(ProviderInternal<? extends T> provider) {
+        pending.removePending(provider);
+    }
+
+    @Override
+    public void onFlush(Action<ProviderInternal<? extends T>> action) {
+        pending.onFlush(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
@@ -20,15 +20,15 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.provider.ProviderInternal;
 
 public interface PendingSource<T> {
-    void flushPending();
+    void realizePending();
 
-    void flushPending(Class<?> type);
+    void realizePending(Class<?> type);
 
     void addPending(ProviderInternal<? extends T> provider);
 
     void removePending(ProviderInternal<? extends T> provider);
 
-    void onFlush(Action<ProviderInternal<? extends T>> action);
+    void onRealize(Action<ProviderInternal<? extends T>> action);
 
     boolean isEmpty();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.provider.ProviderInternal;
+
+public interface PendingSource<T> {
+    void flushPending();
+
+    void flushPending(Class<?> type);
+
+    void addPending(ProviderInternal<? extends T> provider);
+
+    void removePending(ProviderInternal<? extends T> provider);
+
+    void onFlush(Action<ProviderInternal<? extends T>> action);
+
+    boolean isEmpty();
+
+    int size();
+
+    void clear();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.collections;
 
+import org.gradle.api.Action;
+import org.gradle.api.internal.provider.ProviderInternal;
+
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -23,6 +26,7 @@ import java.util.TreeSet;
 
 public class SortedSetElementSource<T> implements ElementSource<T> {
     private final TreeSet<T> values;
+    private final PendingSource<T> pending = new DefaultPendingSource<T>();
 
     public SortedSetElementSource(Comparator<T> comparator) {
         this.values = new TreeSet<T>(comparator);
@@ -30,36 +34,44 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
 
     @Override
     public boolean isEmpty() {
-        return values.isEmpty();
+        return values.isEmpty() && pending.isEmpty();
     }
 
     @Override
     public boolean constantTimeIsEmpty() {
-        return values.isEmpty();
+        return values.isEmpty() && pending.isEmpty();
     }
 
     @Override
     public int size() {
-        return values.size();
+        return values.size() + pending.size();
     }
 
     @Override
     public int estimatedSize() {
-        return values.size();
+        return values.size() + pending.size();
     }
 
     @Override
     public Iterator<T> iterator() {
+        pending.flushPending();
+        return values.iterator();
+    }
+
+    @Override
+    public Iterator<T> iteratorNoFlush() {
         return values.iterator();
     }
 
     @Override
     public boolean contains(Object element) {
+        pending.flushPending();
         return values.contains(element);
     }
 
     @Override
     public boolean containsAll(Collection<?> elements) {
+        pending.flushPending();
         return values.containsAll(elements);
     }
 
@@ -75,6 +87,32 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
 
     @Override
     public void clear() {
+        pending.clear();
         values.clear();
+    }
+
+    @Override
+    public void flushPending() {
+        pending.flushPending();
+    }
+
+    @Override
+    public void flushPending(Class<?> type) {
+        pending.flushPending(type);
+    }
+
+    @Override
+    public void addPending(ProviderInternal<? extends T> provider) {
+        pending.addPending(provider);
+    }
+
+    @Override
+    public void removePending(ProviderInternal<? extends T> provider) {
+        pending.removePending(provider);
+    }
+
+    @Override
+    public void onFlush(Action<ProviderInternal<? extends T>> action) {
+        pending.onFlush(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -54,7 +54,7 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
 
     @Override
     public Iterator<T> iterator() {
-        pending.flushPending();
+        pending.realizePending();
         return values.iterator();
     }
 
@@ -65,13 +65,13 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
 
     @Override
     public boolean contains(Object element) {
-        pending.flushPending();
+        pending.realizePending();
         return values.contains(element);
     }
 
     @Override
     public boolean containsAll(Collection<?> elements) {
-        pending.flushPending();
+        pending.realizePending();
         return values.containsAll(elements);
     }
 
@@ -92,13 +92,13 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     }
 
     @Override
-    public void flushPending() {
-        pending.flushPending();
+    public void realizePending() {
+        pending.realizePending();
     }
 
     @Override
-    public void flushPending(Class<?> type) {
-        pending.flushPending(type);
+    public void realizePending(Class<?> type) {
+        pending.realizePending(type);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     }
 
     @Override
-    public void onFlush(Action<ProviderInternal<? extends T>> action) {
-        pending.onFlush(action);
+    public void onRealize(Action<ProviderInternal<? extends T>> action) {
+        pending.onRealize(action);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -53,19 +53,19 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         assert otherType.isInstance(d)
     }
 
-    def canGetAllDomainObjectsForEmptyCollection() {
+    def "can get all domain objects for empty collection"() {
         expect:
         container.isEmpty()
         container.size() == 0
     }
 
-    def canIterateOverEmptyCollection() {
+    def "can iterate over empty collection"() {
         expect:
         def iterator = container.iterator()
         !iterator.hasNext()
     }
 
-    def elementAddedUsingProviderIsNotRealizedWhenAdded() {
+    def "element added using provider is not realized when added"() {
         def provider = Mock(ProviderInternal)
 
         when:
@@ -80,7 +80,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !container.empty
     }
 
-    def providerForElementIsNotQueriedWhenAnotherElementAdded() {
+    def "provider for element is not queried when another element added"() {
         def provider = Mock(ProviderInternal)
 
         given:
@@ -98,7 +98,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !container.empty
     }
 
-    def canCheckForMembership() {
+    def "can check for membership"() {
         given:
         container.add(b)
         container.add(a)
@@ -108,7 +108,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.contains(a)
     }
 
-    def providerForElementIsQueriedWhenMembershipChecked() {
+    def "provider for element is queried when membership checked"() {
         def provider = Mock(ProviderInternal)
 
         given:
@@ -125,7 +125,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         1 * provider.get() >> a
     }
 
-    def canGetAllDomainObjectsOrderedByOrderAdded() {
+    def "can get all domain objects ordered by order added"() {
         given:
         container.add(b)
         container.add(a)
@@ -135,7 +135,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         toList(container) == iterationOrder(b, a, c)
     }
 
-    def canIterateOverDomainObjectsOrderedByOrderAdded() {
+    def "can iterate over domain objects ordered by order added"() {
         container.add(b)
         container.add(a)
         container.add(c)
@@ -150,7 +150,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         seen == iterationOrder(b, a, c)
     }
 
-    def providerForElementIsQueriedWhenElementsIteratedButInsertionOrderIsNotRetained() {
+    def "provider for element is queried when elements iterated but insertion order is not retained"() {
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
 
@@ -172,7 +172,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
-    def canGetFilteredCollectionContainingAllObjectsWhichHaveType() {
+    def "can get filtered collection containing all objects which have type"() {
         container.add(c)
         container.add(a)
         container.add(d)
@@ -182,7 +182,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         toList(container.withType(otherType)) == iterationOrder(d)
     }
 
-    def providerForElementIsQueriedWhenFilteredCollectionWithMatchingTypeCreated() {
+    def "provider for element is queried when filtered collection with matching type created"() {
         def provider = Mock(ProviderInternal)
 
         container.add(c)
@@ -212,7 +212,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * provider._
     }
 
-    def providerForElementIsNotQueriedWhenFilteredCollectionWithNonMatchingTypeCreated() {
+    def "provider for element is not queried when filtered collection with non matching type created"() {
         def provider = Mock(ProviderInternal)
 
         container.add(c)
@@ -242,7 +242,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * provider._
     }
 
-    def canExecuteActionForAllElementsInATypeFilteredCollection() {
+    def "can execute action for all elements in a type filtered collection"() {
         def action = Mock(Action)
 
         container.add(c)
@@ -263,7 +263,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * action._
     }
 
-    def canExecuteClosureForAllElementsInATypeFilteredCollection() {
+    def "can execute closure for all elements in a type filtered collection"() {
         def seen = []
         def closure = { seen << it }
 
@@ -283,7 +283,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         seen == [c, a]
     }
 
-    def actionForAllElementsInATypeFilteredCollectionCanAddMoreElements() {
+    def "action for all elements in a type filtered collection can add more elements"() {
         def action = Mock(Action)
 
         container.add(c)
@@ -300,7 +300,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * action._
     }
 
-    def providerForElementIsQueriedAndActionExecutedForFilteredCollectionWithMatchingType() {
+    def "provider for element is queried and action executed for filtered collection with matching type"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
@@ -327,7 +327,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
-    def providerForElementIsNotQueriedAndActionExecutedForFilteredCollectionWithNonMatchingType() {
+    def "provider for element is not queried and action executed for filtered collection with non matching type"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
@@ -351,7 +351,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
-    def canExecuteActionToConfigureElementWhenElementIsRealized() {
+    def "can execute action to configure element when element is realized"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
@@ -389,7 +389,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
-    def runsConfigureElementActionImmediatelyWhenElementAlreadyRealized() {
+    def "runs configure element action immediately when element already realized"() {
         def action = Mock(Action)
         def provider = Mock(ProviderInternal)
 
@@ -406,7 +406,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
-    def runsConfigureElementActionImmediatelyWhenElementAddedDirectly() {
+    def "runs configure element action immediately when element added directly"() {
         def action = Mock(Action)
 
         given:
@@ -420,7 +420,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
-    def canExecuteActionToConfigureElementOfGivenTypeWhenElementIsRealized() {
+    def "can execute action to configure element of given type when element is realized"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
@@ -453,4 +453,101 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
+    def "provider is not queried or element configured until collection is realized when lazy action is registered on type-filtered collection"() {
+        def action = Mock(Action)
+        def provider1 = Mock(ProviderInternal)
+        def provider2 = Mock(ProviderInternal)
+
+        given:
+        _ * provider1.type >> type
+        _ * provider2.type >> type
+        container.addLater(provider1)
+        container.addLater(provider2)
+        def filtered = container.withType(type)
+
+        when:
+        filtered.configureEachLater(action)
+
+        then:
+        0 * provider1.get()
+        0 * provider2.get()
+        0 * action.execute(_)
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        1 * provider1.get() >> a
+        1 * provider2.get() >> b
+        result == iterationOrder(a, b)
+
+        and:
+        1 * action.execute(a)
+        1 * action.execute(b)
+    }
+
+    def "only realized elements of given type are configured when lazy action is registered on type-filtered collection"() {
+        def action = Mock(Action)
+        def provider1 = Mock(ProviderInternal)
+        def provider2 = Mock(ProviderInternal)
+
+        given:
+        _ * provider1.type >> otherType
+        _ * provider2.type >> type
+        container.addLater(provider1)
+        container.addLater(provider2)
+        def filtered = container.withType(type)
+
+        when:
+        filtered.configureEachLater(action)
+
+        then:
+        0 * provider1.get()
+        0 * provider2.get()
+        0 * action.execute(_)
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        0 * provider1.get() >> a
+        1 * provider2.get() >> b
+        result == iterationOrder(b)
+
+        and:
+        0 * action.execute(a)
+        1 * action.execute(b)
+    }
+
+    def "provider is queried but element not configured when lazy action is registered on non-matching filter"() {
+        def action = Mock(Action)
+        def provider1 = Mock(ProviderInternal)
+        def provider2 = Mock(ProviderInternal)
+
+        given:
+        _ * provider1.type >> type
+        _ * provider2.type >> type
+        container.addLater(provider1)
+        container.addLater(provider2)
+        def filtered = container.matching { it == b }
+
+        when:
+        filtered.configureEachLater(action)
+
+        then:
+        0 * provider1.get()
+        0 * provider2.get()
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        1 * provider1.get() >> a
+        1 * provider2.get() >> b
+        result == iterationOrder(b)
+
+        and:
+        0 * action.execute(a)
+        1 * action.execute(b)
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/DefaultPendingSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/DefaultPendingSourceTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections
+
+import org.gradle.api.Action
+import org.gradle.api.internal.provider.ProviderInternal
+import spock.lang.Specification
+
+class DefaultPendingSourceTest extends Specification {
+    def pending = new DefaultPendingSource()
+    def provider1 = Mock(ProviderInternal)
+    def provider2 = Mock(ProviderInternal)
+    def provider3 = Mock(ProviderInternal)
+    def realize = Mock(Action)
+
+    def setup() {
+        pending.onRealize(realize)
+    }
+
+    def "realizes pending elements on flush"() {
+        when:
+        pending.addPending(provider1)
+        pending.addPending(provider2)
+        pending.addPending(provider3)
+        pending.realizePending()
+
+        then:
+        1 * realize.execute(provider1)
+        1 * realize.execute(provider2)
+        1 * realize.execute(provider3)
+
+        and:
+        pending.isEmpty()
+    }
+
+    def "realizes only pending elements with a given type"() {
+        _ * provider1.getType() >> SomeType.class
+        _ * provider2.getType() >> SomeOtherType.class
+        _ * provider3.getType() >> SomeType.class
+
+        when:
+        pending.addPending(provider1)
+        pending.addPending(provider2)
+        pending.addPending(provider3)
+        pending.realizePending(SomeType.class)
+
+        then:
+        1 * realize.execute(provider1)
+        0 * realize.execute(provider2)
+        1 * realize.execute(provider3)
+
+        and:
+        pending.size() == 1
+    }
+
+    def "cannot realize pending elements when realize action is not set"() {
+        given:
+        pending.onRealize(null)
+
+        when:
+        pending.addPending(provider1)
+        pending.addPending(provider2)
+        pending.addPending(provider3)
+        pending.realizePending()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "can remove pending elements"() {
+        when:
+        pending.addPending(provider1)
+        pending.addPending(provider2)
+        pending.addPending(provider3)
+        pending.removePending(provider1)
+
+        then:
+        pending.size() == 2
+
+        when:
+        pending.realizePending()
+
+        then:
+        0 * realize.execute(provider1)
+        1 * realize.execute(provider2)
+        1 * realize.execute(provider3)
+
+        and:
+        pending.isEmpty()
+    }
+
+    def "can clear pending elements"() {
+        when:
+        pending.addPending(provider1)
+        pending.addPending(provider2)
+        pending.addPending(provider3)
+        pending.clear()
+
+        then:
+        pending.isEmpty()
+
+        when:
+        pending.realizePending()
+
+        then:
+        0 * realize.execute()
+    }
+
+    class BaseType {}
+    class SomeType extends BaseType {}
+    class SomeOtherType extends BaseType {}
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -122,16 +122,13 @@ abstract class WellBehavedPluginTest extends AbstractIntegrationSpec {
                     return
                 }
                 
-                assert configuredTasks.size() == 3
+                assert configuredTasks.size() == 2
 
                 // This should be the only task configured
                 assert ":help" in configuredTaskPaths
                 
                 // This task needs to be able to register publications lazily
                 assert ":jar" in configuredTaskPaths
-                
-                // This task is eagerly configured with configureEachLater
-                assert ":test" in configuredTaskPaths
             }
         """
         expect:


### PR DESCRIPTION
This refactors the "pending" elements in domain object collections so that there is always a single set of elements and a single set of pending elements that travel around together regardless of how they are filtered or layered.

This fixes #5148 as well as the known issue of `configureEachLater()` eagerly creating tasks.