### PR TITLE
Add support for dependency attributes on project dependencies

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.util.Path;
@@ -69,7 +70,7 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
         for (BuildIdentifier nextTarget : buildDependencies.get(targetBuild)) {
             if (sourceBuild.equals(nextTarget)) {
                 candidateCycle.add(nextTarget);
-                ProjectComponentSelector selector = new DefaultProjectComponentSelector(candidateCycle.get(0), Path.ROOT, Path.ROOT, ":");
+                ProjectComponentSelector selector = new DefaultProjectComponentSelector(candidateCycle.get(0), Path.ROOT, Path.ROOT, ":", ImmutableAttributes.EMPTY);
                 throw new ModuleVersionResolveException(selector, "Included build dependency cycle: " + reportCycle(candidateCycle));
             }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -43,4 +44,15 @@ public interface ComponentSelector {
      * @since 1.10
      */
     boolean matchesStrictly(ComponentIdentifier identifier);
+
+    /**
+     * The attributes of the module to select the component from. The attributes only include
+     * selector specific attributes. This means it typically doesn't include any consumer specific attribute.
+     *
+     * @return the attributes
+     *
+     * @since 4.9
+     */
+    @Incubating
+    AttributeContainer getAttributes();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.VersionConstraint;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -59,15 +58,4 @@ public interface ModuleComponentSelector extends ComponentSelector {
      */
     @Incubating
     VersionConstraint getVersionConstraint();
-
-    /**
-     * The attributes of the module to select the component from. The attributes only include
-     * selector specific attributes. This means it typically doesn't include any consumer specific attribute.
-     *
-     * @return the attributes
-     *
-     * @since 4.8
-     */
-    @Incubating
-    AttributeContainer getAttributes();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesAttributesIntegrationTest.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import spock.lang.Unroll
+
+class ProjectDependenciesAttributesIntegrationTest extends AbstractIntegrationSpec {
+
+    ResolveTestFixture resolve = new ResolveTestFixture(buildFile, 'conf')
+
+    def setup() {
+        buildFile << """
+            configurations {
+               conf
+            }
+        """
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        resolve.prepare()
+    }
+
+    @Unroll
+    def "uses dependency attributes to select the right configuration on the target project (color=#color)"() {
+        given:
+        settingsFile << "include 'dep'"
+        buildFile << """
+            dependencies {
+                conf(project(':dep')) {
+                    attributes {
+                        attribute(Attribute.of('color', String), '$color')                        
+                    }
+                }
+            }
+        """
+        file("dep/build.gradle") << blueAndRedVariants()
+
+        when:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                project(':dep', "test:dep:unspecified") {
+                    variant "${color}Variant", [color: color]
+                    noArtifacts()
+                }
+            }
+        }
+
+        where:
+        color << ['blue', 'red']
+    }
+
+    def "Fails with reasonable error message when no target variant can be found"() {
+        given:
+        settingsFile << "include 'dep'"
+        buildFile << """
+            dependencies {
+                conf(project(':dep')) {
+                    attributes {
+                        attribute(Attribute.of('color', String), 'green')                        
+                    }
+                }
+            }
+        """
+        file("dep/build.gradle") << blueAndRedVariants()
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("""Unable to find a matching variant of project :dep:
+  - Variant 'blueVariant': Required color 'green' and found incompatible value 'blue'.
+  - Variant 'redVariant': Required color 'green' and found incompatible value 'red'.""")
+    }
+
+    def "dependency attributes override configuration attributes"() {
+        given:
+        settingsFile << "include 'dep'"
+        buildFile << """
+            configurations {
+                conf {
+                    attributes {
+                        attribute(Attribute.of('color', String), 'blue')                        
+                    }
+                }
+            }
+            dependencies {
+                conf(project(':dep')) {
+                    attributes {
+                        attribute(Attribute.of('color', String), 'red')                        
+                    }
+                }
+            }
+        """
+        file("dep/build.gradle") << blueAndRedVariants()
+
+        when:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                project(':dep', "test:dep:unspecified") {
+                    variant "redVariant", [color: 'red']
+                    noArtifacts()
+                }
+            }
+        }
+
+    }
+
+    private static String blueAndRedVariants() {
+        """
+            configurations {
+                blueVariant {
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Attribute.of('color', String), 'blue')
+                    }
+                }
+                redVariant {
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Attribute.of('color', String), 'red')
+                    }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/UnversionedModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/UnversionedModuleComponentSelector.java
@@ -20,6 +20,8 @@ import com.google.common.base.Objects;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 class UnversionedModuleComponentSelector implements ComponentSelector {
     private final ModuleIdentifier moduleIdentifier;
@@ -40,6 +42,11 @@ class UnversionedModuleComponentSelector implements ComponentSelector {
     @Override
     public boolean matchesStrictly(ComponentIdentifier identifier) {
         return false;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return ImmutableAttributes.EMPTY;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadataWrapper;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -38,7 +39,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
     public LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer clientAttributes, ModuleDependency dependency) {
         ProjectDependencyInternal projectDependency = (ProjectDependencyInternal) dependency;
         projectDependency.beforeResolved();
-        ComponentSelector selector = DefaultProjectComponentSelector.newSelector(projectDependency.getDependencyProject());
+        ComponentSelector selector = DefaultProjectComponentSelector.newSelector(projectDependency.getDependencyProject(), ((AttributeContainerInternal)projectDependency.getAttributes()).asImmutable());
 
         List<ExcludeMetadata> excludes = convertExcludeRules(clientConfiguration, dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -132,13 +132,13 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
 
     @Nullable
     @Override
-    public ArtifactSet resolveArtifacts(final ComponentResolveMetadata component, final ConfigurationMetadata configuration, final ArtifactTypeRegistry artifactTypeRegistry, final ModuleExclusion exclusions, ImmutableAttributes overriddenAttributes) {
+    public ArtifactSet resolveArtifacts(final ComponentResolveMetadata component, final ConfigurationMetadata configuration, final ArtifactTypeRegistry artifactTypeRegistry, final ModuleExclusion exclusions, final ImmutableAttributes overriddenAttributes) {
         if (isProjectModule(component.getId())) {
             ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) component.getId();
             return projectStateRegistry.stateFor(projectId).withMutableState(new Factory<ArtifactSet>() {
                 @Override
                 public ArtifactSet create() {
-                    return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, ImmutableAttributes.EMPTY);
+                    return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes);
                 }
             });
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CandidateModule;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
@@ -190,7 +189,7 @@ class ModuleResolveState implements CandidateModule {
     }
 
     private void restartUnattachedDependencies(ComponentState selected) {
-        if (unattachedDependencies.size()==1) {
+        if (unattachedDependencies.size() == 1) {
             unattachedDependencies.get(0).restart(selected);
         } else {
             for (EdgeState dependency : new ArrayList<EdgeState>(unattachedDependencies)) {
@@ -240,10 +239,8 @@ class ModuleResolveState implements CandidateModule {
     private ImmutableAttributes appendAttributes(ImmutableAttributes dependencyAttributes, SelectorState selectorState) {
         try {
             ComponentSelector selector = selectorState.getDependencyMetadata().getSelector();
-            if (selector instanceof ModuleComponentSelector) {
-                ImmutableAttributes attributes = ((AttributeContainerInternal) ((ModuleComponentSelector) selector).getAttributes()).asImmutable();
-                dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
-            }
+            ImmutableAttributes attributes = ((AttributeContainerInternal) selector.getAttributes()).asImmutable();
+            dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
         } catch (AttributeMergingException e) {
             attributeMergingError = e;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -52,20 +52,20 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         if (Implementation.ROOT_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             String projectName = decoder.readString();
-            return new DefaultProjectComponentSelector(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
+            return new DefaultProjectComponentSelector(buildIdentifier, Path.ROOT, Path.ROOT, projectName, readAttributes(decoder));
         } else if (Implementation.ROOT_BUILD_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path projectPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, projectPath, projectPath, projectPath.getName());
+            return new DefaultProjectComponentSelector(buildIdentifier, projectPath, projectPath, projectPath.getName(), readAttributes(decoder));
         } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path identityPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, identityPath.getName());
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, identityPath.getName(), readAttributes(decoder));
         } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path identityPath = Path.path(decoder.readString());
             Path projectPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, projectPath, projectPath.getName());
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, projectPath, projectPath.getName(), readAttributes(decoder));
         } else if (Implementation.MODULE.getId() == id) {
             return DefaultModuleComponentSelector.newSelector(decoder.readString(), decoder.readString(), readVersionConstraint(decoder), readAttributes(decoder));
         } else if (Implementation.LIBRARY.getId() == id) {
@@ -109,19 +109,23 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getProjectName());
+            writeAttributes(encoder, projectComponentSelector.getAttributes());
         } else if (implementation == Implementation.ROOT_BUILD_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getProjectPath());
+            writeAttributes(encoder, projectComponentSelector.getAttributes());
         } else if (implementation == Implementation.OTHER_BUILD_ROOT_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
+            writeAttributes(encoder, projectComponentSelector.getAttributes());
         } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
             encoder.writeString(projectComponentSelector.getProjectPath());
+            writeAttributes(encoder, projectComponentSelector.getAttributes());
         } else if (implementation == Implementation.LIBRARY) {
             LibraryComponentSelector libraryComponentSelector = (LibraryComponentSelector) value;
             encoder.writeString(libraryComponentSelector.getProjectPath());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLibraryComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLibraryComponentSelector.java
@@ -21,6 +21,8 @@ import com.google.common.base.Strings;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import javax.annotation.Nullable;
 
@@ -80,6 +82,11 @@ public class DefaultLibraryComponentSelector implements LibraryComponentSelector
         }
 
         return false;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return ImmutableAttributes.EMPTY;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModule
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.ProjectBackedModule
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -63,7 +64,7 @@ class DefaultComponentIdentifierFactoryTest extends Specification {
     def "can create component identifier for project dependency in same build"() {
         given:
         def buildId = new DefaultBuildIdentifier("build")
-        def selector = new DefaultProjectComponentSelector(buildId, Path.path(":id:path"), Path.path(":project:path"), "name")
+        def selector = new DefaultProjectComponentSelector(buildId, Path.path(":id:path"), Path.path(":project:path"), "name", ImmutableAttributes.EMPTY)
 
         when:
         def componentIdentifier = componentIdentifierFactory.createProjectComponentIdentifier(selector)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata
@@ -62,7 +63,7 @@ public class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDe
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData);
         assertFalse(dependencyMetaData.isChanging());
         assertFalse(dependencyMetaData.isForce());
-        assertEquals(new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root"), dependencyMetaData.getSelector());
+        assertEquals(new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root", ImmutableAttributes.EMPTY), dependencyMetaData.getSelector());
         assertSame(projectDependency, dependencyMetaData.source);
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.component.local.model
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.util.Path
 import spock.lang.Specification
@@ -30,7 +31,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName", ImmutableAttributes.EMPTY)
 
         then:
         defaultBuildComponentSelector.projectPath == ":project:path"
@@ -75,7 +76,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "matches id (#buildName #projectPath)"() {
         expect:
-        def selector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        def selector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName", ImmutableAttributes.EMPTY)
         def sameIdPath = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
         def differentIdPath = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path2"), Path.path(":project:path"), "projectName")
         selector.matchesStrictly(sameIdPath)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.util.Path;
 
 public class TestComponentIdentifiers {
@@ -45,6 +46,6 @@ public class TestComponentIdentifiers {
         if (name == null) {
             name = "root";
         }
-        return new DefaultProjectComponentSelector(new DefaultBuildIdentifier(buildName), path, path, name);
+        return new DefaultProjectComponentSelector(new DefaultBuildIdentifier(buildName), path, path, name, ImmutableAttributes.EMPTY);
     }
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -786,6 +786,19 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
     def "can publish java-library with dependencies/constraints with attributes"() {
         requiresExternalDependencies = true
         given:
+        settingsFile << "include 'utils'\n"
+        file("utils/build.gradle") << '''
+            def attr1 = Attribute.of('custom', String)
+            version = '1.0'
+            configurations {
+                one {
+                    attributes.attribute(attr1, 'magnificient')
+                }
+                two {
+                    attributes.attribute(attr1, 'bazinga')
+                }
+            }
+        '''
         createBuildScripts("""
             def attr1 = Attribute.of('custom', String)
             def attr2 = Attribute.of('nice', Boolean)
@@ -794,6 +807,12 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 api("org.test:bar:1.0") {
                     attributes {
                         attribute(attr1, 'hello')
+                    }
+                }
+                
+                api(project(':utils')) {
+                    attributes {
+                        attribute(attr1, 'bazinga')
                     }
                 }
                 
@@ -827,12 +846,18 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
             dependency('org.test:bar:1.0') {
                 hasAttribute('custom', 'hello')
             }
+            dependency('publishTest:utils:1.0') {
+                hasAttribute('custom', 'bazinga')
+            }
             noMoreDependencies()
         }
 
         javaLibrary.parsedModuleMetadata.variant('runtime') {
             dependency('org.test:bar:1.0') {
                 hasAttribute('custom', 'hello')
+            }
+            dependency('publishTest:utils:1.0') {
+                hasAttribute('custom', 'bazinga')
             }
             constraint('org.test:bar:1.1') {
                 hasAttributes(custom: 'world', nice: true)

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -718,6 +718,19 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     def "can publish java-library with dependencies/constraints with attributes"() {
         requiresExternalDependencies = true
         given:
+        settingsFile << "include 'utils'\n"
+        file("utils/build.gradle") << '''
+            def attr1 = Attribute.of('custom', String)
+            version = '1.0'
+            configurations {
+                one {
+                    attributes.attribute(attr1, 'magnificient')
+                }
+                two {
+                    attributes.attribute(attr1, 'bazinga')
+                }
+            }
+        '''
         createBuildScripts("""
             def attr1 = Attribute.of('custom', String)
             def attr2 = Attribute.of('nice', Boolean)
@@ -726,6 +739,12 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 api("org.test:bar:1.0") {
                     attributes {
                         attribute(attr1, 'hello')
+                    }
+                }
+                
+                api(project(':utils')) {
+                    attributes {
+                        attribute(attr1, 'bazinga')
                     }
                 }
                 
@@ -759,12 +778,18 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
             dependency('org.test:bar:1.0') {
                 hasAttribute('custom', 'hello')
             }
+            dependency('publishTest:utils:1.0') {
+                hasAttribute('custom', 'bazinga')
+            }
             noMoreDependencies()
         }
 
         javaLibrary.parsedModuleMetadata.variant('runtime') {
             dependency('org.test:bar:1.0') {
                 hasAttribute('custom', 'hello')
+            }
+            dependency('publishTest:utils:1.0') {
+                hasAttribute('custom', 'bazinga')
             }
             constraint('org.test:bar:1.1') {
                 hasAttributes(custom: 'world', nice: true)


### PR DESCRIPTION
### Context

There was an inconsistency with dependency attributes, that could be used to
select an external dependency, but not a project dependency. This commit aligns
what is possible for both.

