### PR TITLE
Revert changes to SourceToNameConverter

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/CompilationSourceDirs.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/CompilationSourceDirs.java
@@ -45,7 +45,7 @@ public class CompilationSourceDirs {
         this.sources = sources;
     }
 
-    public List<String> getSourceRoots() {
+    public List<File> getSourceRoots() {
         return resolveRoots().getSourceRoots();
     }
 
@@ -64,7 +64,7 @@ public class CompilationSourceDirs {
 
     private static class SourceRoots implements FileCollectionVisitor {
         private boolean canInferSourceRoots = true;
-        private List<String> sourceRoots = Lists.newArrayList();
+        private List<File> sourceRoots = Lists.newArrayList();
 
         @Override
         public void visitCollection(FileCollectionInternal fileCollection) {
@@ -78,7 +78,7 @@ public class CompilationSourceDirs {
 
         @Override
         public void visitDirectoryTree(DirectoryFileTree directoryTree) {
-            sourceRoots.add(absolutePath(directoryTree.getDir()));
+            sourceRoots.add(directoryTree.getDir());
         }
 
         private void cannotInferSourceRoots(FileCollectionInternal fileCollection) {
@@ -90,12 +90,8 @@ public class CompilationSourceDirs {
             return canInferSourceRoots;
         }
 
-        public List<String> getSourceRoots() {
+        public List<File> getSourceRoots() {
             return sourceRoots;
-        }
-
-        private String absolutePath(File source) {
-            return source.getAbsolutePath() + File.separatorChar;
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverter.java
@@ -16,15 +16,14 @@
 
 package org.gradle.api.internal.tasks.compile.incremental;
 
+import org.gradle.util.RelativePathUtil;
+
 import java.io.File;
 import java.util.List;
 
 import static java.lang.String.format;
 
 public class SourceToNameConverter {
-
-    private static final String JAVA_EXTENSION = ".java";
-    private static final int JAVA_EXTENSION_LENGTH = JAVA_EXTENSION.length();
 
     private CompilationSourceDirs sourceDirs;
 
@@ -33,19 +32,17 @@ public class SourceToNameConverter {
     }
 
     public String getClassName(File javaSourceClass) {
-        List<String> dirs = sourceDirs.getSourceRoots();
-        for (String sourceDirAbsolutePath : dirs) {
-            String javaSourceClassAbsolutePath = javaSourceClass.getAbsolutePath();
-            if (javaSourceClassAbsolutePath.startsWith(sourceDirAbsolutePath)) {
-                int startIndex = sourceDirAbsolutePath.length();
-                int endIndexWithoutExtension = javaSourceClassAbsolutePath.endsWith(JAVA_EXTENSION) ? javaSourceClassAbsolutePath.length() - JAVA_EXTENSION_LENGTH : javaSourceClassAbsolutePath.length();
-                int anonymousInnerClassStartIndex = javaSourceClassAbsolutePath.indexOf('$', startIndex);
-                String relativePath = javaSourceClassAbsolutePath.substring(startIndex, Math.max(anonymousInnerClassStartIndex, endIndexWithoutExtension));
-                return relativePath.replace(File.separatorChar, '.');
+        List<File> dirs = sourceDirs.getSourceRoots();
+        for (File sourceDir : dirs) {
+            if (javaSourceClass.getAbsolutePath().startsWith(sourceDir.getAbsolutePath())) { //perf tweak only
+                String relativePath = RelativePathUtil.relativePath(sourceDir, javaSourceClass);
+                if (!relativePath.startsWith("..")) {
+                    return relativePath.replaceAll("/", ".").replaceAll("\\.java$", "");
+                }
             }
         }
         throw new IllegalArgumentException(format("Unable to find source java class: '%s' because it does not belong to any of the source dirs: '%s'",
-                javaSourceClass, dirs));
+            javaSourceClass, dirs));
 
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverterTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/SourceToNameConverterTest.groovy
@@ -27,7 +27,7 @@ class SourceToNameConverterTest extends Specification {
 
     @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
     def srcDirs = Stub(CompilationSourceDirs) {
-        getSourceRoots() >> ["src/main/java", "src/main/java2"].collect { temp.file(it).absolutePath + File.separatorChar }
+        getSourceRoots() >> ["src/main/java", "src/main/java2"].collect { temp.file(it) }
     }
     @Subject converter = new SourceToNameConverter(srcDirs)
 


### PR DESCRIPTION
The performance improvements made this class
inconsistent with other classes doing similar
jobs like OutputToNameConverter.

Since incremental builds rarely change a significant
amount of the code base, it is unlikely that this will
actually become a bottleneck. The reason for the perf
improvements was a different usage of this class,
which we have removed in the meantime.