### PR TITLE
Don't pass empty string value to `-cp`

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -97,8 +97,11 @@ public class DefaultDaemonStarter implements DaemonStarter {
 
         List<String> daemonOpts = daemonParameters.getEffectiveJvmArgs();
         daemonArgs.addAll(daemonOpts);
-        daemonArgs.add("-cp");
-        daemonArgs.add(CollectionUtils.join(File.pathSeparator, classpath.getAsFiles()));
+
+        if (!classpath.isEmpty()) {
+            daemonArgs.add("-cp");
+            daemonArgs.add(CollectionUtils.join(File.pathSeparator, classpath.getAsFiles()));
+        }
 
         if (Boolean.getBoolean("org.gradle.daemon.debug")) {
             daemonArgs.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");


### PR DESCRIPTION
Because it has become illegal starting with Java 9.

https://bugs.openjdk.java.net/browse/JDK-8172215

This allows TestKit to be used from a TestKit test on Java 9 like it's done in [this Kotlin DSL test](https://github.com/gradle/kotlin-dsl/blob/09cc3f5374ba38e3f5fdd177ddb7b383699ff009/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/TestKitIntegrationTest.kt#L27).