### PR TITLE
Remove performance improvement for hasTask/getTasks

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -16,7 +16,6 @@
 
 package org.gradle.execution.taskgraph;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
@@ -74,7 +73,6 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     private final DefaultTaskExecutionPlan taskExecutionPlan;
     private final BuildOperationExecutor buildOperationExecutor;
     private TaskGraphState taskGraphState = TaskGraphState.EMPTY;
-    private List<Task> allTasks;
 
     private final Set<Task> requestedTasks = Sets.newTreeSet();
     private Spec<? super Task> filter = Specs.SATISFIES_ALL;
@@ -214,10 +212,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
     public List<Task> getAllTasks() {
         ensurePopulated();
-        if (allTasks == null) {
-            allTasks = ImmutableList.copyOf(taskExecutionPlan.getTasks());
-        }
-        return allTasks;
+        return taskExecutionPlan.getTasks();
     }
 
     @Override
@@ -233,7 +228,6 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
                     "Task information is not available, as this task execution graph has not been populated.");
             case DIRTY:
                 taskExecutionPlan.determineExecutionPlan();
-                allTasks = null;
                 taskGraphState = TaskGraphState.POPULATED;
                 return;
             case POPULATED:

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -35,8 +35,8 @@ import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskState;
-import org.gradle.internal.Cast;
 import org.gradle.execution.TaskExecutionGraphInternal;
+import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -196,7 +196,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
     public boolean hasTask(Task task) {
         ensurePopulated();
-        return taskExecutionPlan.getTasks().contains(task);
+        return taskExecutionPlan.hasTask(task);
     }
 
     public boolean hasTask(String path) {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -531,8 +531,8 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     }
 
     @Override
-    public Set<Task> getTasks() {
-        return executionPlan.keySet();
+    public List<Task> getTasks() {
+        return new ArrayList<Task>(executionPlan.keySet());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -534,6 +534,11 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     }
 
     @Override
+    public boolean hasTask(Task task) {
+        return executionPlan.containsKey(task);
+    }
+
+    @Override
     public List<Task> getTasks() {
         return executionPlan == null ? ImmutableList.<Task>of() : ImmutableList.copyOf(executionPlan.keySet());
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -19,6 +19,7 @@ package org.gradle.execution.taskgraph;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -94,6 +95,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     private final TaskFailureCollector failureCollector = new TaskFailureCollector();
     private final TaskInfoFactory nodeFactory = new TaskInfoFactory(failureCollector);
     private Spec<? super Task> filter = Specs.satisfyAll();
+    private List<Task> allTasks;
 
     private boolean continueOnFailure;
 
@@ -348,7 +350,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
         }
         executionQueue.clear();
         executionQueue.addAll(executionPlan.values());
-
+        allTasks = null;
     }
 
     @Override
@@ -519,6 +521,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
     public void clear() {
         nodeFactory.clear();
         entryTasks.clear();
+        allTasks = null;
         executionPlan.clear();
         executionQueue.clear();
         projectLocks.clear();
@@ -532,7 +535,10 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
 
     @Override
     public List<Task> getTasks() {
-        return new ArrayList<Task>(executionPlan.keySet());
+        if (allTasks == null) {
+            allTasks = ImmutableList.copyOf(executionPlan.keySet());
+        }
+        return allTasks;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -56,7 +56,7 @@ public class DefaultTaskPlanExecutor implements TaskPlanExecutor {
         this.executorFactory = executorFactory;
         this.cancellationToken = cancellationToken;
         this.coordinationService = coordinationService;
-        int numberOfParallelExecutors = parallelismConfiguration.getMaxWorkerCount();
+        int numberOfParallelExecutors = parallelismConfiguration.isParallelProjectExecutionEnabled() ? parallelismConfiguration.getMaxWorkerCount() : 1;
         if (numberOfParallelExecutors < 1) {
             throw new IllegalArgumentException("Not a valid number of parallel executors: " + numberOfParallelExecutors);
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -23,6 +23,7 @@ import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -50,9 +51,9 @@ public interface TaskExecutionPlan extends Describable {
     Set<Task> getDependencies(Task task);
 
     /**
-     * @return The set of all available tasks. This includes tasks that have not yet been executed, as well as tasks that have been processed.
+     * @return The list of all available tasks. This includes tasks that have not yet been executed, as well as tasks that have been processed.
      */
-    Set<Task> getTasks();
+    List<Task> getTasks();
 
     /**
      * @return The set of all filtered tasks that don't get executed.

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -50,6 +50,8 @@ public interface TaskExecutionPlan extends Describable {
     @Incubating
     Set<Task> getDependencies(Task task);
 
+    boolean hasTask(Task task);
+
     /**
      * @return The list of all available tasks. This includes tasks that have not yet been executed, as well as tasks that have been processed.
      */

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
@@ -312,7 +312,7 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
         addToGraphAndPopulate([finalized])
 
         then:
-        executionPlan.tasks as List == [finalizedDependency, finalized, finalizerDependency, finalizer]
+        executionPlan.tasks == [finalizedDependency, finalized, finalizerDependency, finalizer]
         executedTasks == [finalizedDependency]
     }
 
@@ -327,7 +327,7 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
         addToGraphAndPopulate([finalizer, finalized])
 
         then:
-        executionPlan.tasks as List == [finalizedDependency, finalized, finalizerDependency, finalizer]
+        executionPlan.tasks == [finalizedDependency, finalized, finalizerDependency, finalizer]
         executedTasks == [finalizedDependency, finalizerDependency, finalizer]
     }
 
@@ -745,7 +745,7 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
         executionPlan.clear()
 
         then:
-        executionPlan.tasks == [] as Set
+        executionPlan.tasks == []
         executedTasks == []
     }
 
@@ -852,8 +852,8 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
     }
 
     void executes(Task... expectedTasks) {
-        assert executionPlan.tasks as List == expectedTasks as List
-        assert executedTasks == expectedTasks as List
+        assert executionPlan.tasks == expectedTasks as List
+        assert expectedTasks == expectedTasks as List
     }
 
     void filtered(Task... expectedTasks) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -36,7 +36,9 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
             invocationCount = iterations
             warmUpCount = iterations
             action {
-                def model = model(tapiClass(EclipseProject)).setJvmArguments("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").get()
+                def builder = model(tapiClass(EclipseProject))
+                builder.setJvmArguments("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                def model = builder.get()
                 // we must actually do something to highlight some performance issues
                 forEachEclipseProject(model) {
                     buildCommands.each {
@@ -96,7 +98,9 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
             invocationCount = iterations
             warmUpCount = iterations
             action {
-                def model = model(tapiClass(IdeaProject)).setJvmArguments("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}").get()
+                def builder = model(tapiClass(IdeaProject))
+                builder.setJvmArguments("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                def model = builder.get()
                 // we must actually do something to highlight some performance issues
                 model.with {
                     name

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
-        runner.targetVersions = ["4.8-20180510001718+0000"]
+        runner.targetVersions = ["4.8-20180506235948+0000"]
         runner.args += ["-Dorg.gradle.parallel=$parallel"]
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
-        runner.targetVersions = ["4.8-20180506235948+0000"]
+        runner.targetVersions = ["4.8-20180509000019+0000"]
         runner.args += ["-Dorg.gradle.parallel=$parallel"]
 
         when:


### PR DESCRIPTION
Those changes seemed to have caused `up-to-date assemble on largeJavaMultiProject (parallel false)` to fail.
I don't quite understand why the problem is fixed when removing the optimisation, but it works anyway...