### PR TITLE
Track type literals in annotations

### DIFF
--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzerTest.groovy
@@ -90,11 +90,11 @@ class DefaultClassDependenciesAnalyzerTest extends Specification {
 
     def "knows if a class uses annotations with source retention"() {
         expect:
-        analyze(UsesRuntimeAnnotation).classDependencies.isEmpty()
+        analyze(UsesRuntimeAnnotation).classDependencies  == ["org.gradle.api.internal.tasks.compile.incremental.analyzer.annotations.SomeRuntimeAnnotation"] as Set
         analyze(SomeRuntimeAnnotation).classDependencies.isEmpty()
         !analyze(SomeRuntimeAnnotation).dependencyToAll
 
-        analyze(UsesClassAnnotation).classDependencies.isEmpty()
+        analyze(UsesClassAnnotation).classDependencies == ["org.gradle.api.internal.tasks.compile.incremental.analyzer.annotations.SomeClassAnnotation"] as Set
         analyze(SomeClassAnnotation).classDependencies.isEmpty()
         !analyze(SomeClassAnnotation).dependencyToAll
 


### PR DESCRIPTION
Annotations are part of a classes API.
Annotation processors can read the value
and need to be called again if the referenced
type changes.