### PR TITLE
Fix incorrect handling of cycles with root component

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -51,7 +51,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
         assert !candidates.isEmpty();
 
         // If the module matches, add the root component into the mix
-        if (moduleId.equals(rootModuleId)) {
+        if (moduleId.equals(rootModuleId) && !candidates.contains(rootComponent)) {
             candidates = new ArrayList<T>(candidates);
             candidates.add(rootComponent);
         }


### PR DESCRIPTION
## Context

Whenever the root component was added back through a dependency cycle, we
introduced a conflict, which was solved by the latest module conflict
resolver _unless_ `failOnVersionConflict()` was used. Instead, we shouldn't
even try to resolve a conflict because there's none. This commit fixes the
problem by checking if the root component is already added.

Fixes gradle/gradle-private#1268
