### PR TITLE
Validate conventions for release-features.txt

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -91,6 +91,7 @@ gradlebuildJava {
 
 ext {
     srcDocsDir = file('src/docs')
+    releaseFeaturesFile = file("$srcDocsDir/release/release-features.txt")
     userguideSrcDir = new File(srcDocsDir, 'userguide')
     asciidocSanitizeStylesheet = file("$srcDocsDir/stylesheets/asciidocSanitize.xsl")
     asciidocOutputDir = new File(buildDir, 'asciidoc/userguide')
@@ -488,7 +489,7 @@ tasks.addRule("view«Doc Task Name» - Opens entry point") { String taskName ->
 }
 
 task copyReleaseFeatures(type: Copy) {
-    from 'src/docs/release/release-features.txt'
+    from releaseFeaturesFile
     into generatedResourcesDir
 }
 
@@ -501,6 +502,7 @@ test {
     inputs.property "systemProperties", [:]
     systemProperty "org.gradle.docs.releasenotes.source", releaseNotesMarkdown.markdownFile
     systemProperty "org.gradle.docs.releasenotes.rendered", new File(releaseNotes.destinationDir, releaseNotes.fileName)
+    systemProperty "org.gradle.docs.releasefeatures", releaseFeaturesFile
 }
 
 task docs {

--- a/subprojects/docs/src/test/groovy/org/gradle/docs/SystemPropertyFiles.groovy
+++ b/subprojects/docs/src/test/groovy/org/gradle/docs/SystemPropertyFiles.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.docs.releasenotes
+package org.gradle.docs
 
-import org.gradle.docs.SystemPropertyFiles
+class SystemPropertyFiles {
 
-class ReleaseNotesTestContext {
-
-    File getSourceFile() {
-        SystemPropertyFiles.get("org.gradle.docs.releasenotes.source")
-    }
-
-    File getRenderedFile() {
-        SystemPropertyFiles.get("org.gradle.docs.releasenotes.rendered")
+    static File get(String property) {
+        def value = System.getProperty(property)
+        assert value != null : "System property '$property' is not set"
+        def file = new File(value)
+        assert file.file : "File '$file' (from system property '$property') does not exist"
+        file
     }
 
 }

--- a/subprojects/docs/src/test/groovy/org/gradle/docs/releasefeatures/ReleaseFeaturesTest.groovy
+++ b/subprojects/docs/src/test/groovy/org/gradle/docs/releasefeatures/ReleaseFeaturesTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.docs.releasenotes
+package org.gradle.docs.releasefeatures
 
 import org.gradle.docs.SystemPropertyFiles
+import spock.lang.Specification
 
-class ReleaseNotesTestContext {
+class ReleaseFeaturesTest extends Specification {
 
-    File getSourceFile() {
-        SystemPropertyFiles.get("org.gradle.docs.releasenotes.source")
+    def "release features must follow conventions"() {
+        given:
+        def featuresFile = SystemPropertyFiles.get("org.gradle.docs.releasefeatures")
+
+        when:
+        def featuresText = featuresFile.text
+
+        then:
+        def lines = featuresText.readLines()
+        lines.size() <= 10
+        lines.every { it.startsWith(" - ") }
+        lines.every { it.length() <= 80 }
     }
-
-    File getRenderedFile() {
-        SystemPropertyFiles.get("org.gradle.docs.releasenotes.rendered")
-    }
-
 }


### PR DESCRIPTION
This PR adds the following sanity checks for release-features.txt:

- At most 10 lines in total
- Every line starts with `" - "`
- Every line has at most 80 characters