### PR TITLE
Extend POM DSL to support distributionManagement.downloadUrl

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.publish.maven.MavenPomDistributionManagement.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.publish.maven.MavenPomDistributionManagement.xml
@@ -23,6 +23,9 @@
                     <td>Name</td>
                 </tr>
             </thead>
+            <tr>
+                <td>downloadUrl</td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomCustomizationIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomCustomizationIntegTest.groovy
@@ -104,6 +104,7 @@ class MavenPublishPomCustomizationIntegTest extends AbstractMavenPublishIntegTes
                                 url = "https://ci.example.org/"
                             }
                             distributionManagement {
+                                downloadUrl = "https://example.org/download/"
                                 relocation {
                                     groupId = "new-group"
                                     artifactId = "new-artifact-id"
@@ -201,6 +202,7 @@ class MavenPublishPomCustomizationIntegTest extends AbstractMavenPublishIntegTes
         parsedPom.ciManagement.url.text() == "https://ci.example.org/"
 
         and:
+        parsedPom.distributionManagement.downloadUrl.text() == "https://example.org/download/"
         parsedPom.distributionManagement.relocation[0].groupId.text() == "new-group"
         parsedPom.distributionManagement.relocation[0].artifactId.text() == "new-artifact-id"
         parsedPom.distributionManagement.relocation[0].version.text() == "42"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomCustomizationKotlinDslIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomCustomizationKotlinDslIntegTest.groovy
@@ -19,13 +19,10 @@ package org.gradle.api.publish.maven
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
-import spock.lang.Ignore
 
-import static org.gradle.util.TestPrecondition.JDK9_OR_EARLIER
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
-@Ignore
-@Requires([KOTLIN_SCRIPT, JDK9_OR_EARLIER])
+@Requires([KOTLIN_SCRIPT])
 class MavenPublishPomCustomizationKotlinDslIntegTest extends AbstractMavenPublishIntegTest {
 
     @Override
@@ -36,6 +33,10 @@ class MavenPublishPomCustomizationKotlinDslIntegTest extends AbstractMavenPublis
     @Override
     protected TestFile getSettingsFile() {
         testDirectory.file('settings.gradle.kts')
+    }
+
+    def setup() {
+        requireOwnGradleUserHomeDir() // Isolate Kotlin DSL extensions API jar
     }
 
     def "can customize POM using Kotlin DSL"() {
@@ -118,6 +119,7 @@ class MavenPublishPomCustomizationKotlinDslIntegTest extends AbstractMavenPublis
                                 url.set("https://ci.example.org/")
                             }
                             distributionManagement {
+                                downloadUrl.set("https://example.org/download/")
                                 relocation {
                                     groupId.set("new-group")
                                     artifactId.set("new-artifact-id")

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDistributionManagement.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDistributionManagement.java
@@ -18,12 +18,11 @@ package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
  * The distribution management configuration of a Maven publication.
- *
- * <p>Currently, only the <em>relocation</em> information can be set.
  *
  * @since 4.8
  * @see MavenPom
@@ -31,6 +30,11 @@ import org.gradle.internal.HasInternalProtocol;
 @Incubating
 @HasInternalProtocol
 public interface MavenPomDistributionManagement {
+
+    /**
+     * The download URL of the corresponding Maven publication.
+     */
+    Property<String> getDownloadUrl();
 
     /**
      * Configures the relocation information.

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPomDistributionManagement.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPomDistributionManagement.java
@@ -18,6 +18,7 @@ package org.gradle.api.publish.maven.internal.publication;
 
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.publish.maven.MavenPomRelocation;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -25,11 +26,18 @@ public class DefaultMavenPomDistributionManagement implements MavenPomDistributi
 
     private final Instantiator instantiator;
     private final ObjectFactory objectFactory;
+    private final Property<String> downloadUrl;
     private MavenPomRelocation relocation;
 
     public DefaultMavenPomDistributionManagement(Instantiator instantiator, ObjectFactory objectFactory) {
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
+        downloadUrl = objectFactory.property(String.class);
+    }
+
+    @Override
+    public Property<String> getDownloadUrl() {
+        return downloadUrl;
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
@@ -190,6 +190,7 @@ public class MavenPomFileGenerator {
 
     private DistributionManagement convertDistributionManagement(MavenPomDistributionManagementInternal source) {
         DistributionManagement target = new DistributionManagement();
+        target.setDownloadUrl(source.getDownloadUrl().getOrNull());
         if (source.getRelocation() != null) {
             target.setRelocation(convertRelocation(source.getRelocation()));
         }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGeneratorTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGeneratorTest.groovy
@@ -24,15 +24,15 @@ import org.gradle.api.provider.Property
 import org.gradle.api.publication.maven.internal.VersionRangeMapper
 import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInternal
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomDeveloper
+import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomDistributionManagement
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomLicense
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomMailingList
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomOrganization
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomProjectManagement
-import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomRelocation
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPomScm
-import org.gradle.api.publish.maven.internal.publication.ReadableMavenProjectIdentity
-import org.gradle.api.publish.maven.internal.publication.MavenPomDistributionManagementInternal
 import org.gradle.api.publish.maven.internal.publication.MavenPomInternal
+import org.gradle.api.publish.maven.internal.publication.ReadableMavenProjectIdentity
+import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.CollectionUtils
@@ -47,6 +47,7 @@ class MavenPomFileGeneratorTest extends Specification {
     def projectIdentity = new ReadableMavenProjectIdentity("group-id", "artifact-id", "1.0")
     def rangeMapper = Stub(VersionRangeMapper)
     def generator = new MavenPomFileGenerator(projectIdentity, rangeMapper)
+    def instantiator = DirectInstantiator.INSTANCE
     def objectFactory = TestUtil.objectFactory()
 
     def "writes correct prologue and schema declarations"() {
@@ -121,11 +122,12 @@ class MavenPomFileGeneratorTest extends Specification {
             getCiManagement() >> new DefaultMavenPomProjectManagement(objectFactory) {{
                 getSystem().set("Anthill")
             }}
-            getDistributionManagement() >> Mock(MavenPomDistributionManagementInternal) {
-                getRelocation() >> new DefaultMavenPomRelocation(objectFactory) {{
-                    getGroupId().set("org.example.new")
-                }}
-            }
+            getDistributionManagement() >> new DefaultMavenPomDistributionManagement(instantiator, objectFactory) {{
+                getDownloadUrl().set("https://example.org/download/")
+                relocation { r ->
+                    r.getGroupId().set("org.example.new")
+                }
+            }}
             getMailingLists() >> [new DefaultMavenPomMailingList(objectFactory) {{
                 getName().set("Users")
             }}]


### PR DESCRIPTION
This property is used by projects to point users to alternate download locations.

Resolves #5340.