### PR TITLE
Let :init Maven conversion fail with reasonable error when --dsl kotlin

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -332,6 +332,17 @@ Root project 'webinar-parent'
 """
     }
 
+    def "kotlin dsl is not supported"() {
+        given:
+        resources.maybeCopy('MavenConversionIntegrationTest/singleModule')
+
+        when:
+        fails 'init', '--dsl', 'kotlin'
+
+        then:
+        failure.assertHasCause("The requested DSL 'kotlin' is not supported in 'pom' setup type")
+    }
+
     void gradleFilesGenerated(TestFile parentFolder = file(".")) {
         assert parentFolder.file("build.gradle").exists()
         assert parentFolder.file("settings.gradle").exists()

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -112,6 +112,9 @@ public class InitBuild extends DefaultTask {
         }
 
         ProjectInitDescriptor initDescriptor = projectLayoutRegistry.get(type);
+        if (!initDescriptor.supports(dsl)) {
+            throw new GradleException("The requested DSL '" + dsl + "' is not supported in '" + type + "' setup type");
+        }
         if (!testFramework.equals(BuildInitTestFramework.NONE) && !initDescriptor.supports(testFramework)) {
             throw new GradleException("The requested test framework '" + testFramework.getId() + "' is not supported in '" + type + "' setup type");
         }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException
 import org.gradle.buildinit.plugins.internal.BuildInitTypeIds
 import org.gradle.buildinit.plugins.internal.ProjectInitDescriptor
 import org.gradle.buildinit.plugins.internal.ProjectLayoutSetupRegistry
+import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
@@ -27,6 +28,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
+import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework.NONE
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework.SPOCK
 
@@ -112,7 +114,23 @@ class InitBuildSpec extends Specification {
         e.message == "The requested test framework 'spock' is not supported in 'basic' setup type"
     }
 
-    private void supportedType(String type, ProjectInitDescriptor projectSetupDescriptor) {
+    def "should throw exception if requested DSL is not supported for the specified type"() {
+        given:
+        supportedType(BuildInitTypeIds.POM, projectSetupDescriptor)
+        projectSetupDescriptor.supports(KOTLIN) >> false
+        init.type = BuildInitTypeIds.POM
+        init.dsl = "kotlin"
+
+        when:
+        init.setupProjectLayout()
+
+        then:
+        GradleException e = thrown()
+        e.message == "The requested DSL 'kotlin' is not supported in 'pom' setup type"
+    }
+
+    private void supportedType(String type, BuildInitDsl dsl = GROOVY, ProjectInitDescriptor projectSetupDescriptor) {
+        projectSetupDescriptor.supports(dsl) >> true
         projectLayoutRegistry.supports(type) >> true
         projectLayoutRegistry.get(type) >> projectSetupDescriptor
     }


### PR DESCRIPTION
instead of silently ignoring the --dsl option, and generating Groovy scripts.

Converting a Maven build to Kotlin DSL scripts it is not supported yet, see #3493
