### PR TITLE
Mark maven-publish and ivy-publish as stable

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -22,6 +22,24 @@
             "type": "org.gradle.api.tasks.diagnostics.DependencyInsightReportTask",
             "member": "Method org.gradle.api.tasks.diagnostics.DependencyInsightReportTask.getVersionParser()",
             "acceptation": "Injected service"
+        },
+        {
+            "type": "org.gradle.api.publish.PublicationArtifact",
+            "member": "Class org.gradle.api.publish.PublicationArtifact",
+            "acceptation": "Common super-interface for already existing IvyArtifact and MavenArtifact",
+            "changes": [
+                "Interface has been added"
+            ]
+        },
+        {
+            "type": "org.gradle.api.publish.PublicationArtifact",
+            "member": "Method org.gradle.api.publish.PublicationArtifact.builtBy(java.lang.Object[])",
+            "acceptation": "Method already existed on IvyArtifact and MavenArtifact"
+        },
+        {
+            "type": "org.gradle.api.publish.PublicationArtifact",
+            "member": "Method org.gradle.api.publish.PublicationArtifact.getFile()",
+            "acceptation": "Method already existed on IvyArtifact and MavenArtifact"
         }
     ]
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -82,6 +82,10 @@ See the User guide section on the “[Feature Lifecycle](userguide/feature_lifec
 
 The following are the features that have been promoted in this Gradle release.
 
+### Ivy Publish and Maven Publish Plugins marked stable
+
+The [Ivy Publish Plugin](userguide/publishing_ivy.html) and [Maven Publish Plugin](userguide/publishing_maven.html) that have been _incubating_ since Gradle 1.3 are now marked as stable. Both plugins now [support signing](#signing-publications) and [publish configuration-wide dependency excludes](#configuration-wide-dependency-excludes-are-now-published). The [Maven Publish Plugin](userguide/publishing_maven.html) introduces a new dedicated DSL for [customizing the generated POM](#customizing-the-generated-pom). In addition, some usage quirks with the `publishing` extension have been addressed which now [behaves like other extension objects](https://github.com/gradle/gradle/issues/4945). Thus, these plugins are now the preferred option for publishing artifacts to Ivy and Maven repositories, respectively.
+
 ## Fixed issues
 
 ### Nested `afterEvaluate` requests are no longer silently ignored

--- a/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtml.xsl
@@ -191,12 +191,12 @@
                             </li>
                             <li><a class="nav-dropdown" data-toggle="collapse" href="#publishing-artifacts" aria-expanded="false" aria-controls="publishing-artifacts">Publishing Artifacts</a>
                                 <ul id="publishing-artifacts">
-                                    <li><a href="/userguide/distribution_plugin.html">Distribution Plugin</a></li>
-                                    <li><a href="/userguide/maven_plugin.html">Maven Plugin</a></li>
                                     <li><a href="/userguide/publishing_maven.html">Maven Publish Plugin</a></li>
                                     <li><a href="/userguide/publishing_ivy.html">Ivy Publish Plugin</a></li>
                                     <li><a href="/userguide/artifact_management.html">Publishing Artifacts Overview</a></li>
+                                    <li><a href="/userguide/maven_plugin.html">Old Maven Plugin</a></li>
                                     <li><a href="/userguide/signing_plugin.html">Signing Plugin</a></li>
+                                    <li><a href="/userguide/distribution_plugin.html">Distribution Plugin</a></li>
                                 </ul>
                             </li>
                             <li><a class="nav-dropdown" data-toggle="collapse" href="#sample-gradle-builds" aria-expanded="false" aria-controls="sample-gradle-builds">Sample Gradle Builds</a>

--- a/subprojects/docs/src/docs/userguide/artifactManagement.adoc
+++ b/subprojects/docs/src/docs/userguide/artifactManagement.adoc
@@ -19,9 +19,9 @@
 [NOTE]
 ====
 
-This chapter describes the _original_ publishing mechanism available in Gradle 1.0: in Gradle 1.3 a new mechanism for publishing was introduced. While this new mechanism is <<feature_lifecycle,incubating>> and not yet complete, it introduces some new concepts and features that do (and will) make Gradle publishing even more powerful.
+This chapter describes the _original_ publishing mechanism available in Gradle 1.0: in Gradle 1.3 a new mechanism for publishing was introduced. This new mechanism introduces some new concepts and features that make Gradle publishing even more powerful and is now the preferred option for publishing artifacts.
 
-You can read about the new publishing plugins in <<publishing_ivy>> and <<publishing_maven>>. Please try them out and give us feedback.
+You can read about the new publishing plugins in <<publishing_ivy>> and <<publishing_maven>>.
 
 ====
 

--- a/subprojects/docs/src/docs/userguide/mavenPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/mavenPlugin.adoc
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 [[maven_plugin]]
-== The Maven Plugin
+== Maven Plugin
 
 
 [NOTE]
 ====
- 
-This chapter is a work in progress
- 
+
+This chapter describes deploying artifacts to Maven repositories using the _original_ publishing mechanism available in Gradle 1.0: in Gradle 1.3 a new mechanism for publishing was introduced. This new mechanism introduces some new concepts and features that make Gradle publishing even more powerful and is now the preferred option for publishing artifacts.
+
+You can read about the new publishing plugins in <<publishing_ivy>> and <<publishing_maven>>.
+
 ====
 
 The Maven plugin adds support for deploying artifacts to Maven repositories.

--- a/subprojects/docs/src/docs/userguide/publishingIvy.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingIvy.adoc
@@ -13,32 +13,34 @@
 // limitations under the License.
 
 [[publishing_ivy]]
-== Ivy Publishing (new)
+== Ivy Publish Plugin
 
 
 [NOTE]
 ====
 
-This chapter describes the new <<feature_lifecycle,incubating>> Ivy publishing support provided by the Ivy Publish Plugin. Eventually this new publishing support will replace publishing via the `Upload` task.
+This chapter describes the new Ivy publishing support provided by the Ivy Publish Plugin. This new publishing support is the preferred option for publishing artifacts and will eventually replace publishing via the `Upload` task.
 
-If you are looking for documentation on the original Ivy publishing support using the `Upload` task please see <<artifact_management>>.
+If you are looking for documentation on the original Ivy publishing support using the `Upload` task please see the chapter on <<artifact_management,publishing artifacts>>.
 
 ====
 
-This chapter describes how to publish build artifacts in the http://ant.apache.org/ivy/[Apache Ivy] format, usually to a repository for consumption by other builds or projects. What is published is one or more artifacts created by the build, and an Ivy _module descriptor_ (normally `ivy.xml`) that describes the artifacts and the dependencies of the artifacts, if any.
+The Ivy Publish Plugin provides the ability to publish build artifacts in the http://ant.apache.org/ivy/[Apache Ivy] format, usually to a repository for consumption by other builds or projects. What is published is one or more artifacts created by the build, and an Ivy _module descriptor_ (normally `ivy.xml`) that describes the artifacts and the dependencies of the artifacts, if any.
 
 A published Ivy module can be consumed by Gradle (see <<declaring_dependencies>>) and other tools that understand the Ivy format.
 
 
-[[publishing_ivy:plugin]]
-=== The Ivy Publish Plugin
+[[publishing_ivy:usage]]
+=== Usage
 
-The ability to publish in the Ivy format is provided by the Ivy Publish Plugin. It uses an extension on the project named `publishing` of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The Ivy Publish Plugin works with api:org.gradle.api.publish.ivy.IvyPublication[] publications and api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] repositories.
+The Ivy Publish Plugin uses an extension on the project named `publishing` of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The Ivy Publish Plugin works with api:org.gradle.api.publish.ivy.IvyPublication[] publications and api:org.gradle.api.artifacts.repositories.IvyArtifactRepository[] repositories.
+
+To use the Ivy Publish Plugin, include the following in your build script:
 
 ++++
 <sample id="publishing_ivy:apply-plugin-snippet" dir="ivy-publish/quickstart" title="Applying the Ivy Publish Plugin">
-            <sourcefile file="build.gradle" snippet="use-plugin"/>
-        </sample>
+    <sourcefile file="build.gradle" snippet="use-plugin"/>
+</sample>
 ++++
 
 Applying the Ivy Publish Plugin does the following:
@@ -281,13 +283,3 @@ Note that `«PUBLICATION-TIME-STAMP»` in this example Ivy module descriptor wil
     <sourcefile file="output-ivy.xml" snippet="content"/>
 </sample>
 ++++
-
-
-[[publishing_ivy:future]]
-=== Future features
-
-The Ivy Publish Plugin functionality as described above is incomplete, as the feature is still <<feature_lifecycle,incubating>>. In upcoming Gradle releases, the functionality will be expanded to include (but not limited to):
-
-* Convenient customization of module attributes (`module`, `organisation` etc.)
-* Convenient customization of dependencies reported in `module descriptor`.
-* Multiple discrete publications per project

--- a/subprojects/docs/src/docs/userguide/publishingMaven.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingMaven.adoc
@@ -13,23 +13,25 @@
 // limitations under the License.
 
 [[publishing_maven]]
-== Maven Publishing (new)
+== Maven Publish Plugin
 
 
 [NOTE]
 ====
-This chapter describes the new <<feature_lifecycle,incubating>> Maven publishing support provided by the Maven Publish Plugin. Eventually this new publishing support will replace publishing via the `Upload` task.
+This chapter describes the new Maven publishing support provided by the Maven Publish Plugin. This new publishing support is the preferred option for publishing artifacts and will eventually replace publishing via the `Upload` task.
 
-If you are looking for documentation on the original Maven publishing support using the `Upload` task please see <<artifact_management>>.
+If you are looking for documentation on the original Maven publishing support using the `Upload` task please see the chapters on <<artifact_management, publishing artifacts>> and the <<maven_plugin, old Maven Plugin>>.
 ====
 
-This chapter describes how to publish build artifacts to an http://maven.apache.org/[Apache Maven] repository. A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies>>) and other tools that understand the Maven repository format.
+The Maven Publish Plugin provides the ability to publish build artifacts to an http://maven.apache.org/[Apache Maven] repository. A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies>>) and other tools that understand the Maven repository format.
 
 
-[[sec:the_mavenpublish_plugin]]
-=== The Maven Publish Plugin
+[[publishing_maven:usage]]
+=== Usage
 
-The ability to publish in the Maven format is provided by the Maven Publish Plugin. It uses an extension on the project named `publishing` of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The Maven Publish Plugin works with api:org.gradle.api.publish.maven.MavenPublication[] publications and api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] repositories.
+The Maven Publish Plugin uses an extension on the project named `publishing` of type api:org.gradle.api.publish.PublishingExtension[]. This extension provides a container of named publications and a container of named repositories. The Maven Publish Plugin works with api:org.gradle.api.publish.maven.MavenPublication[] publications and api:org.gradle.api.artifacts.repositories.MavenArtifactRepository[] repositories.
+
+To use the Maven Publish Plugin, include the following in your build script:
 
 ++++
 <sample id="publishing_maven:apply_plugin" dir="maven-publish/quickstart" title="Applying the Maven Publish Plugin">
@@ -129,7 +131,7 @@ Maven restricts 'groupId' and 'artifactId' to a limited character set (`[A-Za-z0
 
 The only Unicode values that are explicitly prohibited are `\`, `/` and any ISO control character. Supplied values are validated early in publication.
 
-[[sec:customizing_the_generated_pom]]
+[[sec:modifying_the_generated_pom]]
 ==== Customizing the generated POM
 
 The generated POM file can be customized before publishing. For example, when publishing a library to Maven Central you will need to set certain metadata. The Maven Publish Plugin provides a DSL for that purpose. Please see api:org.gradle.api.publish.maven.MavenPom[] in the DSL Reference for the complete documentation of available properties and methods. The following sample shows how to use the most common ones:

--- a/subprojects/docs/src/docs/userguide/standardPlugins.adoc
+++ b/subprojects/docs/src/docs/userguide/standardPlugins.adoc
@@ -121,10 +121,20 @@ These plugins provide some integration with various runtime technologies.
 | `java`
 | Adds support for building J2EE applications.
 
+| <<publishing_ivy, `ivy-publish` >>
+| -
+| `application`, `distribution`, `java`, `war`
+| Provides a new DSL to support publishing artifacts to Ivy repositories, which improves on the existing DSL.
+
+| <<publishing_maven, `maven-publish` >>
+| -
+| `application`, `distribution`, `java`, `war`
+| Provides a new DSL to support publishing artifacts to Maven repositories, which improves on the existing DSL.
+
 | <<maven_plugin, `maven` >>
 | -
 | `java`, `war`
-| Adds support for publishing artifacts to Maven repositories.
+| Adds support for publishing artifacts to Maven repositories using the _original_ publishing mechanism available in Gradle 1.0. See also <<artifact_management>>.
 
 | <<osgi_plugin, `osgi` >>
 | `java-base`
@@ -160,16 +170,6 @@ These plugins provide some integration with various runtime technologies.
 | `java`, `distribution`
 | -
 | Adds support for building ZIP and TAR distributions for a Java library.
-
-| <<publishing_ivy, `ivy-publish` >>
-| -
-| `java`, `war`
-| This plugin provides a new DSL to support publishing artifacts to Ivy repositories, which improves on the existing DSL.
-
-| <<publishing_maven, `maven-publish` >>
-| -
-| `java`, `war`
-| This plugin provides a new DSL to support publishing artifacts to Maven repositories, which improves on the existing DSL.
 |===
 
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/InvalidIvyPublicationException.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/InvalidIvyPublicationException.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.InvalidUserDataException;
  *
  * @since 1.5
  */
-@Incubating
 public class InvalidIvyPublicationException extends InvalidUserDataException {
     public InvalidIvyPublicationException(String publicationName, String error) {
         super(formatMessage(publicationName, error));

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyArtifact.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.publish.PublicationArtifact;
 
 import javax.annotation.Nullable;
@@ -24,7 +23,6 @@ import javax.annotation.Nullable;
 /**
  * An artifact published as part of a {@link IvyPublication}.
  */
-@Incubating
 public interface IvyArtifact extends PublicationArtifact {
     /**
      * The name used to publish the artifact file, never <code>null</code>.

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyArtifactSet.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyArtifactSet.java
@@ -17,7 +17,6 @@ package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.Incubating;
 
 /**
  * A Collection of {@link IvyArtifact}s to be included in an {@link IvyPublication}.
@@ -39,7 +38,6 @@ import org.gradle.api.Incubating;
  *
  * @see DomainObjectSet
  */
-@Incubating
 public interface IvyArtifactSet extends DomainObjectSet<IvyArtifact> {
     /**
      * Creates and adds a {@link IvyArtifact} to the set.

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyConfiguration.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 import java.util.Set;
@@ -24,7 +23,6 @@ import java.util.Set;
 /**
  * A configuration included in an {@link IvyPublication}, which will be published in the ivy descriptor file generated.
  */
-@Incubating
 public interface IvyConfiguration extends Named {
 
     /**

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyConfigurationContainer.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyConfigurationContainer.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 
 /**
@@ -37,6 +36,5 @@ import org.gradle.api.NamedDomainObjectContainer;
  * }
  * </pre>
  */
-@Incubating
 public interface IvyConfigurationContainer extends NamedDomainObjectContainer<IvyConfiguration> {
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyDependency.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyDependency.java
@@ -16,13 +16,11 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A module dependency declared in an ivy dependency descriptor published as part of an {@link IvyPublication}.
  */
-@Incubating
 @HasInternalProtocol
 public interface IvyDependency {
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyExtraInfoSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyExtraInfoSpec.java
@@ -16,14 +16,12 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ivy.IvyExtraInfo;
 
 /**
  * Represents a modifiable form of IvyExtraInfo so that "extra" info elements
  * can be configured on an Ivy publication.
  */
-@Incubating
 public interface IvyExtraInfoSpec extends IvyExtraInfo {
 
     /**

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.XmlProvider;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -32,7 +31,6 @@ import javax.annotation.Nullable;
  *
  * @since 1.3
  */
-@Incubating
 @HasInternalProtocol
 public interface IvyModuleDescriptorSpec {
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -17,10 +17,9 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.internal.HasInternalProtocol;
 import org.gradle.api.publish.Publication;
+import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A {@code IvyPublication} is the representation/configuration of how Gradle should publish something in Ivy format, to an Ivy repository.
@@ -88,7 +87,6 @@ import org.gradle.api.publish.Publication;
  *
  * @since 1.3
  */
-@Incubating
 @HasInternalProtocol
 public interface IvyPublication extends Publication {
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/package-info.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 1.3
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.ivy;

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
@@ -59,7 +58,6 @@ import static org.apache.commons.lang.StringUtils.capitalize;
  *
  * @since 1.3
  */
-@Incubating
 public class IvyPublishPlugin implements Plugin<Project> {
 
     private final Instantiator instantiator;

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/package-info.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 1.3
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.ivy.plugins;

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyConfiguration;
@@ -40,7 +39,6 @@ import java.io.File;
  *
  * @since 1.4
  */
-@Incubating
 public class GenerateIvyDescriptor extends DefaultTask {
 
     private IvyModuleDescriptorSpec descriptor;

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.file.FileCollection;
@@ -39,7 +38,6 @@ import java.util.concurrent.Callable;
  *
  * @since 1.3
  */
-@Incubating
 public class PublishToIvyRepository extends DefaultTask {
 
     private IvyPublicationInternal publication;

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/package-info.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 1.3
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.ivy.tasks;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/InvalidMavenPublicationException.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/InvalidMavenPublicationException.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.InvalidUserDataException;
  *
  * @since 1.4
  */
-@Incubating
 public class InvalidMavenPublicationException extends InvalidUserDataException {
     public InvalidMavenPublicationException(String publicationName, String error) {
         super(formatMessage(publicationName, error));

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenArtifact.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.publish.PublicationArtifact;
 
 import javax.annotation.Nullable;
@@ -23,7 +22,6 @@ import javax.annotation.Nullable;
 /**
  * An artifact published as part of a {@link MavenPublication}.
  */
-@Incubating
 public interface MavenArtifact extends PublicationArtifact {
     /**
      * The extension used to publish the artifact file, never <code>null</code>.

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenArtifactSet.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenArtifactSet.java
@@ -17,7 +17,6 @@ package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.Incubating;
 
 /**
  * A Collection of {@link MavenArtifact}s to be included in a {@link MavenPublication}.
@@ -39,7 +38,6 @@ import org.gradle.api.Incubating;
  *
  * @see DomainObjectSet
  */
-@Incubating
 public interface MavenArtifactSet extends DomainObjectSet<MavenArtifact> {
     /**
      * Creates and adds a {@link MavenArtifact} to the set.

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenDependency.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenDependency.java
@@ -15,13 +15,11 @@
  */
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A dependency declared as part of an {@link MavenPublication}.
  */
-@Incubating
 @HasInternalProtocol
 public interface MavenDependency {
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
@@ -35,7 +35,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 1.4
  */
-@Incubating
 @HasInternalProtocol
 public interface MavenPom {
 
@@ -54,6 +53,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     Property<String> getName();
 
     /**
@@ -61,6 +61,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     Property<String> getDescription();
 
     /**
@@ -68,6 +69,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     Property<String> getUrl();
 
     /**
@@ -75,6 +77,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     Property<String> getInceptionYear();
 
     /**
@@ -82,6 +85,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void licenses(Action<? super MavenPomLicenseSpec> action);
 
     /**
@@ -89,6 +93,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void organization(Action<? super MavenPomOrganization> action);
 
     /**
@@ -96,6 +101,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void developers(Action<? super MavenPomDeveloperSpec> action);
 
     /**
@@ -103,6 +109,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void contributors(Action<? super MavenPomContributorSpec> action);
 
     /**
@@ -110,6 +117,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void scm(Action<? super MavenPomScm> action);
 
     /**
@@ -117,6 +125,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void issueManagement(Action<? super MavenPomIssueManagement> action);
 
     /**
@@ -124,6 +133,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void ciManagement(Action<? super MavenPomCiManagement> action);
 
     /**
@@ -131,6 +141,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void distributionManagement(Action<? super MavenPomDistributionManagement> action);
 
     /**
@@ -138,6 +149,7 @@ public interface MavenPom {
      *
      * @since 4.8
      */
+    @Incubating
     void mailingLists(Action<? super MavenPomMailingListSpec> action);
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.internal.HasInternalProtocol;
@@ -100,7 +99,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 1.4
  */
-@Incubating
 @HasInternalProtocol
 public interface MavenPublication extends Publication {
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/package-info.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 1.4
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.maven;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
@@ -61,7 +60,6 @@ import static org.apache.commons.lang.StringUtils.capitalize;
  *
  * @since 1.4
  */
-@Incubating
 public class MavenPublishPlugin implements Plugin<Project> {
 
     public static final String PUBLISH_LOCAL_LIFECYCLE_TASK_NAME = "publishToMavenLocal";

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/package-info.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 1.4
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.maven.plugins;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/AbstractPublishToMaven.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/AbstractPublishToMaven.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
@@ -35,7 +34,6 @@ import java.util.concurrent.Callable;
  *
  * @since 2.4
  */
-@Incubating
 public abstract class AbstractPublishToMaven extends DefaultTask {
 
     private MavenPublicationInternal publication;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.publication.maven.internal.VersionRangeMapper;
 import org.gradle.api.publish.maven.MavenDependency;
@@ -38,7 +37,6 @@ import java.io.File;
  *
  * @since 1.4
  */
-@Incubating
 public class GenerateMavenPom extends DefaultTask {
 
     private MavenPom pom;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.publish.internal.PublishOperation;
 import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
@@ -31,7 +30,6 @@ import org.gradle.api.tasks.TaskAction;
  *
  * @since 1.4
  */
-@Incubating
 public class PublishToMavenLocal extends AbstractPublishToMaven {
 
     @TaskAction

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
@@ -36,7 +35,6 @@ import javax.inject.Inject;
  *
  * @since 1.4
  */
-@Incubating
 public class PublishToMavenRepository extends AbstractPublishToMaven {
 
     private MavenArtifactRepository repository;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/package-info.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 1.4
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.maven.tasks;

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/PublicationArtifact.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/PublicationArtifact.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish;
 
 import org.gradle.api.Buildable;
-import org.gradle.api.Incubating;
 
 import java.io.File;
 
@@ -26,7 +25,6 @@ import java.io.File;
  *
  * @since 4.8
  */
-@Incubating
 public interface PublicationArtifact extends Buildable {
     /**
      * The actual file contents to publish.

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -41,7 +40,6 @@ import javax.inject.Inject;
  *
  * @since 1.3
  */
-@Incubating
 public class PublishingPlugin implements Plugin<Project> {
 
     public static final String PUBLISH_TASK_GROUP = "publishing";

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/package-info.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/package-info.java
@@ -15,9 +15,8 @@
  */
 
 /**
- * Publishing plugins.
+ * Publishing plugin.
  *
  * @since 1.3
  */
-@org.gradle.api.Incubating
 package org.gradle.api.publish.plugins;


### PR DESCRIPTION
This PR removes `@Incubating` from all publishing plugin related classes and methods that have been present prior to 4.8. In addition, the User Guide chapters now clearly present the new mechanism as the preferred option. The Release Notes now include a summary of the changes in the Promotions section.

In light of our discussion in #4939 and since the 4.8 RC needs to be done this week, I've changed the sidebar to look like this for now:

<img width="232" alt="screen shot 2018-05-07 at 11 47 30" src="https://user-images.githubusercontent.com/214207/39695946-8331484e-51ec-11e8-9151-ba8d9e57ceb3.png">

I ~will create~ created a follow-up issue to further improve the publishing documentation for 4.9: #5311.

Resolves #4939.