### PR TITLE
Update Scans Plugin to 1.13.4

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -12,7 +12,7 @@ apply {
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.5")
     implementation("org.jsoup:jsoup:1.11.2")
-    implementation("com.gradle:build-scan-plugin:1.13.3")
+    implementation("com.gradle:build-scan-plugin:1.13.4")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedBuildScanPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedBuildScanPlugin.java
@@ -28,5 +28,5 @@ public interface AutoAppliedBuildScanPlugin {
     PluginId ID = new DefaultPluginId("com.gradle.build-scan");
     String GROUP = "com.gradle";
     String NAME = "build-scan-plugin";
-    String VERSION = "1.13.3";
+    String VERSION = "1.13.4";
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -42,7 +42,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "1.13",
         "1.13.1",
         "1.13.2",
-        "1.13.3"
+        "1.13.3",
+        "1.13.4"
     ]
 
     @Unroll


### PR DESCRIPTION
A new version of the scans plugin (1.13.4) has been released.

This PR updates to the latest version, in the hope we can get it into 4.8-rc-2

(hence request to merge to the release branch)