### PR TITLE
Use the correct compiler tool when probing the system libraries for native language

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/plugins/AssemblerLangPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/plugins/AssemblerLangPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.language.nativeplatform.internal.NativeLanguageTransform;
 import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.internal.DefaultTool;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.ComponentType;
 import org.gradle.platform.base.TypeBuilder;
 
@@ -65,6 +66,11 @@ public class AssemblerLangPlugin implements Plugin<Project> {
         @Override
         public String getLanguageName() {
             return "asm";
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.ASSEMBLER;
         }
 
         @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/c/plugins/CLangPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/c/plugins/CLangPlugin.java
@@ -36,6 +36,7 @@ import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.internal.DefaultPreprocessingTool;
 import org.gradle.nativeplatform.internal.pch.PchEnabledLanguageTransform;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.ComponentType;
 import org.gradle.platform.base.TypeBuilder;
 
@@ -83,6 +84,11 @@ public class CLangPlugin implements Plugin<Project> {
         @Override
         public String getLanguageName() {
             return "c";
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.C_COMPILER;
         }
 
         @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLangPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLangPlugin.java
@@ -37,6 +37,7 @@ import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.internal.DefaultPreprocessingTool;
 import org.gradle.nativeplatform.internal.pch.PchEnabledLanguageTransform;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.ComponentType;
 import org.gradle.platform.base.TypeBuilder;
 
@@ -84,6 +85,11 @@ public class CppLangPlugin implements Plugin<Project> {
         @Override
         public String getLanguageName() {
             return "cpp";
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.CPP_COMPILER;
         }
 
         @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/CompileTaskConfig.java
@@ -26,12 +26,10 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.internal.LanguageSourceSetInternal;
 import org.gradle.language.base.internal.SourceTransformTaskConfig;
-import org.gradle.language.base.internal.registry.LanguageTransform;
 import org.gradle.language.nativeplatform.DependentSourceSet;
 import org.gradle.language.nativeplatform.HeaderExportingSourceSet;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
 import org.gradle.nativeplatform.NativeDependencySet;
-import org.gradle.nativeplatform.ObjectFile;
 import org.gradle.nativeplatform.PreprocessingTool;
 import org.gradle.nativeplatform.SharedLibraryBinarySpec;
 import org.gradle.nativeplatform.Tool;
@@ -52,10 +50,10 @@ import java.util.concurrent.Callable;
 
 public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
 
-    private final LanguageTransform<? extends LanguageSourceSet, ObjectFile> languageTransform;
+    private final NativeLanguageTransform<?> languageTransform;
     private final Class<? extends DefaultTask> taskType;
 
-    public CompileTaskConfig(LanguageTransform<? extends LanguageSourceSet, ObjectFile> languageTransform, Class<? extends DefaultTask> taskType) {
+    public CompileTaskConfig(NativeLanguageTransform<?> languageTransform, Class<? extends DefaultTask> taskType) {
         this.languageTransform = languageTransform;
         this.taskType = taskType;
     }
@@ -76,7 +74,7 @@ public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
         configureCompileTask((AbstractNativeCompileTask) task, (NativeBinarySpecInternal) binary, (LanguageSourceSetInternal) sourceSet);
     }
 
-    private void configureCompileTaskCommon(AbstractNativeCompileTask task, final NativeBinarySpecInternal binary, final LanguageSourceSetInternal sourceSet) {
+    private void configureCompileTaskCommon(final AbstractNativeCompileTask task, final NativeBinarySpecInternal binary, final LanguageSourceSetInternal sourceSet) {
         task.getToolChain().set(binary.getToolChain());
         task.getTargetPlatform().set(binary.getTargetPlatform());
         task.setPositionIndependentCode(binary instanceof SharedLibraryBinarySpec);
@@ -97,7 +95,7 @@ public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
             @Override
             public Set<File> getFiles() {
                 PlatformToolProvider platformToolProvider = ((NativeToolChainInternal) binary.getToolChain()).select((NativePlatformInternal) binary.getTargetPlatform());
-                ToolType toolType = determineToolType(languageTransform.getLanguageName());
+                ToolType toolType = languageTransform.getToolType();
                 return new LinkedHashSet<File>(platformToolProvider.getSystemLibraries(toolType).getIncludeDirs());
             }
 
@@ -115,13 +113,6 @@ public abstract class CompileTaskConfig implements SourceTransformTaskConfig {
 
             task.getCompilerArgs().set(tool.getArgs());
         }
-    }
-
-    private ToolType determineToolType(String languageName) {
-        if (languageName.equals("cpp")) {
-            return ToolType.CPP_COMPILER;
-        }
-        return ToolType.C_COMPILER;
     }
 
     abstract void configureCompileTask(AbstractNativeCompileTask task, final NativeBinarySpecInternal binary, final LanguageSourceSetInternal sourceSet);

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/NativeLanguageTransform.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/NativeLanguageTransform.java
@@ -20,6 +20,7 @@ import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.internal.registry.LanguageTransform;
 import org.gradle.nativeplatform.NativeBinarySpec;
 import org.gradle.nativeplatform.ObjectFile;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.BinarySpec;
 
 public abstract class NativeLanguageTransform<U extends LanguageSourceSet> implements LanguageTransform<U, ObjectFile> {
@@ -28,6 +29,8 @@ public abstract class NativeLanguageTransform<U extends LanguageSourceSet> imple
     public boolean applyToBinary(BinarySpec binary) {
         return binary instanceof NativeBinarySpec;
     }
+
+    public abstract ToolType getToolType();
 
     @Override
     public Class<ObjectFile> getOutputType() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/PCHCompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/PCHCompileTaskConfig.java
@@ -20,11 +20,8 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.internal.LanguageSourceSetInternal;
-import org.gradle.language.base.internal.registry.LanguageTransform;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
-import org.gradle.nativeplatform.ObjectFile;
 import org.gradle.nativeplatform.internal.NativeBinarySpecInternal;
 import org.gradle.nativeplatform.tasks.PrefixHeaderFileGenerateTask;
 import org.gradle.nativeplatform.toolchain.internal.PreCompiledHeader;
@@ -32,7 +29,7 @@ import org.gradle.nativeplatform.toolchain.internal.PreCompiledHeader;
 import java.io.File;
 
 public class PCHCompileTaskConfig extends CompileTaskConfig {
-    public PCHCompileTaskConfig(LanguageTransform<? extends LanguageSourceSet, ObjectFile> languageTransform, Class<? extends DefaultTask> taskType) {
+    public PCHCompileTaskConfig(NativeLanguageTransform<?> languageTransform, Class<? extends DefaultTask> taskType) {
         super(languageTransform, taskType);
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/SourceCompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/SourceCompileTaskConfig.java
@@ -19,19 +19,16 @@ package org.gradle.language.nativeplatform.internal;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.internal.LanguageSourceSetInternal;
-import org.gradle.language.base.internal.registry.LanguageTransform;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask;
-import org.gradle.nativeplatform.ObjectFile;
 import org.gradle.nativeplatform.internal.NativeBinarySpecInternal;
 import org.gradle.nativeplatform.toolchain.internal.PreCompiledHeader;
 
 import java.io.File;
 
 public class SourceCompileTaskConfig extends CompileTaskConfig {
-    public SourceCompileTaskConfig(LanguageTransform<? extends LanguageSourceSet, ObjectFile> languageTransform, Class<? extends DefaultTask> taskType) {
+    public SourceCompileTaskConfig(NativeLanguageTransform<?> languageTransform, Class<? extends DefaultTask> taskType) {
         super(languageTransform, taskType);
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/objectivec/plugins/ObjectiveCLangPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/objectivec/plugins/ObjectiveCLangPlugin.java
@@ -35,6 +35,7 @@ import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.internal.DefaultPreprocessingTool;
 import org.gradle.nativeplatform.internal.pch.PchEnabledLanguageTransform;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.ComponentType;
 import org.gradle.platform.base.TypeBuilder;
 
@@ -80,6 +81,11 @@ public class ObjectiveCLangPlugin implements Plugin<Project> {
         @Override
         public String getLanguageName() {
             return "objc";
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.OBJECTIVEC_COMPILER;
         }
 
         @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/objectivecpp/plugins/ObjectiveCppLangPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/objectivecpp/plugins/ObjectiveCppLangPlugin.java
@@ -35,6 +35,7 @@ import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.internal.DefaultPreprocessingTool;
 import org.gradle.nativeplatform.internal.pch.PchEnabledLanguageTransform;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.ComponentType;
 import org.gradle.platform.base.TypeBuilder;
 
@@ -80,6 +81,11 @@ public class ObjectiveCppLangPlugin implements Plugin<Project> {
         @Override
         public String getLanguageName() {
             return "objcpp";
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.OBJECTIVECPP_COMPILER;
         }
 
         @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/plugins/WindowsResourceScriptPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/plugins/WindowsResourceScriptPlugin.java
@@ -31,6 +31,7 @@ import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.NativeBinarySpec;
 import org.gradle.nativeplatform.internal.DefaultPreprocessingTool;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
 import org.gradle.platform.base.BinarySpec;
 import org.gradle.platform.base.ComponentType;
 import org.gradle.platform.base.TypeBuilder;
@@ -77,6 +78,11 @@ public class WindowsResourceScriptPlugin implements Plugin<Project> {
         @Override
         public String getLanguageName() {
             return "rc";
+        }
+
+        @Override
+        public ToolType getToolType() {
+            return ToolType.WINDOW_RESOURCES_COMPILER;
         }
 
         @Override


### PR DESCRIPTION

### Context

This change improves the accuracy of the system library calculation for native languages built using the software model + a GCC compatible tool chain, by passing the correct language selection command-line options to the compiler when probing the compiler implementation. In practice this currently only affects the objective-c++ system headers.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
