### PR TITLE
Treat Gradle modules as immutable files

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -15,7 +15,9 @@
  */
 package org.gradle.api.internal.classpath;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.classpath.CachedJarFileStore;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.installation.GradleInstallation;
@@ -42,7 +44,7 @@ import java.util.zip.ZipFile;
 /**
  * Determines the classpath for a module by looking for a '${module}-classpath.properties' resource with 'name' set to the name of the module.
  */
-public class DefaultModuleRegistry implements ModuleRegistry {
+public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore {
     private final GradleInstallation gradleInstallation;
     private final Map<String, Module> modules = new HashMap<String, Module>();
     private final Map<String, Module> externalModules = new HashMap<String, Module>();
@@ -68,6 +70,11 @@ public class DefaultModuleRegistry implements ModuleRegistry {
         }
     }
 
+    @Override
+    public List<File> getFileStoreRoots() {
+        return ImmutableList.<File>builder().addAll(gradleInstallation.getLibDirs()).addAll(classpath).build();
+    }
+    
     @Override
     public ClassPath getAdditionalClassPath() {
         return gradleInstallation == null ? DefaultClassPath.of(classpath) : ClassPath.EMPTY;


### PR DESCRIPTION
The files in the Gradle distribution never change,
so there is no point in snapshotting them more than
once for the lifetime of the daemon.

This speeds up our embedded integration tests as
they use the libraries directly instead of generating
a gradle-api jar.