### PR TITLE
Fix tooling API model building with composite builds

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -188,7 +188,7 @@ public class DefaultIncludedBuild implements IncludedBuildState, ConfigurableInc
     private GradleLauncher getGradleLauncher() {
         if (gradleLauncher == null) {
             // Use a defensive copy of the build definition, as it may be mutated during build execution
-            gradleLauncher = gradleLauncherFactory.nestedInstance(buildDefinition.newInstance(), buildIdentifier);
+            gradleLauncher = gradleLauncherFactory.nestedInstance(buildDefinition.newInstance(), this);
         }
         return gradleLauncher;
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -31,7 +31,7 @@ import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.IncludedBuildState;
-import org.gradle.internal.build.NestedBuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
@@ -164,7 +164,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     }
 
     @Override
-    public NestedBuildState addNestedBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory) {
+    public StandAloneNestedBuild addNestedBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory) {
         if (buildDefinition.getName() == null) {
             throw new UnsupportedOperationException("Not yet implemented."); // but should be
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -31,8 +31,8 @@ import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.IncludedBuildState;
-import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.build.RootBuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.ListenerManager;
@@ -177,6 +177,15 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         });
         addBuild(build);
         return build;
+    }
+
+    @Override
+    public StandAloneNestedBuild addNestedBuildTree(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory) {
+        if (buildDefinition.getName() != null || buildDefinition.getBuildRootDir() != null) {
+            throw new UnsupportedOperationException("Not yet implemented."); // but should be
+        }
+        BuildIdentifier buildIdentifier = idFor(buildDefinition.getStartParameter().getCurrentDir().getName());
+        return new RootOfNestedBuildTree(buildDefinition, buildIdentifier, nestedBuildFactory);
     }
 
     private IncludedBuildState registerBuild(BuildDefinition buildDefinition, boolean isImplicit, NestedBuildFactory nestedBuildFactory) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -25,12 +25,12 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
-import org.gradle.internal.build.NestedBuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.util.Path;
 
-class DefaultNestedBuild implements NestedBuildState {
+class DefaultNestedBuild implements StandAloneNestedBuild {
     private final BuildDefinition buildDefinition;
     private final NestedBuildFactory nestedBuildFactory;
     private final BuildStateListener buildStateListener;
@@ -46,7 +46,7 @@ class DefaultNestedBuild implements NestedBuildState {
 
     @Override
     public <T> T run(Transformer<T, ? super BuildController> buildAction) {
-        GradleLauncher gradleLauncher = nestedBuildFactory.nestedInstance(buildDefinition, buildIdentifier);
+        GradleLauncher gradleLauncher = nestedBuildFactory.nestedInstance(buildDefinition, this);
         GradleBuildController buildController = new GradleBuildController(gradleLauncher);
         try {
             final GradleInternal gradle = buildController.getGradle();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -37,20 +37,20 @@ class DefaultRootBuildState implements RootBuildState {
     private final BuildRequestContext requestContext;
     private final GradleLauncherFactory gradleLauncherFactory;
     private final ListenerManager listenerManager;
-    private final ServiceRegistry services;
+    private final ServiceRegistry parentServices;
     private SettingsInternal settings;
 
-    DefaultRootBuildState(BuildDefinition buildDefinition, BuildRequestContext requestContext, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager, ServiceRegistry services) {
+    DefaultRootBuildState(BuildDefinition buildDefinition, BuildRequestContext requestContext, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager, ServiceRegistry parentServices) {
         this.buildDefinition = buildDefinition;
         this.requestContext = requestContext;
         this.gradleLauncherFactory = gradleLauncherFactory;
         this.listenerManager = listenerManager;
-        this.services = services;
+        this.parentServices = parentServices;
     }
 
     @Override
     public <T> T run(Transformer<T, ? super BuildController> buildAction) {
-        GradleLauncher gradleLauncher = gradleLauncherFactory.newInstance(buildDefinition, getBuildIdentifier(), requestContext, services);
+        GradleLauncher gradleLauncher = gradleLauncherFactory.newInstance(buildDefinition, this, requestContext, parentServices);
         final GradleBuildController buildController = new GradleBuildController(gradleLauncher);
         try {
             RootBuildLifecycleListener buildLifecycleListener = listenerManager.getBroadcaster(RootBuildLifecycleListener.class);

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
@@ -57,7 +57,7 @@ class DefaultNestedBuildTest extends Specification {
         result == '<result>'
 
         and:
-        1 * factory.nestedInstance(buildDefinition, buildIdentifier) >> launcher
+        1 * factory.nestedInstance(buildDefinition, build) >> launcher
 
         then:
         1 * action.transform(!null) >> { BuildController controller ->
@@ -76,7 +76,7 @@ class DefaultNestedBuildTest extends Specification {
         result == null
 
         and:
-        1 * factory.nestedInstance(buildDefinition, buildIdentifier) >> launcher
+        1 * factory.nestedInstance(buildDefinition, build) >> launcher
         1 * action.transform(!null) >> { BuildController controller ->
             return null
         }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -65,7 +65,7 @@ class DefaultRootBuildStateTest extends Specification {
         result == '<result>'
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
 
         then:
         1 * lifecycleListener.afterStart()
@@ -90,7 +90,7 @@ class DefaultRootBuildStateTest extends Specification {
         result == null
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * action.transform(!null) >> { BuildController controller ->
             return null
         }
@@ -105,7 +105,7 @@ class DefaultRootBuildStateTest extends Specification {
         result == '<result>'
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * launcher.executeTasks() >> gradle
         1 * action.transform(!null) >> { BuildController controller ->
             assert controller.run() == gradle
@@ -122,7 +122,7 @@ class DefaultRootBuildStateTest extends Specification {
         result == '<result>'
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * launcher.getConfiguredBuild() >> gradle
         1 * action.transform(!null) >> { BuildController controller ->
             assert controller.configure() == gradle
@@ -146,7 +146,7 @@ class DefaultRootBuildStateTest extends Specification {
         e.message == 'Cannot use launcher after build has completed.'
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * launcher.executeTasks() >> gradle
         1 * launcher.stop()
     }
@@ -162,7 +162,7 @@ class DefaultRootBuildStateTest extends Specification {
         e == failure
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * action.transform(!null) >> { BuildController controller -> throw failure }
         1 * lifecycleListener.beforeComplete()
         1 * launcher.stop()
@@ -179,7 +179,7 @@ class DefaultRootBuildStateTest extends Specification {
         e == failure
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * launcher.executeTasks() >> { throw failure }
         1 * action.transform(!null) >> { BuildController controller ->
             controller.run()
@@ -199,7 +199,7 @@ class DefaultRootBuildStateTest extends Specification {
         e == failure
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * launcher.getConfiguredBuild() >> { throw failure }
         1 * action.transform(!null) >> { BuildController controller ->
             controller.configure()
@@ -217,7 +217,7 @@ class DefaultRootBuildStateTest extends Specification {
         e.message == 'Cannot use launcher after build has completed.'
 
         and:
-        1 * factory.newInstance(buildDefinition, build.buildIdentifier, buildRequestContext, sessionServices) >> launcher
+        1 * factory.newInstance(buildDefinition, build, buildRequestContext, sessionServices) >> launcher
         1 * launcher.configuredBuild >> { throw new RuntimeException() }
         1 * action.transform(!null) >> { BuildController controller ->
             try {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GradleBuildTaskIntegrationTest.groovy
@@ -89,6 +89,84 @@ println "build script code source: " + getClass().protectionDomain.codeSource.lo
         outputContains(":other:buildSrc:assemble")
     }
 
+    def "buildSrc can have nested build"() {
+        given:
+        file('buildSrc/src/main/java/Thing.java') << "class Thing { }"
+        file('buildSrc/build.gradle') << """
+            task otherBuild(type:GradleBuild) {
+                dir = '../other'
+                tasks = ['build']
+            }
+            classes.dependsOn(otherBuild)
+        """
+        file('other/build.gradle') << """
+            task build
+        """
+
+        when:
+        run()
+
+        then:
+        // TODO - Fix test fixtures to allow assertions on buildSrc tasks rather than relying on output scraping in tests
+        outputContains(":buildSrc:other:build")
+        outputContains(":buildSrc:otherBuild")
+    }
+
+    def "nested build can nest more builds"() {
+        given:
+        buildFile << """
+            task otherBuild(type:GradleBuild) {
+                dir = 'other'
+                tasks = ['otherBuild']
+            }
+        """
+        file('other/build.gradle') << """
+            task otherBuild(type:GradleBuild) {
+                dir = '../other2'
+                tasks = ['build']
+            }
+        """
+        file('other2/build.gradle') << """
+            task build
+        """
+
+        when:
+        run 'otherBuild'
+
+        then:
+        // TODO - Fix test fixtures to allow assertions on buildSrc tasks rather than relying on output scraping in tests
+        outputContains(":other:otherBuild")
+        outputContains(":other:other2:build")
+    }
+
+    def "nested build can contain project dependencies"() {
+        given:
+        buildFile << """
+            task otherBuild(type:GradleBuild) {
+                dir = 'other'
+                tasks = ['resolve']
+            }
+        """
+        file("other/settings.gradle") << """
+            include 'a', 'b'
+        """
+        file("other/build.gradle") << """
+            allprojects { configurations.create('default') }
+            dependencies { "default" project(':a') }
+            project(':a') {
+                dependencies { "default" project(':b') }
+            }
+            task resolve {
+                inputs.files configurations.default
+                doLast {
+                }
+            }
+        """
+
+        expect:
+        succeeds 'otherBuild'
+    }
+
     @Rule
     BlockingHttpServer barrier = new BlockingHttpServer()
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/GradleBuild.java
@@ -19,8 +19,8 @@ import org.gradle.StartParameter;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.invocation.BuildController;
 
@@ -34,10 +34,12 @@ import java.util.List;
  */
 public class GradleBuild extends ConventionTask {
     private final NestedBuildFactory nestedBuildFactory;
+    private final BuildStateRegistry buildStateRegistry;
     private StartParameter startParameter;
 
     public GradleBuild() {
         this.nestedBuildFactory = getServices().get(NestedBuildFactory.class);
+        this.buildStateRegistry = getServices().get(BuildStateRegistry.class);
         this.startParameter = getServices().get(StartParameter.class).newBuild();
         startParameter.setCurrentDir(getProject().getProjectDir());
     }
@@ -153,7 +155,7 @@ public class GradleBuild extends ConventionTask {
     void build() {
         // TODO: Allow us to inject plugins into GradleBuild nested builds too.
         BuildDefinition buildDefinition = BuildDefinition.fromStartParameter(getStartParameter());
-        StandAloneNestedBuild nestedBuild = nestedBuildFactory.nestedBuildTree(buildDefinition, new DefaultBuildIdentifier(buildDefinition.getStartParameter().getCurrentDir().getName()));
+        StandAloneNestedBuild nestedBuild = buildStateRegistry.addNestedBuildTree(buildDefinition, nestedBuildFactory);
         nestedBuild.run(new Transformer<Void, BuildController>() {
             @Override
             public Void transform(BuildController buildController) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -33,7 +33,6 @@ import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
 import org.gradle.internal.build.NestedBuildState;
 import org.gradle.internal.build.RootBuildState;
-import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.TaskExecutionLogger;
@@ -43,7 +42,6 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.featurelifecycle.ScriptUsageLocationReporter;
-import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -214,20 +212,18 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         }
 
         @Override
-        public StandAloneNestedBuild nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
+        public GradleLauncher nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
             StartParameter startParameter = buildDefinition.getStartParameter();
             final ServiceRegistry userHomeServices = userHomeDirServiceRegistry.getServicesFor(startParameter.getGradleUserHomeDir());
             BuildRequestMetaData buildRequestMetaData = new DefaultBuildRequestMetaData(Time.currentTimeMillis());
             BuildSessionScopeServices sessionScopeServices = new BuildSessionScopeServices(userHomeServices, crossBuildSessionScopeServices, startParameter, buildRequestMetaData, ClassPath.EMPTY);
             BuildTreeScopeServices buildTreeScopeServices = new BuildTreeScopeServices(sessionScopeServices);
-            GradleLauncher childInstance = createChildInstance(buildDefinition, buildIdentifier, parent, buildTreeScopeServices, ImmutableList.of(buildTreeScopeServices, sessionScopeServices, new Stoppable() {
+            return createChildInstance(buildDefinition, buildIdentifier, parent, buildTreeScopeServices, ImmutableList.of(buildTreeScopeServices, sessionScopeServices, new Stoppable() {
                 @Override
                 public void stop() {
-
                     userHomeDirServiceRegistry.release(userHomeServices);
                 }
             }));
-            return new RootOfNestedBuildTree(buildIdentifier, new GradleBuildController(childInstance));
         }
 
         public void setParent(DefaultGradleLauncher parent) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -31,6 +31,8 @@ import org.gradle.configuration.BuildConfigurer;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
+import org.gradle.internal.build.NestedBuildState;
+import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.TaskExecutionLogger;
@@ -93,10 +95,10 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
     }
 
     @Override
-    public GradleLauncher newInstance(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier, BuildRequestContext requestContext, ServiceRegistry parentRegistry) {
+    public GradleLauncher newInstance(BuildDefinition buildDefinition, RootBuildState build, BuildRequestContext requestContext, ServiceRegistry parentRegistry) {
         // This should only be used for top-level builds
         if (rootBuild != null) {
-            throw new IllegalStateException("Cannot have a current build");
+            throw new IllegalStateException("Cannot have a current root build");
         }
 
         if (!(parentRegistry instanceof BuildTreeScopeServices)) {
@@ -104,7 +106,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         }
         BuildTreeScopeServices buildTreeScopeServices = (BuildTreeScopeServices) parentRegistry;
 
-        DefaultGradleLauncher launcher = doNewInstance(buildDefinition, buildIdentifier, null,
+        DefaultGradleLauncher launcher = doNewInstance(buildDefinition, build.getBuildIdentifier(), null,
             requestContext.getCancellationToken(),
             requestContext, requestContext.getEventConsumer(), buildTreeScopeServices,
             ImmutableList.of(new Stoppable() {
@@ -210,8 +212,8 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         }
 
         @Override
-        public GradleLauncher nestedInstance(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
-            return createChildInstance(buildDefinition, buildIdentifier, parent, buildTreeScopeServices, ImmutableList.of());
+        public GradleLauncher nestedInstance(BuildDefinition buildDefinition, NestedBuildState build) {
+            return createChildInstance(buildDefinition, build.getBuildIdentifier(), parent, buildTreeScopeServices, ImmutableList.of());
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncherFactory.java
@@ -15,13 +15,12 @@
  */
 package org.gradle.initialization;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.service.ServiceRegistry;
 
 /**
- * <p>A {@code GradleLauncherFactory} is responsible for creating a {@link GradleLauncher} instance for a build, from a {@link
- * org.gradle.StartParameter}.</p>
+ * <p>A {@code GradleLauncherFactory} is responsible for creating a {@link GradleLauncher} instance for a root build.
  *
  * Caller must call {@link GradleLauncher#stop()} when finished with the launcher.
  *
@@ -33,9 +32,9 @@ public interface GradleLauncherFactory {
      * Fails if a build is in progress.
      *
      * @param buildDefinition The settings for the build.
-     * @param buildIdentifier The identity of the build.
+     * @param build The build to create the {@link GradleLauncher} for.
      * @param requestContext The context in which the build is running.
-     * @param parent The parent service registry for this build.
+     * @param parentRegistry The parent service registry for this build.
      */
-    GradleLauncher newInstance(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier, BuildRequestContext requestContext, ServiceRegistry parent);
+    GradleLauncher newInstance(BuildDefinition buildDefinition, RootBuildState build, BuildRequestContext requestContext, ServiceRegistry parentRegistry);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/NestedBuildFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NestedBuildFactory.java
@@ -18,13 +18,16 @@ package org.gradle.initialization;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.internal.build.NestedBuildState;
 import org.gradle.internal.invocation.BuildController;
 
 public interface NestedBuildFactory {
     /**
-     * Creates a nested {@link GradleLauncher} instance with the provided parameters.
+     * Creates a nested {@link GradleLauncher} instance for the given nested build.
+     *
+     * <p>You should be using the methods on {@link org.gradle.internal.build.BuildStateRegistry} to create various kinds of nested builds, instead of this method.</p>
      */
-    GradleLauncher nestedInstance(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier);
+    GradleLauncher nestedInstance(BuildDefinition buildDefinition, NestedBuildState build);
 
     /**
      * Creates a {@link BuildController} for nested build instance with the provided parameters.

--- a/subprojects/core/src/main/java/org/gradle/initialization/NestedBuildFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NestedBuildFactory.java
@@ -19,7 +19,6 @@ package org.gradle.initialization;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.build.NestedBuildState;
-import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.invocation.BuildController;
 
 public interface NestedBuildFactory {
@@ -34,5 +33,5 @@ public interface NestedBuildFactory {
      * Creates a {@link BuildController} for nested build instance with the provided parameters.
      * The nested build will be created with a new session.
      */
-    StandAloneNestedBuild nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier);
+    GradleLauncher nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/NestedBuildFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NestedBuildFactory.java
@@ -19,6 +19,7 @@ package org.gradle.initialization;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.build.NestedBuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.invocation.BuildController;
 
 public interface NestedBuildFactory {
@@ -33,5 +34,5 @@ public interface NestedBuildFactory {
      * Creates a {@link BuildController} for nested build instance with the provided parameters.
      * The nested build will be created with a new session.
      */
-    BuildController nestedBuildController(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier);
+    StandAloneNestedBuild nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootOfNestedBuildTree.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootOfNestedBuildTree.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.internal.build.StandAloneNestedBuild;
+import org.gradle.internal.invocation.BuildController;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.util.Path;
+
+public class RootOfNestedBuildTree implements StandAloneNestedBuild {
+    private final BuildIdentifier buildIdentifier;
+    private final BuildController buildController;
+
+    public RootOfNestedBuildTree(BuildIdentifier buildIdentifier, BuildController buildController) {
+        this.buildIdentifier = buildIdentifier;
+        this.buildController = buildController;
+    }
+
+    @Override
+    public BuildIdentifier getBuildIdentifier() {
+        return buildIdentifier;
+    }
+
+    @Override
+    public boolean isImplicitBuild() {
+        return false;
+    }
+
+    @Override
+    public SettingsInternal getLoadedSettings() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Path getIdentityPathForProject(Path projectPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T run(final Transformer<T, ? super BuildController> buildAction) {
+        final GradleInternal gradle = buildController.getGradle();
+        try {
+            BuildOperationExecutor executor = gradle.getServices().get(BuildOperationExecutor.class);
+            return executor.call(new CallableBuildOperation<T>() {
+                @Override
+                public T call(BuildOperationContext context) {
+                    T result = buildAction.transform(buildController);
+                    context.setResult(new RunNestedBuildBuildOperationType.Result() {
+                    });
+                    return result;
+                }
+
+                @Override
+                public BuildOperationDescriptor.Builder description() {
+                    return BuildOperationDescriptor.displayName("Run nested build")
+                        .details(new RunNestedBuildBuildOperationType.Details() {
+                            @Override
+                            public String getBuildPath() {
+                                return gradle.getIdentityPath().getPath();
+                            }
+                        });
+                }
+            });
+        } finally {
+            buildController.stop();
+        }
+    }
+}
+
+

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSourceBuilder.java
@@ -27,7 +27,7 @@ import org.gradle.cache.LockOptions;
 import org.gradle.initialization.DefaultSettings;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.BuildStateRegistry;
-import org.gradle.internal.build.NestedBuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.invocation.BuildController;
@@ -113,7 +113,7 @@ public class BuildSourceBuilder {
     }
 
     private ClassPath buildBuildSrc(final BuildDefinition buildDefinition) {
-        NestedBuildState nestedBuild = buildRegistry.addNestedBuild(buildDefinition, nestedBuildFactory);
+        StandAloneNestedBuild nestedBuild = buildRegistry.addNestedBuild(buildDefinition, nestedBuildFactory);
         return nestedBuild.run(new Transformer<ClassPath, BuildController>() {
             @Override
             public ClassPath transform(BuildController buildController) {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -60,7 +60,7 @@ public interface BuildStateRegistry {
     /**
      * Registers a child build that is not an included or implicit build.
      */
-    NestedBuildState addNestedBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
+    StandAloneNestedBuild addNestedBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
 
     /**
      * Registers an implicit build. An implicit build is-a child build whose outputs are used by dependency resolution.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -53,17 +53,22 @@ public interface BuildStateRegistry {
     void registerRootBuild(SettingsInternal settings);
 
     /**
-     * Registers an included build. An included build is-a child build whose projects and outputs are treated as part of the composite build.
+     * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
      */
     IncludedBuildState addExplicitBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
 
     /**
-     * Registers a child build that is not an included or implicit build.
+     * Creates a standalone nested build.
      */
     StandAloneNestedBuild addNestedBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
 
     /**
-     * Registers an implicit build. An implicit build is-a child build whose outputs are used by dependency resolution.
+     * Creates an implicit build. An implicit build is-a nested build whose outputs are used by dependency resolution.
      */
     IncludedBuildState addImplicitBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
+
+    /**
+     * Creates a new nested build tree.
+     */
+    StandAloneNestedBuild addNestedBuildTree(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -28,9 +28,9 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Encapsulates the identity and state of an included build.
+ * Encapsulates the identity and state of an included build. An included build is a nested build that participates in dependency resolution and task execution with the root build and other included builds in the build tree.
  */
-public interface IncludedBuildState extends BuildState {
+public interface IncludedBuildState extends NestedBuildState {
     String getName();
     ConfigurableIncludedBuild getModel();
     List<Action<? super DependencySubstitutions>> getRegisteredDependencySubstitutions();

--- a/subprojects/core/src/main/java/org/gradle/internal/build/StandAloneNestedBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/StandAloneNestedBuild.java
@@ -16,8 +16,15 @@
 
 package org.gradle.internal.build;
 
+import org.gradle.api.Transformer;
+import org.gradle.internal.invocation.BuildController;
+
 /**
- * A build that is a child of some other build, and runs within the lifetime of that containing build.
+ * A stand alone nested build, which is a nested build that runs as part of some containing build as a single atomic step, without participating in task execution of the containing build.
  */
-public interface NestedBuildState extends BuildState {
+public interface StandAloneNestedBuild extends NestedBuildState {
+    /**
+     * Runs a single invocation of this build, executing the given action and returning the result. Should be called once only for a given build instance.
+     */
+    <T> T run(Transformer<T, ? super BuildController> buildAction);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -74,7 +74,7 @@ public class GradleBuildController implements BuildController {
     public GradleInternal run() {
         return doBuild(new Callable<GradleInternal>() {
             @Override
-            public GradleInternal call() throws Exception {
+            public GradleInternal call() {
                 return getLauncher().executeTasks();
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -27,6 +27,7 @@ import org.gradle.initialization.DefaultBuildCancellationToken;
 import org.gradle.initialization.DefaultBuildIdentity;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.internal.build.NestedBuildState;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleInstallation;
 import org.gradle.internal.invocation.BuildController;
@@ -66,7 +67,7 @@ public class TestBuildScopeServices extends BuildScopeServices {
     protected NestedBuildFactory createNestedBuildFactory() {
         return new NestedBuildFactory() {
             @Override
-            public GradleLauncher nestedInstance(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
+            public GradleLauncher nestedInstance(BuildDefinition buildDefinition, NestedBuildState build) {
                 throw new UnsupportedOperationException();
             }
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -28,7 +28,6 @@ import org.gradle.initialization.DefaultBuildIdentity;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.NestedBuildState;
-import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleInstallation;
 import org.gradle.internal.service.ServiceRegistry;
@@ -72,7 +71,7 @@ public class TestBuildScopeServices extends BuildScopeServices {
             }
 
             @Override
-            public StandAloneNestedBuild nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
+            public GradleLauncher nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -28,9 +28,9 @@ import org.gradle.initialization.DefaultBuildIdentity;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.NestedBuildState;
+import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleInstallation;
-import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
@@ -72,7 +72,7 @@ public class TestBuildScopeServices extends BuildScopeServices {
             }
 
             @Override
-            public BuildController nestedBuildController(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
+            public StandAloneNestedBuild nestedBuildTree(BuildDefinition buildDefinition, BuildIdentifier buildIdentifier) {
                 throw new UnsupportedOperationException();
             }
         };

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/GradleBuildTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/GradleBuildTest.groovy
@@ -16,15 +16,11 @@
 package org.gradle.api.tasks
 
 import org.gradle.api.Transformer
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.BuildDefinition
-import org.gradle.api.internal.GradleInternal
 import org.gradle.initialization.NestedBuildFactory
+import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.StandAloneNestedBuild
 import org.gradle.internal.invocation.BuildController
-import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.BuildOperationRef
-import org.gradle.internal.service.ServiceRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -34,19 +30,9 @@ class GradleBuildTest extends Specification {
     @Rule
     public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
     def buildFactory = Mock(NestedBuildFactory)
+    def buildStateRegistry = Mock(BuildStateRegistry)
     def build = Mock(StandAloneNestedBuild)
-    def gradle = Mock(GradleInternal)
-    def services = Mock(ServiceRegistry)
-    def buildOperationExecutor = Mock(BuildOperationExecutor)
-    def buildOperation = Mock(BuildOperationRef)
-    GradleBuild task = TestUtil.create(temporaryFolder).task(GradleBuild, [nestedBuildFactory: buildFactory])
-
-    def setup() {
-        _ * build.getGradle() >> gradle
-        _ * gradle.getServices() >> services
-        _ * services.get(BuildOperationExecutor) >> buildOperationExecutor
-        _ * buildOperationExecutor.currentOperation >> buildOperation
-    }
+    GradleBuild task = TestUtil.create(temporaryFolder).task(GradleBuild, [nestedBuildFactory: buildFactory, buildStateRegistry: buildStateRegistry])
 
     void usesCopyOfCurrentBuildsStartParams() {
         def expectedStartParameter = task.project.gradle.startParameter.newBuild()
@@ -69,7 +55,7 @@ class GradleBuildTest extends Specification {
 
         then:
 
-        1 * buildFactory.nestedBuildTree(_, _) >> { BuildDefinition buildDefinition, BuildIdentifier buildIdentifier ->
+        1 * buildStateRegistry.addNestedBuildTree(_, _) >> { BuildDefinition buildDefinition, NestedBuildFactory buildFactory ->
             assert buildDefinition.startParameter == task.startParameter
             build
         }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/BuildActionCompositeBuildCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/BuildActionCompositeBuildCrossVersionSpec.groovy
@@ -19,10 +19,51 @@ package org.gradle.plugins.ide.tooling.r33
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import spock.lang.Issue
 
 @ToolingApiVersion('>=3.3')
 @TargetGradleVersion('>=3.3')
 class BuildActionCompositeBuildCrossVersionSpec extends ToolingApiSpecification {
+    def "Can run no-op build action against root of composite build"() {
+        given:
+        singleProjectBuildInRootFolder("root") {
+            settingsFile << """
+                includeBuild('includedBuild')
+            """
+        }
+        singleProjectBuildInSubfolder("includedBuild")
+
+        when:
+        def result = withConnection {
+            action(new NoOpBuildAction()).run()
+        }
+
+        then:
+        result == "result"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/5167")
+    def "Can run no-op build action against root of composite build with substitutions"() {
+        given:
+        singleProjectBuildInRootFolder("root") {
+            settingsFile << """
+                includeBuild('includedBuild') { 
+                    dependencySubstitution { 
+                        substitute module('group:name') with project(':other') 
+                    } 
+                }
+            """
+        }
+        singleProjectBuildInSubfolder("includedBuild")
+
+        when:
+        def result = withConnection {
+            action(new NoOpBuildAction()).run()
+        }
+
+        then:
+        result == "result"
+    }
 
     def "Can fetch build scoped models from included builds"() {
         given:
@@ -34,12 +75,35 @@ class BuildActionCompositeBuildCrossVersionSpec extends ToolingApiSpecification 
         singleProjectBuildInSubfolder("includedBuild")
 
         when:
-        def environments = withConnection {
-            action(new FetchBuildEnvironments()).run()
+        def builds = withConnection {
+            action(new FetchBuilds()).run()
         }
 
         then:
-        environments.size() == 2
+        builds.rootProject.name == ["root", "includedBuild"]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/5167")
+    def "Can fetch build scoped models from included builds with substitutions"() {
+        given:
+        singleProjectBuildInRootFolder("root") {
+            settingsFile << """
+                includeBuild('includedBuild') { 
+                    dependencySubstitution { 
+                        substitute module('group:name') with project(':other') 
+                    } 
+                }
+            """
+        }
+        singleProjectBuildInSubfolder("includedBuild")
+
+        when:
+        def builds = withConnection {
+            action(new FetchBuilds()).run()
+        }
+
+        then:
+        builds.rootProject.name == ["root", "includedBuild"]
     }
 
     def "Can fetch project scoped models from included builds"() {
@@ -47,6 +111,29 @@ class BuildActionCompositeBuildCrossVersionSpec extends ToolingApiSpecification 
         multiProjectBuildInRootFolder("root", ["a", "b"]) {
             settingsFile << """
                 includeBuild 'includedBuild'
+            """
+        }
+        multiProjectBuildInSubFolder("includedBuild", ["c", "d"])
+
+        when:
+        def eclipseProjects = withConnection {
+            action(new FetchEclipseProjects()).run()
+        }
+
+        then:
+        eclipseProjects*.name == ['root', 'a', 'b', 'includedBuild', 'c', 'd']
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/5167")
+    def "Can fetch project scoped models from included builds with substitutions"() {
+        given:
+        multiProjectBuildInRootFolder("root", ["a", "b"]) {
+            settingsFile << """
+                includeBuild('includedBuild') { 
+                    dependencySubstitution { 
+                        substitute module('group:name') with project(':other') 
+                    } 
+                }
             """
         }
         multiProjectBuildInSubFolder("includedBuild", ["c", "d"])

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/FetchBuilds.java
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/FetchBuilds.java
@@ -18,21 +18,20 @@ package org.gradle.plugins.ide.tooling.r33;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
-import org.gradle.tooling.model.build.BuildEnvironment;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class FetchBuildEnvironments implements BuildAction<List<BuildEnvironment>> {
+public class FetchBuilds implements BuildAction<List<GradleBuild>> {
     @Override
-    public List<BuildEnvironment> execute(BuildController controller) {
-        List<BuildEnvironment> environments = new ArrayList<BuildEnvironment>();
+    public List<GradleBuild> execute(BuildController controller) {
+        List<GradleBuild> result = new ArrayList<GradleBuild>();
         GradleBuild build = controller.getBuildModel();
-        environments.add(controller.getModel(build, BuildEnvironment.class));
+        result.add(controller.getModel(build, GradleBuild.class));
         for (GradleBuild includedBuild : build.getIncludedBuilds()) {
-            environments.add(controller.getModel(includedBuild, BuildEnvironment.class));
+            result.add(controller.getModel(includedBuild, GradleBuild.class));
         }
-        return environments;
+        return result;
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/NoOpBuildAction.java
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/NoOpBuildAction.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r33;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+
+public class NoOpBuildAction implements BuildAction<String> {
+    @Override
+    public String execute(BuildController controller) {
+        return "result";
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaNestedBuildIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaNestedBuildIntegrationTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.idea
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+
+class IdeaNestedBuildIntegrationTest extends AbstractIntegrationSpec {
+    def "can use GradleBuild task to run a build that applies the IDEA plugin"() {
+        buildFile << """
+            task go(type: GradleBuild) {
+                dir = 'other'
+            }
+        """
+        file("other/build.gradle") << """
+            apply plugin: 'idea'
+        """
+
+        expect:
+        succeeds("go")
+    }
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -19,9 +19,11 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.BuildCancelledException;
+import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.ProjectConfigurer;
+import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
@@ -67,6 +69,12 @@ public class BuildModelActionRunner implements BuildActionRunner {
             this.buildModelAction = buildModelAction;
         }
 
+        @Override
+        public void projectsEvaluated(Gradle gradle) {
+            if (buildModelAction.isModelRequest()) {
+                forceFullConfiguration((GradleInternal) gradle);
+            }
+        }
 
         @Override
         public void buildFinished(BuildResult result) {
@@ -76,9 +84,6 @@ public class BuildModelActionRunner implements BuildActionRunner {
         }
 
         private static BuildActionResult buildResult(GradleInternal gradle, BuildModelAction buildModelAction) {
-            if (buildModelAction.isModelRequest()) {
-                forceFullConfiguration(gradle);
-            }
             PayloadSerializer serializer = gradle.getServices().get(PayloadSerializer.class);
             try {
                 Object model = buildModel(gradle, buildModelAction);
@@ -97,17 +102,16 @@ public class BuildModelActionRunner implements BuildActionRunner {
 
         private static void forceFullConfiguration(GradleInternal gradle) {
             try {
-                ProjectInternal rootProject = gradle.getRootProject();
-                getProjectConfigurer(gradle).configureHierarchyFully(rootProject);
+                gradle.getServices().get(ProjectConfigurer.class).configureHierarchyFully(gradle.getRootProject());
+                for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
+                    GradleInternal build = ((IncludedBuildState) includedBuild).getConfiguredBuild();
+                    forceFullConfiguration(build);
+                }
             } catch (BuildCancelledException e) {
                 throw new InternalBuildCancelledException(e);
             } catch (RuntimeException e) {
                 throw new BuildExceptionVersion1(e);
             }
-        }
-
-        private static ProjectConfigurer getProjectConfigurer(GradleInternal gradle) {
-            return gradle.getServices().get(ProjectConfigurer.class);
         }
 
         private static ToolingModelBuilder getModelBuilder(GradleInternal gradle, String modelName) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
@@ -19,10 +19,11 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.BuildCancelledException;
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.internal.build.IncludedBuildState;
-import org.gradle.execution.ProjectConfigurer;
 import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.execution.ProjectConfigurer;
+import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
@@ -51,6 +52,11 @@ public class ClientProvidedBuildActionRunner implements BuildActionRunner {
 
         gradle.addBuildListener(new BuildAdapter() {
             @Override
+            public void projectsEvaluated(Gradle gradle) {
+                forceFullConfiguration((GradleInternal) gradle);
+            }
+
+            @Override
             public void buildFinished(BuildResult result) {
                 if (result.getFailure() == null) {
                     buildController.setResult(buildResult(clientAction, gradle));
@@ -67,8 +73,6 @@ public class ClientProvidedBuildActionRunner implements BuildActionRunner {
 
     @SuppressWarnings("deprecation")
     private BuildActionResult buildResult(Object clientAction, GradleInternal gradle) {
-        forceFullConfiguration(gradle);
-
         DefaultBuildController internalBuildController = new DefaultBuildController(gradle);
         Object model = null;
         Throwable failure = null;


### PR DESCRIPTION
### Context

Fixes for https://github.com/gradle/gradle/issues/5167 and https://github.com/gradle/gradle/issues/5351

The fix for #5167 includes some duplication and complexity that should be refactored out by a follow on PR.

The fix for #5351 continues to restructure so that the lifecycle and state for a particular build within a Gradle invocation is encapsulated by a single `BuildState` object rather than sprinkled across bunch of services. In this change, the root of a nested build tree is extracted as a thing, and this can start to be wired in consistently with the other kinds of builds.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
