### PR TITLE
Align eager/lazy task creation and configuration failure cases

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -263,7 +263,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             index.removePending(name);
             getStore().removePending(provider);
             // TODO - this isn't correct, assumes that a side effect is to add the element
-            provider.get();
+            provider.getOrNull();
             // Use the index here so we can apply any filters to the realized element
             return index.get(name);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -622,6 +622,348 @@ class DefaultTaskContainerTest extends Specification {
         0 * deferredAction._
     }
 
+    void "fails task creation when creation rule throw exception"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        when:
+        container.create("task", DefaultTask, action)
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing creation rule"
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        container.getByNameLater(DefaultTask, "task").isPresent()
+        container.getByNameLater(DefaultTask, "task").get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing creation rule") }
+    }
+
+    void "fails later creation upon realizing through createLater provider when creation rule throw exception"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        def provider = container.createLater("task", DefaultTask, action)
+
+        when:
+        provider.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing creation rule"
+
+        and:
+        provider.isPresent()
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        container.getByNameLater(DefaultTask, "task").isPresent()
+        container.getByNameLater(DefaultTask, "task").get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing creation rule") }
+
+        when:
+        provider.get()
+
+        then:
+        0 * _
+    }
+
+    void "fails later creation upon realizing through getByNameLater provider when creation rule throw exception"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        def creationProvider = container.createLater("task", DefaultTask, action)
+        def provider = container.getByNameLater(DefaultTask, "task")
+
+        when:
+        provider.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing creation rule"
+
+        and:
+        provider.isPresent()
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        creationProvider.isPresent()
+        creationProvider.get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing creation rule") }
+
+        when:
+        provider.get()
+
+        then:
+        0 * _
+    }
+
+    void "fails task creation when task instantiation is unsuccessful"() {
+        def action = Mock(Action)
+
+        when:
+        container.create("task", DefaultTask, action)
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing constructor"
+
+        and:
+        container.findByName("task") == null
+
+        and:
+        !container.getByNameLater(DefaultTask, "task").isPresent()
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> { throw new RuntimeException("Failing constructor") }
+        0 * action.execute(_)
+    }
+
+    void "fails later creation upon realizing through createLater provider when task instantiation is unsuccessful"() {
+        def action = Mock(Action)
+
+        given:
+        def provider = container.createLater("task", DefaultTask, action)
+
+        when:
+        provider.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing constructor"
+
+        and:
+        !provider.isPresent()
+
+        and:
+        container.findByName("task") == null
+
+        and:
+        !container.getByNameLater(DefaultTask, "task").isPresent()
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> { throw new RuntimeException("Failing constructor") }
+        0 * action.execute(_)
+
+        when:
+        provider.getOrNull()
+
+        then:
+        0 * _
+    }
+
+    void "fails later creation upon realizing through getByNameLater provider when task instantiation is unsuccessful"() {
+        def action = Mock(Action)
+
+        given:
+        def creationProvider = container.createLater("task", DefaultTask, action)
+        def provider = container.getByNameLater(DefaultTask, "task")
+
+        when:
+        provider.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing constructor"
+
+        and:
+        !provider.isPresent()
+
+        and:
+        container.findByName("task") == null
+
+        and:
+        !creationProvider.isPresent()
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> { throw new RuntimeException("Failing constructor") }
+        0 * action.execute(_)
+
+        when:
+        provider.getOrNull()
+
+        then:
+        0 * _
+    }
+
+    void "fails task creation when task configuration via withType is unsuccessful"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        container.withType(DefaultTask, action)
+
+        when:
+        container.create("task", DefaultTask)
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing withType configuration rule"
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        container.getByNameLater(DefaultTask, "task").isPresent()
+        container.getByNameLater(DefaultTask, "task").get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing withType configuration rule") }
+    }
+
+    void "fails later creation when task configuration via withType is unsuccessful"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        container.withType(DefaultTask, action)
+
+        when:
+        // The following throw an exception immediately because a failing eager configuration rule is registered
+        container.createLater("task", DefaultTask)
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing withType configuration rule"
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        container.getByNameLater(DefaultTask, "task").isPresent()
+        container.getByNameLater(DefaultTask, "task").get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing withType configuration rule")}
+    }
+
+    void "fails task creation when task configuration via configureEachLater is unsuccessful"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        container.configureEachLater(DefaultTask, action)
+
+        when:
+        container.create("task", DefaultTask)
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing configureEachLater configuration rule"
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        container.getByNameLater(DefaultTask, "task").isPresent()
+        container.getByNameLater(DefaultTask, "task").get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing configureEachLater configuration rule") }
+    }
+
+    void "fails later creation upon realizing through createLater provider when task configuration via configureEachLater is unsuccessful"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        container.configureEachLater(DefaultTask, action)
+        def provider = container.createLater("task", DefaultTask)
+
+        when:
+        provider.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing configureEachLater configuration rule"
+
+        and:
+        provider.isPresent()
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        container.getByNameLater(DefaultTask, "task").isPresent()
+        container.getByNameLater(DefaultTask, "task").get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing configureEachLater configuration rule") }
+
+        when:
+        provider.get()
+
+        then:
+        0 * _
+    }
+
+    void "fails later creation upon realizing through getByNameLater provider when task configuration via configureEachLater is unsuccessful"() {
+        def action = Mock(Action)
+        def task = task("task")
+
+        given:
+        container.configureEachLater(DefaultTask, action)
+        def creationProvider = container.createLater("task", DefaultTask)
+        def provider = container.getByNameLater(DefaultTask, "task")
+
+        when:
+        provider.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message == "Failing configureEachLater configuration rule"
+
+        and:
+        provider.isPresent()
+
+        and:
+        container.findByName("task") != null
+        container.findByName("task") == task
+
+        and:
+        creationProvider.isPresent()
+        creationProvider.get() == task
+
+        and:
+        1 * taskFactory.create("task", DefaultTask) >> task
+        1 * action.execute(_) >> { throw new RuntimeException("Failing configureEachLater configuration rule") }
+
+        when:
+        provider.get()
+
+        then:
+        0 * _
+    }
+
     void "can locate task that already exists by type and name without triggering creation or configuration"() {
         def task = task("task")
 


### PR DESCRIPTION
The lazy task API should behave closely to how the eager API behave.
This commit add test coverage for both API and ensure the behavior is
similar.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native/issues/641

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Ferror-handling)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
