### PR TITLE
Allow at most 3 parallel performance coordinators

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -17,6 +17,7 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Sta
         build/report-*-performance-tests.zip => .
     """.trimIndent()
     detectHangingBuilds = false
+    maxRunningBuilds = 3
 
     if (type == PerformanceTestType.test) {
         features {


### PR DESCRIPTION
While having the performance agents busy is important, it seems to me
that the average time to complete each coordinator went up due to all
performance agents occupied.

Looking at the Teamcity statistics the average running time of the
coordinator build went from 80 minutes to 155 minutes. I think that
justifies re-instantiating the limit.

Especially when the pipeline is busy, we should limit the number of
parallel performance test coordinators running.
