### PR TITLE
Allow a build operation notification listeners during continuous build

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.notify
+
+import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
+import org.gradle.launcher.exec.RunBuildBuildOperationType
+
+class BuildOperationNotificationContinuousBuildIntegrationTest extends AbstractContinuousIntegrationTest {
+
+    def notifications = new BuildOperationNotificationFixture(testDirectory)
+
+    def "obtains notifications about init scripts"() {
+        when:
+        buildScript """
+           ${notifications.registerListenerWithDrainRecordings()}
+            apply plugin: "java"
+        """
+
+        buildFile << """
+        """
+        file("src/main/java/Thing.java") << "class Thing {}"
+
+        then:
+        succeeds("build")
+        def run1 = notifications.op(RunBuildBuildOperationType.Details)
+
+        when:
+        file("src/main/java/Thing.java").text = "class Thing {\n\n}"
+
+        then:
+        succeeds()
+        def run2 = notifications.op(RunBuildBuildOperationType.Details)
+
+        and:
+        run1.id != run2.id
+    }
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationFixture.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationFixture.groovy
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.notify
+
+import com.google.common.base.Predicate
+import groovy.json.JsonSlurper
+import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
+import org.gradle.test.fixtures.file.TestFile
+
+class BuildOperationNotificationFixture {
+
+    TestFile dir
+
+    BuildOperationNotificationFixture(TestFile dir) {
+        this.dir = dir
+    }
+
+    def op(Class<?> detailsClass, Map<String, String> details = [:]) {
+        def found = recordedOps.findAll { op ->
+            return op.detailsType == detailsClass.name && op.details.subMap(details.keySet()) == details
+        }
+        assert found.size() == 1
+        found.first()
+    }
+
+    void started(Class<?> type, Predicate<? super Map<String, ?>> payloadTest) {
+        has(true, type, payloadTest)
+    }
+
+    void started(Class<?> type, Map<String, ?> payload = null) {
+        has(true, type, (Map) payload)
+    }
+
+    void finished(Class<?> type, Map<String, ?> payload = null) {
+        has(false, type, (Map) payload)
+    }
+
+    void has(boolean started, Class<?> type, Map<String, ?> payload) {
+        has(started, type, payload ? { it == payload } : { true })
+    }
+
+    void has(boolean started, Class<?> type, Predicate<? super Map<String, ?>> payloadTest) {
+        def typedOps = recordedOps.findAll { op ->
+            return started ? op.detailsType == type.name : op.resultType == type.name
+        }
+        assert typedOps.size() > 0
+
+        if (payloadTest != null) {
+            def matchingOps = typedOps.findAll { matchingOp ->
+                started ? payloadTest.apply(matchingOp.details) : payloadTest.apply(matchingOp.result)
+            }
+            assert matchingOps.size()
+        }
+    }
+
+    def getRecordedOps() {
+        new JsonSlurper().parse(jsonFile())
+    }
+
+    void notIncluded(Class<?> type) {
+        assert !recordedOps.any { it.detailsType == type.name }
+    }
+
+    String registerListener() {
+        listenerClass() + """
+        registrar.registerBuildScopeListener(listener)
+        """
+    }
+
+    String registerListenerWithDrainRecordings() {
+        listenerClass() + """
+        registrar.registerBuildScopeListenerAndReceiveStoredOperations(listener)
+        """
+    }
+
+    String listenerClass() {
+        """
+            def listener = new ${BuildOperationNotificationListener.name}() {
+
+                LinkedHashMap<Object,BuildOpsEntry> ops = new LinkedHashMap().asSynchronized()
+            
+                @Override
+                void started(${BuildOperationStartedNotification.name} startedNotification) {
+            
+                    def details = startedNotification.notificationOperationDetails
+                    if (details instanceof org.gradle.internal.execution.ExecuteTaskBuildOperationType.Details) {
+                        details = [taskPath: details.taskPath, buildPath: details.buildPath, taskClass: details.taskClass.name]
+                    } else  if (details instanceof org.gradle.api.internal.plugins.ApplyPluginBuildOperationType.Details) {
+                        details = [pluginId: details.pluginId, pluginClass: details.pluginClass.name, targetType: details.targetType, targetPath: details.targetPath, buildPath: details.buildPath]
+                    }
+
+                    ops.put(startedNotification.notificationOperationId, new BuildOpsEntry(id: startedNotification.notificationOperationId?.id,
+                            parentId: startedNotification.notificationOperationParentId?.id,
+                            detailsType: startedNotification.notificationOperationDetails.getClass().getInterfaces()[0].getName(),
+                            details: details, 
+                            started: startedNotification.notificationOperationStartedTimestamp))
+                }
+            
+                @Override
+                void finished(${BuildOperationFinishedNotification.name} finishedNotification) {
+                    def result = finishedNotification.getNotificationOperationResult()
+                    if (result instanceof ${ResolveConfigurationDependenciesBuildOperationType.Result.name}) {
+                        result = []
+                    }
+                    def op = ops.get(finishedNotification.notificationOperationId)
+                    op.resultType = finishedNotification.getNotificationOperationResult().getClass().getInterfaces()[0].getName()
+                    op.result = result
+                    op.finished = finishedNotification.getNotificationOperationFinishedTimestamp()
+                }
+            
+                void store(File target){
+                    target.withPrintWriter { pw ->
+                        String json = groovy.json.JsonOutput.toJson(ops.values());
+                        pw.append(json)
+                    }
+                }
+            
+                static class BuildOpsEntry {
+                    Object id
+                    Object parentId
+                    Object details
+                    Object result
+                    String detailsType
+                    String resultType
+                    long started
+                    long finished
+                }
+            }
+
+            def registrar = services.get($BuildOperationNotificationListenerRegistrar.name)            
+            gradle.buildFinished {
+                listener.store(file('${jsonFile().toURI()}'))
+            }
+        """
+    }
+
+    private TestFile jsonFile() {
+        dir.file('buildOpNotifications.json')
+    }
+
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.operations.notify
 
-import com.google.common.base.Predicate
-import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
 import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType
 import org.gradle.configuration.ApplyScriptPluginBuildOperationType
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
@@ -33,6 +31,8 @@ import org.gradle.launcher.exec.RunBuildBuildOperationType
 
 class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec {
 
+    def notifications = new BuildOperationNotificationFixture(testDirectory)
+
     def "obtains notifications about init scripts"() {
         when:
         executer.requireOwnGradleUserHomeDir()
@@ -40,7 +40,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
             println "init script"
         """
         buildScript """
-           ${registerListenerWithDrainRecordings()}
+           ${notifications.registerListenerWithDrainRecordings()}
             task t
         """
 
@@ -49,42 +49,42 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         succeeds "t"
 
         then:
-        started(ApplyScriptPluginBuildOperationType.Details, [targetType: "gradle", targetPath: null, file: init.absolutePath, buildPath: ":", uri: null])
-        started(ApplyScriptPluginBuildOperationType.Details, [targetType: "gradle", targetPath: null, file: init.absolutePath, buildPath: ":buildSrc", uri: null])
+        notifications.started(ApplyScriptPluginBuildOperationType.Details, [targetType: "gradle", targetPath: null, file: init.absolutePath, buildPath: ":", uri: null])
+        notifications.started(ApplyScriptPluginBuildOperationType.Details, [targetType: "gradle", targetPath: null, file: init.absolutePath, buildPath: ":buildSrc", uri: null])
     }
 
     def "can emit notifications from start of build"() {
         when:
         buildScript """
-           ${registerListenerWithDrainRecordings()}
+           ${notifications.registerListenerWithDrainRecordings()}
             task t
         """
 
         succeeds "t", "-S"
 
         then:
-        started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: testDirectory.absolutePath, settingsFile: settingsFile.absolutePath, buildPath: ":"])
-        finished(EvaluateSettingsBuildOperationType.Result, [:])
-        started(LoadProjectsBuildOperationType.Details, [buildPath: ":"])
-        finished(LoadProjectsBuildOperationType.Result)
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ':', projectPath: ':'])
-        started(ApplyPluginBuildOperationType.Details, [pluginId: "org.gradle.help-tasks", pluginClass: "org.gradle.api.plugins.HelpTasksPlugin", targetType: "project", targetPath: ":", buildPath: ":"])
-        finished(ApplyPluginBuildOperationType.Result, [:])
-        started(ApplyScriptPluginBuildOperationType.Details, [targetType: "project", targetPath: ":", file: buildFile.absolutePath, buildPath: ":", uri: null])
-        finished(ApplyScriptPluginBuildOperationType.Result, [:])
-        finished(ConfigureProjectBuildOperationType.Result, [:])
+        notifications.started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
+        notifications.started(EvaluateSettingsBuildOperationType.Details, [settingsDir: testDirectory.absolutePath, settingsFile: settingsFile.absolutePath, buildPath: ":"])
+        notifications.finished(EvaluateSettingsBuildOperationType.Result, [:])
+        notifications.started(LoadProjectsBuildOperationType.Details, [buildPath: ":"])
+        notifications.finished(LoadProjectsBuildOperationType.Result)
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ':', projectPath: ':'])
+        notifications.started(ApplyPluginBuildOperationType.Details, [pluginId: "org.gradle.help-tasks", pluginClass: "org.gradle.api.plugins.HelpTasksPlugin", targetType: "project", targetPath: ":", buildPath: ":"])
+        notifications.finished(ApplyPluginBuildOperationType.Result, [:])
+        notifications.started(ApplyScriptPluginBuildOperationType.Details, [targetType: "project", targetPath: ":", file: buildFile.absolutePath, buildPath: ":", uri: null])
+        notifications.finished(ApplyScriptPluginBuildOperationType.Result, [:])
+        notifications.finished(ConfigureProjectBuildOperationType.Result, [:])
 
-        started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
-        finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
-        started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
-        finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
+        notifications.started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
+        notifications.finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
+        notifications.started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
+        notifications.finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
     }
 
     def "can emit notifications from point of registration"() {
         when:
         buildScript """
-           ${registerListener()}
+           ${notifications.registerListener()}
             task t
         """
 
@@ -92,15 +92,15 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         then:
         // Operations that started before the listener registration are not included (even if they finish _after_ listener registration)
-        notIncluded(EvaluateSettingsBuildOperationType.Details)
-        notIncluded(LoadProjectsBuildOperationType.Details)
-        notIncluded(ApplyPluginBuildOperationType.Details)
-        notIncluded(ConfigureProjectBuildOperationType.Details)
+        notifications.notIncluded(EvaluateSettingsBuildOperationType.Details)
+        notifications.notIncluded(LoadProjectsBuildOperationType.Details)
+        notifications.notIncluded(ApplyPluginBuildOperationType.Details)
+        notifications.notIncluded(ConfigureProjectBuildOperationType.Details)
 
-        started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
-        finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
-        started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
-        finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
+        notifications.started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
+        notifications.finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
+        notifications.started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
+        notifications.finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
     }
 
     def "can emit notifications for nested builds"() {
@@ -111,7 +111,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         file("a/settings.gradle") << ""
         file("settings.gradle") << "includeBuild 'a'"
         buildScript """
-           ${registerListenerWithDrainRecordings()}
+           ${notifications.registerListenerWithDrainRecordings()}
             task t {
                 dependsOn gradle.includedBuild("a").task(":t")
             }
@@ -120,60 +120,60 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         succeeds "t"
 
         then:
-        started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
+        notifications.started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
 
-        started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
-        started(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"])
-        started(LoadBuildBuildOperationType.Details, [buildPath: ":a"])
-        started(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"])
+        notifications.started(LoadBuildBuildOperationType.Details, [buildPath: ":"])
+        notifications.started(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"])
+        notifications.started(LoadBuildBuildOperationType.Details, [buildPath: ":a"])
+        notifications.started(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"])
 
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('buildSrc').absolutePath, settingsFile: file('buildSrc/settings.gradle').absolutePath, buildPath: ":buildSrc"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a').absolutePath, settingsFile: file('a/settings.gradle').absolutePath, buildPath: ":a"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a/buildSrc').absolutePath, settingsFile: file('a/buildSrc/settings.gradle').absolutePath, buildPath: ":a:buildSrc"])
-        started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('.').absolutePath, settingsFile: file('settings.gradle').absolutePath, buildPath: ":"])
+        notifications.started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('buildSrc').absolutePath, settingsFile: file('buildSrc/settings.gradle').absolutePath, buildPath: ":buildSrc"])
+        notifications.started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a').absolutePath, settingsFile: file('a/settings.gradle').absolutePath, buildPath: ":a"])
+        notifications.started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('a/buildSrc').absolutePath, settingsFile: file('a/buildSrc/settings.gradle').absolutePath, buildPath: ":a:buildSrc"])
+        notifications.started(EvaluateSettingsBuildOperationType.Details, [settingsDir: file('.').absolutePath, settingsFile: file('settings.gradle').absolutePath, buildPath: ":"])
 
-        started(LoadProjectsBuildOperationType.Details, [buildPath: ":buildSrc"])
-        started(LoadProjectsBuildOperationType.Details, [buildPath: ":a:buildSrc"])
-        started(LoadProjectsBuildOperationType.Details, [buildPath: ":a"])
-        started(LoadProjectsBuildOperationType.Details, [buildPath: ":"])
+        notifications.started(LoadProjectsBuildOperationType.Details, [buildPath: ":buildSrc"])
+        notifications.started(LoadProjectsBuildOperationType.Details, [buildPath: ":a:buildSrc"])
+        notifications.started(LoadProjectsBuildOperationType.Details, [buildPath: ":a"])
+        notifications.started(LoadProjectsBuildOperationType.Details, [buildPath: ":"])
 
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
 
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
 
         // evaluate hierarchies
-        op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).parentId == op(RunBuildBuildOperationType.Details).id
-        op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
-        op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
-        op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
+        notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
+        notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
+        notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
 
-        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
-        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).id
-        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).id
-        op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
+        notifications.op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).id
+        notifications.op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).id
+        notifications.op(EvaluateSettingsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
 
-        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).parentId == op(RunBuildBuildOperationType.Details).id
-        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
-        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
-        op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
+        notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
+        notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
+        notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
 
-        op(LoadProjectsBuildOperationType.Details, [buildPath: ":"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
-        op(LoadProjectsBuildOperationType.Details, [buildPath: ":a"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).id
-        op(LoadProjectsBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).id
-        op(LoadProjectsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
+        notifications.op(LoadProjectsBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":"]).id
+        notifications.op(LoadProjectsBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a"]).id
+        notifications.op(LoadProjectsBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":buildSrc"]).id
+        notifications.op(LoadProjectsBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(ConfigureBuildBuildOperationType.Details, [buildPath: ":a:buildSrc"]).id
     }
 
     def "emits for GradleBuild tasks"() {
         when:
         def initScript = file("init.gradle") << """
             if (parent == null) {
-                ${registerListener()}
+                ${notifications.registerListener()}
             }
         """
 
@@ -190,11 +190,11 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         then:
         executedTasks.find { it.endsWith(":o") }
 
-        started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
-        started(ConfigureProjectBuildOperationType.Details) {
+        notifications.started(ConfigureProjectBuildOperationType.Details, [buildPath: ":", projectPath: ":"])
+        notifications.started(ConfigureProjectBuildOperationType.Details) {
             it.projectPath == ":" && it.buildPath != ":"
         }
-        started(ExecuteTaskBuildOperationType.Details) {
+        notifications.started(ExecuteTaskBuildOperationType.Details) {
             it.taskPath == ":o"
         }
     }
@@ -202,11 +202,11 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
     def "listeners are deregistered after build"() {
         when:
         executer.requireDaemon().requireIsolatedDaemons()
-        buildFile << registerListener() << "task t"
+        buildFile << notifications.registerListener() << "task t"
         succeeds("t")
 
         then:
-        finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
+        notifications.finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
 
         when:
         // remove listener
@@ -214,7 +214,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         succeeds("x")
 
         then:
-        recordedOps.findAll { it.detailsType == CalculateTaskGraphBuildOperationType.Result.name }.size() == 0
+        notifications.recordedOps.findAll { it.detailsType == CalculateTaskGraphBuildOperationType.Result.name }.size() == 0
     }
 
     // This test simulates what the build scan plugin does.
@@ -222,7 +222,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         given:
         file("buildSrc/build.gradle") << ""
         file("build.gradle") << """
-            ${registerListenerWithDrainRecordings()}
+            ${notifications.registerListenerWithDrainRecordings()}
             task t
         """
 
@@ -231,132 +231,9 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         then:
         output.contains(":buildSrc:compileJava") // executedTasks check fails with in process executer
-        recordedOps.findAll { it.detailsType == ConfigureProjectBuildOperationType.Details.name }.size() == 2
-        recordedOps.findAll { it.detailsType == ExecuteTaskBuildOperationType.Details.name }.size() == 14 // including all buildSrc task execution events
+        notifications.recordedOps.findAll { it.detailsType == ConfigureProjectBuildOperationType.Details.name }.size() == 2
+        notifications.recordedOps.findAll { it.detailsType == ExecuteTaskBuildOperationType.Details.name }.size() == 14 // including all buildSrc task execution events
     }
 
-
-    def isChildren(def parent, def child) {
-        assert parent.id == child.parentId
-        true
-    }
-
-    def op(Class<ConfigureProjectBuildOperationType.Details> detailsClass, Map<String, String> details = [:]) {
-        recordedOps.find { op ->
-            return op.detailsType == detailsClass.name && op.details.subMap(details.keySet()) == details
-        }
-    }
-
-    void started(Class<?> type, Predicate<? super Map<String, ?>> payloadTest) {
-        has(true, type, payloadTest)
-    }
-
-    void started(Class<?> type, Map<String, ?> payload = null) {
-        has(true, type, (Map) payload)
-    }
-
-    void finished(Class<?> type, Map<String, ?> payload = null) {
-        has(false, type, (Map) payload)
-    }
-
-    void has(boolean started, Class<?> type, Map<String, ?> payload) {
-        has(started, type, payload ? { it == payload } : { true })
-    }
-
-    void has(boolean started, Class<?> type, Predicate<? super Map<String, ?>> payloadTest) {
-        def typedOps = recordedOps.findAll { op ->
-            return started ? op.detailsType == type.name : op.resultType == type.name
-        }
-        assert typedOps.size() > 0
-
-        if (payloadTest != null) {
-            def matchingOps = typedOps.findAll { matchingOp ->
-                started ? payloadTest.apply(matchingOp.details) : payloadTest.apply(matchingOp.result)
-            }
-            assert matchingOps.size()
-        }
-    }
-
-    def getRecordedOps() {
-        def jsonSlurper = new groovy.json.JsonSlurper()
-        jsonSlurper.parse(file('buildOpNotifications.json'))
-    }
-
-    void notIncluded(Class<?> type) {
-        assert !recordedOps.any { it.detailsType == type.name }
-    }
-
-    String registerListener() {
-        listenerClass() + """
-        registrar.registerBuildScopeListener(listener)
-        """
-    }
-
-    String registerListenerWithDrainRecordings() {
-        listenerClass() + """
-        registrar.registerBuildScopeListenerAndReceiveStoredOperations(listener)
-        """
-    }
-
-    String listenerClass() {
-        """
-            def listener = new ${BuildOperationNotificationListener.name}() {
-
-                LinkedHashMap<Object,BuildOpsEntry> ops = new LinkedHashMap()
-            
-                @Override
-                void started(${BuildOperationStartedNotification.name} startedNotification) {
-            
-                    def details = startedNotification.notificationOperationDetails
-                    if (details instanceof org.gradle.internal.execution.ExecuteTaskBuildOperationType.Details) {
-                        details = [taskPath: details.taskPath, buildPath: details.buildPath, taskClass: details.taskClass.name]
-                    } else  if (details instanceof org.gradle.api.internal.plugins.ApplyPluginBuildOperationType.Details) {
-                        details = [pluginId: details.pluginId, pluginClass: details.pluginClass.name, targetType: details.targetType, targetPath: details.targetPath, buildPath: details.buildPath]
-                    }
-
-                    ops.put(startedNotification.notificationOperationId, new BuildOpsEntry(id: startedNotification.notificationOperationId?.id,
-                            parentId: startedNotification.notificationOperationParentId?.id,
-                            detailsType: startedNotification.notificationOperationDetails.getClass().getInterfaces()[0].getName(),
-                            details: details, 
-                            started: startedNotification.notificationOperationStartedTimestamp))
-                }
-            
-                @Override
-                void finished(${BuildOperationFinishedNotification.name} finishedNotification) {
-                    def result = finishedNotification.getNotificationOperationResult()
-                    if (result instanceof ${ResolveConfigurationDependenciesBuildOperationType.Result.name}) {
-                        result = []
-                    }
-                    def op = ops.get(finishedNotification.notificationOperationId)
-                    op.resultType = finishedNotification.getNotificationOperationResult().getClass().getInterfaces()[0].getName()
-                    op.result = result
-                    op.finished = finishedNotification.getNotificationOperationFinishedTimestamp()
-                }
-            
-                void store(File target){
-                    target.withPrintWriter { pw ->
-                        String json = groovy.json.JsonOutput.toJson(ops.values());
-                        pw.append(json)
-                    }
-                }
-            
-                static class BuildOpsEntry {
-                    Object id
-                    Object parentId
-                    Object details
-                    Object result
-                    String detailsType
-                    String resultType
-                    long started
-                    long finished
-                }
-            }
-
-            def registrar = services.get($BuildOperationNotificationListenerRegistrar.name)            
-            gradle.buildFinished {
-                listener.store(file('${file('buildOpNotifications.json').toURI()}'))
-            }
-        """
-    }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationValve.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationValve.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations.notify;
+
+/**
+ * Controls an instance of build operation notifications.
+ *
+ * This is required as the build operation notification machinery is effectively session scoped,
+ * but we need to allow, external (i.e. non ListenerManager), listeners per build.
+ *
+ * Furthermore, the actual lifecycle is not something that we currently model with the service registries.
+ * The notification listener is effectively of cross build tree scope, which doesn't exist.
+ * This is because GradleBuild uses a discrete tree (which is intended to change later).
+ */
+public interface BuildOperationNotificationValve {
+
+    void start();
+
+    void stop();
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfig.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfig.java
@@ -65,9 +65,14 @@ public interface BuildScanConfig {
         boolean isRootProjectHasVcsMappings();
 
         /**
-         * Whether any {@link org.gradle.deployment.internal.Deployment}s have been started in the current build session.
+         * Deprecated.
          *
-         * @since 4.8
+         * See https://github.com/gradle/gradle/issues/5347.
+         * This was used by 4.8-rc-1 and scan plugin 1.13.3.
+         * For 4.8-rc-2, the constraint on disabling the scan plugin for continuous builds was removed.
+         *
+         * @since 4.8-rc-1
+         * @deprecated 4.8-rc-2
          */
         boolean isAnyDeploymentsStarted();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
@@ -31,8 +31,8 @@ import org.gradle.vcs.internal.VcsResolver;
  */
 public class BuildScanConfigServices {
 
-    BuildScanPluginCompatibility createBuildScanPluginCompatibility(GradleInternal gradle) {
-        return new BuildScanPluginCompatibility(gradle);
+    BuildScanPluginCompatibility createBuildScanPluginCompatibility() {
+        return new BuildScanPluginCompatibility();
     }
 
     BuildScanConfigManager createBuildScanConfigManager(
@@ -63,7 +63,7 @@ public class BuildScanConfigServices {
 
                     @Override
                     public boolean isAnyDeploymentsStarted() {
-                        return BuildScanPluginCompatibility.isAnyDeploymentsStarted(gradle);
+                        return false;
                     }
                 };
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.scan.config;
 
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.deployment.internal.DeploymentRegistryInternal;
 import org.gradle.util.VersionNumber;
 
 class BuildScanPluginCompatibility {
@@ -31,19 +29,9 @@ class BuildScanPluginCompatibility {
     public static final String UNSUPPORTED_VCS_MAPPINGS_MESSAGE =
         "Build scans are not supported when using VCS mappings. It may be supported when using newer versions of the build scan plugin.";
 
-    public static final VersionNumber MIN_VERSION_AWARE_OF_DEPLOYMENTS = VersionNumber.parse("1.13.3");
-    public static final String UNSUPPORTED_CONTINUOUS_BUILD_MESSAGE =
-        "Build scan data will not be captured due to this build being part of a Continuous Build.";
-
     // Used just to test the mechanism
     public static final String UNSUPPORTED_TOGGLE = "org.gradle.internal.unsupported-scan-plugin";
     public static final String UNSUPPORTED_TOGGLE_MESSAGE = "Build scan support disabled by secret toggle";
-
-    private final GradleInternal gradle;
-
-    BuildScanPluginCompatibility(GradleInternal gradle) {
-        this.gradle = gradle;
-    }
 
     String unsupportedReason(VersionNumber pluginVersion, BuildScanConfig.Attributes attributes) {
         if (isEarlierThan(pluginVersion, MIN_SUPPORTED_VERSION)) {
@@ -52,10 +40,6 @@ class BuildScanPluginCompatibility {
 
         if (isEarlierThan(pluginVersion, MIN_VERSION_AWARE_OF_VCS_MAPPINGS) && attributes.isRootProjectHasVcsMappings()) {
             return UNSUPPORTED_VCS_MAPPINGS_MESSAGE;
-        }
-
-        if (isEarlierThan(pluginVersion, MIN_VERSION_AWARE_OF_DEPLOYMENTS) && isAnyDeploymentsStarted(gradle)) {
-            return UNSUPPORTED_CONTINUOUS_BUILD_MESSAGE;
         }
 
         if (Boolean.getBoolean(UNSUPPORTED_TOGGLE)) {
@@ -67,11 +51,6 @@ class BuildScanPluginCompatibility {
 
     private static boolean isEarlierThan(VersionNumber pluginVersion, VersionNumber minSupportedVersion) {
         return pluginVersion.compareTo(minSupportedVersion) < 0;
-    }
-
-    static boolean isAnyDeploymentsStarted(GradleInternal gradle) {
-        DeploymentRegistryInternal deploymentRegistry = gradle.getServices().get(DeploymentRegistryInternal.class);
-        return deploymentRegistry.isAnyStarted();
     }
 
     UnsupportedBuildScanPluginVersionException unsupportedVersionException() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
@@ -34,6 +34,7 @@ import org.gradle.internal.operations.DelegatingBuildOperationExecutor;
 import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 import org.gradle.internal.operations.notify.BuildOperationNotificationBridge;
 import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar;
+import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
 import org.gradle.internal.progress.BuildProgressLogger;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -91,11 +92,16 @@ public class CrossBuildSessionScopeServices implements Closeable {
     }
 
     BuildOperationExecutor createBuildOperationExecutor() {
+        // Wrap to prevent exposing Stoppable, as we don't want to stop at this scope
         return new DelegatingBuildOperationExecutor(services.get(BuildOperationExecutor.class));
     }
 
     BuildOperationNotificationListenerRegistrar createBuildOperationNotificationListenerRegistrar() {
         return buildOperationNotificationBridge.getRegistrar();
+    }
+
+    BuildOperationNotificationValve createBuildOperationNotificationValve() {
+        return buildOperationNotificationBridge.getValve();
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
@@ -17,10 +17,7 @@
 package org.gradle.internal.scan.config
 
 import org.gradle.StartParameter
-import org.gradle.api.internal.GradleInternal
-import org.gradle.deployment.internal.DeploymentRegistryInternal
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.service.ServiceRegistry
 import org.gradle.testing.internal.util.Specification
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
@@ -29,7 +26,6 @@ class BuildScanConfigManagerTest extends Specification {
 
     boolean scanEnabled
     boolean scanDisabled
-    boolean anyStarted
 
     def attributes = Mock(BuildScanConfig.Attributes)
 
@@ -144,15 +140,7 @@ class BuildScanConfigManagerTest extends Specification {
             getSystemPropertiesArgs() >> { [:] }
         }
 
-        def gradle = Mock(GradleInternal) {
-            getServices() >> Mock(ServiceRegistry) {
-                get(DeploymentRegistryInternal) >> Mock(DeploymentRegistryInternal) {
-                    isAnyStarted() >> anyStarted
-                }
-            }
-        }
-
-        new BuildScanConfigManager(startParameter, Mock(ListenerManager), new BuildScanPluginCompatibility(gradle), { attributes })
+        new BuildScanConfigManager(startParameter, Mock(ListenerManager), new BuildScanPluginCompatibility(), { attributes })
     }
 
     BuildScanConfig config(String versionNumber = BuildScanPluginCompatibility.MIN_SUPPORTED_VERSION) {


### PR DESCRIPTION
This accidentally worked < 4.7. In 4.7 the notification bridge became cross session scoped in order to support bridging the logging output to progress notifications. This broke what was accidentally working, by retaining the notification listener across builds of a continuous build.

This change restores the accidental support by explicitly clearing the bridge state after each build of a continuous build, allowing a new listener on the subsequent build.

Fixes #5347.

CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Fcontinuous-build-operation-notification-listener