### PR TITLE
More concurrency fixes in parallel dependency resolution

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -55,8 +55,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
             return new DefaultBuildableCompositeBuildContext(moduleIdentifierFactory);
         }
 
-        public LocalComponentProvider createLocalComponentProvider(BuildStateRegistry buildRegistry) {
-            return new LocalComponentInAnotherBuildProvider(buildRegistry, new IncludedBuildDependencyMetadataBuilder());
+        public LocalComponentProvider createLocalComponentProvider(ProjectStateRegistry projectRegistry) {
+            return new LocalComponentInAnotherBuildProvider(projectRegistry, new IncludedBuildDependencyMetadataBuilder());
         }
 
         public IncludedBuildControllers createIncludedBuildControllers(ExecutorFactory executorFactory, BuildStateRegistry buildRegistry) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/LocalComponentInAnotherBuildProvider.java
@@ -22,11 +22,14 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentProvider;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -35,8 +38,8 @@ import java.util.concurrent.ExecutionException;
  * Currently, the metadata for a component is different based on whether it is consumed from the producing build or from another build. This difference should go away, but in the meantime this class provides the mapping.
  */
 public class LocalComponentInAnotherBuildProvider implements LocalComponentProvider {
+    private final ProjectStateRegistry projectRegistry;
     private final IncludedBuildDependencyMetadataBuilder dependencyMetadataBuilder;
-    private final BuildStateRegistry buildRegistry;
     private final LoadingCache<ProjectComponentIdentifier, LocalComponentMetadata> projectMetadata = CacheBuilder.newBuilder().build(new CacheLoader<ProjectComponentIdentifier, LocalComponentMetadata>() {
         @Override
         public LocalComponentMetadata load(ProjectComponentIdentifier projectIdentifier) {
@@ -44,9 +47,9 @@ public class LocalComponentInAnotherBuildProvider implements LocalComponentProvi
         }
     });
 
-    public LocalComponentInAnotherBuildProvider(BuildStateRegistry buildRegistry, IncludedBuildDependencyMetadataBuilder dependencyMetadataBuilder) {
+    public LocalComponentInAnotherBuildProvider(ProjectStateRegistry projectRegistry, IncludedBuildDependencyMetadataBuilder dependencyMetadataBuilder) {
+        this.projectRegistry = projectRegistry;
         this.dependencyMetadataBuilder = dependencyMetadataBuilder;
-        this.buildRegistry = buildRegistry;
     }
 
     @Override
@@ -60,8 +63,17 @@ public class LocalComponentInAnotherBuildProvider implements LocalComponentProvi
         }
     }
 
-    private LocalComponentMetadata getRegisteredProject(ProjectComponentIdentifier project) {
-        IncludedBuildState includedBuild = buildRegistry.getIncludedBuild(project.getBuild());
-        return dependencyMetadataBuilder.build(includedBuild, project);
+    private LocalComponentMetadata getRegisteredProject(final ProjectComponentIdentifier project) {
+        ProjectState projectState = projectRegistry.stateFor(project);
+        // TODO - this should work for any build, rather than just an included build
+        final IncludedBuildState includedBuild = (IncludedBuildState) projectState.getOwner();
+        // Metadata builder uses mutable project state, so synchronize access to the project state
+        return projectState.withMutableState(new Factory<LocalComponentMetadata>() {
+            @Nullable
+            @Override
+            public LocalComponentMetadata create() {
+                return dependencyMetadataBuilder.build(includedBuild, project);
+            }
+        });
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
@@ -214,6 +214,7 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
+                task jar {} // ignored
                 task checkArtifacts {
                     inputs.files configurations.compile
                     doLast {
@@ -253,6 +254,7 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
+                task jar {} // ignored
                 task checkArtifacts {
                     inputs.files configurations.compile
                     doLast {
@@ -296,6 +298,7 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
+                task classes {} // ignored
                 task checkArtifacts {
                     inputs.files configurations.compile
                     doLast {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
@@ -69,7 +69,6 @@ public class DefaultProjectLocalComponentProvider implements LocalComponentProvi
         if (!isLocalProject(projectIdentifier)) {
             return null;
         }
-        Object result;
         try {
             return projects.get(projectIdentifier);
         } catch (ExecutionException e) {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/CompositeBuildIdeaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/CompositeBuildIdeaProjectIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.plugins.ide.fixtures.IdeaFixtures
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
-import spock.lang.Ignore
 
 /**
  * Tests for generating IDEA metadata for projects within a composite build.
@@ -170,8 +169,6 @@ class CompositeBuildIdeaProjectIntegrationTest extends AbstractIntegrationSpec {
         imlHasDependencies(["buildB"], ["external-dep-1.0.jar"])
     }
 
-    @Issue("https://github.com/gradle/gradle-private/issues/1145")	
-    @Ignore
     def "builds IDEA metadata with dependency cycle between substituted projects in a multiproject build"() {
         given:
         dependency "org.test:buildB:1.0"


### PR DESCRIPTION

### Context

This change plugs another hole where multiple threads can reach across and touch the mutable state of a project at the same time, causing problems when this causes lazy mutations to happen.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
