### PR TITLE
Rebase `up-to-date assemble on largeMonolithicJavaProject (parallel false)` and `create many empty projects` performance test on newer nightly

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ProjectCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ProjectCreationPerformanceTest.groovy
@@ -25,7 +25,7 @@ class ProjectCreationPerformanceTest extends AbstractCrossVersionPerformanceTest
         runner.testProject = "bigEmpty"
         runner.tasksToRun = ['help']
         runner.gradleOpts = ['-Xms1500m', '-Xmx1500m']
-        runner.targetVersions = ["4.8-20180510001718+0000"]
+        runner.targetVersions = ["4.8-20180511042602+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -30,7 +30,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
-        runner.targetVersions = ["4.8-20180510001718+0000"]
+        runner.targetVersions = ["4.9-20180516235936+0000"]
         runner.args += ["-Dorg.gradle.parallel=$parallel"]
 
         when:


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See: https://github.com/gradle/gradle-private/issues/1285 and https://github.com/gradle/gradle-private/issues/1286

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Frebase-for-regression-in-get-by-name-later)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
