### PR TITLE
Support component attributes in a component metadata supplier

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataBuilder.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
 
 import java.util.List;
 
@@ -38,4 +40,20 @@ public interface ComponentMetadataBuilder {
      * @param scheme the status scheme
      */
     void setStatusScheme(List<String> scheme);
+
+    /**
+     * Configures the attributes of this component
+     * @param attributesConfiguration the configuration action
+     *
+     * @since 4.9
+     */
+    void attributes(Action<? super AttributeContainer> attributesConfiguration);
+
+    /**
+     * Returns the attributes of the component.
+     * @return the attributes of the component, guaranteed to be mutable.
+     *
+     * @since 4.9
+     */
+    AttributeContainer getAttributes();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.suppliers
+
+import groovy.json.JsonBuilder
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures([
+    // we only need to check without experimental, it doesn't depend on this flag
+    @RequiredFeature(feature = GradleMetadataResolveRunner.EXPERIMENTAL_RESOLVE_BEHAVIOR, value = "false"),
+    // we only need to check without Gradle metadata, it doesn't matter either
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
+])
+class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDependencyResolveTest {
+    private final static String TEST_A_METADATA = new JsonBuilder(
+        [
+            [version: '3', attributes: ['org.gradle.status': 'release', 'custom': 'foo']],
+            [version: '2', attributes: ['org.gradle.status': 'integration', 'custom': 'bar']],
+            [version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'bar']]
+        ]
+    )
+    private final static String TEST_B_METADATA = new JsonBuilder(
+        [
+            [version: '2', attributes: ['org.gradle.status': 'release', 'custom': 'bar']],
+            [version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'foo']]
+        ]
+    )
+    private final static String ALL_METADATA = new JsonBuilder(
+        [
+            [group:'org', name: 'testA', version: '3', attributes: ['org.gradle.status': 'release', 'custom': 'foo']],
+            [group:'org', name: 'testA', version: '2', attributes: ['org.gradle.status': 'integration', 'custom': 'bar']],
+            [group:'org', name: 'testA', version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'bar']],
+            [group:'org', name: 'testB', version: '2', attributes: ['org.gradle.status': 'release', 'custom': 'bar']],
+            [group:'org', name: 'testB', version: '1', attributes: ['org.gradle.status': 'release', 'custom': 'foo']]
+        ]
+    )
+
+    void "can use the same remote cached external resource to get both version list and module metadata"() {
+        def versions = ['org:testA': TEST_A_METADATA,
+                        'org:testB': TEST_B_METADATA]
+        def supplierInteractions = withPerModuleExternalResourceListerAndSupplier(versions, true)
+        given:
+        repository {
+            'org:testA:1'()
+            'org:testA:2'()
+            'org:testA:3'()
+            'org:testB:1'()
+            'org:testB:2'()
+        }
+        buildFile << """
+            def customAttr = Attribute.of('custom', String)
+            
+            dependencies {
+                conf "org:testA:latest.release"
+                conf "org:testB:latest.release"
+            }
+            
+            configurations.conf.attributes.attribute(customAttr, 'bar')
+        """
+
+        when:
+        supplierInteractions.expectGetMetadata('org', 'testA') // one network request for A
+        supplierInteractions.expectGetMetadata('org', 'testB') // and one for B
+        repositoryInteractions {
+            // only the resolved modules are going to get their metadata files fetched (for variant matching)
+            // and no additional network request is performed because we got the attributes from the same
+            // cached external resource
+            'org:testA:1' {
+                expectResolve()
+            }
+            'org:testB:2' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDeps'
+
+        and:
+        outputContains "Listing versions for module testA"
+        outputContains "Listed [3, 2, 1] for org:testA"
+        outputContains "Supplying metadata for module org:testA:3"
+        outputContains "Supplying metadata for module org:testA:2"
+        outputContains "Supplying metadata for module org:testA:1"
+        outputContains "Listing versions for module testB"
+        outputContains "Listed [2, 1] for org:testB"
+        outputContains "Supplying metadata for module org:testB:2"
+        outputDoesNotContain("Supplying metadata for module org:testB:1")
+    }
+
+    void "can use the same remote cached external resource to get both version list and module metadata for all modules at once"() {
+        withGlobalExternalResourceListerAndSupplier(ALL_METADATA, true)
+        given:
+        repository {
+            'org:testA:1'()
+            'org:testA:2'()
+            'org:testA:3'()
+            'org:testB:1'()
+            'org:testB:2'()
+        }
+        buildFile << """
+            def customAttr = Attribute.of('custom', String)
+            
+            dependencies {
+                conf "org:testA:latest.release"
+                conf "org:testB:latest.release"
+            }
+            
+            configurations.conf.attributes.attribute(customAttr, 'bar')
+        """
+
+        when:
+        repositoryInteractions {
+            // only the resolved modules are going to get their metadata files fetched (for variant matching)
+            // and no additional network request is performed because we got the attributes from the same
+            // cached external resource
+            'org:testA:1' {
+                expectResolve()
+            }
+            'org:testB:2' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDeps'
+
+        and:
+        outputContains("""Listing versions for module testA
+Listed [3, 2, 1] for org:testA
+Supplying metadata for module org:testA:3
+Supplying metadata for module org:testA:2
+Supplying metadata for module org:testA:1
+Listing versions for module testB
+Listed [2, 1] for org:testB
+Supplying metadata for module org:testB:2
+""")
+        outputDoesNotContain("Supplying metadata for module org:testB:1")
+    }
+
+    private ListerAndSupplierInteractions withPerModuleExternalResourceListerAndSupplier(Map<String, String> moduleToVersions, boolean logQueries = false) {
+        metadataListerClass = 'MyLister'
+        metadataSupplierClass = 'MySupplier'
+        buildFile << """import groovy.json.JsonSlurper
+
+            class MyLister implements ComponentMetadataVersionLister {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataListerDetails details) {
+                    def id = details.moduleIdentifier
+                    if ($logQueries) { println("Listing versions for module \$id.name") }
+                    repositoryResourceAccessor.withResource("\${id.group}/\${id.name}/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def versions = json.collect { it.version }
+                        if ($logQueries) { println("Listed \$versions for \$id") }
+                        details.listed(versions)
+                    }
+                }
+            }
+            
+            class MySupplier implements ComponentMetadataSupplier {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MySupplier(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataSupplierDetails details) {
+                    def id = details.id
+                    if ($logQueries) { println("Supplying metadata for module \$id") }
+                    repositoryResourceAccessor.withResource("\${id.group}/\${id.module}/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def version = json.find { it.version == id.version }
+                        details.result.attributes { attrs ->
+                            version.attributes.each { k, v ->
+                                attrs.attribute(Attribute.of(k, String), v)
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        def files = [:]
+        moduleToVersions.each { module, json ->
+            def file = temporaryFolder.createFile("metadata-${module}.json")
+            file.setText(json, 'utf-8')
+            files[module] = file
+        }
+        new ExternalResourceListerInteractions(files)
+    }
+
+    private ListerAndSupplierInteractions withGlobalExternalResourceListerAndSupplier(String jsonFile, boolean logQueries = false) {
+        metadataListerClass = 'MyLister'
+        metadataSupplierClass = 'MySupplier'
+        buildFile << """import groovy.json.JsonSlurper
+
+            class MyLister implements ComponentMetadataVersionLister {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataListerDetails details) {
+                    def id = details.moduleIdentifier
+                    if ($logQueries) { println("Listing versions for module \$id.name") }
+                    repositoryResourceAccessor.withResource("/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def versions = json.findAll { it.name == id.name && it.group == id.group }.collect { it.version }
+                        if ($logQueries) { println("Listed \$versions for \$id") }
+                        details.listed(versions)
+                    }
+                }
+            }
+            
+            class MySupplier implements ComponentMetadataSupplier {
+
+                final RepositoryResourceAccessor repositoryResourceAccessor
+            
+                @javax.inject.Inject
+                MySupplier(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
+
+                void execute(ComponentMetadataSupplierDetails details) {
+                    def id = details.id
+                    if ($logQueries) { println("Supplying metadata for module \$id") }
+                    repositoryResourceAccessor.withResource("/metadata.json") {
+                        def json = new JsonSlurper().parse(it, 'utf-8')
+                        def version = json.find { it.group == id.group && it.name == id.module && it.version == id.version }
+                        details.result.attributes { attrs ->
+                            version.attributes.each { k, v ->
+                                attrs.attribute(Attribute.of(k, String), v)
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        def file = temporaryFolder.createFile("metadata-all.json")
+        file.setText(jsonFile, 'utf-8')
+        server.expectGet("/repo/metadata.json", file)
+        new ExternalResourceListerInteractions([:])
+    }
+
+    interface ListerAndSupplierInteractions {
+        void expectGetMetadata(String group, String module)
+
+        void expectRefresh(String group, String module)
+    }
+
+
+    class ExternalResourceListerInteractions implements ListerAndSupplierInteractions {
+        private final Map<String, File> files
+
+        ExternalResourceListerInteractions(Map<String, File> files) {
+            this.files = files
+        }
+
+        @Override
+        void expectGetMetadata(String group, String module) {
+            String id = "$group:$module"
+            server.expectGet("/repo/${group.replace('.', '/')}/$module/metadata.json", files[id])
+        }
+
+        @Override
+        void expectRefresh(String group, String module) {
+            String id = "$group:$module"
+            server.expectHead("/repo/${group.replace('.', '/')}/$module/metadata.json", files[id])
+        }
+    }
+
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
@@ -203,7 +203,7 @@ Supplying metadata for module org:testB:2
         """
         def files = [:]
         moduleToVersions.each { module, json ->
-            def file = temporaryFolder.createFile("metadata-${module}.json")
+            def file = temporaryFolder.createFile("metadata-${module.replace(':', '_')}.json")
             file.setText(json, 'utf-8')
             files[module] = file
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -124,8 +124,10 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
         }
 
         // At this point, we need the component metadata, because it may declare attributes that are needed for matching
-        if (provider.resolve()) {
-            AttributeContainerInternal attributes = (AttributeContainerInternal) provider.getMetaData().getAttributes();
+        // Component metadata may not necessarily hit the network if there is a custom component metadata supplier
+        ComponentMetadata componentMetadata = provider.getComponentMetadata();
+        if (componentMetadata != null) {
+            AttributeContainerInternal attributes = (AttributeContainerInternal) componentMetadata.getAttributes();
             boolean matching = attributesSchema.matcher().isMatching(attributes, consumerAttributes);
             if (!matching) {
                 return new RejectedByAttributesVersion(id, attributesSchema.matcher().describeMatching(attributes, consumerAttributes));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProvider.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import com.google.common.collect.Lists;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.api.artifacts.ComponentMetadataBuilder;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
@@ -23,16 +26,20 @@ import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataAdapter;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
+import org.gradle.internal.text.TreeFormatter;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -119,7 +126,6 @@ public class MetadataProvider {
         private final ModuleVersionIdentifier id;
         private boolean mutated; // used internally to determine if a rule effectively did something
 
-        private String status;
         private List<String> statusScheme = ComponentResolveMetadata.DEFAULT_STATUS_SCHEME;
         private final AttributeContainerInternal attributes;
 
@@ -130,7 +136,7 @@ public class MetadataProvider {
 
         @Override
         public void setStatus(String status) {
-            this.status = status;
+            attributes.attribute(ProjectInternal.STATUS_ATTRIBUTE, status);
             mutated = true;
         }
 
@@ -140,9 +146,52 @@ public class MetadataProvider {
             mutated = true;
         }
 
+        @Override
+        public void attributes(Action<? super AttributeContainer> attributesConfiguration) {
+            mutated = true;
+            attributesConfiguration.execute(attributes);
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            mutated = true;
+            return attributes;
+        }
+
+        private ImmutableAttributes validateAttributeTypes(AttributeContainerInternal attributes) {
+            List<Attribute<?>> invalidAttributes = null;
+            for (Attribute<?> attribute : attributes.keySet()) {
+                if (!isValidType(attribute)) {
+                    if (invalidAttributes == null) {
+                        invalidAttributes = Lists.newArrayList();
+                    }
+                    invalidAttributes.add(attribute);
+                }
+            }
+            maybeThrowValidationError(invalidAttributes);
+            return attributes.asImmutable();
+        }
+
+        private void maybeThrowValidationError(List<Attribute<?>> invalidAttributes) {
+            if (invalidAttributes != null) {
+                TreeFormatter fm = new TreeFormatter();
+                fm.node("Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans");
+                fm.startChildren();
+                for (Attribute<?> invalidAttribute : invalidAttributes) {
+                    fm.node("Attribute '" + invalidAttribute.getName() + "' has type " + invalidAttribute.getType());
+                }
+                fm.endChildren();
+                throw new InvalidUserDataException(fm.toString());
+            }
+        }
+
+        private static boolean isValidType(Attribute<?> attribute) {
+            Class<?> type = attribute.getType();
+            return type == String.class || type == Boolean.class || type == Boolean.TYPE;
+        }
+
         ComponentMetadata build() {
-            attributes.attribute(ProjectInternal.STATUS_ATTRIBUTE, status);
-            return new UserProvidedMetadata(id, statusScheme, attributes.asImmutable());
+            return new UserProvidedMetadata(id, statusScheme, validateAttributeTypes(attributes));
         }
 
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult
 import org.gradle.util.TestUtil
 import spock.lang.Specification
+import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class MetadataProviderTest extends Specification {
     def dep = Stub(DependencyMetadata)
@@ -259,9 +260,9 @@ class MetadataProviderTest extends Specification {
 
         then:
         InvalidUserDataException ex = thrown()
-        ex.message == """Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans:
+        ex.message == toPlatformLineSeparators("""Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans:
   - Attribute 'integer' has type class java.lang.Integer
-  - Attribute 'long' has type class java.lang.Long"""
+  - Attribute 'long' has type class java.lang.Long""")
     }
 
 }


### PR DESCRIPTION
### Context

This pull request builds on top of #5283. It adds support for providing component attributes using a component metadata supplier. This makes it possible to use the same external resource to both list the versions of a component and provide the necessary metadata to perform the selection of a version during dynamic version selection.

In practice, it means that both listing and selecting a version that uses attributes can now be done using a single request, instead of having to list versions then get metadata for each module version.

Again this is WIP, waiting for 4.9 branching to happen.