### PR TITLE
Run finalizers in parallel in all cases

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionPlan.java
@@ -945,7 +945,7 @@ public class DefaultTaskExecutionPlan implements TaskExecutionPlan {
                 return true;
             }
         }
-        return false;
+        return !runningTasks.isEmpty();
     }
 
     private static class GraphEdge {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelProjectExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelProjectExecutionIntegrationTest.groovy
@@ -104,6 +104,20 @@ allprojects {
         run 'b:pingC'
     }
 
+    def "finalizer tasks are run in parallel"() {
+        buildFile << """
+            tasks.getByPath(':c:ping').dependsOn ":a:ping", ":b:ping"
+            tasks.getByPath(':d:ping').finalizedBy ":c:ping"
+        """
+
+        expect:
+        blockingServer.expect(':d:ping')
+        blockingServer.expectConcurrent(':a:ping', ':b:ping')
+        blockingServer.expect(':c:ping')
+
+        run 'd:ping'
+    }
+
     void 'tasks with should run after ordering rules are preferred when running over an idle worker thread'() {
         buildFile << """
             tasks.getByPath(':a:pingA').shouldRunAfter(':b:pingB')


### PR DESCRIPTION
When all remaining tasks in the queue were finalizers
and the task that they finalize hadn't completed yet,
all other task workers determined that there was nothing
more to do and shut down, leading to the finalizers being
executed on the last remaining worker.

This is now fixed by waiting for more potential finalizers
until there are no more tasks running.