### PR TITLE
Fix for LockFileReaderWriter construction

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/file/PathToFileResolver.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/file/PathToFileResolver.java
@@ -31,4 +31,11 @@ public interface PathToFileResolver {
      * Returns a resolver that resolves paths relative to the given base dir.
      */
     PathToFileResolver newResolver(File baseDir);
+
+    /**
+     * Indicates if this resolver is able to resolved relative paths.
+     *
+     * @return {@code true} if it can resolve relative path, {@code false} otherwise.
+     */
+    boolean canResolveRelativePath();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractBaseDirFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractBaseDirFileResolver.java
@@ -83,4 +83,9 @@ public abstract class AbstractBaseDirFileResolver extends AbstractFileResolver {
 
         return file;
     }
+
+    @Override
+    public boolean canResolveRelativePath() {
+        return true;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/IdentityFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/IdentityFileResolver.java
@@ -54,4 +54,9 @@ public class IdentityFileResolver extends AbstractFileResolver {
     public String resolveAsRelativePath(Object path) {
         throw new UnsupportedOperationException(String.format("Cannot convert path %s to a relative path.", path));
     }
+
+    @Override
+    public boolean canResolveRelativePath() {
+        return false;
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -42,6 +42,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
     DefaultDependencyLockingProvider provider
 
     def setup() {
+        resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
         startParameter.getLockedDependenciesToUpdate() >> []
         provider = new DefaultDependencyLockingProvider(resolver, startParameter)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -34,6 +34,7 @@ class LockFileReaderWriterTest extends Specification {
 
     def setup() {
         FileResolver resolver = Mock()
+        resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
         lockFileReaderWriter = new LockFileReaderWriter(resolver)
     }
@@ -60,5 +61,33 @@ line2"""
 
         then:
         result == ['line1', 'line2']
+    }
+
+    def 'fails to read a lockfile if root could not be determined'() {
+        FileResolver resolver = Mock()
+        resolver.canResolveRelativePath() >> false
+        lockFileReaderWriter = new LockFileReaderWriter(resolver)
+
+        when:
+        lockFileReaderWriter.readLockFile('foo')
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.getMessage().contains('Dependency locking cannot be used for configuration')
+        ex.getMessage().contains('foo')
+    }
+
+    def 'fails to write a lockfile if root could not be determined'() {
+        FileResolver resolver = Mock()
+        resolver.canResolveRelativePath() >> false
+        lockFileReaderWriter = new LockFileReaderWriter(resolver)
+
+        when:
+        lockFileReaderWriter.writeLockFile('foo', [])
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.getMessage().contains('Dependency locking cannot be used for configuration')
+        ex.getMessage().contains('foo')
     }
 }

--- a/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
@@ -140,6 +140,7 @@ The resolution may cause other module versions to update, as dictated by the Gra
 If you only perform the second step above, then locking will effectively no longer be applied.
 However, if that configuration happens to be resolved in the future at a time where lock state is persisted, it will once again be locked.
 
+[[locking_limitations]]
 === Locking limitations
 
 * It is currently not possible to lock the <<sec:applying_plugins_buildscript,`classpath` configuration>> used for build plugins.

--- a/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
@@ -143,7 +143,7 @@ However, if that configuration happens to be resolved in the future at a time wh
 [[locking_limitations]]
 === Locking limitations
 
-* It is currently not possible to lock the <<sec:applying_plugins_buildscript,`classpath` configuration>> used for build plugins.
+* It is currently not possible to lock the <<sec:applying_plugins_buildscript,`classpath` configuration>> used for script plugins.
 * Locking can not be applied to source dependencies.
 
 === Nebula locking plugin


### PR DESCRIPTION
This PR removes the exception path, replaced by a method that indicates if a `FileResolver` supports relative paths.