### PR TITLE
Fix "forced" flag being sometimes ignored

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -152,6 +152,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
             resolveState = new SelectorState(idGenerator.generateId(), dependencyState, idResolver, versionSelectorScheme, this, moduleIdentifier);
             selectors.put(requested, resolveState);
         }
+        resolveState.update(dependencyState);
         return resolveState;
     }
 


### PR DESCRIPTION
### Context

If the first direct dependency we see for a specific module version (g,a,v) has forced=false, then
if another first level dependency (g,a,v) with forced=true is added later, we ignore the fact that
the second one has forced=true. This case was lost during refactorings, due to insufficient test
coverage.

Fixes #5364

