### PR TITLE
Move some performance tests to experiment stage

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -17,16 +17,19 @@
 package org.gradle.performance.regression.java
 
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListener
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
 import org.gradle.performance.measure.MeasuredOperation
 import org.gradle.util.GFileUtils
+import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
+@Category(PerformanceExperiment)
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -27,52 +27,6 @@ class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     }
 
     @Unroll
-    def "clean assemble on #testProject"() {
-        given:
-        runner.testProject = testProject
-        runner.tasksToRun = ["assemble"]
-        runner.cleanTasks = ["clean"]
-        runner.gradleOpts = ["-Xms$maxMemory", "-Xmx$maxMemory"]
-        runner.runs = iterations
-        runner.warmUpRuns = iterations
-
-        when:
-        def result = runner.run()
-
-        then:
-        result.assertCurrentVersionHasNotRegressed()
-
-        where:
-        testProject                       | maxMemory | iterations
-        "smallNative"                     | '256m'    | 40
-        "mediumNative"                    | '256m'    | null
-        "bigNative"                       | '1g'      | null
-        "multiNative"                     | '256m'    | null
-        "smallCppApp"                     | '256m'    | 40
-        "mediumCppApp"                    | '256m'    | null
-        "mediumCppAppWithMacroIncludes"   | '256m'    | null
-        "bigCppApp"                       | '256m'    | null
-        "smallCppMulti"                   | '256m'    | 40
-        "mediumCppMulti"                  | '256m'    | null
-        "mediumCppMultiWithMacroIncludes" | '256m'    | null
-        "bigCppMulti"                     | '1g'      | null
-    }
-
-    def "clean assemble on manyProjectsNative"() {
-        given:
-        runner.testProject = "manyProjectsNative"
-        runner.tasksToRun = ["assemble"]
-        runner.cleanTasks = ["clean"]
-        runner.args = ["--parallel", "--max-workers=12"]
-
-        when:
-        def result = runner.run()
-
-        then:
-        result.assertCurrentVersionHasNotRegressed()
-    }
-
-    @Unroll
     def "up-to-date assemble on #testProject"() {
         given:
         runner.testProject = testProject

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.regression.nativeplatform
+
+import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.categories.PerformanceExperiment
+import org.junit.experimental.categories.Category
+import spock.lang.Unroll
+
+@Category(PerformanceExperiment)
+class NativeCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
+    def setup() {
+        runner.minimumVersion = '4.1' // minimum version that contains new C++ plugins
+        runner.targetVersions = ["4.8-20180506235948+0000"]
+    }
+
+    @Unroll
+    def "clean assemble on #testProject"() {
+        given:
+        runner.testProject = testProject
+        runner.tasksToRun = ["assemble"]
+        runner.cleanTasks = ["clean"]
+        runner.gradleOpts = ["-Xms$maxMemory", "-Xmx$maxMemory"]
+        runner.runs = iterations
+        runner.warmUpRuns = iterations
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        where:
+        testProject                       | maxMemory | iterations
+        "smallNative"                     | '256m'    | 40
+        "mediumNative"                    | '256m'    | null
+        "bigNative"                       | '1g'      | null
+        "multiNative"                     | '256m'    | null
+        "smallCppApp"                     | '256m'    | 40
+        "mediumCppApp"                    | '256m'    | null
+        "mediumCppAppWithMacroIncludes"   | '256m'    | null
+        "bigCppApp"                       | '256m'    | null
+        "smallCppMulti"                   | '256m'    | 40
+        "mediumCppMulti"                  | '256m'    | null
+        "mediumCppMultiWithMacroIncludes" | '256m'    | null
+        "bigCppMulti"                     | '1g'      | null
+    }
+
+    def "clean assemble on manyProjectsNative"() {
+        given:
+        runner.testProject = "manyProjectsNative"
+        runner.tasksToRun = ["assemble"]
+        runner.cleanTasks = ["clean"]
+        runner.args = ["--parallel", "--max-workers=12"]
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
+}


### PR DESCRIPTION
Testing clean builds is very time-consuming and
rarely tells us anything about Gradle's performance,
because it is mostly constrained by the performance
of the tools we are calling.

The first-use use case takes a long time as well and
is not important enough to hold up the commit pipeline.