### PR TITLE
Fix generating flamegraphs for JavaIDEModelPerformanceTest

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -343,7 +343,8 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                     params.jvmArguments += profiler.getAdditionalJvmOpts(spec)
                 }
                 try {
-                    method.invoke(operation, args)
+                    def returnValue = method.invoke(operation, args)
+                    return returnValue == operation ? proxy : returnValue
                 } finally {
                     stoppable.stop()
                 }


### PR DESCRIPTION
We need to return the proxy for nested calls.
