### PR TITLE
Add validation for `TaskContainer#getByNameLater`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -59,7 +59,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
     Task getByPath(String path) throws UnknownTaskException;
 
     /**
-     * Locates a task by type and name, without triggering its creation or configuration.
+     * Locates a task by type and name, without triggering its creation or configuration, failing if there is no such object.
      *
      * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.provider.AbstractProvider;
+import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.TaskReference;
@@ -331,6 +332,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public <T extends Task> TaskProvider<T> getByNameLater(Class<T> type, String name) throws InvalidUserDataException {
+        Task task = findByNameWithoutRules(name);
+        if (task == null || !type.isAssignableFrom(task.getClass())) {
+            ProviderInternal<? extends Task> taskProvider = findByNameLaterWithoutRules(name);
+            if (taskProvider == null || !type.isAssignableFrom(taskProvider.getType())) {
+                throw createNotFoundException(name);
+            }
+        }
+
         return new TaskLookupProvider<T>(type, name);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -335,9 +335,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         Task task = findByNameWithoutRules(name);
         if (task == null || !type.isAssignableFrom(task.getClass())) {
             ProviderInternal<? extends Task> taskProvider = findByNameLaterWithoutRules(name);
-            if (taskProvider == null || !type.isAssignableFrom(taskProvider.getType())) {
+            if (taskProvider == null) {
                 throw createNotFoundException(name);
+            } else if (!type.isAssignableFrom(taskProvider.getType())) {
+                throw new IllegalArgumentException(String.format("Task with name '%s' found but have a type mismatch, found %s expected %s, in %s.", name, taskProvider.getType().getName(), type.getName(), project));
             }
+            return (TaskProvider<T>)taskProvider;
         }
 
         return new TaskLookupProvider<T>(type, name);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -721,6 +721,129 @@ class DefaultTaskContainerTest extends Specification {
         container.maybeCreate("task", CustomTask) == task
     }
 
+    void "getByNameLater fails if unknown task is requested"() {
+        when:
+        container.getByNameLater(DefaultTask, "unknown")
+
+        then:
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'unknown' not found in Mock for type 'ProjectInternal' named '<project>'."
+    }
+
+    void "getByNameLater fails if eagerly created task type is not a subtype"() {
+        given:
+        taskFactory.create("task", DefaultTask) >> task("task")
+        container.create("task", DefaultTask)
+
+        when:
+        container.getByNameLater(CustomTask, "task")
+
+        then:
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
+    }
+
+    void "getByNameLater fails if lazily created task type is not a subtype"() {
+        container.createLater("task", DefaultTask)
+
+        when:
+        container.getByNameLater(CustomTask, "task")
+
+        then:
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
+        0 * taskFactory.create("task", DefaultTask)
+    }
+
+    void "can getByNameLater for eagerly created task subtype"() {
+        given:
+        taskFactory.create("task", CustomTask) >> task("task")
+        container.create("task", CustomTask)
+
+        when:
+        container.getByNameLater(Task, "task")
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "can getByNameLater for lazily created task subtype"() {
+        container.createLater("task", CustomTask)
+
+        when:
+        container.getByNameLater(Task, "task")
+
+        then:
+        noExceptionThrown()
+        0 * taskFactory.create("task", DefaultTask)
+    }
+
+    void "can getByNameLater if task is eagerly created before"() {
+        given:
+        taskFactory.create("task", DefaultTask) >> task("task")
+        container.create("task", DefaultTask)
+
+        when:
+        container.getByNameLater(DefaultTask, "task")
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "can getByNameLater if task is lazily created before"() {
+        given:
+        container.createLater("task", DefaultTask)
+
+        when:
+        container.getByNameLater(DefaultTask, "task")
+
+        then:
+        noExceptionThrown()
+        0 * taskFactory.create("task", DefaultTask)
+    }
+
+    void "can getByNameLater if eagerly created task type gets overwrite"() {
+        given:
+        taskFactory.create("task", CustomTask) >> task("task", CustomTask)
+        taskFactory.create("task", DefaultTask) >> task("task", DefaultTask)
+        container.create("task", CustomTask)
+
+        when:
+        container.getByNameLater(DefaultTask, "task")
+
+        then:
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
+
+        when:
+        container.create([name: "task", type: DefaultTask, overwrite: true])
+        container.getByNameLater(DefaultTask, "task")
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "can getByNameLater if lazy created task gets overwrite"() {
+        given:
+        container.createLater("task", CustomTask)
+
+        when:
+        container.getByNameLater(DefaultTask, "task")
+
+        then:
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
+        0 * taskFactory.create("task", CustomTask)
+
+        when:
+        container.create([name: "task", type: DefaultTask, overwrite: true])
+        container.getByNameLater(DefaultTask, "task")
+
+        then:
+        noExceptionThrown()
+        1 * taskFactory.create("task", DefaultTask) >> task("task")
+    }
+
     private ProjectInternal expectTaskLookupInOtherProject(final String projectPath, final String taskName, def task) {
         def otherProject = Mock(ProjectInternal)
         def otherTaskContainer = Mock(TaskContainerInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -750,8 +750,8 @@ class DefaultTaskContainerTest extends Specification {
         container.getByNameLater(CustomTask, "task")
 
         then:
-        def ex = thrown(UnknownTaskException)
-        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "Task with name 'task' found but have a type mismatch, found ${DefaultTask.name} expected ${CustomTask.name}, in Mock for type 'ProjectInternal' named '<project>'."
         0 * taskFactory.create("task", DefaultTask)
     }
 
@@ -831,8 +831,8 @@ class DefaultTaskContainerTest extends Specification {
         container.getByNameLater(DefaultTask, "task")
 
         then:
-        def ex = thrown(UnknownTaskException)
-        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "Task with name 'task' found but have a type mismatch, found ${CustomTask.name} expected ${DefaultTask.name}, in Mock for type 'ProjectInternal' named '<project>'."
         0 * taskFactory.create("task", CustomTask)
 
         when:


### PR DESCRIPTION
This API will behave like the `TaskContainer#getByName`. If a task
haven't been created, either lazily or eagerly, this API will throw an
`UnknownTaskException`.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native/issues/637.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fget-by-name-later-validation)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
