### PR TITLE
Fix ClassCastException upon 'gradle eclipse'

### DIFF
--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -74,13 +74,13 @@ open class IdePlugin : Plugin<Project> {
                 classpath {
                     file.whenMerged(Action<Classpath> {
                         //There are classes in here not designed to be compiled, but just used in our testing
-                        entries.removeAll { (it as AbstractClasspathEntry).path.contains("src/integTest/resources") }
+                        entries.removeAll { it is AbstractClasspathEntry && it.path.contains("src/integTest/resources") }
                         //Workaround for some projects referring to themselves as dependent projects
-                        entries.removeAll { (it as AbstractClasspathEntry).path.contains("$project.name") && it.kind == "src" }
+                        entries.removeAll { it is AbstractClasspathEntry && it.path.contains("$project.name") && it.kind == "src" }
                         // Remove references to libraries in the build folder
-                        entries.removeAll { (it as AbstractClasspathEntry).path.contains("$project.name/build") && it.kind == "lib" }
+                        entries.removeAll { it is AbstractClasspathEntry && it.path.contains("$project.name/build") && it.kind == "lib" }
                         // Remove references to other project's binaries
-                        entries.removeAll { (it as AbstractClasspathEntry).path.contains("/subprojects") && it.kind == "lib" }
+                        entries.removeAll { it is AbstractClasspathEntry && it.path.contains("/subprojects") && it.kind == "lib" }
                         // Add needed resources for running gradle as a non daemon java application
                         entries.add(SourceFolder("build/generated-resources/main", null))
                         if (file("build/generated-resources/test").exists()) {


### PR DESCRIPTION
Resolves Issue: #5278

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
