### PR TITLE
Fixes to names and paths used in dependency resolution results for composite builds

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationDescriptor.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationDescriptor.java
@@ -133,6 +133,8 @@ public final class BuildOperationDescriptor {
          * Define the parent of the operation. Needs to be the state of an operations that is running at the same time
          * the described operation will run (see: {@link org.gradle.internal.operations.BuildOperationExecutor#getCurrentOperation()}).
          * If parent ID is not set, The last started operation of the executing thread will be used as parent.
+         *
+         * Note: you should use this <em>only</em> for a build operation that is started in some other thread.
          */
         public Builder parent(BuildOperationRef parent) {
             this.parent = parent;

--- a/subprojects/base-services/src/main/java/org/gradle/util/Path.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/Path.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.InvalidUserDataException;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -173,6 +174,7 @@ public class Path implements Comparable<Path> {
      *
      * @return The base name,
      */
+    @Nullable
     public String getName() {
         if (segments.length == 0) {
             return null;

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -65,7 +65,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         loadOps[0].parentId == root.id
         loadOps[1].displayName == "Load build (buildB)"
         // TODO should have a buildPath associated
-        loadOps[1].parentId == root.id
+        loadOps[1].parentId == loadOps[0].id
         loadOps[2].displayName == "Load build (:buildB:buildSrc)"
         loadOps[2].details.buildPath == ":buildB:buildSrc"
         loadOps[2].parentId == buildSrcOps[0].id
@@ -75,12 +75,12 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         configureOps[0].displayName == "Configure build (:buildB:buildSrc)"
         configureOps[0].details.buildPath == ":buildB:buildSrc"
         configureOps[0].parentId == buildSrcOps[0].id
-        configureOps[1].displayName == "Configure build (buildB)"
-        // TODO - should have a buildPath associated
+        configureOps[1].displayName == "Configure build"
+        configureOps[1].details.buildPath == ":"
         configureOps[1].parentId == root.id
-        configureOps[2].displayName == "Configure build"
-        configureOps[2].details.buildPath == ":"
-        configureOps[2].parentId == root.id
+        configureOps[2].displayName == "Configure build (:buildB)"
+        configureOps[2].details.buildPath == ":buildB"
+        configureOps[2].parentId == configureOps[1].id
 
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 3
@@ -136,25 +136,25 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         loadOps[1].parentId == buildSrcOps[0].id
         loadOps[2].displayName == "Load build (buildB)"
         // TODO should have a buildPath associated
-        loadOps[2].parentId == root.id
+        loadOps[2].parentId == loadOps[0].id
         loadOps[3].displayName == "Load build (:buildB:buildSrc)"
         loadOps[3].details.buildPath == ":buildB:buildSrc"
         loadOps[3].parentId == buildSrcOps[1].id
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 4
-        configureOps[0].displayName == "Configure build (buildSrc)"
+        configureOps[0].displayName == "Configure build (:buildSrc)"
         configureOps[0].details.buildPath == ":buildSrc"
         configureOps[0].parentId == buildSrcOps[0].id
         configureOps[1].displayName == "Configure build (:buildB:buildSrc)"
         configureOps[1].details.buildPath == ":buildB:buildSrc"
         configureOps[1].parentId == buildSrcOps[1].id
-        configureOps[2].displayName == "Configure build (buildB)"
-        // TODO - should have a buildPath associated
+        configureOps[2].displayName == "Configure build"
+        configureOps[2].details.buildPath == ":"
         configureOps[2].parentId == root.id
-        configureOps[3].displayName == "Configure build"
-        configureOps[3].details.buildPath == ":"
-        configureOps[3].parentId == root.id
+        configureOps[3].displayName == "Configure build (:buildB)"
+        configureOps[3].details.buildPath == ":buildB"
+        configureOps[3].parentId == configureOps[2].id
 
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 4

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -92,7 +92,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         taskGraphOps[1].parentId == root.id
         taskGraphOps[2].displayName == "Calculate task graph (:buildB)"
         taskGraphOps[2].details.buildPath == ":buildB"
-        taskGraphOps[2].parentId == root.id
+        taskGraphOps[2].parentId == taskGraphOps[1].id
 
         def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
         runTasksOps.size() == 3
@@ -169,7 +169,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         taskGraphOps[2].parentId == root.id
         taskGraphOps[3].displayName == "Calculate task graph (:buildB)"
         taskGraphOps[3].details.buildPath == ":buildB"
-        taskGraphOps[3].parentId == root.id
+        taskGraphOps[3].parentId == taskGraphOps[2].id
 
         def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
         runTasksOps.size() == 4

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -45,10 +45,9 @@ class CompositeBuildBuildSrcIdentityIntegrationTest extends AbstractCompositeBui
 
         then:
         failure.assertHasDescription("Could not resolve all files for configuration ':buildB:buildSrc:runtimeClasspath'.")
-        // TODO - incorrect project path
         failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
 Required by:
-    project :buildSrc""")
+    project :buildB:buildSrc""")
     }
 
     def "includes build identifier in task failure error message"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -32,6 +32,86 @@ class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegr
         includedBuilds << buildB
     }
 
+    def "includes build identifier in logging output"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.buildFile << """
+            println "configuring \$project.path"
+            classes.doLast { t ->
+                println "classes of \$t.path"
+            }
+        """
+
+        when:
+        execute(buildA, ":assemble")
+
+        then:
+        outputContains("> Configure project :buildB")
+        result.groupedOutput.task(":buildB:classes").output.contains("classes of :classes")
+    }
+
+    def "includes configured root project name in build identifier in logging output"() {
+        dependency 'org.test:someLib:1.0'
+
+        buildB.settingsFile << """
+            rootProject.name = 'someLib'
+        """
+
+        buildB.buildFile << """
+            println "configuring \$project.path"
+            classes.doLast { t ->
+                println "classes of \$t.path"
+            }
+        """
+
+        when:
+        execute(buildA, ":assemble")
+
+        then:
+        outputContains("> Configure project :someLib")
+        result.groupedOutput.task(":someLib:classes").output.contains("classes of :classes")
+    }
+
+    def "includes build identifier in dependency report"() {
+        dependency 'org.test:buildB:1.0'
+
+        buildB.buildFile << """
+            dependencies { implementation project(':b1') }
+        """
+
+        when:
+        execute(buildA, ":dependencies")
+
+        then:
+        outputContains("""
+runtimeClasspath - Runtime classpath of source set 'main'.
+\\--- org.test:buildB:1.0 -> project :buildB
+     \\--- project :buildB:b1
+""")
+    }
+
+    def "includes configured root project name in build identifier in dependency report"() {
+        dependency 'org.test:someLib:1.0'
+
+        buildB.settingsFile << """
+            rootProject.name = 'someLib'
+        """
+
+        buildB.buildFile << """
+            dependencies { implementation project(':b1') }
+        """
+
+        when:
+        execute(buildA, ":dependencies")
+
+        then:
+        outputContains("""
+runtimeClasspath - Runtime classpath of source set 'main'.
+\\--- org.test:someLib:1.0 -> project :someLib
+     \\--- project :someLib:b1
+""")
+    }
+
     def "includes build identifier in error message on failure to resolve dependencies of build"() {
         dependency 'org.test:buildB:1.0'
 
@@ -48,6 +128,27 @@ class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegr
         failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
 Required by:
     project :buildB""")
+    }
+
+    def "includes configured root project name in build identifier in error message on failure to resolve dependencies of build"() {
+        dependency 'org.test:someLib:1.0'
+
+        buildB.settingsFile << """
+            rootProject.name = 'someLib'
+        """
+        buildB.buildFile << """
+            dependencies { implementation "test:test:1.2" }
+        """
+
+        when:
+        fails(buildA, ":assemble")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':someLib:compileJava'.")
+        failure.assertHasCause("Could not resolve all task dependencies for configuration ':someLib:compileClasspath'.")
+        failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
+Required by:
+    project :someLib""")
     }
 
     def "includes build identifier in task failure error message"() {
@@ -67,23 +168,96 @@ Required by:
         failure.assertHasCause("broken")
     }
 
+    def "includes configured root project name in build identifier in task failure error message"() {
+        dependency 'org.test:someLib:1.0'
+
+        buildB.settingsFile << """
+            rootProject.name = 'someLib'
+        """
+        buildB.buildFile << """
+            classes.doLast {
+                throw new RuntimeException("broken")
+            }
+        """
+
+        when:
+        fails(buildA, ":assemble")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':someLib:classes'.")
+        failure.assertHasCause("broken")
+    }
+
     def "includes build identifier in dependency resolution results"() {
         dependency 'org.test:buildB:1.0'
+        buildB.buildFile << """
+            dependencies { implementation project(':b1') }
+        """
 
         buildA.buildFile << """
             classes.doLast {
-                def components = configurations.compileClasspath.incoming.resolutionResult.allComponents.id
-                assert components.size() == 2
+                def components = configurations.runtimeClasspath.incoming.resolutionResult.allComponents.id
+                assert components.size() == 3
                 assert components[0].build.name == ':'
                 assert components[0].build.currentBuild
                 assert components[0].projectPath == ':'
-                // TODO - should be 'buildA'
-                assert components[0].projectName == ':'
+                assert components[0].projectName == 'buildA'
                 assert components[1].build.name == 'buildB'
                 assert !components[1].build.currentBuild
                 assert components[1].projectPath == ':'
                 assert components[1].projectName == 'buildB'
+                assert components[2].build.name == 'buildB'
+                assert !components[2].build.currentBuild
+                assert components[2].projectPath == ':b1'
+                assert components[2].projectName == 'b1'
+
+                def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
+                assert selectors.size() == 2
+                assert selectors[0].displayName == 'org.test:buildB:1.0'
+                assert selectors[1].displayName == 'project :buildB:b1'
+                assert selectors[1].buildName == 'buildB'
+                assert selectors[1].projectPath == ':b1'
             }
+        """
+
+        expect:
+        execute(buildA, ":assemble")
+    }
+
+    def "includes configured root project name in build identifier in dependency resolution results"() {
+        dependency 'org.test:someLib:1.0'
+        buildB.buildFile << """
+            dependencies { implementation project(':b1') }
+        """
+
+        buildA.buildFile << """
+            classes.doLast {
+                def components = configurations.runtimeClasspath.incoming.resolutionResult.allComponents.id
+                assert components.size() == 3
+                assert components[0].build.name == ':'
+                assert components[0].build.currentBuild
+                assert components[0].projectPath == ':'
+                assert components[0].projectName == 'buildA'
+                assert components[1].build.name == 'someLib'
+                assert !components[1].build.currentBuild
+                assert components[1].projectPath == ':'
+                assert components[1].projectName == 'someLib'
+                assert components[2].build.name == 'someLib'
+                assert !components[2].build.currentBuild
+                assert components[2].projectPath == ':b1'
+                assert components[2].projectName == 'b1'
+
+                def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
+                assert selectors.size() == 2
+                assert selectors[0].displayName == 'org.test:someLib:1.0'
+                assert selectors[1].displayName == 'project :someLib:b1'
+                // TODO - should be 'someLib'
+                assert selectors[1].buildName == 'buildB'
+                assert selectors[1].projectPath == ':b1'
+            }
+        """
+        buildB.settingsFile << """
+            rootProject.name = 'someLib'
         """
 
         expect:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -81,16 +81,16 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         loadOps[0].parentId == root.id
         loadOps[1].displayName == "Load build (buildB)"
         loadOps[1].details.buildPath == ":buildB"
-        loadOps[1].parentId == root.id
+        loadOps[1].parentId == loadOps[0].id
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2
-        configureOps[0].displayName == "Configure build (buildB)"
-        configureOps[0].details.buildPath == ":buildB"
+        configureOps[0].displayName == "Configure build"
+        configureOps[0].details.buildPath == ":"
         configureOps[0].parentId == root.id
-        configureOps[1].displayName == "Configure build"
-        configureOps[1].details.buildPath == ":"
-        configureOps[1].parentId == root.id
+        configureOps[1].displayName == "Configure build (:buildB)"
+        configureOps[1].details.buildPath == ":buildB"
+        configureOps[1].parentId == configureOps[0].id
 
         def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
         taskGraphOps.size() == 2

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -99,7 +99,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         taskGraphOps[0].parentId == root.id
         taskGraphOps[1].displayName == "Calculate task graph (:buildB)"
         taskGraphOps[1].details.buildPath == ":buildB"
-        taskGraphOps[1].parentId == root.id
+        taskGraphOps[1].parentId == taskGraphOps[0].id
 
         def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
         runTasksOps.size() == 2

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -123,6 +123,11 @@ public class DefaultIncludedBuild implements IncludedBuildState, ConfigurableInc
     }
 
     @Override
+    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+        return DefaultProjectComponentIdentifier.newProjectId(buildIdentifier, projectPath.getPath());
+    }
+
+    @Override
     public void dependencySubstitution(Action<? super DependencySubstitutions> action) {
         if (resolvedDependencySubstitutions) {
             throw new IllegalStateException("Cannot configure included build after dependency substitutions are resolved.");

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.Pair;
+import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.concurrent.Stoppable;
@@ -51,7 +52,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
-public class DefaultIncludedBuild implements IncludedBuildState, ConfigurableIncludedBuild, Stoppable {
+public class DefaultIncludedBuild extends AbstractBuildState implements IncludedBuildState, ConfigurableIncludedBuild, Stoppable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultIncludedBuild.class);
 
     private final BuildIdentifier buildIdentifier;
@@ -123,11 +124,6 @@ public class DefaultIncludedBuild implements IncludedBuildState, ConfigurableInc
     }
 
     @Override
-    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
-        return DefaultProjectComponentIdentifier.newProjectId(buildIdentifier, projectPath.getPath());
-    }
-
-    @Override
     public void dependencySubstitution(Action<? super DependencySubstitutions> action) {
         if (resolvedDependencySubstitutions) {
             throw new IllegalStateException("Cannot configure included build after dependency substitutions are resolved.");
@@ -156,16 +152,18 @@ public class DefaultIncludedBuild implements IncludedBuildState, ConfigurableInc
 
     private void registerProject(Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules, ProjectInternal project) {
         LocalComponentRegistry localComponentRegistry = project.getServices().get(LocalComponentRegistry.class);
-        ProjectComponentIdentifier projectIdentifier = new DefaultProjectComponentIdentifier(buildIdentifier, project.getPath());
+        ProjectComponentIdentifier projectIdentifier = new DefaultProjectComponentIdentifier(buildIdentifier, project.getIdentityPath(), project.getProjectPath(), project.getName());
         DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(projectIdentifier);
         ModuleVersionIdentifier moduleId = originalComponent.getModuleVersionId();
         LOGGER.info("Registering " + project + " in composite build. Will substitute for module '" + moduleId.getModule() + "'.");
         availableModules.add(Pair.of(moduleId, projectIdentifier));
     }
 
-    public ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(String projectPath) {
+    @Override
+    public ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier) {
         // Need to use a 'foreign' build id to make BuildIdentifier.isCurrentBuild and BuildIdentifier.name work in dependency results
-        return new DefaultProjectComponentIdentifier(new ForeignBuildIdentifier(buildIdentifier.getName(), getName()), projectPath);
+        DefaultProjectComponentIdentifier original = (DefaultProjectComponentIdentifier) identifier;
+        return new DefaultProjectComponentIdentifier(new ForeignBuildIdentifier(buildIdentifier.getName(), getName()), original.getIdentityPath(), original.projectPath(), original.getProjectName());
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -121,7 +121,11 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         // Set the only visible included builds from the root build
         settings.getGradle().setIncludedBuilds(modelElements);
         registerProjects(includedBuilds);
-        registerSubstitutions(includedBuilds);
+    }
+
+    @Override
+    public void beforeConfigureRootBuild() {
+        registerSubstitutions(includedBuilds.values());
     }
 
     private void registerProjects(Collection<IncludedBuildState> includedBuilds) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -108,6 +108,20 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     }
 
     @Override
+    public BuildState getBuild(BuildIdentifier buildIdentifier) {
+        BuildState buildState = builds.get(buildIdentifier);
+        if (buildState == null) {
+            throw new IllegalArgumentException("Could not find " + buildIdentifier);
+        }
+        return buildState;
+    }
+
+    @Override
+    public void register(BuildState build) {
+        addBuild(build);
+    }
+
+    @Override
     public void registerRootBuild(SettingsInternal settings) {
         validateIncludedBuilds(settings);
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -49,6 +49,7 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
     public void awaitCompletion(BuildIdentifier targetBuild, String taskPath) {
         // Start task execution if necessary: this is required for building plugin artifacts,
         // since these are built on-demand prior to the regular start signal for included builds.
+        includedBuilds.populateTaskGraphs();
         includedBuilds.startTaskExecution();
 
         getBuildController(targetBuild).awaitCompletion(taskPath);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -69,7 +69,7 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
         for (BuildIdentifier nextTarget : buildDependencies.get(targetBuild)) {
             if (sourceBuild.equals(nextTarget)) {
                 candidateCycle.add(nextTarget);
-                ProjectComponentSelector selector = DefaultProjectComponentSelector.newSelector(candidateCycle.get(0), Path.ROOT.getPath());
+                ProjectComponentSelector selector = new DefaultProjectComponentSelector(candidateCycle.get(0), Path.ROOT, Path.ROOT, ":");
                 throw new ModuleVersionResolveException(selector, "Included build dependency cycle: " + reportCycle(candidateCycle));
             }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -20,19 +20,18 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.util.Path;
 
-class DefaultNestedBuild implements StandAloneNestedBuild {
+class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedBuild {
     private final BuildDefinition buildDefinition;
     private final NestedBuildFactory nestedBuildFactory;
     private final BuildStateListener buildStateListener;
@@ -86,10 +85,5 @@ class DefaultNestedBuild implements StandAloneNestedBuild {
     @Override
     public Path getIdentityPathForProject(Path projectPath) {
         return getLoadedSettings().getGradle().getRootProject().getProjectRegistry().getProject(projectPath.getPath()).getIdentityPath();
-    }
-
-    @Override
-    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
-        return DefaultProjectComponentIdentifier.newProjectId(getBuildIdentifier(), projectPath.getPath());
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -20,9 +20,11 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.build.StandAloneNestedBuild;
@@ -84,5 +86,10 @@ class DefaultNestedBuild implements StandAloneNestedBuild {
     @Override
     public Path getIdentityPathForProject(Path projectPath) {
         return getLoadedSettings().getGradle().getRootProject().getProjectRegistry().getProject(projectPath.getPath()).getIdentityPath();
+    }
+
+    @Override
+    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+        return DefaultProjectComponentIdentifier.newProjectId(getBuildIdentifier(), projectPath.getPath());
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -18,15 +18,14 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.invocation.BuildController;
@@ -34,7 +33,7 @@ import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.util.Path;
 
-class DefaultRootBuildState implements RootBuildState {
+class DefaultRootBuildState extends AbstractBuildState implements RootBuildState {
     private final BuildDefinition buildDefinition;
     private final BuildRequestContext requestContext;
     private final GradleLauncherFactory gradleLauncherFactory;
@@ -92,11 +91,6 @@ class DefaultRootBuildState implements RootBuildState {
     @Override
     public BuildIdentifier getBuildIdentifier() {
         return DefaultBuildIdentifier.ROOT;
-    }
-
-    @Override
-    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
-        return DefaultProjectComponentIdentifier.newProjectId(getBuildIdentifier(), projectPath.getPath());
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -18,9 +18,11 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.GradleLauncherFactory;
@@ -46,6 +48,11 @@ class DefaultRootBuildState implements RootBuildState {
         this.gradleLauncherFactory = gradleLauncherFactory;
         this.listenerManager = listenerManager;
         this.parentServices = parentServices;
+    }
+
+    @Override
+    public String toString() {
+        return "root build";
     }
 
     @Override
@@ -85,6 +92,11 @@ class DefaultRootBuildState implements RootBuildState {
     @Override
     public BuildIdentifier getBuildIdentifier() {
         return DefaultBuildIdentifier.ROOT;
+    }
+
+    @Override
+    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+        return DefaultProjectComponentIdentifier.newProjectId(getBuildIdentifier(), projectPath.getPath());
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencyMetadataBuilder.java
@@ -37,7 +37,7 @@ public class IncludedBuildDependencyMetadataBuilder {
         LocalComponentRegistry localComponentRegistry = gradle.getServices().get(LocalComponentRegistry.class);
         DefaultLocalComponentMetadata originalComponent = (DefaultLocalComponentMetadata) localComponentRegistry.getComponent(projectIdentifier);
 
-        ProjectComponentIdentifier foreignIdentifier = build.idToReferenceProjectFromAnotherBuild(projectIdentifier.getProjectPath());
+        ProjectComponentIdentifier foreignIdentifier = build.idToReferenceProjectFromAnotherBuild(projectIdentifier);
         return createCompositeCopy(foreignIdentifier, originalComponent);
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -50,7 +50,7 @@ public class IncludedBuildDependencySubstitutionsBuilder {
     }
 
     private DependencySubstitutionsInternal resolveDependencySubstitutions(IncludedBuildState build) {
-        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build.getBuildIdentifier(), moduleIdentifierFactory);
+        DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build, moduleIdentifierFactory);
         for (Action<? super DependencySubstitutions> action : build.getRegisteredDependencySubstitutions()) {
             action.execute(dependencySubstitutions);
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -19,9 +19,11 @@ package org.gradle.composite.internal;
 import org.gradle.BuildAdapter;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.initialization.GradleLauncher;
@@ -63,6 +65,11 @@ public class RootOfNestedBuildTree implements StandAloneNestedBuild {
     @Override
     public Path getIdentityPathForProject(Path projectPath) {
         return gradleLauncher.getGradle().getIdentityPath().append(projectPath);
+    }
+
+    @Override
+    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+        return DefaultProjectComponentIdentifier.newProjectId(buildIdentifier, projectPath.getPath());
     }
 
     @Override

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -49,15 +49,19 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def rootBuild = registry.addRootBuild(Stub(BuildDefinition), Stub(BuildRequestContext))
         !rootBuild.implicitBuild
         rootBuild.buildIdentifier == DefaultBuildIdentifier.ROOT
+
+        registry.getBuild(rootBuild.buildIdentifier).is(rootBuild)
     }
 
     def "can add an explicit included build"() {
         def dir = tmpDir.createDir("b1")
         def buildDefinition = build(dir)
         def includedBuild = Stub(IncludedBuildState)
+        def buildIdentifier = new DefaultBuildIdentifier("b1")
+        includedBuild.buildIdentifier >> buildIdentifier
 
         given:
-        includedBuildFactory.createBuild(new DefaultBuildIdentifier("b1"), buildDefinition, false, _) >> includedBuild
+        includedBuildFactory.createBuild(buildIdentifier, buildDefinition, false, _) >> includedBuild
 
         expect:
         def result = registry.addExplicitBuild(buildDefinition, nestedBuildFactory)
@@ -65,6 +69,9 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         registry.hasIncludedBuilds()
         registry.includedBuilds as List == [includedBuild]
+
+        registry.getBuild(buildIdentifier).is(includedBuild)
+        registry.getIncludedBuild(buildIdentifier).is(includedBuild)
     }
 
     def "can add multiple explicit included build"() {
@@ -117,6 +124,8 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         registry.hasIncludedBuilds()
         registry.includedBuilds as List == [includedBuild1, includedBuild2, includedBuild3]
+
+        registry.getBuild(id1).is(includedBuild1)
     }
 
     def "can add the same explicit included build multiple times"() {
@@ -156,6 +165,8 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def nestedBuild = registry.addNestedBuild(buildDefinition, Stub(NestedBuildFactory))
         nestedBuild.implicitBuild
         nestedBuild.buildIdentifier == new DefaultBuildIdentifier("nested")
+
+        registry.getBuild(nestedBuild.buildIdentifier).is(nestedBuild)
     }
 
     def "can add multiple nested builds with same name"() {

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTest.groovy
@@ -18,18 +18,23 @@ package org.gradle.composite.internal
 
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.BuildDefinition
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.ForeignBuildIdentifier
 import org.gradle.initialization.NestedBuildFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
+import org.gradle.util.Path
 import spock.lang.Specification
 
 class DefaultIncludedBuildTest extends Specification {
     def "creates a foreign id for projects"() {
         def build = new DefaultIncludedBuild(Stub(BuildIdentifier), Stub(BuildDefinition), false, Stub(NestedBuildFactory), Stub(WorkerLeaseRegistry.WorkerLease))
+        def projectId = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path("id"), Path.path("project"), "name")
 
         expect:
-        def id = build.idToReferenceProjectFromAnotherBuild(":a:b:c")
+        def id = build.idToReferenceProjectFromAnotherBuild(projectId)
         id.build instanceof ForeignBuildIdentifier
-        id.projectPath == ":a:b:c"
+        id.identityPath == projectId.identityPath
+        id.projectPath == projectId.projectPath
+        id.projectName == projectId.projectName
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -135,13 +135,13 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
 
 
         then:
-        def rootBuildOperation = operations()[1]
+        def rootBuildOperation = operations()[0]
         rootBuildOperation.result.buildPath == ":"
         rootBuildOperation.result.rootProject.path == ":"
         verifyProject(rootBuildOperation.result.rootProject, 'root', ':', [':a'], testDirectory, 'root.gradle')
         verifyProject(project(":a", rootBuildOperation), 'a')
 
-        def nestedBuildOperation = operations()[0]
+        def nestedBuildOperation = operations()[1]
         nestedBuildOperation.result.buildPath == ":nested"
         nestedBuildOperation.result.rootProject.path == ":"
         verifyProject(nestedBuildOperation.result.rootProject, 'nested', ':nested', [':b'], testDirectory.file('nested'))

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -54,7 +54,7 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
 
         def configureOps = ops.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2
-        configureOps[0].displayName == "Configure build (buildSrc)"
+        configureOps[0].displayName == "Configure build (:buildSrc)"
         configureOps[0].details.buildPath == ":buildSrc"
         configureOps[0].parentId == buildSrcOps[0].id
         configureOps[1].displayName == "Configure build"

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -149,7 +149,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         // evaluate hierarchies
         op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).parentId == op(RunBuildBuildOperationType.Details).id
-        op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == op(RunBuildBuildOperationType.Details).id
+        op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
         op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
         op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
 
@@ -159,7 +159,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
 
         op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).parentId == op(RunBuildBuildOperationType.Details).id
-        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == op(RunBuildBuildOperationType.Details).id
+        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
         op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
         op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.TaskExecutionGraphInternal;
-import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
@@ -46,10 +45,6 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
     GradleInternal getParent();
 
     GradleInternal getRoot();
-
-    @Nullable
-    BuildOperationRef getBuildOperation();
-    void setBuildOperation(BuildOperationRef operation);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
@@ -15,25 +15,32 @@
  */
 package org.gradle.api.internal.artifacts;
 
-import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.util.Path;
 
 public class DefaultProjectComponentIdentifier implements ProjectComponentIdentifier {
     private final BuildIdentifier buildIdentifier;
-    private final String projectPath;
+    private final Path projectPath;
+    private final Path identityPath;
+    private final String projectName;
     private String displayName;
 
-    public DefaultProjectComponentIdentifier(BuildIdentifier buildIdentifier, String projectPath) {
+    public DefaultProjectComponentIdentifier(BuildIdentifier buildIdentifier, Path identityPath, Path projectPath, String projectName) {
         assert buildIdentifier != null : "build cannot be null";
+        assert identityPath != null : "identity path cannot be null";
         assert projectPath != null : "project path cannot be null";
+        assert projectName != null : "project name cannot be null";
+        this.identityPath = identityPath;
+        this.projectName = projectName;
         this.buildIdentifier = buildIdentifier;
         this.projectPath = projectPath;
     }
 
+    @Override
     public String getDisplayName() {
         if (displayName == null) {
-            displayName = "project " + fullPath(buildIdentifier, projectPath);
+            displayName = "project " + identityPath.getPath();
         }
         return displayName;
     }
@@ -43,16 +50,22 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
         return buildIdentifier;
     }
 
+    public Path getIdentityPath() {
+        return identityPath;
+    }
+
+    @Override
     public String getProjectPath() {
+        return projectPath.getPath();
+    }
+
+    public Path projectPath() {
         return projectPath;
     }
 
+    @Override
     public String getProjectName() {
-        if (projectPath.equals(":")) {
-            return buildIdentifier.getName();
-        }
-        int index = projectPath.lastIndexOf(':');
-        return projectPath.substring(index + 1);
+        return projectName;
     }
 
     @Override
@@ -65,31 +78,16 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
         }
 
         DefaultProjectComponentIdentifier that = (DefaultProjectComponentIdentifier) o;
-        return Objects.equal(projectPath, that.projectPath)
-            && Objects.equal(buildIdentifier, that.buildIdentifier);
+        return identityPath.equals(that.identityPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(projectPath, buildIdentifier);
+        return identityPath.hashCode();
     }
 
     @Override
     public String toString() {
         return getDisplayName();
-    }
-
-    private static String fullPath(BuildIdentifier build, String projectPath) {
-        if (build.getName().equals(":")) {
-            return projectPath;
-        } else if (projectPath.equals(":")) {
-            return ":" + build.getName();
-        } else {
-            return ":" + build.getName() + projectPath;
-        }
-    }
-
-    public static ProjectComponentIdentifier newProjectId(BuildIdentifier buildIdentifier, String projectPath) {
-        return new DefaultProjectComponentIdentifier(buildIdentifier, projectPath);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
@@ -16,11 +16,8 @@
 package org.gradle.api.internal.artifacts;
 
 import com.google.common.base.Objects;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.initialization.BuildIdentity;
 
 public class DefaultProjectComponentIdentifier implements ProjectComponentIdentifier {
     private final BuildIdentifier buildIdentifier;
@@ -95,10 +92,4 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
     public static ProjectComponentIdentifier newProjectId(BuildIdentifier buildIdentifier, String projectPath) {
         return new DefaultProjectComponentIdentifier(buildIdentifier, projectPath);
     }
-
-    public static ProjectComponentIdentifier newProjectId(Project project) {
-        BuildIdentifier buildId = ((ProjectInternal) project).getServices().get(BuildIdentity.class).getCurrentBuild();
-        return new DefaultProjectComponentIdentifier(buildId, project.getPath());
-    }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -16,8 +16,10 @@
 package org.gradle.api.internal.project;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.internal.build.BuildState;
+import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
@@ -41,6 +43,11 @@ public interface ProjectStateRegistry {
      * Locates the state object that owns the project with the given identifier.
      */
     ProjectState stateFor(ProjectComponentIdentifier identifier);
+
+    /**
+     * Locates the state object for the given project.
+     */
+    ProjectState stateFor(BuildIdentifier buildIdentifier, Path projectPath);
 
     /**
      * Registers a project.

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildController.java
@@ -22,7 +22,6 @@ public interface IncludedBuildController {
 
     boolean isComplete(String taskPath);
 
-
     void startTaskExecution();
     void stopTaskExecution();
 

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
@@ -18,6 +18,8 @@ package org.gradle.composite.internal;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 
 public interface IncludedBuildControllers {
+    void rootBuildOperationStarted();
+
     void startTaskExecution();
 
     void stopTaskExecution();

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
@@ -18,8 +18,17 @@ package org.gradle.composite.internal;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 
 public interface IncludedBuildControllers {
+    /**
+     * Notify the controllers that the root build operation has started.
+     * Should be using something like {@link org.gradle.initialization.RootBuildLifecycleListener} however, this is currently called outside the root build operation.
+     */
     void rootBuildOperationStarted();
 
+    void populateTaskGraphs();
+
+    /**
+     * Starts running any scheduled tasks. Does nothing when {@link #populateTaskGraphs()} has not been called to schedule the tasks.
+     */
     void startTaskExecution();
 
     void stopTaskExecution();

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultBuildConfigurer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultBuildConfigurer.java
@@ -18,20 +18,23 @@ package org.gradle.configuration;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.execution.ProjectConfigurer;
+import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.util.SingleMessageLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DefaultBuildConfigurer implements BuildConfigurer {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultBuildConfigurer.class);
     private final ProjectConfigurer projectConfigurer;
+    private final BuildStateRegistry buildRegistry;
 
-    public DefaultBuildConfigurer(ProjectConfigurer projectConfigurer) {
+    public DefaultBuildConfigurer(ProjectConfigurer projectConfigurer, BuildStateRegistry buildRegistry) {
         this.projectConfigurer = projectConfigurer;
+        this.buildRegistry = buildRegistry;
     }
 
     public void configure(GradleInternal gradle) {
         maybeInformAboutIncubatingMode(gradle);
+        if (gradle.getParent() == null) {
+            buildRegistry.beforeConfigureRootBuild();
+        }
         if (gradle.getStartParameter().isConfigureOnDemand()) {
             projectConfigurer.configure(gradle.getRootProject());
         } else {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -251,8 +251,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
                     public String getBuildPath() {
                         return gradle.getIdentityPath().toString();
                     }
-                })
-                .parent(getGradle().getBuildOperation());
+                });
         }
     }
 
@@ -278,7 +277,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
                     public String getBuildPath() {
                         return getGradle().getIdentityPath().toString();
                     }
-                }).parent(gradle.getBuildOperation());
+                });
         }
     }
 
@@ -323,7 +322,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
                     public String getBuildPath() {
                         return getGradle().getIdentityPath().getPath();
                     }
-                }).parent(getGradle().getBuildOperation());
+                });
         }
     }
 
@@ -340,7 +339,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
         @Override
         public BuildOperationDescriptor.Builder description() {
-            return BuildOperationDescriptor.displayName(contextualize("Run tasks")).parent(getGradle().getBuildOperation());
+            return BuildOperationDescriptor.displayName(contextualize("Run tasks"));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -292,6 +292,12 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
             final TaskExecutionGraphInternal taskGraph = gradle.getTaskGraph();
             taskGraph.populate();
+
+            if (!isNestedBuild()) {
+                IncludedBuildControllers buildControllers = gradle.getServices().get(IncludedBuildControllers.class);
+                buildControllers.populateTaskGraphs();
+            }
+
             buildOperationContext.setResult(new CalculateTaskGraphBuildOperationType.Result() {
                 @Override
                 public List<String> getRequestedTaskPaths() {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build;
+
+import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
+import org.gradle.initialization.DefaultProjectDescriptor;
+import org.gradle.util.Path;
+
+public abstract class AbstractBuildState implements BuildState {
+    @Override
+    public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+        BuildIdentifier buildIdentifier = getBuildIdentifier();
+        Path identityPath = getIdentityPathForProject(projectPath);
+        DefaultProjectDescriptor project = getLoadedSettings().getProjectRegistry().getProject(projectPath.getPath());
+        if (project == null) {
+            throw new IllegalArgumentException("Project " + projectPath + " not found.");
+        }
+        String name = project.getName();
+        return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, projectPath, name);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.build;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.util.Path;
 
@@ -28,7 +29,15 @@ public interface BuildState {
 
     boolean isImplicitBuild();
 
-    SettingsInternal getLoadedSettings();
+    SettingsInternal getLoadedSettings() throws IllegalStateException;
 
+    /**
+     * Calculates the identity path for a project in this build.
+     */
     Path getIdentityPathForProject(Path projectPath);
+
+    /**
+     * Calculates the identifier for a project in this build.
+     */
+    ProjectComponentIdentifier getIdentifierForProject(Path projectPath);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -53,6 +53,13 @@ public interface BuildStateRegistry {
     void registerRootBuild(SettingsInternal settings);
 
     /**
+     * Notification that the root build is about to be configured.
+     *
+     * This shouldn't be on this interface, as this is state for the root build that should be managed internally by the {@link RootBuildState} instance instead. This method is here to allow transition towards that structure.
+     */
+    void beforeConfigureRootBuild();
+
+    /**
      * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
      */
     IncludedBuildState addExplicitBuild(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -40,10 +40,15 @@ public interface BuildStateRegistry {
     Collection<? extends IncludedBuildState> getIncludedBuilds();
 
     /**
-     * Locates an included build by {@link BuildIdentifier}, if present.
+     * Locates an included build by {@link BuildIdentifier}, if present. Fails if not an included build.
      */
     @Nullable
     IncludedBuildState getIncludedBuild(BuildIdentifier buildIdentifier);
+
+    /**
+     * Locates a build.
+     */
+    BuildState getBuild(BuildIdentifier buildIdentifier);
 
     /**
      * Notification that the settings have been loaded for the root build.
@@ -78,4 +83,6 @@ public interface BuildStateRegistry {
      * Creates a new nested build tree.
      */
     StandAloneNestedBuild addNestedBuildTree(BuildDefinition buildDefinition, NestedBuildFactory nestedBuildFactory);
+
+    void register(BuildState build);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -39,7 +39,7 @@ public interface IncludedBuildState extends NestedBuildState {
     /**
      * Creates a copy of the identifier for a project in this build, to use in the dependency resolution result from some other build
      */
-    ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(String path);
+    ProjectComponentIdentifier idToReferenceProjectFromAnotherBuild(ProjectComponentIdentifier identifier);
 
     GradleInternal getConfiguredBuild();
     void finishBuild();

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -17,7 +17,6 @@ package org.gradle.internal.invocation;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.initialization.GradleLauncher;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.Collections;
@@ -92,14 +91,10 @@ public class GradleBuildController implements BuildController {
     }
 
     private GradleInternal doBuild(final Callable<GradleInternal> build) {
-        GradleInternal gradle = getGradle();
-        BuildOperationExecutor buildOperationExecutor = gradle.getServices().get(BuildOperationExecutor.class);
-        gradle.setBuildOperation(buildOperationExecutor.getCurrentOperation());
         try {
             // TODO:pm Move this to RunAsBuildOperationBuildActionRunner when BuildOperationWorkerRegistry scope is changed
             return workerLeaseService.withLocks(Collections.singleton(workerLeaseService.getWorkerLease()), build);
         } finally {
-            gradle.setBuildOperation(null);
             state = State.Completed;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -362,7 +362,7 @@ public class BuildOperationTrace implements Stoppable {
 
     private class LoggingListener extends BuildAdapter implements BuildOperationListener {
 
-        // This is a workaround for https://github.com/gradle/gradle/issues/3873
+        // This is a workaround for https://github.com/gradle/gradle/issues/4241
         // Several early typed operations have `buildPath` property,
         // the value of which can only be determined after the settings file for the build has loaded.
         //

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -389,8 +389,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new TaskPathProjectEvaluator(cancellationToken);
     }
 
-    protected BuildConfigurer createBuildConfigurer(ProjectConfigurer projectConfigurer) {
-        return new DefaultBuildConfigurer(projectConfigurer);
+    protected BuildConfigurer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildStateRegistry buildStateRegistry) {
+        return new DefaultBuildConfigurer(projectConfigurer, buildStateRegistry);
     }
 
     protected ProjectAccessListener createProjectAccessListener() {

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -46,7 +46,6 @@ import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleInstallation;
-import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.scan.config.BuildScanConfigInit;
 import org.gradle.internal.service.ServiceRegistry;
@@ -76,7 +75,6 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     private boolean projectsLoaded;
     private Path identityPath;
     private final ClassLoaderScope classLoaderScope;
-    private BuildOperationRef operation;
 
     public DefaultGradle(GradleInternal parent, StartParameter startParameter, ServiceRegistryFactory parentRegistry) {
         this.parent = parent;
@@ -144,22 +142,6 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             throw new IllegalStateException("Identity path already set");
         }
         identityPath = path;
-    }
-
-    @Override
-    public BuildOperationRef getBuildOperation() {
-        if (operation != null) {
-            return operation;
-        }
-        if (parent != null) {
-            return parent.getBuildOperation();
-        }
-        return null;
-    }
-
-    @Override
-    public void setBuildOperation(BuildOperationRef operation) {
-        this.operation = operation;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -121,7 +121,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             if (parent == null) {
                 identityPath = Path.ROOT;
             } else {
-                if (rootProject == null) {
+                if (settings == null) {
                     // Not known yet
                     return null;
                 }
@@ -130,7 +130,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
                     // Not known yet
                     return null;
                 }
-                this.identityPath = parentIdentityPath.child(rootProject.getName());
+                this.identityPath = parentIdentityPath.child(settings.getRootProject().getName());
             }
         }
         return identityPath;

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -19,11 +19,13 @@ package org.gradle.testfixtures.internal;
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.AsmBackedClassGenerator;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
@@ -180,6 +182,11 @@ public class ProjectBuilderImpl {
         @Override
         public Path getIdentityPathForProject(Path projectPath) {
             return projectPath;
+        }
+
+        @Override
+        public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+            return DefaultProjectComponentIdentifier.newProjectId(getBuildIdentifier(), projectPath.getPath());
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifierTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifierTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.component.BuildIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.util.Path
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -25,49 +25,23 @@ import static org.gradle.util.Matchers.strictlyEquals
 class DefaultProjectComponentIdentifierTest extends Specification {
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        ProjectComponentIdentifier defaultBuildComponentIdentifier = newProjectId(':myPath')
+        def id = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
 
         then:
-        defaultBuildComponentIdentifier.projectPath == ':myPath'
-        defaultBuildComponentIdentifier.displayName == 'project :myPath'
-        defaultBuildComponentIdentifier.toString() == 'project :myPath'
-    }
-
-    def "includes build name in path"() {
-        when:
-        ProjectComponentIdentifier defaultBuildComponentIdentifier = newProjectId(buildId("TEST"), ":myPath")
-
-        then:
-        defaultBuildComponentIdentifier.projectPath == ':myPath'
-        defaultBuildComponentIdentifier.displayName == 'project :TEST:myPath'
-        defaultBuildComponentIdentifier.toString() == 'project :TEST:myPath'
-
-        when:
-        defaultBuildComponentIdentifier = newProjectId(buildId("TEST"), ":")
-
-        then:
-        defaultBuildComponentIdentifier.projectPath == ':'
-        defaultBuildComponentIdentifier.displayName == 'project :TEST'
-        defaultBuildComponentIdentifier.toString() == 'project :TEST'
-    }
-
-    def "is instantiated with null constructor parameter value"() {
-        when:
-        newProjectId((String) null)
-
-        then:
-        Throwable t = thrown(AssertionError)
-        t.message == 'project path cannot be null'
+        id.projectPath == ':project:path'
+        id.projectName == 'projectName'
+        id.displayName == 'project :id:path'
+        id.toString() == 'project :id:path'
     }
 
     @Unroll
     def "can compare with other instance (#projectPath)"() {
         expect:
-        ProjectComponentIdentifier defaultBuildComponentIdentifier1 = newProjectId(':myProjectPath1')
-        ProjectComponentIdentifier defaultBuildComponentIdentifier2 = newProjectId(projectPath)
-        strictlyEquals(defaultBuildComponentIdentifier1, defaultBuildComponentIdentifier2) == equality
-        (defaultBuildComponentIdentifier1.hashCode() == defaultBuildComponentIdentifier2.hashCode()) == hashCode
-        (defaultBuildComponentIdentifier1.toString() == defaultBuildComponentIdentifier2.toString()) == stringRepresentation
+        def id1 = newProjectId(':myProjectPath1')
+        def id2 = newProjectId(projectPath)
+        strictlyEquals(id1, id2) == equality
+        (id1.hashCode() == id2.hashCode()) == hashCode
+        (id1.toString() == id2.toString()) == stringRepresentation
 
         where:
         projectPath       | equality | hashCode | stringRepresentation
@@ -80,7 +54,7 @@ class DefaultProjectComponentIdentifierTest extends Specification {
     }
 
     private static newProjectId(BuildIdentifier build, String path) {
-        new DefaultProjectComponentIdentifier(build, path)
+        new DefaultProjectComponentIdentifier(build, Path.path(path), Path.path(path), "name")
     }
 
     private static buildId(String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -108,7 +108,7 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         build.loadedSettings >> settings
         build.buildIdentifier >> DefaultBuildIdentifier.ROOT
         build.getIdentityPathForProject(_) >> { Path path -> path }
-        build.getIdentifierForProject(_) >> { Path path -> DefaultProjectComponentIdentifier.newProjectId(DefaultBuildIdentifier.ROOT, path.path) }
+        build.getIdentifierForProject(_) >> { Path path -> new DefaultProjectComponentIdentifier(DefaultBuildIdentifier.ROOT, path, path, "??") }
         return build
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.project
 
 import org.gradle.api.internal.SettingsInternal
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultProjectDescriptorRegistry
 import org.gradle.internal.build.BuildState
@@ -50,6 +52,10 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         registry.stateFor(root.componentIdentifier).is(root)
         registry.stateFor(p1.componentIdentifier).is(p1)
         registry.stateFor(p2.componentIdentifier).is(p2)
+
+        registry.stateFor(build.buildIdentifier, Path.ROOT).is(root)
+        registry.stateFor(build.buildIdentifier, Path.path(":p1")).is(p1)
+        registry.stateFor(build.buildIdentifier, Path.path(":p2")).is(p2)
     }
 
     def "one thread can access state at a time"() {
@@ -100,7 +106,9 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
 
         def build = Stub(BuildState)
         build.loadedSettings >> settings
+        build.buildIdentifier >> DefaultBuildIdentifier.ROOT
         build.getIdentityPathForProject(_) >> { Path path -> path }
+        build.getIdentifierForProject(_) >> { Path path -> DefaultProjectComponentIdentifier.newProjectId(DefaultBuildIdentifier.ROOT, path.path) }
         return build
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultBuildConfigurerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultBuildConfigurerTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.StartParameter
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.execution.ProjectConfigurer
+import org.gradle.internal.build.BuildStateRegistry
 import spock.lang.Specification
 
 class DefaultBuildConfigurerTest extends Specification {
@@ -26,7 +27,8 @@ class DefaultBuildConfigurerTest extends Specification {
     private gradle = Mock(GradleInternal)
     private rootProject = Mock(ProjectInternal)
     private projectConfigurer = Mock(ProjectConfigurer)
-    private configurer = new DefaultBuildConfigurer(projectConfigurer)
+    private buildRegistry = Mock(BuildStateRegistry)
+    private configurer = new DefaultBuildConfigurer(projectConfigurer, buildRegistry)
 
     def setup() {
         gradle.startParameter >> startParameter

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
@@ -50,6 +50,8 @@ import org.gradle.initialization.DefaultGradlePropertiesLoader
 import org.gradle.initialization.IGradlePropertiesLoader
 import org.gradle.initialization.NotifyingBuildLoader
 import org.gradle.internal.Factory
+import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.buildevents.BuildStartedTime
 import org.gradle.internal.classloader.ClassLoaderFactory
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.classloader.ClasspathHasher
@@ -66,7 +68,6 @@ import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceLookupException
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.internal.buildevents.BuildStartedTime
 import org.gradle.internal.time.Clock
 import org.gradle.model.internal.inspect.ModelRuleSourceDetector
 import org.gradle.plugin.use.internal.InjectedPluginClasspath
@@ -116,6 +117,7 @@ class BuildScopeServicesTest extends Specification {
         sessionServices.get(InjectedPluginClasspath) >> Mock(InjectedPluginClasspath)
         sessionServices.get(BuildOperationExecutor) >> Mock(BuildOperationExecutor)
         sessionServices.get(BuildStartedTime) >> BuildStartedTime.startingAt(0)
+        sessionServices.get(BuildStateRegistry) >> Mock(BuildStateRegistry)
         def parentListenerManager = Mock(ListenerManager)
         sessionServices.get(ListenerManager) >> parentListenerManager
         parentListenerManager.createChild() >> listenerManager

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.invocation
 
 import org.gradle.StartParameter
 import org.gradle.api.Action
+import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.GradleInternal
@@ -399,11 +400,11 @@ class DefaultGradleSpec extends Specification {
     def "has identity path"() {
         given:
         def child1 = classGenerator.newInstance(DefaultGradle, gradle, Stub(StartParameter), serviceRegistryFactory)
-        child1.rootProject = project('child1')
+        child1.settings = settings('child1')
 
         and:
         def child2 = classGenerator.newInstance(DefaultGradle, child1, Stub(StartParameter), serviceRegistryFactory)
-        child2.rootProject = project('child2')
+        child2.settings = settings('child2')
 
         expect:
         gradle.identityPath == Path.ROOT
@@ -412,6 +413,15 @@ class DefaultGradleSpec extends Specification {
     }
 
     def projectRegistry = new DefaultProjectRegistry()
+
+    private SettingsInternal settings(String rootProjectName) {
+        def rootProject = Stub(ProjectDescriptor)
+        rootProject.name >> rootProjectName
+
+        def settings = Stub(SettingsInternal)
+        settings.rootProject >> rootProject
+        return settings
+    }
 
     private ProjectInternal project(String name) {
         def project = Spy(DefaultProject, constructorArgs: [

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -674,8 +674,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         }
     }
 
-    void "get useful error message when replacing an external dependency with a project that does not exist"()
-    {
+    void "get useful error message when replacing an external dependency with a project that does not exist"() {
         settingsFile << 'include "api", "impl"'
 
         buildFile << """
@@ -701,9 +700,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         fails ":impl:checkDeps"
 
         then:
-        failure.assertHasDescription("Could not determine the dependencies of task ':impl:checkDeps'.")
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':impl:conf'.")
-        failure.assertHasCause("project :doesnotexist not found.")
+        failure.assertHasDescription("A problem occurred evaluating root project 'depsub'.")
+        failure.assertHasCause("Project :doesnotexist not found.")
     }
 
     void "replacing external module dependency with project dependency keeps the original configuration"()
@@ -1151,7 +1149,7 @@ Required by:
             }
 
             configurations.conf.resolutionStrategy.dependencySubstitution {
-                substitute project(":foo") with module("org.gradle:test")
+                substitute project(":") with module("org.gradle:test")
             }
 """
 
@@ -1159,6 +1157,7 @@ Required by:
         fails "checkDeps"
 
         then:
+        failure.assertHasDescription("A problem occurred evaluating root project 'root'.")
         failure.assertHasCause("Must specify version for target of dependency substitution")
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -125,8 +125,8 @@ class DependencyManagementBuildScopeServices {
         return new DefaultDependencyManagementServices(parent);
     }
 
-    ComponentIdentifierFactory createComponentIdentifierFactory(BuildIdentity buildIdentity) {
-        return new DefaultComponentIdentifierFactory(buildIdentity);
+    ComponentIdentifierFactory createComponentIdentifierFactory(BuildIdentity buildIdentity, BuildStateRegistry buildRegistry) {
+        return new DefaultComponentIdentifierFactory(buildRegistry.getBuild(buildIdentity.getCurrentBuild()));
     }
 
     DependencyFactory createDependencyFactory(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
@@ -19,24 +19,24 @@ package org.gradle.api.internal.artifacts.component;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.Module;
-import org.gradle.initialization.BuildIdentity;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
+import org.gradle.util.Path;
 
 public class DefaultComponentIdentifierFactory implements ComponentIdentifierFactory {
-    private final BuildIdentity buildIdentity;
+    private final BuildState currentBuild;
 
-    public DefaultComponentIdentifierFactory(BuildIdentity buildIdentity) {
-        this.buildIdentity = buildIdentity;
+    public DefaultComponentIdentifierFactory(BuildState currentBuild) {
+        this.currentBuild = currentBuild;
     }
 
     public ComponentIdentifier createComponentIdentifier(Module module) {
         String projectPath = module.getProjectPath();
 
         if (projectPath != null) {
-            return new DefaultProjectComponentIdentifier(buildIdentity.getCurrentBuild(), projectPath);
+            return currentBuild.getIdentifierForProject(Path.path(projectPath));
         }
 
         return new DefaultModuleComponentIdentifier(module.getGroup(), module.getName(), module.getVersion());
@@ -44,11 +44,11 @@ public class DefaultComponentIdentifierFactory implements ComponentIdentifierFac
 
     @Override
     public ProjectComponentSelector createProjectComponentSelector(String projectPath) {
-        return DefaultProjectComponentSelector.newSelector(buildIdentity.getCurrentBuild(), projectPath);
+        return DefaultProjectComponentSelector.newSelector(currentBuild.getIdentifierForProject(Path.path(projectPath)));
     }
 
     @Override
     public ProjectComponentIdentifier createProjectComponentIdentifier(ProjectComponentSelector selector) {
-        return new DefaultProjectComponentIdentifier(((DefaultProjectComponentSelector)selector).getBuildIdentifier(), selector.getProjectPath());
+        return ((DefaultProjectComponentSelector) selector).toIdentifier();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
@@ -35,6 +34,7 @@ import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.internal.Actions;
+import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.NotationConvertResult;
@@ -42,6 +42,7 @@ import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.TypeConversionException;
+import org.gradle.util.Path;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -70,7 +71,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         return new DefaultDependencySubstitutions(VersionSelectionReasons.SELECTED_BY_RULE, projectSelectorNotationParser, moduleIdentifierFactory);
     }
 
-    public static DefaultDependencySubstitutions forIncludedBuild(BuildIdentifier build, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+    public static DefaultDependencySubstitutions forIncludedBuild(IncludedBuildState build, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
         NotationParser<Object, ComponentSelector> projectSelectorNotationParser = NotationParserBuilder
                 .toType(ComponentSelector.class)
                 .fromCharSequence(new CompositeProjectPathConverter(build))
@@ -187,9 +188,9 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
     }
 
     private static class CompositeProjectPathConverter implements NotationConverter<String, ProjectComponentSelector> {
-        private final BuildIdentifier build;
+        private final IncludedBuildState build;
 
-        private CompositeProjectPathConverter(BuildIdentifier build) {
+        private CompositeProjectPathConverter(IncludedBuildState build) {
             this.build = build;
         }
 
@@ -200,7 +201,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
 
         @Override
         public void convert(String notation, NotationConvertResult<? super ProjectComponentSelector> result) throws TypeConversionException {
-            result.converted(DefaultProjectComponentSelector.newSelector(build, notation));
+            result.converted(DefaultProjectComponentSelector.newSelector(build.getIdentifierForProject(Path.path(notation))));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
@@ -22,13 +22,14 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.util.Path;
 
 import java.io.IOException;
 
@@ -38,9 +39,23 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
     public ComponentIdentifier read(Decoder decoder) throws IOException {
         byte id = decoder.readByte();
 
-        if (Implementation.BUILD.getId() == id) {
+        if (Implementation.ROOT_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            return new DefaultProjectComponentIdentifier(buildIdentifier, decoder.readString());
+            String projectName = decoder.readString();
+            return new DefaultProjectComponentIdentifier(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
+        } else if (Implementation.ROOT_BUILD_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            Path projectPath = Path.path(decoder.readString());
+            return new DefaultProjectComponentIdentifier(buildIdentifier, projectPath, projectPath, projectPath.getName());
+        } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            Path identityPath = Path.path(decoder.readString());
+            return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, Path.ROOT, identityPath.getName());
+        } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            Path identityPath = Path.path(decoder.readString());
+            Path projectPath = Path.path(decoder.readString());
+            return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, projectPath, identityPath.getName());
         } else if (Implementation.MODULE.getId() == id) {
             return new DefaultModuleComponentIdentifier(decoder.readString(), decoder.readString(), decoder.readString());
         } else if (Implementation.SNAPSHOT.getId() == id) {
@@ -72,10 +87,26 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
             encoder.writeString(snapshotIdentifier.getModule());
             encoder.writeString(snapshotIdentifier.getVersion());
             encoder.writeString(snapshotIdentifier.getTimestamp());
-        } else if (implementation == Implementation.BUILD) {
+        } else if (implementation == Implementation.ROOT_PROJECT) {
             ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
             BuildIdentifier build = projectComponentIdentifier.getBuild();
             buildIdentifierSerializer.write(encoder, build);
+            encoder.writeString(projectComponentIdentifier.getProjectName());
+        } else if (implementation == Implementation.ROOT_BUILD_PROJECT) {
+            ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
+            BuildIdentifier build = projectComponentIdentifier.getBuild();
+            buildIdentifierSerializer.write(encoder, build);
+            encoder.writeString(projectComponentIdentifier.getProjectPath());
+        } else if (implementation == Implementation.OTHER_BUILD_ROOT_PROJECT) {
+            DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
+            BuildIdentifier build = projectComponentIdentifier.getBuild();
+            buildIdentifierSerializer.write(encoder, build);
+            encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
+        } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
+            DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
+            BuildIdentifier build = projectComponentIdentifier.getBuild();
+            buildIdentifierSerializer.write(encoder, build);
+            encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
             encoder.writeString(projectComponentIdentifier.getProjectPath());
         } else if (implementation == Implementation.LIBRARY) {
             LibraryBinaryIdentifier libraryIdentifier = (LibraryBinaryIdentifier) value;
@@ -103,28 +134,38 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
     }
 
     private Implementation resolveImplementation(ComponentIdentifier value) {
-        Implementation implementation;
         if (value instanceof MavenUniqueSnapshotComponentIdentifier) {
-            implementation = Implementation.SNAPSHOT;
+            return Implementation.SNAPSHOT;
         } else if (value instanceof ModuleComponentIdentifier) {
-            implementation = Implementation.MODULE;
-        } else if (value instanceof ProjectComponentIdentifier) {
-            implementation = Implementation.BUILD;
+            return Implementation.MODULE;
+        } else if (value instanceof DefaultProjectComponentIdentifier) {
+            DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
+            // Special case some common combinations of names and paths
+            boolean isARootProject = projectComponentIdentifier.projectPath().equals(Path.ROOT);
+            if (projectComponentIdentifier.getIdentityPath().equals(Path.ROOT) && isARootProject) {
+                return Implementation.ROOT_PROJECT;
+            }
+            if (projectComponentIdentifier.getIdentityPath().equals(projectComponentIdentifier.projectPath()) && projectComponentIdentifier.projectPath().getName().equals(projectComponentIdentifier.getProjectName())) {
+                return Implementation.ROOT_BUILD_PROJECT;
+            }
+            if (isARootProject && projectComponentIdentifier.getProjectName().equals(projectComponentIdentifier.getIdentityPath().getName())) {
+                return Implementation.OTHER_BUILD_ROOT_PROJECT;
+            }
+            return Implementation.OTHER_BUILD_PROJECT;
         } else if (value instanceof LibraryBinaryIdentifier) {
-            implementation = Implementation.LIBRARY;
+            return Implementation.LIBRARY;
         } else {
             throw new IllegalArgumentException("Unsupported component identifier class: " + value.getClass());
         }
-        return implementation;
     }
 
     private enum Implementation {
-        MODULE((byte) 1), BUILD((byte) 2), LIBRARY((byte) 3), SNAPSHOT((byte) 4);
+        MODULE(1), ROOT_PROJECT(2), ROOT_BUILD_PROJECT(3), OTHER_BUILD_ROOT_PROJECT(4), OTHER_BUILD_PROJECT(5), LIBRARY(6), SNAPSHOT(7);
 
         private final byte id;
 
-        Implementation(byte id) {
-            this.id = id;
+        Implementation(int id) {
+            this.id = (byte) id;
         }
 
         private byte getId() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -31,6 +32,7 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.util.Path;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,8 +49,23 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
     public ComponentSelector read(Decoder decoder) throws IOException {
         byte id = decoder.readByte();
 
-        if (Implementation.BUILD.getId() == id) {
-            return new DefaultProjectComponentSelector(buildIdentifierSerializer.read(decoder), decoder.readString());
+        if (Implementation.ROOT_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            String projectName = decoder.readString();
+            return new DefaultProjectComponentSelector(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
+        } else if (Implementation.ROOT_BUILD_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            Path projectPath = Path.path(decoder.readString());
+            return new DefaultProjectComponentSelector(buildIdentifier, projectPath, projectPath, projectPath.getName());
+        } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            Path identityPath = Path.path(decoder.readString());
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, identityPath.getName());
+        } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
+            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+            Path identityPath = Path.path(decoder.readString());
+            Path projectPath = Path.path(decoder.readString());
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, projectPath, projectPath.getName());
         } else if (Implementation.MODULE.getId() == id) {
             return DefaultModuleComponentSelector.newSelector(decoder.readString(), decoder.readString(), readVersionConstraint(decoder), readAttributes(decoder));
         } else if (Implementation.LIBRARY.getId() == id) {
@@ -88,9 +105,22 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             VersionConstraint versionConstraint = moduleComponentSelector.getVersionConstraint();
             writeVersionConstraint(encoder, versionConstraint);
             writeAttributes(encoder, moduleComponentSelector.getAttributes());
-        } else if (implementation == Implementation.BUILD) {
+        } else if (implementation == Implementation.ROOT_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
+            encoder.writeString(projectComponentSelector.getProjectName());
+        } else if (implementation == Implementation.ROOT_BUILD_PROJECT) {
+            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
+            buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
+            encoder.writeString(projectComponentSelector.getProjectPath());
+        } else if (implementation == Implementation.OTHER_BUILD_ROOT_PROJECT) {
+            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
+            buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
+            encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
+        } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
+            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
+            buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
+            encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
             encoder.writeString(projectComponentSelector.getProjectPath());
         } else if (implementation == Implementation.LIBRARY) {
             LibraryComponentSelector libraryComponentSelector = (LibraryComponentSelector) value;
@@ -121,7 +151,19 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         if (value instanceof DefaultModuleComponentSelector) {
             implementation = Implementation.MODULE;
         } else if (value instanceof DefaultProjectComponentSelector) {
-            implementation = Implementation.BUILD;
+            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
+            // Special case some common combinations of names and paths
+            boolean isARootProject = projectComponentSelector.projectPath().equals(Path.ROOT);
+            if (projectComponentSelector.getIdentityPath().equals(Path.ROOT) && isARootProject) {
+                return Implementation.ROOT_PROJECT;
+            }
+            if (projectComponentSelector.getIdentityPath().equals(projectComponentSelector.projectPath()) && projectComponentSelector.projectPath().getName().equals(projectComponentSelector.getProjectName())) {
+                return Implementation.ROOT_BUILD_PROJECT;
+            }
+            if (isARootProject && projectComponentSelector.getProjectName().equals(projectComponentSelector.getIdentityPath().getName())) {
+                return Implementation.OTHER_BUILD_ROOT_PROJECT;
+            }
+            return Implementation.OTHER_BUILD_PROJECT;
         } else if (value instanceof DefaultLibraryComponentSelector) {
             implementation = Implementation.LIBRARY;
         } else {
@@ -132,12 +174,12 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
     }
 
     private enum Implementation {
-        MODULE((byte) 1), BUILD((byte) 2), LIBRARY((byte) 3), BINARY((byte) 4);
+        MODULE(1), ROOT_PROJECT(2), ROOT_BUILD_PROJECT(3), OTHER_BUILD_ROOT_PROJECT(4), OTHER_BUILD_PROJECT(5), LIBRARY(6), SNAPSHOT(7);
 
         private final byte id;
 
-        Implementation(byte id) {
-            this.id = id;
+        Implementation(int id) {
+            this.id = (byte) id;
         }
 
         byte getId() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -123,7 +123,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                     LocalComponentMetadata componentMetaData = localComponentRegistry.getComponent(entry.right);
 
                     if (componentMetaData == null) {
-                        result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(includedBuild.getBuildIdentifier(), entry.right.getProjectPath()), spec.getDisplayName() + " could not be resolved into a usable project."));
+                        result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(entry.right), spec.getDisplayName() + " could not be resolved into a usable project."));
                     } else {
                         result.resolved(componentMetaData);
                     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -16,48 +16,45 @@
 
 package org.gradle.api.internal.artifacts.component
 
-import org.gradle.api.Project
-import org.gradle.api.artifacts.component.BuildIdentifier
-import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModule
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
-import org.gradle.api.internal.artifacts.Module
 import org.gradle.api.internal.artifacts.ProjectBackedModule
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.initialization.BuildIdentity
+import org.gradle.internal.build.BuildState
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+import org.gradle.util.Path
 import spock.lang.Specification
 
 class DefaultComponentIdentifierFactoryTest extends Specification {
-    BuildIdentity buildIdentity = Mock(BuildIdentity)
-    ComponentIdentifierFactory componentIdentifierFactory = new DefaultComponentIdentifierFactory(buildIdentity)
+    def buildIdentity = Mock(BuildState)
+    def componentIdentifierFactory = new DefaultComponentIdentifierFactory(buildIdentity)
 
     def "can create project component identifier"() {
         given:
-        BuildIdentifier buildId = new DefaultBuildIdentifier("build")
-        Project project = Mock(ProjectInternal)
-        Module module = new ProjectBackedModule(project)
+        def project = Mock(ProjectInternal)
+        def expectedId = Stub(ProjectComponentIdentifier)
+        def module = new ProjectBackedModule(project)
 
         when:
-        ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module)
+        def componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module)
 
         then:
         project.path >> ':a'
-        buildIdentity.getCurrentBuild() >> buildId
+        buildIdentity.getIdentifierForProject(Path.path(':a')) >> expectedId
 
         and:
-        componentIdentifier == new DefaultProjectComponentIdentifier(buildId, ':a')
+        componentIdentifier == expectedId
     }
 
     def "can create module component identifier"() {
         given:
-        Module module = new DefaultModule('some-group', 'some-name', '1.0')
+        def module = new DefaultModule('some-group', 'some-name', '1.0')
 
         when:
-        ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module)
+        def componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module)
 
         then:
         componentIdentifier == new DefaultModuleComponentIdentifier('some-group', 'some-name', '1.0')
@@ -65,16 +62,16 @@ class DefaultComponentIdentifierFactoryTest extends Specification {
 
     def "can create component identifier for project dependency in same build"() {
         given:
-        BuildIdentifier buildId = new DefaultBuildIdentifier("build")
-        ProjectComponentSelector selector = new DefaultProjectComponentSelector(buildId, ":a")
+        def buildId = new DefaultBuildIdentifier("build")
+        def selector = new DefaultProjectComponentSelector(buildId, Path.path(":id:path"), Path.path(":project:path"), "name")
 
         when:
-        ComponentIdentifier componentIdentifier = componentIdentifierFactory.createProjectComponentIdentifier(selector)
+        def componentIdentifier = componentIdentifierFactory.createProjectComponentIdentifier(selector)
 
         then:
         buildIdentity.getCurrentBuild() >> buildId
 
         and:
-        componentIdentifier == new DefaultProjectComponentIdentifier(buildId, ':a')
+        componentIdentifier == new DefaultProjectComponentIdentifier(buildId, selector.identityPath, selector.projectPath(), selector.projectName)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.initialization.BuildIdentity
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.typeconversion.UnsupportedNotationException
+import org.gradle.util.Path
 import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.dsl.ComponentSelectorParsers.multiParser
@@ -110,7 +111,9 @@ public class ComponentSelectorParsersTest extends Specification {
         def services = new DefaultServiceRegistry()
         services.add(BuildIdentity, buildIdentity)
         def project = Mock(ProjectInternal) {
-            getPath() >> ":bar"
+            getIdentityPath() >> Path.path(":id:bar")
+            getProjectPath() >> Path.path(":bar")
+            getName() >> "name"
             getServices() >> services
         }
         def v = multiParser().parseNotation(project) as List

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.initialization.BuildIdentity
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.typeconversion.UnsupportedNotationException
+import org.gradle.util.Path
 import spock.lang.Specification
 
 class DefaultDependencySubstitutionSpec extends Specification {
@@ -82,6 +83,10 @@ class DefaultDependencySubstitutionSpec extends Specification {
 
     def "can specify target project"() {
         def project = Mock(ProjectInternal)
+        project.identityPath >> Path.path(":id:path")
+        project.projectPath >> Path.path(":bar")
+        project.name >> "bar"
+
         def services = new DefaultServiceRegistry()
         services.add(BuildIdentity, Stub(BuildIdentity))
 
@@ -89,7 +94,6 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.useTarget(project)
 
         then:
-        _ * project.path >> ":bar"
         project.getServices() >> services
         details.target instanceof ProjectComponentSelector
         details.target.projectPath == ":bar"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import org.junit.Rule
 import org.junit.Test
@@ -61,7 +62,7 @@ public class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDe
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData);
         assertFalse(dependencyMetaData.isChanging());
         assertFalse(dependencyMetaData.isForce());
-        assertEquals(new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, ":"), dependencyMetaData.getSelector());
+        assertEquals(new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root"), dependencyMetaData.getSelector());
         assertSame(projectDependency, dependencyMetaData.source);
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
@@ -18,12 +18,12 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier
 import org.gradle.internal.serialize.SerializerSpec
-
-import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
+import org.gradle.util.Path
 
 class ComponentIdentifierSerializerTest extends SerializerSpec {
     ComponentIdentifierSerializer serializer = new ComponentIdentifierSerializer()
@@ -62,14 +62,59 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
         result.libraryName == 'lib'
     }
 
-    def "serializes ProjectComponentIdentifier"() {
+    def "serializes root ProjectComponentIdentifier"() {
         given:
-        ProjectComponentIdentifier identifier = newProjectId(':myPath')
+        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier("build"), Path.ROOT, Path.ROOT, "someProject")
 
         when:
-        ProjectComponentIdentifier result = serialize(identifier, serializer)
+        def result = serialize(identifier, serializer)
 
         then:
-        result.projectPath == ':myPath'
+        result.identityPath == identifier.identityPath
+        result.projectPath == identifier.projectPath
+        result.projectPath() == identifier.projectPath()
+        result.projectName == identifier.projectName
+    }
+
+    def "serializes root build ProjectComponentIdentifier"() {
+        given:
+        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier("build"), Path.path(":a:b"), Path.path(":a:b"), "b")
+
+        when:
+        def result = serialize(identifier, serializer)
+
+        then:
+        result.identityPath == identifier.identityPath
+        result.projectPath == identifier.projectPath
+        result.projectPath() == identifier.projectPath()
+        result.projectName == identifier.projectName
+    }
+
+    def "serializes other build root ProjectComponentIdentifier"() {
+        given:
+        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier("build"), Path.path(":prefix:someProject"), Path.ROOT, "someProject")
+
+        when:
+        def result = serialize(identifier, serializer)
+
+        then:
+        result.identityPath == identifier.identityPath
+        result.projectPath == identifier.projectPath
+        result.projectPath() == identifier.projectPath()
+        result.projectName == identifier.projectName
+    }
+
+    def "serializes other build ProjectComponentIdentifier"() {
+        given:
+        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier("build"), Path.path(":prefix:a:b"), Path.path(":a:b"), "b")
+
+        when:
+        def result = serialize(identifier, serializer)
+
+        then:
+        result.identityPath == identifier.identityPath
+        result.projectPath == identifier.projectPath
+        result.projectPath() == identifier.projectPath()
+        result.projectName == identifier.projectName
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 import org.gradle.api.artifacts.component.LibraryComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
@@ -27,8 +28,10 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.local.model.TestComponentIdentifiers
 import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
@@ -53,6 +56,62 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
         then:
         Throwable t = thrown(IllegalArgumentException)
         t.message == 'Provided component selector may not be null'
+    }
+
+    def "serializes root project ProjectComponentSelector"() {
+        given:
+        def selector = new DefaultProjectComponentSelector(new DefaultBuildIdentifier("build"), Path.ROOT, Path.ROOT, "rootProject")
+
+        when:
+        def result = serialize(selector, serializer)
+
+        then:
+        result.identityPath == selector.identityPath
+        result.projectPath == selector.projectPath
+        result.projectPath() == selector.projectPath()
+        result.projectName == selector.projectName
+    }
+
+    def "serializes root build ProjectComponentSelector"() {
+        given:
+        def selector = new DefaultProjectComponentSelector(new DefaultBuildIdentifier("build"), Path.path(":a:b"), Path.path(":a:b"), "b")
+
+        when:
+        def result = serialize(selector, serializer)
+
+        then:
+        result.identityPath == selector.identityPath
+        result.projectPath == selector.projectPath
+        result.projectPath() == selector.projectPath()
+        result.projectName == selector.projectName
+    }
+
+    def "serializes other build root ProjectComponentSelector"() {
+        given:
+        def selector = new DefaultProjectComponentSelector(new DefaultBuildIdentifier("build"), Path.path(":prefix:a:someProject"), Path.ROOT, "someProject")
+
+        when:
+        def result = serialize(selector, serializer)
+
+        then:
+        result.identityPath == selector.identityPath
+        result.projectPath == selector.projectPath
+        result.projectPath() == selector.projectPath()
+        result.projectName == selector.projectName
+    }
+
+    def "serializes other build ProjectComponentSelector"() {
+        given:
+        def selector = new DefaultProjectComponentSelector(new DefaultBuildIdentifier("build"), Path.path(":prefix:a:b"), Path.path(":a:b"), "b")
+
+        when:
+        def result = serialize(selector, serializer)
+
+        then:
+        result.identityPath == selector.identityPath
+        result.projectPath == selector.projectPath
+        result.projectPath() == selector.projectPath()
+        result.projectName == selector.projectName
     }
 
     def "serializes ModuleComponentSelector"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
@@ -16,13 +16,13 @@
 package org.gradle.internal.component.local.model
 
 import org.gradle.api.artifacts.component.BuildIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.util.Path
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newSelector
 import static org.gradle.util.Matchers.strictlyEquals
 
@@ -30,26 +30,13 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        ProjectComponentSelector defaultBuildComponentSelector = newSelector(buildName , projectPath)
+        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
 
         then:
-        defaultBuildComponentSelector.projectPath == projectPath
-        defaultBuildComponentSelector.displayName == displayName
-        defaultBuildComponentSelector.toString() == displayName
-
-        where:
-        buildName | projectPath | displayName
-        ':'       | ':myPath'   | 'project :myPath'
-        'build'   | ':myPath'   | 'project :build:myPath'
-    }
-
-    def "is instantiated with null constructor parameter value"() {
-        when:
-        new DefaultProjectComponentSelector(Stub(BuildIdentifier), (String) null)
-
-        then:
-        Throwable t = thrown(AssertionError)
-        t.message == 'project path cannot be null'
+        defaultBuildComponentSelector.projectPath == ":project:path"
+        defaultBuildComponentSelector.projectName == "projectName"
+        defaultBuildComponentSelector.displayName == "project :id:path"
+        defaultBuildComponentSelector.toString() == "project :id:path"
     }
 
     @Unroll
@@ -86,18 +73,12 @@ class DefaultProjectComponentSelectorTest extends Specification {
         assert !matches
     }
 
-    @Unroll
     def "matches id (#buildName #projectPath)"() {
         expect:
-        ProjectComponentSelector defaultBuildComponentSelector = newSelector(buildName, ':myProjectPath1')
-        ProjectComponentIdentifier defaultBuildComponentIdentifier = newProjectId("TEST", projectPath)
-        defaultBuildComponentSelector.matchesStrictly(defaultBuildComponentIdentifier) == matchesId
-
-        where:
-        buildName | projectPath       | matchesId
-        'TEST'    | ':myProjectPath1' | true
-        'TEST'    | ':myProjectPath2' | false
-        'OTHER'   | ':myProjectPath1' | false
-        ':'       | ':myProjectPath1' | false
+        def selector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        def sameIdPath = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        def differentIdPath = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path2"), Path.path(":project:path"), "projectName")
+        selector.matchesStrictly(sameIdPath)
+        !selector.matchesStrictly(differentIdPath)
     }
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
@@ -17,6 +17,8 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.util.Path
 import spock.lang.Unroll
 
 /**
@@ -182,7 +184,7 @@ abstract class AbstractProjectDependencyConflictResolutionIntegrationSpec extend
         def projectId(String projectName) {
             def buildId = $buildId
             def projectPath = $projectPath
-            return new org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier(buildId, projectPath)
+            return project.services.get(${BuildStateRegistry.name}).getBuild(buildId).getIdentifierForProject(${Path.name}.path(projectPath))
         }
 """
     }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
+import org.gradle.util.Path;
 
 public class TestComponentIdentifiers {
     public static ProjectComponentIdentifier newProjectId(String projectPath) {
@@ -26,7 +27,12 @@ public class TestComponentIdentifiers {
     }
 
     public static ProjectComponentIdentifier newProjectId(String buildName, String projectPath) {
-        return new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(buildName), projectPath);
+        Path path = Path.path(projectPath);
+        String name = path.getName();
+        if (name == null) {
+            name = "root";
+        }
+        return new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(buildName), path, path, name);
     }
 
     public static ProjectComponentSelector newSelector(String projectPath) {
@@ -34,6 +40,11 @@ public class TestComponentIdentifiers {
     }
 
     public static ProjectComponentSelector newSelector(String buildName, String projectPath) {
-        return new DefaultProjectComponentSelector(new DefaultBuildIdentifier(buildName), projectPath);
+        Path path = Path.path(projectPath);
+        String name = path.getName();
+        if (name == null) {
+            name = "root";
+        }
+        return new DefaultProjectComponentSelector(new DefaultBuildIdentifier(buildName), path, path, name);
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/BuildActionCompositeBuildCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r33/BuildActionCompositeBuildCrossVersionSpec.groovy
@@ -49,7 +49,7 @@ class BuildActionCompositeBuildCrossVersionSpec extends ToolingApiSpecification 
             settingsFile << """
                 includeBuild('includedBuild') { 
                     dependencySubstitution { 
-                        substitute module('group:name') with project(':other') 
+                        substitute module('group:name') with project(':') 
                     } 
                 }
             """
@@ -90,7 +90,7 @@ class BuildActionCompositeBuildCrossVersionSpec extends ToolingApiSpecification 
             settingsFile << """
                 includeBuild('includedBuild') { 
                     dependencySubstitution { 
-                        substitute module('group:name') with project(':other') 
+                        substitute module('group:name') with project(':') 
                     } 
                 }
             """
@@ -131,7 +131,7 @@ class BuildActionCompositeBuildCrossVersionSpec extends ToolingApiSpecification 
             settingsFile << """
                 includeBuild('includedBuild') { 
                     dependencySubstitution { 
-                        substitute module('group:name') with project(':other') 
+                        substitute module('group:name') with project(':') 
                     } 
                 }
             """

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaMultiModuleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaMultiModuleIntegrationTest.groovy
@@ -206,8 +206,7 @@ project(':util') {
 
         def utilDependencies = parseIml("util/util.iml").dependencies
         assert utilDependencies.modules.size() == 1
-        // This name is incorrect (see gradle/composite-builds#99)
-        utilDependencies.assertHasModule(['TEST'], ":")
+        utilDependencies.assertHasModule(['TEST'], "root-project-1")
     }
 
     @Test

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -21,6 +21,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory;
@@ -315,7 +316,10 @@ public class EclipseClasspath {
      * Calculates, resolves and returns dependency entries of this classpath.
      */
     public List<ClasspathEntry> resolveDependencies() {
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ((ProjectInternal) project).getServices().get(IdeArtifactRegistry.class));
+        ProjectInternal projectInternal = (ProjectInternal) this.project;
+        IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
+        ProjectStateRegistry projectRegistry = projectInternal.getServices().get(ProjectStateRegistry.class);
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, projectRegistry);
         return classpathFactory.createEntries();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpComponent.java
@@ -23,9 +23,12 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory;
 import org.gradle.plugins.ide.eclipse.model.internal.WtpComponentFactory;
+import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 
 import java.io.File;
 import java.util.Collections;
@@ -381,7 +384,10 @@ public class EclipseWtpComponent {
 
     public void mergeXmlComponent(WtpComponent xmlComponent) {
         file.getBeforeMerged().execute(xmlComponent);
-        new WtpComponentFactory(project).configure(this, xmlComponent);
+        ProjectInternal projectInternal = (ProjectInternal) this.project;
+        IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
+        ProjectStateRegistry projectRegistry = projectInternal.getServices().get(ProjectStateRegistry.class);
+        new WtpComponentFactory(projectInternal, ideArtifactRegistry, projectRegistry).configure(this, xmlComponent);
         file.getWhenMerged().execute(xmlComponent);
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ClasspathFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.plugins.ide.eclipse.model.internal;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.ClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.Container;
@@ -33,9 +34,9 @@ public class ClasspathFactory {
     private final EclipseClasspath classpath;
     private final EclipseDependenciesCreator dependenciesCreator;
 
-    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry) {
+    public ClasspathFactory(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, ProjectStateRegistry projectRegistry) {
         this.classpath = classpath;
-        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry);
+        this.dependenciesCreator = new EclipseDependenciesCreator(classpath, ideArtifactRegistry, projectRegistry);
     }
 
     public List<ClasspathEntry> createEntries() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -27,8 +27,8 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;
@@ -53,10 +53,12 @@ public class EclipseDependenciesCreator {
     private static final Logger LOGGER = LoggerFactory.getLogger(EclipseDependenciesCreator.class);
     private final EclipseClasspath classpath;
     private final ProjectDependencyBuilder projectDependencyBuilder;
+    private final ProjectComponentIdentifier currentProjectId;
 
-    public EclipseDependenciesCreator(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry) {
+    public EclipseDependenciesCreator(EclipseClasspath classpath, IdeArtifactRegistry ideArtifactRegistry, ProjectStateRegistry projectRegistry) {
         this.classpath = classpath;
         this.projectDependencyBuilder = new ProjectDependencyBuilder(ideArtifactRegistry);
+        currentProjectId = projectRegistry.stateFor(classpath.getProject()).getComponentIdentifier();
     }
 
     public List<AbstractClasspathEntry> createDependencyEntries() {
@@ -72,8 +74,6 @@ public class EclipseDependenciesCreator {
         private final List<AbstractClasspathEntry> files = Lists.newArrayList();
         private final Multimap<String, String> pathToSourceSets = collectLibraryToSourceSetMapping();
         private final UnresolvedIdeDependencyHandler unresolvedIdeDependencyHandler = new UnresolvedIdeDependencyHandler();
-        private final ProjectComponentIdentifier currentProjectId = DefaultProjectComponentIdentifier.newProjectId(classpath.getProject());
-
 
         @Override
         public boolean isOffline() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
@@ -22,9 +22,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent;
 import org.gradle.plugins.ide.eclipse.model.FileReference;
 import org.gradle.plugins.ide.eclipse.model.WbDependentModule;
@@ -43,9 +42,11 @@ import java.util.Set;
 
 public class WtpComponentFactory {
     private final ProjectDependencyBuilder projectDependencyBuilder;
+    private final ProjectComponentIdentifier currentProjectId;
 
-    public WtpComponentFactory(Project project) {
-        projectDependencyBuilder = new ProjectDependencyBuilder(((ProjectInternal) project).getServices().get(IdeArtifactRegistry.class));
+    public WtpComponentFactory(Project project, IdeArtifactRegistry artifactRegistry, ProjectStateRegistry projectRegistry) {
+        projectDependencyBuilder = new ProjectDependencyBuilder(artifactRegistry);
+        currentProjectId = projectRegistry.stateFor(project).getComponentIdentifier();
     }
 
     public void configure(final EclipseWtpComponent wtp, WtpComponent component) {
@@ -91,7 +92,6 @@ public class WtpComponentFactory {
 
     private class WtpDependenciesVisitor implements IdeDependencyVisitor {
         private final Project project;
-        private final ProjectComponentIdentifier currentProjectId;
         private final EclipseWtpComponent wtp;
         private final String deployPath;
         private final List<WbDependentModule> projectEntries = Lists.newArrayList();
@@ -104,7 +104,6 @@ public class WtpComponentFactory {
             this.project = project;
             this.wtp = wtp;
             this.deployPath = deployPath;
-            currentProjectId = DefaultProjectComponentIdentifier.newProjectId(project);
         }
 
         @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -27,6 +27,7 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.language.scala.ScalaPlatform;
 import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
@@ -582,7 +583,9 @@ public class IdeaModule {
      */
     public Set<Dependency> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) project;
-        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal.getServices().get(IdeArtifactRegistry.class));
+        IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
+        ProjectStateRegistry projectRegistry = projectInternal.getServices().get(ProjectStateRegistry.class);
+        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal, ideArtifactRegistry, projectRegistry);
         return ideaDependenciesProvider.provide(this);
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -19,6 +19,7 @@ package org.gradle.plugins.ide.idea.model.internal;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -27,7 +28,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.plugins.ide.idea.model.Dependency;
 import org.gradle.plugins.ide.idea.model.FilePath;
 import org.gradle.plugins.ide.idea.model.IdeaModule;
@@ -51,9 +52,11 @@ public class IdeaDependenciesProvider {
     public static final String SCOPE_MINUS = "minus";
     private final ModuleDependencyBuilder moduleDependencyBuilder;
     private final IdeaDependenciesOptimizer optimizer;
+    private final ProjectComponentIdentifier currentProjectId;
 
-    public IdeaDependenciesProvider(IdeArtifactRegistry artifactRegistry) {
+    public IdeaDependenciesProvider(Project project, IdeArtifactRegistry artifactRegistry, ProjectStateRegistry projectRegistry) {
         moduleDependencyBuilder = new ModuleDependencyBuilder(artifactRegistry);
+        currentProjectId = projectRegistry.stateFor(project).getComponentIdentifier();
         optimizer = new IdeaDependenciesOptimizer();
     }
 
@@ -128,7 +131,6 @@ public class IdeaDependenciesProvider {
     private class IdeaDependenciesVisitor implements IdeDependencyVisitor {
         private final IdeaModule ideaModule;
         private final UnresolvedIdeDependencyHandler unresolvedIdeDependencyHandler = new UnresolvedIdeDependencyHandler();
-        private final ProjectComponentIdentifier currentProjectId;
         private final String scope;
 
         private final List<Dependency> projectDependencies = Lists.newLinkedList();
@@ -138,7 +140,6 @@ public class IdeaDependenciesProvider {
 
         private IdeaDependenciesVisitor(IdeaModule ideaModule, String scope) {
             this.ideaModule = ideaModule;
-            this.currentProjectId = DefaultProjectComponentIdentifier.newProjectId(ideaModule.getProject());
             this.scope = scope;
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -19,6 +19,7 @@ package org.gradle.plugins.ide.internal;
 import com.google.common.collect.Lists;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -37,27 +38,22 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier.newProjectId;
-
 public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
     private final IdeArtifactStore store;
     private final ProjectStateRegistry projectRegistry;
-    private final DomainObjectContext domainObjectContext;
-    private final BuildIdentity buildIdentity;
     private final FileOperations fileOperations;
+    private final ProjectComponentIdentifier currentProject;
 
     public DefaultIdeArtifactRegistry(IdeArtifactStore store, ProjectStateRegistry projectRegistry, FileOperations fileOperations, DomainObjectContext domainObjectContext, BuildIdentity buildIdentity) {
         this.store = store;
         this.projectRegistry = projectRegistry;
         this.fileOperations = fileOperations;
-        this.domainObjectContext = domainObjectContext;
-        this.buildIdentity = buildIdentity;
+        currentProject = projectRegistry.stateFor(buildIdentity.getCurrentBuild(), domainObjectContext.getProjectPath()).getComponentIdentifier();
     }
 
     @Override
     public void registerIdeProject(IdeProjectMetadata ideProjectMetadata) {
-        ProjectComponentIdentifier projectId = newProjectId(buildIdentity.getCurrentBuild(), domainObjectContext.getProjectPath().getPath());
-        store.put(projectId, ideProjectMetadata);
+        store.put(currentProject, ideProjectMetadata);
     }
 
     @Nullable
@@ -78,6 +74,7 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
     @Override
     public <T extends IdeProjectMetadata> List<Reference<T>> getIdeProjects(Class<T> type) {
         List<Reference<T>> result = Lists.newArrayList();
+        BuildIdentifier currentBuild = currentProject.getBuild();
         for (ProjectState project : projectRegistry.getAllProjects()) {
             if (project.getOwner().isImplicitBuild()) {
                 // Do not include implicit builds in workspace
@@ -89,7 +86,7 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
                     final T metadata = type.cast(ideProjectMetadata);
                     // Need to use different APIs to reference a required task from outside the current build
                     // There should be one mechanism rather than two.
-                    if (projectId.getBuild().equals(buildIdentity.getCurrentBuild())) {
+                    if (projectId.getBuild().equals(currentBuild)) {
                         result.add(new MetadataFromThisBuild<T>(metadata, projectId));
                     } else {
                         result.add(new MetadataFromOtherBuild<T>(metadata, projectId));

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreatorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugins.ide.eclipse.model.internal
 
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry
@@ -27,7 +28,7 @@ class EclipseDependenciesCreatorTest extends AbstractProjectBuilderSpec{
     private final ProjectInternal project = TestUtil.createRootProject(temporaryFolder.testDirectory)
     private final ProjectInternal childProject = TestUtil.createChildProject(project, "child", new File("."))
     private final EclipseClasspath eclipseClasspath = new EclipseClasspath(project)
-    private final dependenciesProvider = new EclipseDependenciesCreator(eclipseClasspath, project.services.get(IdeArtifactRegistry))
+    private final dependenciesProvider = new EclipseDependenciesCreator(eclipseClasspath, project.services.get(IdeArtifactRegistry), project.services.get(ProjectStateRegistry))
 
     def "compile dependency on child project"() {
         applyPluginToProjects()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugins.ide.idea.model.internal
 
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.Dependency
 import org.gradle.plugins.ide.idea.model.SingleEntryModuleLibrary
@@ -28,7 +29,7 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
     private final project = TestUtil.createRootProject(temporaryFolder.testDirectory)
     private final childProject = TestUtil.createChildProject(project, "child", new File("."))
     private final artifactRegistry = Stub(IdeArtifactRegistry)
-    private final dependenciesProvider = new IdeaDependenciesProvider(artifactRegistry)
+    private final dependenciesProvider = new IdeaDependenciesProvider(project, artifactRegistry, project.services.get(ProjectStateRegistry))
 
     def setup() {
         _ * artifactRegistry.getIdeProject(_, _) >> { Class c, def m ->
@@ -219,7 +220,6 @@ class IdeaDependenciesProviderTest extends AbstractProjectBuilderSpec {
         applyPluginToProjects()
         project.apply(plugin: 'java')
 
-        def dependenciesProvider = new IdeaDependenciesProvider(artifactRegistry)
         def module = project.ideaModule.module // Mock(IdeaModule)
         module.offline = true
         def extraConfiguration = project.configurations.create('extraConfiguration')

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/internal/ModuleDependencyBuilderTest.groovy
@@ -42,11 +42,11 @@ class ModuleDependencyBuilderTest extends Specification {
 
     def "builds dependency for nonIdea root project"() {
         when:
-        def dependency = builder.create(newProjectId("build-1",":"), 'compile')
+        def dependency = builder.create(newProjectId("build-1",":a"), 'compile')
 
         then:
         dependency.scope == 'compile'
-        dependency.name == "build-1"
+        dependency.name == "a"
 
         and:
         artifactRegistry.getIdeProject(_, _) >> null

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/AutoTestedSamplesCoreApiIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/AutoTestedSamplesCoreApiIntegrationTest.groovy
@@ -24,6 +24,10 @@ class AutoTestedSamplesCoreApiIntegrationTest extends AbstractAutoTestedSamplesT
     @Test
     void runSamples() {
         file('subprojects/abc').createDir() //for example in Settings.java
+        // for example in DependencySubstitutions.java
+        file("settings.gradle") << """
+            include 'api', 'util'
+        """
         runSamplesFrom("subprojects/core-api/src/main/java")
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/RunAsBuildOperationBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/RunAsBuildOperationBuildActionRunner.java
@@ -16,13 +16,14 @@
 
 package org.gradle.launcher.exec;
 
+import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.invocation.BuildActionRunner;
 import org.gradle.internal.invocation.BuildController;
 import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 
 /**
  * An {@link BuildActionRunner} that wraps all work in a build operation.
@@ -42,6 +43,7 @@ public class RunAsBuildOperationBuildActionRunner implements BuildActionRunner {
         buildOperationExecutor.run(new RunnableBuildOperation() {
             @Override
             public void run(BuildOperationContext context) {
+                buildController.getGradle().getServices().get(IncludedBuildControllers.class).rootBuildOperationStarted();
                 delegate.run(action, buildController);
                 context.setResult(RESULT);
             }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/GradleBuildModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/GradleBuildModelCrossVersionSpec.groovy
@@ -56,7 +56,7 @@ class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
                 rootProject.name = 'root'
                 includeBuild('includedBuild') { 
                     dependencySubstitution { 
-                        substitute module('group:name') with project(':other') 
+                        substitute module('group:name') with project(':') 
                     } 
                 }
             """

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -19,8 +19,11 @@ package org.gradle.integtests.tooling.fixture
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.component.BuildIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.initialization.BuildIdentity
 import org.gradle.initialization.DefaultBuildCancellationToken
@@ -29,6 +32,8 @@ import org.gradle.initialization.GradleLauncherFactory
 import org.gradle.initialization.NestedBuildFactory
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.internal.build.BuildState
+import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.concurrent.CompositeStoppable
 import org.gradle.internal.concurrent.Stoppable
@@ -36,10 +41,10 @@ import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.services.LoggingServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.ServiceRegistryBuilder
-import org.gradle.internal.service.scopes.CrossBuildSessionScopeServices
 import org.gradle.internal.service.scopes.BuildScopeServices
 import org.gradle.internal.service.scopes.BuildSessionScopeServices
 import org.gradle.internal.service.scopes.BuildTreeScopeServices
+import org.gradle.internal.service.scopes.CrossBuildSessionScopeServices
 import org.gradle.internal.service.scopes.GlobalScopeServices
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry
 import org.gradle.internal.service.scopes.ProjectScopeServices
@@ -47,6 +52,7 @@ import org.gradle.internal.time.Time
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.gradle.util.Path
 import org.gradle.util.TestUtil
 
 class ToolingApiDistributionResolver {
@@ -107,10 +113,11 @@ class ToolingApiDistributionResolver {
         topLevelRegistry.add(BuildIdentity, new BuildIdentity() {
             @Override
             BuildIdentifier getCurrentBuild() {
-                return new DefaultBuildIdentifier(":")
+                return DefaultBuildIdentifier.ROOT
             }
         })
         topLevelRegistry.add(NestedBuildFactory, {} as NestedBuildFactory)
+        topLevelRegistry.get(BuildStateRegistry).register(new EmptyBuild())
         def projectRegistry = new ProjectScopeServices(topLevelRegistry, TestUtil.create(TestNameTestDirectoryProvider.newInstance()).rootProject(), topLevelRegistry.getFactory(LoggingManagerInternal))
 
         def workerLeaseService = buildSessionServices.get(WorkerLeaseService)
@@ -146,5 +153,32 @@ class ToolingApiDistributionResolver {
 
     void stop() {
         stopLater.stop()
+    }
+
+    static class EmptyBuild implements BuildState {
+        @Override
+        BuildIdentifier getBuildIdentifier() {
+            return DefaultBuildIdentifier.ROOT
+        }
+
+        @Override
+        boolean isImplicitBuild() {
+            return false
+        }
+
+        @Override
+        SettingsInternal getLoadedSettings() throws IllegalStateException {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Path getIdentityPathForProject(Path projectPath) {
+            return projectPath
+        }
+
+        @Override
+        ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
+            return new DefaultProjectComponentIdentifier(buildIdentifier, projectPath, projectPath, projectPath.name ?: "root")
+        }
     }
 }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -66,10 +66,9 @@ class SourceDependencyIdentityIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':buildB:compileJava'.")
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':buildB:compileClasspath'.")
-        // TODO - incorrect project path
         failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
 Required by:
-    project :dep""")
+    project :buildB""")
     }
 
     def "includes build identifier in task failure error message"() {
@@ -100,8 +99,7 @@ Required by:
                 assert components[0].build.name == ':'
                 assert components[0].build.currentBuild
                 assert components[0].projectPath == ':'
-                // TODO - should be 'buildA'
-                assert components[0].projectName == ':'
+                assert components[0].projectName == 'buildA'
                 assert components[1].build.name == 'buildB'
                 assert !components[1].build.currentBuild
                 assert components[1].projectPath == ':'


### PR DESCRIPTION
### Context

This is a fix for #5343 and several other issues with the names used in dependency resolution results.

This change also continues to refactor towards a single class that is responsible for assigning the build and project identifiers, paths and names within a build.

This change restructures the build operation tree for included builds to more accurately reflect where the work is happening, and includes some rearrangement of when the different lifecycle stages of an included build happen to be more consistent with when the corresponding stage of the main build happens.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
