### PR TITLE
Make software model tasks accessible using abbreviated names again

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskSelectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskSelectionIntegrationTest.groovy
@@ -97,6 +97,22 @@ allprojects { task thing }
         result.assertTasksExecuted(":child:child:thing")
     }
 
+    def "can use camel case to match software model tasks"() {
+        buildFile << """
+            model { 
+                tasks {
+                    "sayHelloToUser"(DefaultTask) {
+                    }
+                }
+            }
+        """
+        when:
+        run "sHTU"
+
+        then:
+        result.assertTasksExecuted(":sayHelloToUser")
+    }
+
     def "executes project default tasks when none specified"() {
         settingsFile << "include 'a'"
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -400,11 +400,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     @Override
     public SortedSet<String> getNames() {
         SortedSet<String> names = super.getNames();
-        if (placeholders.isEmpty()) {
+        if (placeholders.isEmpty() && modelNode == null) {
             return names;
         }
         TreeSet<String> allNames = new TreeSet<String>(names);
         allNames.addAll(placeholders.keySet());
+        if (modelNode != null) {
+            allNames.addAll(modelNode.getLinkNames());
+        }
         return allNames;
     }
 

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
@@ -650,7 +650,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         fails 'show'
 
         then:
-        failure.assertHasDescription("Exception thrown while executing model rule: CalculateName#broken(Thing)")
+        failure.assertHasCause("Exception thrown while executing model rule: CalculateName#broken(Thing)")
         failure.assertHasCause("Attempt to modify a read only view of model element 'things.thingA' of type 'Thing' given to rule CalculateName#broken(Thing)")
     }
 

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelMapIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelMapIntegrationTest.groovy
@@ -199,7 +199,7 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
         fails "print"
 
         and:
-        failure.assertHasDescription("Exception thrown while executing model rule: container(Container) @ build.gradle line 8, column 15")
+        failure.assertHasCause("Exception thrown while executing model rule: container(Container) @ build.gradle line 8, column 15")
         failure.assertHasCause("""A model element of type: 'Container' can not be constructed.
 Its property 'org.gradle.model.ModelMap<java.io.InputStream> things' is not a valid managed collection
 A managed collection can not contain 'java.io.InputStream's""")

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslCreationIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslCreationIntegrationTest.groovy
@@ -104,7 +104,7 @@ class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         fails "echo"
-        failure.assertHasDescription('Exception thrown while executing model rule: thing1(Thing) { ... } @ build.gradle line 9, column 17')
+        failure.assertHasCause('Exception thrown while executing model rule: thing1(Thing) { ... } @ build.gradle line 9, column 17')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 


### PR DESCRIPTION
This was broken by a refactoring towards lazy task configuration,
because we had no test coverage for this case.