### PR TITLE
Fix repository mirror script for older versions

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -122,7 +122,8 @@ class RepoScriptBlockUtil {
         }.join("")
         mirrors << """
             import groovy.transform.CompileStatic
-
+            import groovy.transform.CompileDynamic
+            
             apply plugin: MirrorPlugin
 
             @CompileStatic
@@ -136,9 +137,15 @@ class RepoScriptBlockUtil {
                             withMirrors(project.repositories)
                         }
                     }
-        
-                    gradle.settingsEvaluated { Settings settings ->
-                        withMirrors(settings.pluginManagement.repositories)
+                    maybeConfigurePluginManagement(gradle)
+                }
+
+                @CompileDynamic
+                void maybeConfigurePluginManagement(Gradle gradle) {
+                    if (gradle.gradleVersion >= "4.4") {
+                        gradle.settingsEvaluated { Settings settings ->
+                            withMirrors(settings.pluginManagement.repositories)
+                        }
                     }
                 }
                 


### PR DESCRIPTION
Older Gradle versions don't have the PluginMangement block.
Compile that part dynamically and only invoke it on newer versions.