### PR TITLE
Fix bug when finalizer tasks ran too early

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -477,6 +477,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
             if (precedingTasks.add(precedingTask)) {
                 // Any task that the preceding task must run after is also a preceding task.
                 candidateTasks.addAll(precedingTask.getMustSuccessors());
+                candidateTasks.addAll(precedingTask.getFinalizingSuccessors());
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskInfo.java
@@ -148,6 +148,12 @@ public class TaskInfo implements Comparable<TaskInfo> {
             }
         }
 
+        for (TaskInfo dependency : finalizingSuccessors) {
+            if (!dependency.isComplete()) {
+                return false;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Finalizers must run after the last task to be finalized.