### PR TITLE
Improve wording for 'deferred configurable' deprecation message

### DIFF
--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -98,7 +98,7 @@ public class PublishingPlugin implements Plugin<Project> {
                     "Please add 'enableFeaturePreview('STABLE_PUBLISHING')' to your settings file and do a test run by publishing to a local repository.\n" +
                     "If all artifacts are published as expected, there is nothing else to do.\n" +
                     "If the published artifacts change unexpectedly, please see the migration guide for more details: " + documentationRegistry.getDocumentationFor("publishing_maven", "publishing_maven:deferred_configuration") + "\n" +
-                    "Gradle 5.0 will switch this flag on by default."
+                    "In Gradle 5.0 the flag will be removed and the new behavior will become the default."
             );
             return DeferredConfigurablePublishingExtension.class;
         }


### PR DESCRIPTION
Based on feedback from @ldaley the message now clearly indicates that there will be no way to opt-out of the new behavior in Gradle 5.0.