### PR TITLE
Properly handle snapshot versions in dependency locking

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -24,5 +24,5 @@ public interface DependencyLockingProvider {
 
     DependencyLockingState loadLockState(String configurationName);
 
-    void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult);
+    void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult, Set<ModuleComponentIdentifier> changingResolvedModules);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -61,6 +61,6 @@ class DependencyLockingNotationConverter {
     }
 
     String convertToLockNotation(ModuleComponentIdentifier id) {
-        return id.getDisplayName();
+        return id.getGroup() + ":" + id.getModule() + ":" + id.getVersion();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -40,7 +40,7 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     }
 
     @Override
-    public void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult) {
+    public void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult, Set<ModuleComponentIdentifier> changingResolvedModules) {
         // No-op
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -27,6 +27,7 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
 
+import static java.util.Collections.emptySet
 import static org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint.strictConstraint
 
 class DefaultDependencyLockingProviderTest extends Specification {
@@ -55,7 +56,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
         def modules = [module('org', 'foo', '1.0'), module('org','bar','1.3')] as Set
 
         when:
-        provider.persistResolvedDependencies('conf', modules)
+        provider.persistResolvedDependencies('conf', modules, emptySet())
 
         then:
         lockDir.file('conf.lockfile').text == """${LockFileReaderWriter.LOCKFILE_HEADER}org:bar:1.3

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/NoOpDependencyLockingProviderTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.internal.locking
 import spock.lang.Specification
 import spock.lang.Subject
 
+import static java.util.Collections.emptySet
+
 class NoOpDependencyLockingProviderTest extends Specification {
 
     @Subject
@@ -38,7 +40,7 @@ class NoOpDependencyLockingProviderTest extends Specification {
 
 
         when:
-        provider.persistResolvedDependencies('conf', result)
+        provider.persistResolvedDependencies('conf', result, emptySet())
 
         then:
         0 * _

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -64,10 +64,10 @@ You then run a build, telling Gradle to persist lock state:
 
     gradle test --write-locks
 
-Assuming you add the lock files to source control, from this point onward, all configurations that have a lock state will resolve the locked versions.
+From this point onward, for any build where the lock state is available to Gradle, all configurations that have a lock state will resolve the locked versions.
 
 Changes to published dependencies will not impact your build, you will have to re-generate or update the lock before they are considered as dependencies.
-Similarly, changes to your build script that would impact the resolved set of dependencies will cause it to fail,
+On the other hand, changes to your build script that would impact the resolved set of dependencies will cause it to fail,
 ensuring the dependencies do not change without a matching update in the lock file.
 
 Head over to the [dependency locking documentation](userguide/dependency_locking.html) for more details on using this feature.

--- a/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
@@ -32,7 +32,7 @@ The release tag will contain the lock states, allowing that build to be fully re
 Locking is enabled per <<managing_dependency_configurations,dependency configuration>>.
 Once enabled, you must create an initial lock state.
 It will cause Gradle to verify that resolution results do not change, resulting in the same selected dependencies even if newer versions are produced.
-In case the lock state no longer matches the resolution result, the build will fail.
+Modifications to your build that would impact the resolved set of dependencies will cause it to fail.
 This makes sure that changes, either in published dependencies or build definitions, do not alter resolution without adapting the lock state.
 
 [NOTE]
@@ -158,7 +158,7 @@ However, if that configuration happens to be resolved in the future at a time wh
 === Locking limitations
 
 * It is currently not possible to lock the <<sec:applying_plugins_buildscript,`classpath` configuration>> used for script plugins.
-* Locking can not be applied to source dependencies.
+* Locking can not yet be applied to source dependencies.
 
 === Nebula locking plugin
 

--- a/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
+++ b/subprojects/docs/src/docs/userguide/dependencyLocking.adoc
@@ -38,7 +38,8 @@ This makes sure that changes, either in published dependencies or build definiti
 [NOTE]
 ====
 Dependency locking makes sense only with <<sub:declaring_dependency_with_dynamic_version,dynamic versions>>.
-It will have no impact on <<sub:declaring_dependency_with_changing_version,changing versions>> whose coordinates remain the same, though the content may change.
+It will have no impact on <<sub:declaring_dependency_with_changing_version,changing versions>> (like `-SNAPSHOT`) whose coordinates remain the same, though the content may change.
+Gradle will even emit a warning when persisting lock state and changing dependencies are present in the resolution result.
 ====
 
 === Enabling locking on configurations


### PR DESCRIPTION
* Effectively does that by ignoring the timestamp and only locking - and
validating - the base -SNAPSHOT version.
* Added a warning in case changing dependencies are detected while
persisting lock state, with a link to documentation.
* Added info in the documentation that this situation will cause warnings.