### PR TITLE
Fix concat for attributes with same name, different type

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -110,7 +110,7 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
         }
         ImmutableAttributes current = attributes2;
         for (Attribute attribute : attributes1.keySet()) {
-            if (!current.contains(attribute)) {
+            if (!current.findEntry(attribute.getName()).isPresent()) {
                 if (attributes1 instanceof DefaultImmutableAttributes) {
                     current = doConcatIsolatable(current, attribute, ((DefaultImmutableAttributes) attributes1).getIsolatableAttribute(attribute));
                 } else {
@@ -131,8 +131,9 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
         }
         ImmutableAttributes current = attributes2;
         for (Attribute attribute : attributes1.keySet()) {
-            Object currentAttribute = current.getAttribute(attribute);
-            if (currentAttribute != null) {
+            AttributeValue<?> entry = current.findEntry(attribute.getName());
+            if (entry.isPresent()) {
+                Object currentAttribute = entry.get();
                 Object existingAttribute = attributes1.getAttribute(attribute);
                 if (!currentAttribute.equals(existingAttribute)) {
                     throw new AttributeMergingException(attribute, existingAttribute, currentAttribute);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributesFactory.java
@@ -46,12 +46,18 @@ public interface ImmutableAttributesFactory {
 
     /**
      * Merges the second container into the first container and returns the result. Values in the second container win.
+     *
+     * Attributes with same name but different type are considered the same attribute for the purpose of merging. As such
+     * an attribute in the second container will replace any attribute in the first container with the same name,
+     * irrespective of the type of the attributes.
      */
     ImmutableAttributes concat(ImmutableAttributes attributes1, ImmutableAttributes attributes2);
 
     /**
      * Merges the second container into the first container and returns the result. If the second container has the same
      * attribute with a different value, this method will fail instead of overriding the attribute value.
+     *
+     * Attributes with same name but different type are considered equal for the purpose of merging.
      */
     ImmutableAttributes safeConcat(ImmutableAttributes attributes1, ImmutableAttributes attributes2) throws AttributeMergingException;
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -217,37 +217,40 @@ org:leaf:1.0
         mavenRepo.module('org', 'testB', '1.0').publish()
 
         buildFile << """
-            def CUSTOM_ATTRIBUTE = Attribute.of('custom', String)
+            def CUSTOM_ATTRIBUTE = Attribute.of('custom', CustomAttributeType)
             dependencies.attributesSchema.attribute(CUSTOM_ATTRIBUTE)
+            def configValue = objects.named(CustomAttributeType.class, 'conf_value')
+            def dependencyValue = objects.named(CustomAttributeType.class, 'dep_value')
             
             repositories {
                 maven { url "${mavenRepo.uri}" }
             }
             configurations {
                 conf {
-                    attributes.attribute(CUSTOM_ATTRIBUTE, 'conf_value')
+                    attributes.attribute(CUSTOM_ATTRIBUTE, configValue)
                 }
             }
             dependencies {
                 components {
                     all {
                         attributes {
-                            attribute(CUSTOM_ATTRIBUTE, 'dep_value')
+                            attribute(CUSTOM_ATTRIBUTE, dependencyValue)
                         }
                     }
                 }
                 conf('org:testA:1.0') {
                     attributes {
-                        attribute(CUSTOM_ATTRIBUTE, 'dep_value')
+                        attribute(CUSTOM_ATTRIBUTE, dependencyValue)
                     }
                 }
                 conf('org:testB:+') {
                     attributes {
-                        attribute(CUSTOM_ATTRIBUTE, 'dep_value')
+                        attribute(CUSTOM_ATTRIBUTE, dependencyValue)
                     }
                 }
             }
             
+            interface CustomAttributeType extends Named {}
         """
 
         when:


### PR DESCRIPTION
When 2 containers contain attributes with the same name and different
types, the `concat` and `safeConcat` methods of `ImmutableAttributesFactory`
now treat these attributes as equal for the purposes of merging.

Previously, these methods would produce an `AttributeContainer` 
containing both attributes. 
This was a violation of the `AttributeContainer` contract which states:
"It is not allowed to have two attributes with the same name but 
different types in the container"
