### PR TITLE
Treat generated API/TestKit jars as immutable

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.cache.internal
 
 import org.gradle.api.Action
 import org.gradle.cache.CacheRepository
-import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.GlobalScopeServices
@@ -49,10 +47,6 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     @Rule
     ConcurrentTestUtil concurrent = new ConcurrentTestUtil(8000)
 
-    def buildOperationExecutor = [
-        run: { RunnableBuildOperation buildOperation -> buildOperation.run(null) }
-    ] as BuildOperationExecutor
-
     def DefaultServiceRegistry services = (DefaultServiceRegistry) ServiceRegistryBuilder.builder()
             .parent(NativeServicesTestFixture.getInstance())
             .provider(new GlobalScopeServices(false))
@@ -62,7 +56,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     def currentGradleVersion = GradleVersion.current()
     def CacheScopeMapping scopeMapping = new DefaultCacheScopeMapping(tmpDir.testDirectory, null, currentGradleVersion)
     def CacheRepository cacheRepository = new DefaultCacheRepository(scopeMapping, factory)
-    def defaultGeneratedGradleJarCache = new DefaultGeneratedGradleJarCache(cacheRepository, currentGradleVersion.getVersion(), buildOperationExecutor)
+    def defaultGeneratedGradleJarCache = new DefaultGeneratedGradleJarCache(cacheRepository, currentGradleVersion.getVersion())
 
     def cleanup() {
         defaultGeneratedGradleJarCache.close()

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -48,8 +48,6 @@ import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.CacheRepositoryServices;
 import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.CleanupActionFactory;
-import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
-import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.VersionStrategy;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.groovy.scripts.internal.DefaultScriptSourceHasher;
@@ -86,7 +84,6 @@ import org.gradle.internal.work.DefaultAsyncWorkTracker;
 import org.gradle.plugin.use.internal.InjectedPluginClasspath;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
-import org.gradle.util.GradleVersion;
 
 import java.io.File;
 
@@ -126,11 +123,6 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
 
     ListenerManager createListenerManager(ListenerManager parent) {
         return parent.createChild();
-    }
-
-    GeneratedGradleJarCache createGeneratedGradleJarCache(CacheRepository cacheRepository, BuildOperationExecutor buildOperationExecutor) {
-        String gradleVersion = GradleVersion.current().getVersion();
-        return new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor);
     }
 
     CrossProjectConfigurator createCrossProjectConfigurator(BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -47,6 +47,7 @@ import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.CacheRepositoryServices;
 import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
+import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.groovy.scripts.internal.CrossBuildInMemoryCachingScriptClassCache;
 import org.gradle.groovy.scripts.internal.DefaultScriptSourceHasher;
 import org.gradle.groovy.scripts.internal.RegistryAwareClassLoaderHierarchyHasher;
@@ -82,6 +83,7 @@ import org.gradle.process.internal.health.memory.MemoryManager;
 import org.gradle.process.internal.worker.DefaultWorkerProcessFactory;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider;
+import org.gradle.util.GradleVersion;
 
 import java.util.List;
 
@@ -196,5 +198,10 @@ public class GradleUserHomeScopeServices {
 
     WorkerProcessClassPathProvider createWorkerProcessClassPathProvider(CacheRepository cacheRepository) {
         return new WorkerProcessClassPathProvider(cacheRepository);
+    }
+
+    DefaultGeneratedGradleJarCache createGeneratedGradleJarCache(CacheRepository cacheRepository) {
+        String gradleVersion = GradleVersion.current().getVersion();
+        return new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
@@ -21,8 +21,6 @@ import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
-import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
 import org.junit.Rule
@@ -42,13 +40,9 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
     def gradleVersion = GradleVersion.current().version
     def cacheBuilder = Mock(CacheBuilder)
     def cache = Mock(PersistentCache)
-    def buildOperationExecutor = [
-        run: { RunnableBuildOperation buildOperation -> buildOperation.run(null) }
-    ] as BuildOperationExecutor
-
     def "can close cache"() {
         when:
-        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor)
+        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion)
         provider.close()
 
         then:
@@ -67,7 +61,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         def cache = Mock(PersistentCache)
 
         when:
-        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor)
+        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion)
         def resolvedFile = provider.get(identifier) { it.createNewFile() }
 
         then:
@@ -90,7 +84,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         def cache = Mock(PersistentCache)
 
         when:
-        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion, buildOperationExecutor)
+        def provider = new DefaultGeneratedGradleJarCache(cacheRepository, gradleVersion)
         def resolvedFile = provider.get("api") { it.createNewFile() }
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -97,7 +97,7 @@ class GradleUserHomeScopeServicesTest extends Specification {
             _ * it.decorator(_, _) >> Mock(CacheDecorator)
         }
         expectParentServiceLocated(CacheFactory) {
-            _ * it.open(_, _, _, _, _, _, _, _) >> Mock(PersistentCache) { _ * getBaseDir() >> Mock(File) }
+            _ * it.open(_, _, _, _, _, _, _, _) >> Mock(PersistentCache) { _ * getBaseDir() >> new File("").absoluteFile }
         }
         expectParentServiceLocated(LoggingManagerInternal)
         expectParentServiceLocated(Clock)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -152,8 +152,8 @@ class DependencyManagementBuildScopeServices {
             attributesFactory);
     }
 
-    RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory) {
-        return new RuntimeShadedJarFactory(jarCache, progressLoggerFactory, directoryFileTreeFactory);
+    RuntimeShadedJarFactory createRuntimeShadedJarFactory(GeneratedGradleJarCache jarCache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory, BuildOperationExecutor executor) {
+        return new RuntimeShadedJarFactory(jarCache, progressLoggerFactory, directoryFileTreeFactory, executor);
     }
 
     BuildCommencedTimeProvider createBuildTimeProvider() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
@@ -20,6 +20,10 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,23 +37,37 @@ public class RuntimeShadedJarFactory {
     private final GeneratedGradleJarCache cache;
     private final ProgressLoggerFactory progressLoggerFactory;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
+    private final BuildOperationExecutor executor;
 
-    public RuntimeShadedJarFactory(GeneratedGradleJarCache cache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public RuntimeShadedJarFactory(GeneratedGradleJarCache cache, ProgressLoggerFactory progressLoggerFactory, DirectoryFileTreeFactory directoryFileTreeFactory, BuildOperationExecutor executor) {
         this.cache = cache;
         this.progressLoggerFactory = progressLoggerFactory;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
+        this.executor = executor;
     }
 
     public File get(final RuntimeShadedJarType type, final Collection<? extends File> classpath) {
         final File jarFile = cache.get(type.getIdentifier(), new Action<File>() {
             @Override
             public void execute(final File file) {
-                RuntimeShadedJarCreator creator = new RuntimeShadedJarCreator(
-                    progressLoggerFactory,
-                    new ImplementationDependencyRelocator(type),
-                    directoryFileTreeFactory
-                );
-                creator.create(file, classpath);
+                executor.run(new RunnableBuildOperation() {
+                    @Override
+                    public void run(BuildOperationContext context) {
+                        RuntimeShadedJarCreator creator = new RuntimeShadedJarCreator(
+                            progressLoggerFactory,
+                            new ImplementationDependencyRelocator(type),
+                            directoryFileTreeFactory
+                        );
+                        creator.create(file, classpath);
+                    }
+
+                    @Override
+                    public BuildOperationDescriptor.Builder description() {
+                        String displayName = "Generating Jar " + file;
+                        return BuildOperationDescriptor.displayName(displayName).progressDisplayName(displayName);
+                    }
+                });
+
             }
         });
         LOGGER.debug("Using Gradle runtime shaded JAR file: {}", jarFile);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
@@ -76,6 +76,10 @@ class TestProjectGenerator {
                 file projectDir, "src/test/java/${packageName}/Test${it}.java", fileContentGenerator.generateTestClassFile(subProjectNumber, it, dependencyTree)
             }
         }
+
+        if (isRoot) {
+            file projectDir, "buildSrc/src/main/java/Thing.java", "public class Thing {}"
+        }
     }
 
     void file(File dir, String name, String content) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
@@ -78,8 +78,15 @@ class TestProjectGenerator {
         }
 
         if (isRoot) {
-            file projectDir, "buildSrc/src/main/java/Thing.java", "public class Thing {}"
+            addDummyBuildSrcProject(projectDir)
         }
+    }
+
+    /**
+     * This is just to ensure we test the overhead of having a buildSrc project, e.g. snapshotting the Gradle API.
+     */
+    private addDummyBuildSrcProject(File projectDir) {
+        file projectDir, "buildSrc/src/main/java/Thing.java", "public class Thing {}"
     }
 
     void file(File dir, String name, String content) {


### PR DESCRIPTION
This means they will only be snapshotted once.
Previously we would snapshot them on every build.