### PR TITLE
Use "store" instead of "push" in build cache documentation

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCache.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCache.java
@@ -34,12 +34,12 @@ public interface BuildCache {
     void setEnabled(boolean enabled);
 
     /**
-     * Returns whether pushing to the build cache is enabled.
+     * Returns whether storing in build cache is enabled.
      */
     boolean isPush();
 
     /**
-     * Sets whether pushing to the build cache is enabled.
+     * Sets whether storing in the build cache is enabled.
      */
     void setPush(boolean enabled);
 }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCacheConfiguration.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/configuration/BuildCacheConfiguration.java
@@ -47,7 +47,7 @@ public interface BuildCacheConfiguration {
      * Configures the local cache with the given type.
      *
      * <p>If a local build cache has already been configured with a different type, this method replaces it.</p>
-     * <p>Push is enabled by default for the local cache.</p>
+     * <p>Storing ("push") in the local build cache is enabled by default.</p>
      *
      * @param type the type of local cache to configure.
      */
@@ -58,7 +58,7 @@ public interface BuildCacheConfiguration {
      *
      * <p>If a local build cache has already been configured with a different type, this method replaces it.</p>
      * <p>If a local build cache has already been configured with the <b>same</b> type, this method configures it.</p>
-     * <p>Push is enabled by default for the local cache.</p>
+     * <p>Storing ("push") in the local build cache is enabled by default.</p>
      *
      * @param type the type of local cache to configure.
      * @param configuration the configuration to execute against the remote cache.
@@ -84,7 +84,7 @@ public interface BuildCacheConfiguration {
      * If a remote build cache has already been configured with a different type, this method replaces it.
      * </p>
      * <p>
-     * Push is disabled by default for the remote cache.
+     * Storing ("push") in the remote build cache is disabled by default.
      * </p>
      * @param type the type of remote cache to configure.
      *
@@ -100,7 +100,7 @@ public interface BuildCacheConfiguration {
      * If a remote build cache has already been configured with the <b>same</b>, this method configures it.
      * </p>
      * <p>
-     * Push is disabled by default for the remote cache.
+     * Storing ("push") in the remote build cache is disabled by default.
      * </p>
      * @param type the type of remote cache to configure.
      * @param configuration the configuration to execute against the remote cache.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -556,7 +556,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         when:
         withBuildCache().run "customTask", "--info"
         then:
-        output.contains "Not caching task ':customTask' because no valid cache key was generated"
+        output.contains "Not loading task ':customTask' from cache because no valid cache key was generated"
     }
 
     def "task with custom action loaded with custom classloader is not cached"() {
@@ -598,7 +598,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         when:
         withBuildCache().run "customTask", "--info"
         then:
-        output.contains "Not caching task ':customTask' because no valid cache key was generated"
+        output.contains "Not loading task ':customTask' from cache because no valid cache key was generated"
     }
 
     def "task stays up-to-date after loaded from cache"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -902,7 +902,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
         withBuildCache().run "customTask", "--info", "-D${BuildCacheDebugLoggingOption.GRADLE_PROPERTY}=true"
         then:
         output.contains "The implementation of 'bean' cannot be determined, because it was loaded by an unknown classloader"
-        output.contains "Not caching task ':customTask' because no valid cache key was generated"
+        output.contains "Not loading task ':customTask' from cache because no valid cache key was generated"
     }
 
     def "task with nested bean loaded with custom classloader is never up-to-date"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuter.java
@@ -95,10 +95,10 @@ public class SkipCachedTaskExecuter implements TaskExecuter {
                         LOGGER.warn("Failed to load cache entry for {}, falling back to executing task", task, e);
                     }
                 } else {
-                    LOGGER.info("Not loading {} from cache because pulling from cache is disabled for this task", task);
+                    LOGGER.info("Not loading {} from cache because loading from cache is disabled for this task", task);
                 }
             } else {
-                LOGGER.info("Not caching {} because no valid cache key was generated", task);
+                LOGGER.info("Not loading {} from cache because no valid cache key was generated", task);
             }
         }
 
@@ -112,13 +112,13 @@ public class SkipCachedTaskExecuter implements TaskExecuter {
                         Map<String, Map<String, FileContentSnapshot>> outputSnapshots = taskState.getOutputContentSnapshots();
                         buildCache.store(buildCacheCommandFactory.createStore(cacheKey, outputProperties, outputSnapshots, task, context.getExecutionTime()));
                     } catch (Exception e) {
-                        LOGGER.warn("Failed to store cache entry {}", cacheKey.getDisplayName(), task, e);
+                        LOGGER.warn("Failed to store cache entry {}", cacheKey.getDisplayName(), e);
                     }
                 } else {
-                    LOGGER.debug("Not pushing result from {} to cache because the task failed", task);
+                    LOGGER.debug("Not storing result of {} in cache because the task failed", task);
                 }
             } else {
-                LOGGER.info("Not pushing results from {} to cache because no valid cache key was generated", task);
+                LOGGER.info("Not storing results of {} in cache because no valid cache key was generated", task);
             }
         }
     }

--- a/subprojects/docs/src/docs/userguide/buildCache.adoc
+++ b/subprojects/docs/src/docs/userguide/buildCache.adoc
@@ -107,8 +107,8 @@ and `:jar` being Copy-like tasks which are not cacheable since it is generally f
 === Cacheable tasks
 
 Since a task describes all of its inputs and outputs, Gradle can compute a _build cache key_ that uniquely defines the task's outputs based on its inputs.
-That build cache key is used to request previous outputs from a build cache or push new outputs to the build cache. If the previous build is already populated by someone else, e.g. your
-continuous integration server or other developers, you can avoid executing most tasks locally.
+That build cache key is used to request previous outputs from a build cache or store new outputs in the build cache.
+If the previous build outputs have been already stored in the cache by someone else, e.g. your continuous integration server or other developers, you can avoid executing most tasks locally.
 
 The following inputs contribute to the build cache key for a task in the same way that they do for <<sec:how_does_it_work,up-to-date checks>>:
 
@@ -199,7 +199,7 @@ You can configure the build cache by using the api:org.gradle.api.initialization
 Gradle supports a `local` and a `remote` build cache that can be configured separately.
 When both build caches are enabled, Gradle tries to load build outputs from the local build cache first, and then tries the remote build cache if no build outputs are found.
 If outputs are found in the remote cache, they are also stored in the local cache, so next time they will be found locally.
-Gradle pushes build outputs to any build cache that is enabled and has api:org.gradle.caching.configuration.BuildCache#isPush()[] set to `true`.
+Gradle stores ("pushes") build outputs in any build cache that is enabled and has api:org.gradle.caching.configuration.BuildCache#isPush()[] set to `true`.
 
 By default, the local build cache has push enabled, and the remote build cache has push disabled.
 
@@ -263,8 +263,8 @@ This is a convenient workaround, but you shouldn’t use it as a long-term solut
 [[sec:build_cache_configure_use_cases]]
 ==== Configuration use cases
 
-The recommended use case for the build cache is that your continuous integration server populates the remote build cache with clean builds while developers pull
-from the remote build cache and push to a local build cache. The configuration would then look as follows.
+The recommended use case for the build cache is that your continuous integration server populates the remote build cache from clean builds while developers load from the remote build cache and store in the local build cache.
+The configuration would then look as follows.
 
 ++++
 <sample id="developerCiSetup" dir="buildCache/developer-ci-setup" title="Recommended setup for CI push use case">


### PR DESCRIPTION
Push can be misunderstood to mean that the remote cache pushes artifacts
to the local cache/the developer machine. Store makes it clear that
the outputs are stored in the build cache.
