### PR TITLE
Unify generated Gradle jar cache build operations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.cache.internal
 
 import org.gradle.api.Action
 import org.gradle.cache.CacheRepository
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.GlobalScopeServices
@@ -47,6 +49,10 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     @Rule
     ConcurrentTestUtil concurrent = new ConcurrentTestUtil(8000)
 
+    def buildOperationExecutor = [
+        run: { RunnableBuildOperation buildOperation -> buildOperation.run(null) }
+    ] as BuildOperationExecutor
+
     def DefaultServiceRegistry services = (DefaultServiceRegistry) ServiceRegistryBuilder.builder()
             .parent(NativeServicesTestFixture.getInstance())
             .provider(new GlobalScopeServices(false))
@@ -56,7 +62,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     def currentGradleVersion = GradleVersion.current()
     def CacheScopeMapping scopeMapping = new DefaultCacheScopeMapping(tmpDir.testDirectory, null, currentGradleVersion)
     def CacheRepository cacheRepository = new DefaultCacheRepository(scopeMapping, factory)
-    def defaultGeneratedGradleJarCache = new DefaultGeneratedGradleJarCache(cacheRepository, currentGradleVersion.getVersion())
+    def defaultGeneratedGradleJarCache = new DefaultGeneratedGradleJarCache(cacheRepository, currentGradleVersion.getVersion(), buildOperationExecutor)
 
     def cleanup() {
         defaultGeneratedGradleJarCache.close()

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -123,9 +123,9 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return parent.createChild();
     }
 
-    GeneratedGradleJarCache createGeneratedGradleJarCache(CacheRepository cacheRepository) {
+    GeneratedGradleJarCache createGeneratedGradleJarCache(CacheRepository cacheRepository, BuildOperationExecutor buildOperationExecutor) {
         String gradleVersion = GradleVersion.current().getVersion();
-        return new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion);
+        return new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor);
     }
 
     CrossProjectConfigurator createCrossProjectConfigurator(BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
 import org.junit.Rule
@@ -40,10 +42,13 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
     def gradleVersion = GradleVersion.current().version
     def cacheBuilder = Mock(CacheBuilder)
     def cache = Mock(PersistentCache)
+    def buildOperationExecutor = [
+        run: { RunnableBuildOperation buildOperation -> buildOperation.run(null) }
+    ] as BuildOperationExecutor
 
     def "can close cache"() {
         when:
-        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion)
+        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor)
         provider.close()
 
         then:
@@ -62,7 +67,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         def cache = Mock(PersistentCache)
 
         when:
-        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion)
+        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor)
         def resolvedFile = provider.get(identifier) { it.createNewFile() }
 
         then:
@@ -85,7 +90,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         def cache = Mock(PersistentCache)
 
         when:
-        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion)
+        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor)
         def resolvedFile = provider.get("api") { it.createNewFile() }
 
         then:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -152,8 +152,8 @@ class DependencyManagementBuildScopeServices {
             attributesFactory);
     }
 
-    RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory, BuildOperationExecutor buildOperationExecutor) {
-        return new RuntimeShadedJarFactory(jarCache, progressLoggerFactory, buildOperationExecutor, directoryFileTreeFactory);
+    RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory) {
+        return new RuntimeShadedJarFactory(jarCache, progressLoggerFactory, directoryFileTreeFactory);
     }
 
     BuildCommencedTimeProvider createBuildTimeProvider() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
@@ -20,10 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
-import org.gradle.internal.operations.BuildOperationContext;
-import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,13 +32,11 @@ public class RuntimeShadedJarFactory {
 
     private final GeneratedGradleJarCache cache;
     private final ProgressLoggerFactory progressLoggerFactory;
-    private final BuildOperationExecutor buildOperationExecutor;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public RuntimeShadedJarFactory(GeneratedGradleJarCache cache, ProgressLoggerFactory progressLoggerFactory, BuildOperationExecutor buildOperationExecutor, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public RuntimeShadedJarFactory(GeneratedGradleJarCache cache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.cache = cache;
         this.progressLoggerFactory = progressLoggerFactory;
-        this.buildOperationExecutor = buildOperationExecutor;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
@@ -50,26 +44,13 @@ public class RuntimeShadedJarFactory {
         final File jarFile = cache.get(type.getIdentifier(), new Action<File>() {
             @Override
             public void execute(final File file) {
-                buildOperationExecutor.run(new RunnableBuildOperation() {
-                    @Override
-                    public void run(BuildOperationContext context) {
-                        RuntimeShadedJarCreator creator = new RuntimeShadedJarCreator(
-                            progressLoggerFactory,
-                            new ImplementationDependencyRelocator(type),
-                            directoryFileTreeFactory
-                        );
-                        creator.create(file, classpath);
-                    }
-
-                    @Override
-                    public BuildOperationDescriptor.Builder description() {
-                        String displayName = "Generating Jar " + file.getName();
-                        return BuildOperationDescriptor.displayName(displayName)
-                            .progressDisplayName(displayName);
-                    }
-                });
-
-             }
+                RuntimeShadedJarCreator creator = new RuntimeShadedJarCreator(
+                    progressLoggerFactory,
+                    new ImplementationDependencyRelocator(type),
+                    directoryFileTreeFactory
+                );
+                creator.create(file, classpath);
+            }
         });
         LOGGER.debug("Using Gradle runtime shaded JAR file: {}", jarFile);
         return jarFile;


### PR DESCRIPTION
By moving the `BuildOperationExecutor` call to `DefaultGeneratedGradleJarCache` so the generation of Gradle Kotlin DSL API extensions Jar is also reported as a build operation.