### PR TITLE
Resolve source files later

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import groovy.lang.Binding;
@@ -158,7 +157,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                             spec.getCompileOptions().setSourcepath(sourcepathBuilder.build());
                         }
 
-                        spec.setSourceFiles(Collections2.filter(spec.getSourceFiles(), new Predicate<File>() {
+                        spec.setSourceFiles(Iterables.filter(spec.getSourceFiles(), new Predicate<File>() {
                             @Override
                             public boolean apply(File file) {
                                 return hasExtension(file, ".java");

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -17,7 +17,8 @@ package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Transformer;
 import org.gradle.api.logging.Logger;
@@ -28,7 +29,6 @@ import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.List;
 
 import static org.gradle.internal.FileUtils.hasExtension;
@@ -61,7 +61,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                 return '.' + extension;
             }
         });
-        Collection<File> filtered = Collections2.filter(spec.getSourceFiles(), new Predicate<File>() {
+        Iterable<File> filtered = Iterables.filter(spec.getSourceFiles(), new Predicate<File>() {
             @Override
             public boolean apply(File element) {
                 for (String fileExtension : fileExtensions) {
@@ -73,7 +73,7 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
             }
         });
 
-        spec.setSourceFiles(filtered);
+        spec.setSourceFiles(ImmutableSet.copyOf(filtered));
     }
 
     private void resolveClasspath(GroovyJavaJointCompileSpec spec) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -26,13 +26,13 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.JavaToolChainFactory;
-import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorPathFactory;
 import org.gradle.api.internal.tasks.compile.CleaningGroovyCompiler;
 import org.gradle.api.internal.tasks.compile.CompilerForkUtils;
 import org.gradle.api.internal.tasks.compile.DefaultGroovyJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.compile.DefaultGroovyJavaJointCompileSpecFactory;
 import org.gradle.api.internal.tasks.compile.GroovyCompilerFactory;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorPathFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
@@ -93,7 +93,7 @@ public class GroovyCompile extends AbstractCompile {
 
     private DefaultGroovyJavaJointCompileSpec createSpec() {
         DefaultGroovyJavaJointCompileSpec spec = new DefaultGroovyJavaJointCompileSpecFactory(compileOptions).create();
-        spec.setSourceFiles(getSource().getFiles());
+        spec.setSourceFiles(getSource());
         spec.setDestinationDir(getDestinationDir());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
@@ -39,10 +40,15 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
 
     @Override
     public WorkResult execute(JavaCompileSpec spec) {
+        resolveSourceFiles(spec);
         resolveNonStringsInCompilerArgs(spec);
         logSourceFiles(spec);
         logCompilerArguments(spec);
         return delegateAndHandleErrors(spec);
+    }
+
+    private void resolveSourceFiles(JavaCompileSpec spec) {
+        spec.setSourceFiles(ImmutableSet.copyOf(spec.getSourceFiles()));
     }
 
     private void resolveNonStringsInCompilerArgs(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotProvider;
@@ -66,7 +67,7 @@ class SelectiveCompiler implements org.gradle.language.base.internal.compile.Com
 
         incrementalCompilationInitializer.initializeCompilation(spec, recompilationSpec);
 
-        if (spec.getSourceFiles().isEmpty() && spec.getClasses().isEmpty()) {
+        if (Iterables.isEmpty(spec.getSourceFiles()) && spec.getClasses().isEmpty()) {
             LOG.info("None of the classes needs to be compiled! Analysis took {}. ", clock.getElapsed());
             return new RecompilationNotNecessary();
         }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks.compile
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.tasks.WorkResult
 import org.gradle.api.tasks.compile.CompileOptions
@@ -32,6 +33,19 @@ class NormalizingJavaCompilerTest extends Specification {
         def compileOptions = new CompileOptions(TestUtil.objectFactory())
         compileOptions.annotationProcessorPath = ImmutableFileCollection.of(new File("processor.jar"))
         spec.compileOptions = compileOptions
+    }
+
+    def "replaces iterable sources with immutable set"() {
+        spec.sourceFiles = ["Person1.java", "Person2.java"].collect { new File(it) }
+
+        when:
+        compiler.execute(spec)
+
+        then:
+        1 * target.execute(spec) >> {
+            assert spec.sourceFiles == files("Person1.java", "Person2.java")
+            assert spec.sourceFiles instanceof ImmutableSet
+        }
     }
 
     def "delegates to target compiler after resolving source and processor path"() {

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -23,16 +23,14 @@ import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Serializable {
     private File workingDir;
     private File tempDir;
     private List<File> classpath;
     private File destinationDir;
-    private Set<File> sourceFiles;
+    private Iterable<File> sourceFiles;
     private String sourceCompatibility;
     private String targetCompatibility;
 
@@ -80,13 +78,13 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     }
 
     @Override
-    public Collection<File> getSourceFiles() {
+    public Iterable<File> getSourceFiles() {
         return sourceFiles;
     }
 
     @Override
     public void setSourceFiles(Iterable<File> sourceFiles) {
-        this.sourceFiles = ImmutableSet.copyOf(sourceFiles);
+        this.sourceFiles = sourceFiles;
     }
 
     @Override

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.language.base.internal.compile.CompileSpec;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.List;
 
 public interface JvmLanguageCompileSpec extends CompileSpec {
@@ -44,7 +43,7 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
     @Deprecated
     void setSource(FileCollection source);
 
-    Collection<File> getSourceFiles();
+    Iterable<File> getSourceFiles();
 
     void setSourceFiles(Iterable<File> sourceFiles);
 

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/NormalizingScalaCompiler.java
@@ -17,8 +17,10 @@
 package org.gradle.api.internal.tasks.scala;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
+import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -43,11 +45,16 @@ public class NormalizingScalaCompiler implements Compiler<ScalaJavaJointCompileS
 
     @Override
     public WorkResult execute(ScalaJavaJointCompileSpec spec) {
+        resolveSourceFiles(spec);
         resolveClasspath(spec);
         resolveNonStringsInCompilerArgs(spec);
         logSourceFiles(spec);
         logCompilerArguments(spec);
         return delegateAndHandleErrors(spec);
+    }
+
+    private void resolveSourceFiles(JavaCompileSpec spec) {
+        spec.setSourceFiles(ImmutableSet.copyOf(spec.getSourceFiles()));
     }
 
     private void resolveClasspath(ScalaJavaJointCompileSpec spec) {


### PR DESCRIPTION
The cleaning compiler may still remove some of the source files for
some configurations, so we may pass non-existing files to the compiler
which causes the compilation to fail.

See https://github.com/gradle/gradle/issues/5448.