### PR TITLE
Support execution of component metadata rules on top of user provided metadata

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataBuilder.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
 
 import java.util.List;
 
@@ -38,4 +40,20 @@ public interface ComponentMetadataBuilder {
      * @param scheme the status scheme
      */
     void setStatusScheme(List<String> scheme);
+
+    /**
+     * Configures the attributes of this component
+     * @param attributesConfiguration the configuration action
+     *
+     * @since 4.9
+     */
+    void attributes(Action<? super AttributeContainer> attributesConfiguration);
+
+    /**
+     * Returns the attributes of the component.
+     * @return the attributes of the component, guaranteed to be mutable.
+     *
+     * @since 4.9
+     */
+    AttributeContainer getAttributes();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.suppliers
+
+import groovy.json.JsonBuilder
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures([
+    // we only need to check without experimental, it doesn't depend on this flag
+    @RequiredFeature(feature = GradleMetadataResolveRunner.EXPERIMENTAL_RESOLVE_BEHAVIOR, value = "false"),
+    // we only need to check without Gradle metadata, it doesn't matter either
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
+])
+class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDependencyResolveTest {
+    private final static String TEST_A_METADATA = new JsonBuilder(
+        [
+            [version: '3', attributes: ['org.gradle.status': 'release', 'custom': 'foo']],
+            [version: '2', attributes: ['org.gradle.status': 'integration', 'custom': 'bar']],
+            [version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'bar']]
+        ]
+    )
+    private final static String TEST_B_METADATA = new JsonBuilder(
+        [
+            [version: '2', attributes: ['org.gradle.status': 'release', 'custom': 'bar']],
+            [version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'foo']]
+        ]
+    )
+    private final static String ALL_METADATA = new JsonBuilder(
+        [
+            [group:'org', name: 'testA', version: '3', attributes: ['org.gradle.status': 'release', 'custom': 'foo']],
+            [group:'org', name: 'testA', version: '2', attributes: ['org.gradle.status': 'integration', 'custom': 'bar']],
+            [group:'org', name: 'testA', version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'bar']],
+            [group:'org', name: 'testB', version: '2', attributes: ['org.gradle.status': 'release', 'custom': 'bar']],
+            [group:'org', name: 'testB', version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'foo']]
+        ]
+    )
+
+    void "can use the same remote cached external resource to get both version list and module metadata"() {
+        def versions = ['org:testA': TEST_A_METADATA,
+                        'org:testB': TEST_B_METADATA]
+        def supplierInteractions = withPerModuleExternalResourceListerAndSupplier(versions, true)
+        given:
+        repository {
+            'org:testA:1'()
+            'org:testA:2'()
+            'org:testA:3'()
+            'org:testB:1'()
+            'org:testB:2'()
+        }
+        buildFile << """
+            def customAttr = Attribute.of('custom', String)
+            
+            dependencies {
+                conf "org:testA:latest.release"
+                conf "org:testB:latest.release"
+            }
+            
+            configurations.conf.attributes.attribute(customAttr, 'bar')
+        """
+
+        when:
+        supplierInteractions.expectGetMetadata('org', 'testA') // one network request for A
+        supplierInteractions.expectGetMetadata('org', 'testB') // and one for B
+        repositoryInteractions {
+            // only the resolved modules are going to get their metadata files fetched (for variant matching)
+            // and no additional network request is performed because we got the attributes from the same
+            // cached external resource
+            'org:testA:1' {
+                expectResolve()
+            }
+            'org:testB:2' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDeps'
+
+        and:
+        outputContains "Listing versions for module testA"
+        outputContains "Listed [3, 2, 1] for org:testA"
+        outputContains "Supplying metadata for module org:testA:3"
+        outputContains "Supplying metadata for module org:testA:2"
+        outputContains "Supplying metadata for module org:testA:1"
+        outputContains "Listing versions for module testB"
+        outputContains "Listed [2, 1] for org:testB"
+        outputContains "Supplying metadata for module org:testB:2"
+        outputDoesNotContain("Supplying metadata for module org:testB:1")
+    }
+
+    void "can use the same remote cached external resource to get both version list and module metadata for all modules at once"() {
+        withGlobalExternalResourceListerAndSupplier(ALL_METADATA, true)
+        given:
+        repository {
+            'org:testA:1'()
+            'org:testA:2'()
+            'org:testA:3'()
+            'org:testB:1'()
+            'org:testB:2'()
+        }
+        buildFile << """
+            def customAttr = Attribute.of('custom', String)
+            
+            dependencies {
+                conf "org:testA:latest.release"
+                conf "org:testB:latest.release"
+            }
+            
+            configurations.conf.attributes.attribute(customAttr, 'bar')
+        """
+
+        when:
+        repositoryInteractions {
+            // only the resolved modules are going to get their metadata files fetched (for variant matching)
+            // and no additional network request is performed because we got the attributes from the same
+            // cached external resource
+            'org:testA:1' {
+                expectResolve()
+            }
+            'org:testB:2' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDeps'
+
+        and:
+        outputContains("""Listing versions for module testA
+Listed [3, 2, 1] for org:testA
+Supplying metadata for module org:testA:3
+Supplying metadata for module org:testA:2
+Supplying metadata for module org:testA:1
+Listing versions for module testB
+Listed [2, 1] for org:testB
+Supplying metadata for module org:testB:2
+""")
+        outputDoesNotContain("Supplying metadata for module org:testB:1")
+    }
+
+    private ListerAndSupplierInteractions withPerModuleExternalResourceListerAndSupplier(Map<String, String> moduleToVersions, boolean logQueries = false) {
+        metadataListerClass = 'MyLister'
+        metadataSupplierClass = 'MySupplier'
+        buildFile << """import groovy.json.JsonSlurper
+
+            class MyLister implements ComponentMetadataVersionLister {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataListerDetails details) {
+                    def id = details.moduleIdentifier
+                    if ($logQueries) { println("Listing versions for module \$id.name") }
+                    repositoryResourceAccessor.withResource("\${id.group}/\${id.name}/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def versions = json.collect { it.version }
+                        if ($logQueries) { println("Listed \$versions for \$id") }
+                        details.listed(versions)
+                    }
+                }
+            }
+            
+            class MySupplier implements ComponentMetadataSupplier {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MySupplier(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataSupplierDetails details) {
+                    def id = details.id
+                    if ($logQueries) { println("Supplying metadata for module \$id") }
+                    repositoryResourceAccessor.withResource("\${id.group}/\${id.module}/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def version = json.find { it.version == id.version }
+                        details.result.attributes { attrs ->
+                            version.attributes.each { k, v ->
+                                attrs.attribute(Attribute.of(k, String), v)
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        def files = [:]
+        moduleToVersions.each { module, json ->
+            def file = temporaryFolder.createFile("metadata-${module}.json")
+            file.setText(json, 'utf-8')
+            files[module] = file
+        }
+        new ExternalResourceListerInteractions(files)
+    }
+
+    private ListerAndSupplierInteractions withGlobalExternalResourceListerAndSupplier(String jsonFile, boolean logQueries = false) {
+        metadataListerClass = 'MyLister'
+        metadataSupplierClass = 'MySupplier'
+        buildFile << """import groovy.json.JsonSlurper
+
+            class MyLister implements ComponentMetadataVersionLister {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataListerDetails details) {
+                    def id = details.moduleIdentifier
+                    if ($logQueries) { println("Listing versions for module \$id.name") }
+                    repositoryResourceAccessor.withResource("/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def versions = json.findAll { it.name == id.name && it.group == id.group }.collect { it.version }
+                        if ($logQueries) { println("Listed \$versions for \$id") }
+                        details.listed(versions)
+                    }
+                }
+            }
+            
+            class MySupplier implements ComponentMetadataSupplier {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MySupplier(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataSupplierDetails details) {
+                    def id = details.id
+                    if ($logQueries) { println("Supplying metadata for module \$id") }
+                    repositoryResourceAccessor.withResource("/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def version = json.find { it.group == id.group && it.name == id.module && it.version == id.version }
+                        details.result.attributes { attrs ->
+                            version.attributes.each { k, v ->
+                                attrs.attribute(Attribute.of(k, String), v)
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        def file = temporaryFolder.createFile("metadata-all.json")
+        file.setText(jsonFile, 'utf-8')
+        server.expectGet("/repo/metadata.json", file)
+        new ExternalResourceListerInteractions([:])
+    }
+
+    interface ListerAndSupplierInteractions {
+        void expectGetMetadata(String group, String module)
+
+        void expectRefresh(String group, String module)
+    }
+
+
+    class ExternalResourceListerInteractions implements ListerAndSupplierInteractions {
+        private final Map<String, File> files
+
+        ExternalResourceListerInteractions(Map<String, File> files) {
+            this.files = files
+        }
+
+        @Override
+        void expectGetMetadata(String group, String module) {
+            String id = "$group:$module"
+            server.expectGet("/repo/${group.replace('.', '/')}/$module/metadata.json", files[id])
+        }
+
+        @Override
+        void expectRefresh(String group, String module) {
+            String id = "$group:$module"
+            server.expectHead("/repo/${group.replace('.', '/')}/$module/metadata.json", files[id])
+        }
+    }
+
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
@@ -203,7 +203,7 @@ Supplying metadata for module org:testB:2
         """
         def files = [:]
         moduleToVersions.each { module, json ->
-            def file = temporaryFolder.createFile("metadata-${module}.json")
+            def file = temporaryFolder.createFile("metadata-${module.replace(':', '_')}.json")
             file.setText(json, 'utf-8')
             files[module] = file
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.HttpModule
 import org.gradle.test.fixtures.server.http.IvyHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpModule
-import spock.lang.Ignore
 
 @RequiredFeatures([
     // we only need to check without experimental, it doesn't depend on this flag
@@ -837,7 +836,6 @@ group:projectB:2.2;release
         new SimpleSupplierInteractions()
     }
 
-    @Ignore("Component metadata rules are not yet wired after metadata suppliers")
     def "component metadata rules are executed after metadata supplier is called"() {
         given:
         def supplierInteractions = withPerVersionStatusSupplier()
@@ -884,7 +882,11 @@ group:projectB:2.2;release
 
         then:
         outputContains 'Providing metadata for group:projectB:1.1'
-        outputContains "Changing status for 'group:projectB:1.1' from 'should be overriden by rule' to 'release'"
+        // first one comes from the rule executed on shallow metadata, provided by a rule
+        outputContains "Changing status for group:projectB:1.1 from 'should be overriden by rule' to 'release'"
+
+        // second one comes from the rule executed on "real" metadata, after parsing the module
+        outputContains "Changing status for group:projectB:1.1 from '${GradleMetadataResolveRunner.useIvy()?'integration':'release'}' to 'release'"
     }
 
     def checkResolve(Map edges) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
 public interface ComponentMetadataProcessor {
@@ -23,7 +24,20 @@ public interface ComponentMetadataProcessor {
         public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
             return metadata;
         }
+
+        @Override
+        public ComponentMetadata processMetadata(ComponentMetadata metadata) {
+            return metadata;
+        }
     };
 
     ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata);
+
+    /**
+     * Processes "shallow" metadata, only for selecting a version. This metadata is typically
+     * provided by a custom metadata processor.
+     * @param metadata the metadata to be processed
+     * @return updated metadata, if any component metadata rule applies.
+     */
+    ComponentMetadata processMetadata(ComponentMetadata metadata);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -243,8 +243,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory);
         }
 
-        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner) {
-            return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner);
+        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory) {
+            return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory);
         }
 
         DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -295,7 +295,8 @@ class DependencyManagementBuildScopeServices {
             versionSelectorScheme,
             versionComparator,
             moduleIdentifierFactory,
-            repositoryBlacklister, versionParser);
+            repositoryBlacklister,
+            versionParser);
     }
 
     ArtifactDependencyResolver createArtifactDependencyResolver(ResolveIvyFactory resolveIvyFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -21,18 +21,26 @@ import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.VariantMetadata;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.UserProvidedMetadata;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
@@ -66,8 +74,13 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     private final NotationParser<Object, ModuleIdentifier> moduleIdentifierNotationParser;
     private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+    private final ImmutableAttributesFactory attributesFactory;
 
-    public DefaultComponentMetadataHandler(Instantiator instantiator, RuleActionAdapter<ComponentMetadataDetails> ruleActionAdapter, ImmutableModuleIdentifierFactory moduleIdentifierFactory, Interner<String> stringInterner) {
+    public DefaultComponentMetadataHandler(Instantiator instantiator,
+                                           RuleActionAdapter<ComponentMetadataDetails> ruleActionAdapter,
+                                           ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                                           Interner<String> stringInterner,
+                                           ImmutableAttributesFactory attributesFactory) {
         this.instantiator = instantiator;
         this.ruleActionAdapter = ruleActionAdapter;
         this.moduleIdentifierNotationParser = NotationParserBuilder
@@ -76,10 +89,11 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
             .toComposite();
         this.dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl.class, stringInterner);
         this.dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl.class, stringInterner);
+        this.attributesFactory = attributesFactory;
     }
 
-    public DefaultComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, Interner<String> stringInterner) {
-        this(instantiator, createAdapter(), moduleIdentifierFactory, stringInterner);
+    public DefaultComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, Interner<String> stringInterner, ImmutableAttributesFactory attributesFactory) {
+        this(instantiator, createAdapter(), moduleIdentifierFactory, stringInterner, attributesFactory);
     }
 
     private static RuleActionAdapter<ComponentMetadataDetails> createAdapter() {
@@ -150,6 +164,22 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
         return updatedMetadata;
     }
 
+    @Override
+    public ComponentMetadata processMetadata(ComponentMetadata metadata) {
+        ComponentMetadata updatedMetadata;
+        if (rules.isEmpty()) {
+            updatedMetadata = metadata;
+        } else {
+            ShallowComponentMetadataAdapter details = new ShallowComponentMetadataAdapter(metadata, attributesFactory);
+            processAllRules(null, details);
+            updatedMetadata = details.asImmutable();
+        }
+        if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
+            throw new ModuleVersionResolveException(updatedMetadata.getId(), String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().toString(), updatedMetadata.getStatusScheme()));
+        }
+        return updatedMetadata;
+    }
+
     private void processAllRules(ModuleComponentResolveMetadata metadata, ComponentMetadataDetails details) {
         for (SpecRuleAction<? super ComponentMetadataDetails> rule : rules) {
             processRule(rule, metadata, details);
@@ -197,6 +227,80 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
 
         public boolean isSatisfiedBy(ComponentMetadataDetails componentMetadataDetails) {
             return componentMetadataDetails.getId().getGroup().equals(target.getGroup()) && componentMetadataDetails.getId().getName().equals(target.getName());
+        }
+    }
+
+    static class ShallowComponentMetadataAdapter implements ComponentMetadataDetails {
+        private final ModuleVersionIdentifier id;
+        private boolean changing;
+        private List<String> statusScheme;
+        private AttributeContainerInternal attributes;
+
+        public ShallowComponentMetadataAdapter(ComponentMetadata source, ImmutableAttributesFactory attributesFactory) {
+            id = source.getId();
+            changing = source.isChanging();
+            statusScheme = source.getStatusScheme();
+            attributes = attributesFactory.mutable((AttributeContainerInternal) source.getAttributes());
+        }
+
+        @Override
+        public void setChanging(boolean changing) {
+            this.changing = changing;
+        }
+
+        @Override
+        public void setStatus(String status) {
+            this.attributes.attribute(ProjectInternal.STATUS_ATTRIBUTE, status);
+        }
+
+        @Override
+        public void setStatusScheme(List<String> statusScheme) {
+            this.statusScheme = statusScheme;
+        }
+
+        @Override
+        public void withVariant(String name, Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
+        public void allVariants(Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
+        public ModuleVersionIdentifier getId() {
+            return id;
+        }
+
+        @Override
+        public boolean isChanging() {
+            return changing;
+        }
+
+        @Override
+        public String getStatus() {
+            return attributes.getAttribute(ProjectInternal.STATUS_ATTRIBUTE);
+        }
+
+        @Override
+        public List<String> getStatusScheme() {
+            return statusScheme;
+        }
+
+        @Override
+        public ComponentMetadataDetails attributes(Action<? super AttributeContainer> action) {
+            action.execute(attributes);
+            return this;
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return attributes;
+        }
+
+        public ComponentMetadata asImmutable() {
+            return new UserProvidedMetadata(id, statusScheme, attributes.asImmutable());
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -124,8 +124,10 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
         }
 
         // At this point, we need the component metadata, because it may declare attributes that are needed for matching
-        if (provider.resolve()) {
-            AttributeContainerInternal attributes = (AttributeContainerInternal) provider.getMetaData().getAttributes();
+        // Component metadata may not necessarily hit the network if there is a custom component metadata supplier
+        ComponentMetadata componentMetadata = provider.getComponentMetadata();
+        if (componentMetadata != null) {
+            AttributeContainerInternal attributes = (AttributeContainerInternal) componentMetadata.getAttributes();
             boolean matching = attributesSchema.matcher().isMatching(attributes, consumerAttributes);
             if (!matching) {
                 return new RejectedByAttributesVersion(id, attributesSchema.matcher().describeMatching(attributes, consumerAttributes));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProvider.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import com.google.common.collect.Lists;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.api.artifacts.ComponentMetadataBuilder;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
@@ -23,16 +26,20 @@ import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataAdapter;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
+import org.gradle.internal.text.TreeFormatter;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -119,7 +126,6 @@ public class MetadataProvider {
         private final ModuleVersionIdentifier id;
         private boolean mutated; // used internally to determine if a rule effectively did something
 
-        private String status;
         private List<String> statusScheme = ComponentResolveMetadata.DEFAULT_STATUS_SCHEME;
         private final AttributeContainerInternal attributes;
 
@@ -130,7 +136,7 @@ public class MetadataProvider {
 
         @Override
         public void setStatus(String status) {
-            this.status = status;
+            attributes.attribute(ProjectInternal.STATUS_ATTRIBUTE, status);
             mutated = true;
         }
 
@@ -140,9 +146,52 @@ public class MetadataProvider {
             mutated = true;
         }
 
+        @Override
+        public void attributes(Action<? super AttributeContainer> attributesConfiguration) {
+            mutated = true;
+            attributesConfiguration.execute(attributes);
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            mutated = true;
+            return attributes;
+        }
+
+        private ImmutableAttributes validateAttributeTypes(AttributeContainerInternal attributes) {
+            List<Attribute<?>> invalidAttributes = null;
+            for (Attribute<?> attribute : attributes.keySet()) {
+                if (!isValidType(attribute)) {
+                    if (invalidAttributes == null) {
+                        invalidAttributes = Lists.newArrayList();
+                    }
+                    invalidAttributes.add(attribute);
+                }
+            }
+            maybeThrowValidationError(invalidAttributes);
+            return attributes.asImmutable();
+        }
+
+        private void maybeThrowValidationError(List<Attribute<?>> invalidAttributes) {
+            if (invalidAttributes != null) {
+                TreeFormatter fm = new TreeFormatter();
+                fm.node("Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans");
+                fm.startChildren();
+                for (Attribute<?> invalidAttribute : invalidAttributes) {
+                    fm.node("Attribute '" + invalidAttribute.getName() + "' has type " + invalidAttribute.getType());
+                }
+                fm.endChildren();
+                throw new InvalidUserDataException(fm.toString());
+            }
+        }
+
+        private static boolean isValidType(Attribute<?> attribute) {
+            Class<?> type = attribute.getType();
+            return type == String.class || type == Boolean.class || type == Boolean.TYPE;
+        }
+
         ComponentMetadata build() {
-            attributes.attribute(ProjectInternal.STATUS_ATTRIBUTE, status);
-            return new UserProvidedMetadata(id, statusScheme, attributes.asImmutable());
+            return new UserProvidedMetadata(id, statusScheme, validateAttributeTypes(attributes));
         }
 
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentResolveState.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 
 public interface ModuleComponentResolveState extends Versioned {
@@ -26,4 +28,8 @@ public interface ModuleComponentResolveState extends Versioned {
     BuildableModuleComponentMetaDataResolveResult resolve();
 
     ComponentMetadataSupplier getComponentMetadataSupplier();
+
+    ComponentMetadataProcessor getComponentMetadataProcessor();
+
+    ImmutableAttributesFactory getAttributesFactory();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
@@ -44,10 +45,10 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
     private final VersionSelectorScheme versionSelectorScheme;
     private final AttributeContainer consumerAttributes;
 
-    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory) {
+    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessor componentMetadataProcessor) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.versionSelectorScheme = versionSelectorScheme;
-        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory, attributesFactory);
+        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory, attributesFactory, componentMetadataProcessor);
         this.consumerAttributes = consumerAttributes;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -63,7 +63,8 @@ public class ResolveIvyFactory {
                              StartParameterResolutionOverride startParameterResolutionOverride,
                              BuildCommencedTimeProvider timeProvider, VersionSelectorScheme versionSelectorScheme,
                              VersionComparator versionComparator, ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                             RepositoryBlacklister repositoryBlacklister, VersionParser versionParser) {
+                             RepositoryBlacklister repositoryBlacklister,
+                             VersionParser versionParser) {
         this.cacheProvider = cacheProvider;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
         this.timeProvider = timeProvider;
@@ -87,8 +88,8 @@ public class ResolveIvyFactory {
         CachePolicy cachePolicy = resolutionStrategy.getCachePolicy();
         startParameterResolutionOverride.applyToCachePolicy(cachePolicy);
 
-        UserResolverChain moduleResolver = new UserResolverChain(versionSelectorScheme, versionComparator, resolutionStrategy.getComponentSelection(), moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory);
-        ParentModuleLookupResolver parentModuleResolver = new ParentModuleLookupResolver(versionSelectorScheme, versionComparator, moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory);
+        UserResolverChain moduleResolver = new UserResolverChain(versionSelectorScheme, versionComparator, resolutionStrategy.getComponentSelection(), moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor);
+        ParentModuleLookupResolver parentModuleResolver = new ParentModuleLookupResolver(versionSelectorScheme, versionComparator, moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor);
 
         for (ResolutionAwareRepository repository : repositories) {
             ConfiguredModuleComponentRepository baseRepository = repository.createResolver();
@@ -127,8 +128,8 @@ public class ResolveIvyFactory {
     private static class ParentModuleLookupResolver implements ComponentResolvers, DependencyToComponentIdResolver, ComponentMetaDataResolver, ArtifactResolver {
         private final UserResolverChain delegate;
 
-        public ParentModuleLookupResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionParser versionParser, AttributeContainer consumerAttributes, AttributesSchema attributesSchema, ImmutableAttributesFactory attributesFactory) {
-            this.delegate = new UserResolverChain(versionSelectorScheme, versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory);
+        public ParentModuleLookupResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionParser versionParser, AttributeContainer consumerAttributes, AttributesSchema attributesSchema, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessor componentMetadataProcessor) {
+            this.delegate = new UserResolverChain(versionSelectorScheme, versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, componentMetadataProcessor);
         }
 
         public void add(ModuleComponentRepository moduleComponentRepository) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserProvidedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserProvidedMetadata.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
+
+import org.gradle.api.artifacts.ComponentMetadata;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.project.ProjectInternal;
+
+import java.util.List;
+
+public class UserProvidedMetadata implements ComponentMetadata {
+    private final ModuleVersionIdentifier id;
+    private final List<String> statusScheme;
+    private final ImmutableAttributes attributes;
+
+    public UserProvidedMetadata(ModuleVersionIdentifier id, List<String> statusScheme, ImmutableAttributes attributes) {
+        this.id = id;
+        this.statusScheme = statusScheme;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public ModuleVersionIdentifier getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isChanging() {
+        return false;
+    }
+
+    @Override
+    public String getStatus() {
+        return attributes.getAttribute(ProjectInternal.STATUS_ATTRIBUTE);
+    }
+
+    @Override
+    public List<String> getStatusScheme() {
+        return statusScheme;
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return attributes;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.Transformer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
@@ -44,11 +45,12 @@ public class UserResolverChain implements ComponentResolvers {
                              VersionParser versionParser,
                              AttributeContainer consumerAttributes,
                              AttributesSchema attributesSchema,
-                             ImmutableAttributesFactory attributesFactory) {
+                             ImmutableAttributesFactory attributesFactory,
+                             ComponentMetadataProcessor componentMetadataProcessor) {
         this.componentSelectionRules = componentSelectionRules;
         VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules, attributesSchema);
         ModuleTransformer metaDataFactory = new ModuleTransformer();
-        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, moduleIdentifierFactory, versionSelectorScheme, versionParser, consumerAttributes, attributesFactory);
+        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, moduleIdentifierFactory, versionSelectorScheme, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor);
         componentResolver = new RepositoryChainComponentMetaDataResolver(componentChooser, metaDataFactory);
         artifactResolver = new RepositoryChainArtifactResolver();
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -51,9 +51,9 @@ class DefaultComponentMetadataHandlerTest extends Specification {
 
     // For testing ComponentMetadataHandler capabilities
     def stringInterner = SimpleMapInterner.notThreadSafe()
-    def handler = new DefaultComponentMetadataHandler(DirectInstantiator.INSTANCE, moduleIdentifierFactory, stringInterner)
+    def handler = new DefaultComponentMetadataHandler(DirectInstantiator.INSTANCE, moduleIdentifierFactory, stringInterner, TestUtil.attributesFactory())
     RuleActionAdapter<ComponentMetadataDetails> adapter = Mock(RuleActionAdapter)
-    def mockedHandler = new DefaultComponentMetadataHandler(DirectInstantiator.INSTANCE, adapter, moduleIdentifierFactory, stringInterner)
+    def mockedHandler = new DefaultComponentMetadataHandler(DirectInstantiator.INSTANCE, adapter, moduleIdentifierFactory, stringInterner, TestUtil.attributesFactory())
     def ruleAction = Stub(RuleAction)
     def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult
 import org.gradle.util.TestUtil
 import spock.lang.Specification
+import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class MetadataProviderTest extends Specification {
     def dep = Stub(DependencyMetadata)
@@ -259,9 +260,9 @@ class MetadataProviderTest extends Specification {
 
         then:
         InvalidUserDataException ex = thrown()
-        ex.message == """Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans:
+        ex.message == toPlatformLineSeparators("""Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans:
   - Attribute 'integer' has type class java.lang.Integer
-  - Attribute 'long' has type class java.lang.Long"""
+  - Attribute 'long' has type class java.lang.Long""")
     }
 
 }


### PR DESCRIPTION
### Context

This pull request builds on top of #5264 . Whenever a `ComponentMetadataSupplier` was used, we assumed that the metadata used during selection was consistent with the metadata from the supplier. However, there was the possibility that the metadata gets mutated in a rule, once the component **is** selected.

To fix this, we need to call the component metadata processor after the supplier has been executed, so that rules can apply on user provided metadata too. In practice, not all rules would be executed (typically, not the ones on variant metadata since this is not used during dynamic version selection). It also means that the rules can be executed twice: once after supplying, and once after the component has effectively been selected.

This will become more important as soon as component metadata suppliers will have the ability to mutate attributes, which is going to happen in a subsequent pull request.
