### PR TITLE
Upgrade Kotlin DSL {0.17.2 => 0.17.3}

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
@@ -6,7 +6,7 @@ import org.gradle.internal.os.OperatingSystem
 
 object BuildEnvironment {
     val isCiServer = "CI" in System.getenv()
-    val gradleKotlinDslVersion = "0.17.2"
+    val gradleKotlinDslVersion = "0.17.3"
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()
     val isWindows = OperatingSystem.current().isWindows

--- a/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api("org.gradle:gradle-kotlin-dsl:0.17.2")
+    api("org.gradle:gradle-kotlin-dsl:0.17.3")
     testImplementation("junit:junit:4.12")
     testImplementation("com.nhaarman:mockito-kotlin:1.5.0")
 }


### PR DESCRIPTION
This release removes support for nested convention object accessors to avoid future backward compatibility issues.