### PR TITLE
Fix S3Client tests that require JAXB

### DIFF
--- a/subprojects/resources-s3/resources-s3.gradle
+++ b/subprojects/resources-s3/resources-s3.gradle
@@ -29,6 +29,13 @@ gradlebuildJava {
     moduleType = ModuleType.PLUGIN
 }
 
+tasks.withType(Test) {
+    def javaVersion = rootProject.availableJavaInstallations.javaInstallationForTest.javaVersion
+    if (javaVersion.java9Compatible) {
+        jvmArgs '--add-modules', 'java.xml.bind'
+    }
+}
+
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 testFilesCleanup {
     policy = WhenNotEmpty.REPORT

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
@@ -27,7 +27,6 @@ import com.amazonaws.services.s3.model.S3ObjectSummary
 import com.google.common.base.Optional
 import org.apache.commons.io.IOUtils
 import org.gradle.api.Action
-import org.gradle.api.GradleException
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.gradle.internal.IoActions
 import org.gradle.internal.credentials.DefaultAwsCredentials
@@ -35,16 +34,12 @@ import org.gradle.internal.resource.transport.aws.s3.S3Client
 import org.gradle.internal.resource.transport.aws.s3.S3ConnectionProperties
 import org.gradle.internal.resource.transport.aws.s3.S3RegionalResource
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.Requires
 import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
-import static org.gradle.util.TestPrecondition.JDK9_OR_LATER
 
 class S3ClientIntegrationTest extends Specification {
 
@@ -67,21 +62,7 @@ class S3ClientIntegrationTest extends Specification {
         awsCredentials.setSecretKey(secret)
     }
 
-    @Requires(JDK9_OR_LATER)
-    def "should inform the user to add the 'java.xml.bind' jigsaw module"() {
-        given:
-        def s3Client = new S3Client(null, new S3ConnectionProperties())
-
-        when:
-        s3Client.put(null, null, null)
-
-        then:
-        GradleException jigsawException = thrown()
-        jigsawException.getMessage().contains('-addmods java.xml.bind')
-    }
-
     @Unroll
-    @Requires(FIX_TO_WORK_ON_JAVA9)
     @Issue("Currently the 'javax.xml.bind' jigsaw module is not automatically required on the Gradle Jvm")
     def "should perform #authenticationType put get and list on an S3 bucket"() {
         setup:

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -101,7 +101,7 @@ public class S3Client {
                 Class.forName("javax.xml.bind.DatatypeConverter");
             } catch (ClassNotFoundException e) {
                 throw new GradleException("Cannot publish to S3 since the module 'java.xml.bind' is not available. "
-                    + "Please add \"-addmods java.xml.bind '-Dorg.gradle.jvmargs=-addmods java.xml.bind'\" to your GRADLE_OPTS.");
+                    + "Please add \"--add-modules java.xml.bind '-Dorg.gradle.jvmargs=--add-modules java.xml.bind'\" to your GRADLE_OPTS.");
             }
         }
     }

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ClientTest.groovy
@@ -24,21 +24,16 @@ import com.google.common.base.Optional
 import org.gradle.api.resources.ResourceException
 import org.gradle.internal.credentials.DefaultAwsCredentials
 import org.gradle.internal.resource.transport.http.HttpProxySettings
-import org.gradle.util.Requires
 import spock.lang.Ignore
 import spock.lang.Specification
 
-import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
-
 class S3ClientTest extends Specification {
     final S3ConnectionProperties s3ConnectionProperties = Mock()
-
 
     def setup(){
         _ * s3ConnectionProperties.getEndpoint() >> Optional.absent()
     }
 
-    @Requires(FIX_TO_WORK_ON_JAVA9)
     def "Should upload to s3"() {
         given:
         AmazonS3Client amazonS3Client = Mock()
@@ -170,7 +165,6 @@ class S3ClientTest extends Specification {
         ex.message.startsWith("Could not get resource 'https://somehost/file.txt'")
     }
 
-    @Requires(FIX_TO_WORK_ON_JAVA9)
     def "should include uri when upload fails"() {
         AmazonS3Client amazonS3Client = Mock()
         URI uri = new URI("https://somehost/file.txt")


### PR DESCRIPTION
 - Add the javax.xml.bind module when running on JDK >= 9
 - Delete test for exception message when javax.xml.bind is not present
   because it would require another VM which seems overkill for this
   simple scenario.
 - Fix exception message to use `--add-modules` instead of `-addmods`
   which was only present in early access releases.