### PR TITLE
Fix links from Javadoc to User Guide

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCacheConfiguration.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCacheConfiguration.java
@@ -23,7 +23,7 @@ import org.gradle.internal.HasInternalProtocol;
 import javax.annotation.Nullable;
 
 /**
- * Configuration for the <a href="https://docs.gradle.org/current/userguide/build_cache.html">build cache</a> for an entire Gradle build.
+ * Configuration for the <a href="https://docs.gradle.org/current/userguide/build_cache.html" target="_top">build cache</a> for an entire Gradle build.
  *
  * @since 3.5
  */

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -43,7 +43,7 @@ import static groovy.lang.Closure.DELEGATE_FIRST;
  * please use {@link #getArtifacts()} or {@link #getAllArtifacts()}.
  * Read more about declaring artifacts in the configuration in docs for {@link org.gradle.api.artifacts.dsl.ArtifactHandler}
  *
- * Please see <a href="https://docs.gradle.org/current/userguide/defining_and_using_configurations.html" target="_top">the Defining and Using Configurations User Guide chapter</a> for more information.
+ * Please see the <a href="https://docs.gradle.org/current/userguide/managing_dependency_configurations.html" target="_top">Managing Dependency Configurations User Guide chapter</a> for more information.
  */
 @HasInternalProtocol
 public interface Configuration extends FileCollection, HasConfigurableAttributes<Configuration> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
@@ -80,7 +80,7 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * Examples on configuring the <b>resolution strategy</b> - see docs for {@link ResolutionStrategy}
  *
- * Please see <a href="https://docs.gradle.org/current/userguide/defining_and_using_configurations.html" target="_top">the Defining and Using Configurations User Guide chapter</a> for more information.
+ * Please see the <a href="https://docs.gradle.org/current/userguide/managing_dependency_configurations.html" target="_top">Managing Dependency Configurations User Guide chapter</a> for more information.
  */
 @HasInternalProtocol
 public interface ConfigurationContainer extends NamedDomainObjectContainer<Configuration> {


### PR DESCRIPTION
- One chapter has been renamed so the links were broken
- Consistently use `target="_top"` for all links