### PR TITLE
Dependency locking logging

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -274,8 +274,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                        ArtifactTypeRegistry artifactTypeRegistry,
                                                        ComponentSelectorConverter componentSelectorConverter,
                                                        AttributeContainerSerializer attributeContainerSerializer,
-                                                       BuildIdentity buildIdentity,
-                                                       DependencyLockingProvider dependencyLockingProvider) {
+                                                       BuildIdentity buildIdentity) {
             return new ErrorHandlingConfigurationResolver(
                     new ShortCircuitEmptyConfigurationResolver(
                         new DefaultConfigurationResolver(
@@ -297,8 +296,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                             artifactTypeRegistry,
                             componentSelectorConverter,
                             attributeContainerSerializer,
-                            buildIdentity,
-                            dependencyLockingProvider),
+                            buildIdentity
+                        ),
                         componentIdentifierFactory,
                         moduleIdentifierFactory,
                         buildIdentity));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -29,7 +29,6 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
-import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesOnlyVisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DefaultResolvedArtifactsBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
@@ -90,7 +89,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final AttributeContainerSerializer attributeContainerSerializer;
     private final BuildIdentity buildIdentity;
-    private final DependencyLockingProvider dependencyLockingProvider;
 
     public DefaultConfigurationResolver(ArtifactDependencyResolver resolver, RepositoryHandler repositories,
                                         GlobalDependencyResolutionRules metadataHandler,
@@ -103,7 +101,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
                                         ArtifactTypeRegistry artifactTypeRegistry,
                                         ComponentSelectorConverter componentSelectorConverter,
                                         AttributeContainerSerializer attributeContainerSerializer,
-                                        BuildIdentity buildIdentity, DependencyLockingProvider dependencyLockingProvider) {
+                                        BuildIdentity buildIdentity) {
         this.resolver = resolver;
         this.repositories = repositories;
         this.metadataHandler = metadataHandler;
@@ -117,7 +115,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         this.componentSelectorConverter = componentSelectorConverter;
         this.attributeContainerSerializer = attributeContainerSerializer;
         this.buildIdentity = buildIdentity;
-        this.dependencyLockingProvider = dependencyLockingProvider;
     }
 
     @Override
@@ -169,7 +166,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
         results.retainState(new ArtifactResolveState(graphResults, artifactsResults, fileDependencyResults, failures, oldTransientModelBuilder));
         if (lockingVisitor != null && !results.hasError() && failures.isEmpty()) {
-            // TODO is there no way to confirm this state from the visitor itself?
             lockingVisitor.complete();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -70,7 +70,11 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
                         throw new InvalidLockFileException(configurationName, e);
                     }
                 }
-                LOGGER.debug("Found for configuration '{}' locking constraints: {}", configurationName, lockedModules);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Loaded lock state for configuration '{}', state is: {}", configurationName, lockedModules);
+                } else {
+                    LOGGER.info("Loaded lock state for configuration '{}'", configurationName);
+                }
                 return new DefaultDependencyLockingState(partialUpdate, results);
             }
         }
@@ -80,7 +84,13 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     @Override
     public void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolvedModules) {
         if (writeLocks) {
-            lockFileReaderWriter.writeLockFile(configurationName, getModulesOrdered(resolvedModules));
+            List<String> modulesOrdered = getModulesOrdered(resolvedModules);
+            lockFileReaderWriter.writeLockFile(configurationName, modulesOrdered);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Persisted dependency lock state for configuration '{}', state is: {}", configurationName, modulesOrdered);
+            } else {
+                LOGGER.lifecycle("Persisted dependency lock state for configuration '{}'", configurationName);
+            }
         }
     }
 
@@ -90,7 +100,6 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
             modules.add(converter.convertToLockNotation(identifier));
         }
         Collections.sort(modules);
-        LOGGER.debug("Found the following modules:\n\t{}", modules);
         return modules;
     }
 


### PR DESCRIPTION
Add logging for dependency locking operations:
* At `lifecycle` level when persisting lock state
* At `info` level when loading lock state