### PR TITLE
Include class name in deprecation message

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -138,6 +138,6 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds "help"
-        output.contains "The AbstractFileCollection.getBuildDependencies() method has been deprecated and is scheduled to be removed in Gradle 5.0. Do not extend AbstractFileCollection, use Project.files() instead."
+        output.contains "The AbstractFileCollection.getBuildDependencies() method has been deprecated and is scheduled to be removed in Gradle 5.0. CustomFileCollection extends AbstractFileCollection. Don't do that, use Project.files() instead."
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -206,7 +206,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public TaskDependency getBuildDependencies() {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()", "Do not extend AbstractFileCollection, use Project.files() instead.");
+        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()", getClass().getName() + " extends AbstractFileCollection. Don't do that, use Project.files() instead.");
         return TaskDependencies.EMPTY;
     }
 


### PR DESCRIPTION
If not, it is not clear that a third party plugin extended
AbstractFileCollection and it looks like it is a problem with
Gradle core.

See #5141.