### PR TITLE
Put deferred configurable change behind a feature flag

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -27,7 +27,8 @@ public class FeaturePreviews {
      */
     public enum Feature {
         IMPROVED_POM_SUPPORT(true),
-        GRADLE_METADATA(true);
+        GRADLE_METADATA(true),
+        STABLE_PUBLISHING(true);
 
         public static Feature withName(String name) {
             try {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ExtensionsStorage.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ExtensionsStorage.java
@@ -132,7 +132,7 @@ public class ExtensionsStorage {
     }
 
     private <T> ExtensionHolder<T> wrap(String name, TypeOf<T> publicType, T extension) {
-        if (isDeferredConfigurable(extension)) {
+        if (isDeferredConfigurable(extension) && !extension.getClass().getName().startsWith("org.gradle.api.publish.internal.DeferredConfigurablePublishingExtension")) {
             DeprecationLogger.nagUserOfDeprecated("@DeferredConfigurable");
             return new DeferredConfigurableExtensionHolder<T>(name, publicType, extension);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/FeaturePreviewsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/FeaturePreviewsTest.groovy
@@ -16,18 +16,17 @@
 
 package org.gradle.api.internal
 
-import org.gradle.StartParameter
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.api.internal.FeaturePreviews.Feature.GRADLE_METADATA
 import static org.gradle.api.internal.FeaturePreviews.Feature.IMPROVED_POM_SUPPORT
+import static org.gradle.api.internal.FeaturePreviews.Feature.STABLE_PUBLISHING
 
 class FeaturePreviewsTest extends Specification {
 
     def 'has no features enabled by default'() {
         given:
-        StartParameter startParameter = Mock()
         def previews = new FeaturePreviews()
         when:
         def result = previews.isFeatureEnabled(feature)
@@ -40,7 +39,6 @@ class FeaturePreviewsTest extends Specification {
     @Unroll
     def "can enable #feature"() {
         given:
-        StartParameter startParameter = Mock()
         def previews = new FeaturePreviews()
         when:
         previews.enableFeature(feature)
@@ -53,7 +51,6 @@ class FeaturePreviewsTest extends Specification {
     @Unroll
     def "can enable #feature as String"() {
         given:
-        StartParameter startParameter = Mock()
         def previews = new FeaturePreviews()
         when:
         previews.enableFeature(feature)
@@ -65,7 +62,6 @@ class FeaturePreviewsTest extends Specification {
 
     def 'fails when enabling an unknown feature'() {
         given:
-        StartParameter startParameter = Mock()
         def previews = new FeaturePreviews()
         when:
         previews.enableFeature('UNKNOWN_FEATURE')
@@ -76,7 +72,6 @@ class FeaturePreviewsTest extends Specification {
 
     def 'fails when querying an unknown feature'() {
         given:
-        StartParameter startParameter = Mock()
         def previews = new FeaturePreviews()
         when:
         previews.isFeatureEnabled('UNKNOWN_FEATURE')
@@ -87,9 +82,8 @@ class FeaturePreviewsTest extends Specification {
 
     def 'lists active features'() {
         given:
-        StartParameter startParameter = Mock()
         def previews = new FeaturePreviews()
         expect:
-        previews.getActiveFeatures() == [IMPROVED_POM_SUPPORT, GRADLE_METADATA] as Set
+        previews.getActiveFeatures() == [IMPROVED_POM_SUPPORT, GRADLE_METADATA, STABLE_PUBLISHING] as Set
     }
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -139,6 +139,14 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
+### Deferred configuration of the publishing block
+
+Until Gradle 4.7, the `publishing {}` block was implicitly treated as if all the logic inside it was executed after the project is evaluated.
+This caused quite a bit of confusion, because it was the only block that behaved that way.
+As part of the stabilization effort in Gradle 4.8, we are deprecating this behavior and asking all users to migrate their build.
+
+Please see the [migration guide](userguide/publishing_maven.html#publishing_maven:deferred_configuration) for more information.
+
 ### Methods on `FileCollection`
 
 - `FileCollection.add()` is now deprecated. Use `ConfigurableFileCollection.from()` instead. You can create a `ConfigurableFileCollection` via `Project.files()`.

--- a/subprojects/docs/src/docs/userguide/publishingMaven.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingMaven.adoc
@@ -300,3 +300,58 @@ The result is that the following artifacts will be published:
 * The Javadoc JAR artifact that has been explicitly configured: `my-library-1.0-javadoc.jar`
 
 The <<signing_plugin, Signing Plugin>> is used to generate a signature file for each artifact. In addition, checksum files will be generated for all artifacts and signature files.
+
+[[publishing_maven:deferred_configuration]]
+=== Removal of deferred configuration behavior
+
+[NOTE]
+====
+Gradle 5.0 will change the behavior of the publishing {} block. Read on to find out how you can make your build compatible today.
+====
+
+Until Gradle 4.7, the `publishing {}` block was implicitly treated as if all the logic inside it was executed after the project is evaluated.
+This caused quite a bit of confusion, because it was the only block that behaved that way.
+As part of the stabilization effort in Gradle 4.8, we are deprecating this behavior and asking all users to migrate their build.
+
+The new, stable behavior can be switched on by adding the following to your settings file:
+
+    enableFeaturePreview('STABLE_PUBLISHING')
+
+We recommend doing a test run with a local repository to see whether all artifacts still have the expected coordinates.
+In most cases everything should work as before and you are done.
+
+If the coordinates change unexpectedly, you may have some logic inside your publishing block or in a plugin that is depending on the deferred configuration behavior.
+For instance, the following logic assumes that the subprojects will be evaluated when the artifactId is set:
+
+[source,groovy]
+----
+subprojects {
+    publishing {
+        publications {
+            mavenJava {
+                from components.java
+                artifactId = jar.baseName
+            }
+        }
+    }
+}
+----
+
+This kind of logic must be wrapped in an `afterEvaluate {}` block to make it work going forward.
+
+
+[source,groovy]
+----
+subprojects {
+    publishing {
+        publications {
+            mavenJava {
+                from components.java
+                afterEvaluate {
+                    artifactId = jar.baseName
+                }
+            }
+        }
+    }
+}
+----

--- a/subprojects/docs/src/samples/ivy-publish/conditional-publishing/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/conditional-publishing/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'maven-conditional-publishing'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/ivy-publish/descriptor-customization/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/descriptor-customization/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'descriptor-customization'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'ivy-publish-java'
 include 'project1', 'project2'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/ivy-publish/multiple-publications/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/multiple-publications/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'ivy-publish-multiple'
 include 'project1', 'project2'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/ivy-publish/publish-artifact/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/publish-artifact/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'publish-artifact'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/ivy-publish/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/quickstart/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'quickstart'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/conditional-publishing/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/conditional-publishing/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'maven-conditional-publishing'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/distribution/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/distribution/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'distribution'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/javaProject/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/javaProject/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'javaProject'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/multiple-publications/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/multiple-publications/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'maven-publish-multiple'
 include 'project1', 'project2'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/pomGeneration/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/pomGeneration/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'pomGeneration'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/publish-artifact/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/publish-artifact/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'publish-artifact'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/maven-publish/quickstart/settings.gradle
+++ b/subprojects/docs/src/samples/maven-publish/quickstart/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'quickstart'
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/docs/src/samples/signing/maven-publish/settings.gradle
+++ b/subprojects/docs/src/samples/signing/maven-publish/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'distribution'
 enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -86,9 +86,13 @@ public class IvyPublishPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(PublishingPlugin.class);
 
-        PublishingExtension extension = project.getExtensions().getByType(PublishingExtension.class);
-        extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider, instantiator, fileResolver));
-        createTasksLater(project, extension, project.getLayout().getBuildDirectory());
+        project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
+            @Override
+            public void execute(PublishingExtension extension) {
+                extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider, instantiator, fileResolver));
+                createTasksLater(project, extension, project.getLayout().getBuildDirectory());
+            }
+        });
     }
 
     private void createTasksLater(final Project project, final PublishingExtension publishingExtension, final DirectoryProperty buildDir) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -97,9 +97,13 @@ public class MavenPublishPlugin implements Plugin<Project> {
         publishLocalLifecycleTask.setDescription("Publishes all Maven publications produced by this project to the local Maven cache.");
         publishLocalLifecycleTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
 
-        PublishingExtension extension = project.getExtensions().getByType(PublishingExtension.class);
-        extension.getPublications().registerFactory(MavenPublication.class, new MavenPublicationFactory(dependencyMetaDataProvider, instantiator, fileResolver));
-        realizePublishingTasksLater(project, extension);
+        project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
+            @Override
+            public void execute(PublishingExtension extension) {
+                extension.getPublications().registerFactory(MavenPublication.class, new MavenPublicationFactory(dependencyMetaDataProvider, instantiator, fileResolver));
+                realizePublishingTasksLater(project, extension);
+            }
+        });
     }
 
     private void realizePublishingTasksLater(final Project project, final PublishingExtension extension) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
@@ -41,15 +41,19 @@ class IvyPluginPublishingPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.afterEvaluate(new Action<Project>() {
             @Override
-            public void execute(Project project) {
-                GradlePluginDevelopmentExtension pluginDevelopment = project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
+            public void execute(final Project project) {
+                final GradlePluginDevelopmentExtension pluginDevelopment = project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
                 if (!pluginDevelopment.isAutomatedPublishing()) {
                     return;
                 }
-                PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
-                SoftwareComponent mainComponent = project.getComponents().getByName("java");
-                IvyPublication mainPublication = addMainPublication(publishing, mainComponent);
-                addMarkerPublications(mainPublication, publishing, pluginDevelopment);
+                project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
+                    @Override
+                    public void execute(PublishingExtension publishing) {
+                        SoftwareComponent mainComponent = project.getComponents().getByName("java");
+                        IvyPublication mainPublication = addMainPublication(publishing, mainComponent);
+                        addMarkerPublications(mainPublication, publishing, pluginDevelopment);
+                    }
+                });
             }
         });
     }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -39,15 +39,19 @@ class MavenPluginPublishPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.afterEvaluate(new Action<Project>() {
             @Override
-            public void execute(Project project) {
-                GradlePluginDevelopmentExtension pluginDevelopment = project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
+            public void execute(final Project project) {
+                final GradlePluginDevelopmentExtension pluginDevelopment = project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
                 if (!pluginDevelopment.isAutomatedPublishing()) {
                     return;
                 }
-                PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
-                SoftwareComponent mainComponent = project.getComponents().getByName("java");
-                MavenPublication mainPublication = addMainPublication(publishing, pluginDevelopment, mainComponent);
-                addMarkerPublications(mainPublication, publishing, pluginDevelopment);
+                project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
+                    @Override
+                    public void execute(PublishingExtension publishing) {
+                        SoftwareComponent mainComponent = project.getComponents().getByName("java");
+                        MavenPublication mainPublication = addMainPublication(publishing, pluginDevelopment, mainComponent);
+                        addMarkerPublications(mainPublication, publishing, pluginDevelopment);
+                    }
+                });
             }
         });
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DeferredConfigurablePublishingExtension.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DeferredConfigurablePublishingExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.fixtures
+package org.gradle.api.publish.internal;
 
-class FeaturePreviewsFixture {
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.plugins.DeferredConfigurable;
+import org.gradle.api.publish.PublicationContainer;
 
-    static void enableGradleMetadata(File settings) {
-        settings << """
-enableFeaturePreview("GRADLE_METADATA")
-"""
-    }
+@DeferredConfigurable
+public class DeferredConfigurablePublishingExtension extends DefaultPublishingExtension {
 
-    static void enableImprovedPomSupport(File settings) {
-        settings << """
-enableFeaturePreview("IMPROVED_POM_SUPPORT")
-"""
-    }
-
-    static void enableStablePublishing(File settings) {
-        settings << """
-enableFeaturePreview("STABLE_PUBLISHING")
-"""
+    public DeferredConfigurablePublishingExtension(RepositoryHandler repositories, PublicationContainer publications) {
+        super(repositories, publications);
     }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -22,14 +22,19 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactPublicationServices;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.internal.DefaultPublicationContainer;
 import org.gradle.api.publish.internal.DefaultPublishingExtension;
+import org.gradle.api.publish.internal.DeferredConfigurablePublishingExtension;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
@@ -44,25 +49,30 @@ import javax.inject.Inject;
 @Incubating
 public class PublishingPlugin implements Plugin<Project> {
 
+    private static final Logger LOGGER = Logging.getLogger(PublishingPlugin.class);
+
     public static final String PUBLISH_TASK_GROUP = "publishing";
     public static final String PUBLISH_LIFECYCLE_TASK_NAME = "publish";
 
     private final Instantiator instantiator;
     private final ArtifactPublicationServices publicationServices;
     private final ProjectPublicationRegistry projectPublicationRegistry;
+    private final FeaturePreviews featurePreviews;
+    private final DocumentationRegistry documentationRegistry;
 
     @Inject
-    public PublishingPlugin(ArtifactPublicationServices publicationServices, Instantiator instantiator, ProjectPublicationRegistry projectPublicationRegistry) {
+    public PublishingPlugin(ArtifactPublicationServices publicationServices, Instantiator instantiator, ProjectPublicationRegistry projectPublicationRegistry, FeaturePreviews featurePreviews, DocumentationRegistry documentationRegistry) {
         this.publicationServices = publicationServices;
         this.instantiator = instantiator;
         this.projectPublicationRegistry = projectPublicationRegistry;
+        this.featurePreviews = featurePreviews;
+        this.documentationRegistry = documentationRegistry;
     }
 
     public void apply(final Project project) {
         RepositoryHandler repositories = publicationServices.createRepositoryHandler();
         PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator);
-        PublishingExtension extension = project.getExtensions().create(PublishingExtension.class, PublishingExtension.NAME, DefaultPublishingExtension.class, repositories, publications);
-
+        PublishingExtension extension = project.getExtensions().create(PublishingExtension.class, PublishingExtension.NAME, determineExtensionClass(), repositories, publications);
         project.getTasks().createLater(PUBLISH_LIFECYCLE_TASK_NAME, new Action<Task>() {
             @Override
             public void execute(Task task) {
@@ -78,6 +88,22 @@ public class PublishingPlugin implements Plugin<Project> {
             }
         });
         bridgeToSoftwareModelIfNeeded((ProjectInternal) project);
+    }
+
+    private Class<? extends PublishingExtension> determineExtensionClass() {
+        if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_PUBLISHING)) {
+            return DefaultPublishingExtension.class;
+        } else {
+            LOGGER.warn(
+                "As part of making the publishing plugins stable, we are removing the 'deferred configurable' behavior of the 'publishing {}' block.\n" +
+                    "We don't want to silently break your build, so we need your help for the migration.\n" +
+                    "Please add 'enableFeaturePreview('STABLE_PUBLISHING')' to your settings file and do a test run by publishing to a local repository.\n" +
+                    "If all artifacts are published as expected, there is nothing else to do.\n" +
+                    "If the published artifacts change unexpectedly, please see the migration guide for more details: " + documentationRegistry.getDocumentationFor("publishing_maven", "publishing_maven:deferred_configuration") + "\n" +
+                    "Gradle 5.0 will switch this flag on by default."
+            );
+            return DeferredConfigurablePublishingExtension.class;
+        }
     }
 
     private void bridgeToSoftwareModelIfNeeded(ProjectInternal project) {

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -16,12 +16,17 @@
 
 package org.gradle.plugins.signing
 
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.FeaturePreviewsFixture.enableGradleMetadata
 
 class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
 
+    @Override
+    def setup() {
+        FeaturePreviewsFixture.enableStablePublishing(settingsFile)
+    }
 
     def "signs single Maven publication"() {
         given:


### PR DESCRIPTION
Simply removing deferred configurable can silently break builds.
Instead we now add a feature flag and nag users to opt into the
new behavior. The flag will be the new default in Gradle 5.0.
