### PR TITLE
Avoid unexpected http resource cache hit

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
@@ -38,9 +38,6 @@ class TextTask extends DefaultTask {
 
 task text(type: TextTask)
 """
-        executer.beforeExecute {
-            executer.requireOwnGradleUserHomeDir()
-        }
     }
 
     def "reports read of missing text file"() {
@@ -83,10 +80,11 @@ task text(type: TextTask)
 
     def "reports read of missing uri resource"() {
         given:
-        server.expectGetMissing("/myConfig.txt")
+        def uuid = UUID.randomUUID()
+        server.expectGetMissing("/myConfig-${uuid}.txt")
         server.start()
         buildFile << """
-            text.text = resources.text.fromUri("http://localhost:$server.port/myConfig.txt")
+            text.text = resources.text.fromUri("http://localhost:$server.port/myConfig-${uuid}.txt")
 """
 
         expect:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
@@ -38,6 +38,9 @@ class TextTask extends DefaultTask {
 
 task text(type: TextTask)
 """
+        executer.beforeExecute {
+            executer.requireOwnGradleUserHomeDir()
+        }
     }
 
     def "reports read of missing text file"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
@@ -29,6 +29,12 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     public final HttpServer server = new HttpServer()
 
+    def setup() {
+        executer.beforeExecute {
+            executer.requireOwnGradleUserHomeDir()
+        }
+    }
+
     def "string backed text resource"() {
         when:
         run("stringText")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
@@ -29,12 +29,6 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     public final HttpServer server = new HttpServer()
 
-    def setup() {
-        executer.beforeExecute {
-            executer.requireOwnGradleUserHomeDir()
-        }
-    }
-
     def "string backed text resource"() {
         when:
         run("stringText")
@@ -97,15 +91,15 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "uri backed text resource"() {
-
         given:
+        def uuid = UUID.randomUUID()
         def resourceFile = file("web-file.txt")
-        server.expectGet("/myConfig.txt", resourceFile)
+        server.expectGet("/myConfig-${uuid}.txt", resourceFile)
         server.start()
 
         buildFile << """
             task uriText(type: MyTask) {
-                config = resources.text.fromUri("http://localhost:$server.port/myConfig.txt")
+                config = resources.text.fromUri("http://localhost:$server.port/myConfig-${uuid}.txt")
                 output = project.file("output.txt")
             }
 """


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/1273

Since different tests share the same user home, some unexpected cache hit
might happen when two different test resources are assigned same port.
This PR uses unique resource name to avoid that.