### PR TITLE
Split file content caches into mutable and immutable files

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethods.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/RelevantMethods.java
@@ -98,14 +98,24 @@ public class RelevantMethods {
         Iterator<Method> iterator = builder.remainingMethods.iterator();
         while (iterator.hasNext()) {
             Method method = iterator.next();
-            if ((method.getName().startsWith("create") || method.getName().startsWith("decorate"))
-                && method.getParameterTypes().length == 1 && method.getParameterTypes()[0].equals(method.getReturnType())) {
+            if (method.getName().startsWith("create") || method.getName().startsWith("decorate")) {
                 if (method.getReturnType().equals(Void.TYPE)) {
                     throw new ServiceLookupException(String.format("Method %s.%s() must not return void.", type.getSimpleName(), method.getName()));
                 }
-                builder.add(iterator, builder.decorators, method);
+                if (takesReturnTypeAsParameter(method)) {
+                    builder.add(iterator, builder.decorators, method);
+                }
             }
         }
+    }
+
+    private static boolean takesReturnTypeAsParameter(Method method) {
+        for (Class<?> param : method.getParameterTypes()) {
+            if (param.equals(method.getReturnType())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -577,6 +577,24 @@ class DefaultServiceRegistryTest extends Specification {
         decoratorCreator << [ { p -> new RegistryWithDecoratorMethodsWithCreate(p) }, { p -> new RegistryWithDecoratorMethodsWithDecorate(p) } ]
     }
 
+    def "decorator methods can take additional parameters"() {
+        def parent = Mock(ServiceRegistry)
+        def registry = decoratorCreator.call(parent)
+
+        when:
+        def result = registry.get(String)
+
+        then:
+        result == "Foo120"
+
+        and:
+        1 * parent.get(Long) >> 110L
+        1 * parent.get(String) >> "Foo"
+
+        where:
+        decoratorCreator << [ { p -> new RegistryWithDecoratorMethodsWithCreate(p) }, { p -> new RegistryWithDecoratorMethodsWithDecorate(p) } ]
+    }
+
     def decoratorCreateMethodFailsWhenNoParentRegistry() {
         when:
         decoratorCreator.call() /* .call needed in spock 0.7 */
@@ -1562,6 +1580,10 @@ class DefaultServiceRegistryTest extends Specification {
                 }
             };
         }
+
+        protected String createString(String parentValue, Long myValue) {
+            return parentValue + myValue
+        }
     }
 
     private static class RegistryWithDecoratorMethodsWithDecorate extends DefaultServiceRegistry {
@@ -1582,6 +1604,10 @@ class DefaultServiceRegistryTest extends Specification {
                     return factory.create() + 2
                 }
             };
+        }
+
+        protected String decorateString(String parentValue, Long myValue) {
+            return parentValue + myValue
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultWellKnownFileLocations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultWellKnownFileLocations.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import org.gradle.internal.classpath.CachedJarFileStore;
+import org.gradle.internal.file.DefaultFileHierarchySet;
+import org.gradle.internal.file.FileHierarchySet;
+
+import java.io.File;
+import java.util.List;
+
+public class DefaultWellKnownFileLocations implements WellKnownFileLocations {
+    private final FileHierarchySet immutableLocations;
+
+    public DefaultWellKnownFileLocations(List<CachedJarFileStore> fileStores) {
+        FileHierarchySet immutableLocations = DefaultFileHierarchySet.of();
+        for (CachedJarFileStore fileStore : fileStores) {
+            for (File file : fileStore.getFileStoreRoots()) {
+                immutableLocations = immutableLocations.plus(file);
+            }
+        }
+        this.immutableLocations = immutableLocations;
+    }
+
+    @Override
+    public boolean isImmutable(String path) {
+        return immutableLocations.contains(path);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/WellKnownFileLocations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/WellKnownFileLocations.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+/**
+ * This service can tell whether a file is in a location controlled by Gradle,
+ * which usually allows for more optimization than user-provided files.
+ */
+public interface WellKnownFileLocations {
+    boolean isImmutable(String path);
+}

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/SplitFileContentCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/SplitFileContentCacheFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.gradle.api.internal.changedetection.state.WellKnownFileLocations;
+import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.serialize.Serializer;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * A {@link FileContentCacheFactory} that delegates to the global cache for files that are known to be immutable and shared between different builds.
+ * All other requests are delegated to the build-local cache. Closing this factory will only close the local delegate, not the global one.
+ */
+public class SplitFileContentCacheFactory implements FileContentCacheFactory, Closeable {
+    private final FileContentCacheFactory globalFactory;
+    private final FileContentCacheFactory localFactory;
+    private final WellKnownFileLocations wellKnownFileLocations;
+
+    public SplitFileContentCacheFactory(FileContentCacheFactory globalFactory, FileContentCacheFactory localFactory, WellKnownFileLocations wellKnownFileLocations) {
+        this.globalFactory = globalFactory;
+        this.localFactory = localFactory;
+        this.wellKnownFileLocations = wellKnownFileLocations;
+    }
+
+    @Override
+    public void close() throws IOException {
+        CompositeStoppable.stoppable(localFactory).stop();
+    }
+
+    @Override
+    public <V> FileContentCache<V> newCache(String name, int normalizedCacheSize, Calculator<? extends V> calculator, Serializer<V> serializer) {
+        FileContentCache<V> globalCache = globalFactory.newCache(name, normalizedCacheSize, calculator, serializer);
+        FileContentCache<V> localCache = localFactory.newCache(name, normalizedCacheSize, calculator, serializer);
+        return new SplitFileContentCache<V>(globalCache, localCache, wellKnownFileLocations);
+    }
+
+    private static final class SplitFileContentCache<V> implements FileContentCache<V> {
+        private final FileContentCache<V> globalCache;
+        private final FileContentCache<V> localCache;
+        private final WellKnownFileLocations wellKnownFileLocations;
+
+        private SplitFileContentCache(FileContentCache<V> globalCache, FileContentCache<V> localCache, WellKnownFileLocations wellKnownFileLocations) {
+            this.globalCache = globalCache;
+            this.localCache = localCache;
+            this.wellKnownFileLocations = wellKnownFileLocations;
+        }
+
+        @Override
+        public V get(File file) {
+            if (wellKnownFileLocations.isImmutable(file.getPath())) {
+                return globalCache.get(file);
+            } else {
+                return localCache.get(file);
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.changedetection.state.FileSystemSnapshotter;
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
+import org.gradle.api.internal.changedetection.state.WellKnownFileLocations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
 import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
@@ -34,6 +35,7 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.internal.DefaultFileContentCacheFactory;
 import org.gradle.cache.internal.FileContentCacheFactory;
+import org.gradle.cache.internal.SplitFileContentCacheFactory;
 import org.gradle.composite.internal.IncludedBuildTaskGraph;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.execution.BuildConfigurationAction;
@@ -184,8 +186,9 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor);
     }
 
-    FileContentCacheFactory createFileContentCacheFactory(ListenerManager listenerManager, FileSystemSnapshotter fileSystemSnapshotter, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, Gradle gradle) {
-        return new DefaultFileContentCacheFactory(listenerManager, fileSystemSnapshotter, cacheRepository, inMemoryCacheDecoratorFactory, gradle);
+    FileContentCacheFactory createFileContentCacheFactory(FileContentCacheFactory globalCacheFactory, ListenerManager listenerManager, FileSystemSnapshotter fileSystemSnapshotter, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, Gradle gradle, WellKnownFileLocations wellKnownFileLocations) {
+        DefaultFileContentCacheFactory localCacheFactory = new DefaultFileContentCacheFactory(listenerManager, fileSystemSnapshotter, cacheRepository, inMemoryCacheDecoratorFactory, gradle);
+        return new SplitFileContentCacheFactory(globalCacheFactory, localCacheFactory, wellKnownFileLocations);
     }
 
     protected BuildOutputCleanupRegistry createBuildOutputCleanupRegistry(FileResolver fileResolver) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.changedetection.state.DefaultFileSystemMirror
 import org.gradle.api.internal.changedetection.state.DefaultFileSystemSnapshotter
 import org.gradle.api.internal.changedetection.state.DefaultGenericFileCollectionSnapshotter
 import org.gradle.api.internal.changedetection.state.DefaultTaskHistoryStore
+import org.gradle.api.internal.changedetection.state.WellKnownFileLocations
 import org.gradle.api.internal.changedetection.state.FileCollectionSnapshot
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
 import org.gradle.api.internal.changedetection.state.TaskHistoryRepository
@@ -104,7 +105,7 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
         TaskHistoryStore cacheAccess = new DefaultTaskHistoryStore(gradle, cacheRepository, new InMemoryCacheDecoratorFactory(false, cacheFactory))
         def stringInterner = new StringInterner()
         def fileHasher = new TestFileHasher()
-        fileSystemMirror = new DefaultFileSystemMirror([])
+        fileSystemMirror = new DefaultFileSystemMirror(Stub(WellKnownFileLocations))
         fileCollectionSnapshotter = new DefaultGenericFileCollectionSnapshotter(stringInterner, TestFiles.directoryFileTreeFactory(), new DefaultFileSystemSnapshotter(fileHasher, stringInterner, TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror))
         def classLoaderHierarchyHasher = Mock(ConfigurableClassLoaderHierarchyHasher) {
             getClassLoaderHash(_) >> HashCode.fromInt(123)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
@@ -42,7 +42,7 @@ class DefaultClasspathSnapshotterTest extends Specification {
     }
     def fileSystem = TestFiles.fileSystem()
     def directoryFileTreeFactory = TestFiles.directoryFileTreeFactory()
-    def fileSystemMirror = new DefaultFileSystemMirror([])
+    def fileSystemMirror = new DefaultFileSystemMirror(Stub(WellKnownFileLocations))
     def fileHasher = new TestFileHasher()
     def fileSystemSnapshotter = new DefaultFileSystemSnapshotter(fileHasher, stringInterner, fileSystem, directoryFileTreeFactory, fileSystemMirror)
     InMemoryIndexedCache<HashCode, HashCode> resourceHashesCache = new InMemoryIndexedCache<>(new HashCodeSerializer())

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemMirrorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemMirrorTest.groovy
@@ -35,7 +35,7 @@ class DefaultFileSystemMirrorTest extends Specification {
         cacheDir = tmpDir.createDir("cache")
         def fileStore = Stub(CachedJarFileStore)
         fileStore.fileStoreRoots >> [cacheDir]
-        mirror = new DefaultFileSystemMirror([fileStore])
+        mirror = new DefaultFileSystemMirror(new DefaultWellKnownFileLocations([fileStore]))
     }
 
     def "keeps state about a file until task outputs are generated"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 class DefaultFileSystemSnapshotterTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def fileHasher = new TestFileHasher()
-    def fileSystemMirror = new DefaultFileSystemMirror([])
+    def fileSystemMirror = new DefaultFileSystemMirror(Stub(WellKnownFileLocations))
     def snapshotter = new DefaultFileSystemSnapshotter(fileHasher, new StringInterner(), TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror)
 
     def "fetches details of a file and caches the result"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotterTest.groovy
@@ -34,7 +34,7 @@ import static InputPathNormalizationStrategy.ABSOLUTE
 
 class DefaultGenericFileCollectionSnapshotterTest extends Specification {
     def stringInterner = new StringInterner()
-    def fileSystemMirror = new DefaultFileSystemMirror([])
+    def fileSystemMirror = new DefaultFileSystemMirror(Stub(WellKnownFileLocations))
     def snapshotter = new DefaultGenericFileCollectionSnapshotter(stringInterner, TestFiles.directoryFileTreeFactory(), new DefaultFileSystemSnapshotter(new TestFileHasher(), stringInterner, TestFiles.fileSystem(), TestFiles.directoryFileTreeFactory(), fileSystemMirror))
     def listener = Mock(ChangeListener)
     def normalizationStrategy = InputNormalizationStrategy.NOT_CONFIGURED

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/sourceparser/CachingCSourceParser.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/sourceparser/CachingCSourceParser.java
@@ -33,7 +33,7 @@ public class CachingCSourceParser implements CSourceParser {
             public IncludeDirectives calculate(File file, FileType fileType) {
                 return parser.parseSource(file);
             }
-        }, new IncludeDirectivesSerializer());
+        }, IncludeDirectivesSerializer.INSTANCE);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/sourceparser/IncludeDirectivesSerializer.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/sourceparser/IncludeDirectivesSerializer.java
@@ -35,11 +35,16 @@ import java.util.Collection;
 import java.util.List;
 
 public class IncludeDirectivesSerializer implements Serializer<IncludeDirectives> {
+    public static final IncludeDirectivesSerializer INSTANCE = new IncludeDirectivesSerializer();
+
     private final Serializer<IncludeType> enumSerializer = new BaseSerializerFactory().getSerializerFor(IncludeType.class);
     private final Serializer<Expression> expressionSerializer = new ExpressionSerializer(enumSerializer);
     private final ListSerializer<Include> includeListSerializer = new ListSerializer<Include>(new IncludeSerializer(enumSerializer, expressionSerializer));
     private final CollectionSerializer<Macro> macroListSerializer = new CollectionSerializer<Macro>(new MacroSerializer(enumSerializer, expressionSerializer));
     private final CollectionSerializer<MacroFunction> macroFunctionListSerializer = new CollectionSerializer<MacroFunction>(new MacroFunctionSerializer(enumSerializer, expressionSerializer));
+
+    private IncludeDirectivesSerializer() {
+    }
 
     @Override
     public IncludeDirectives read(Decoder decoder) throws Exception {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/SourceParseAndResolutionTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/SourceParseAndResolutionTest.groovy
@@ -38,7 +38,7 @@ class SourceParseAndResolutionTest extends SerializerSpec {
     def fileSystemSnapshotter = new TestFileSnapshotter()
     def resolver = new DefaultSourceIncludesResolver([includeDir], fileSystemSnapshotter)
     def parser = new RegexBackedCSourceParser()
-    def serializer = new IncludeDirectivesSerializer()
+    def serializer = IncludeDirectivesSerializer.INSTANCE
 
     def "resolves macro with value that is a string constant"() {
         given:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/sourceparser/IncludeDirectivesSerializerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/sourceparser/IncludeDirectivesSerializerTest.groovy
@@ -25,7 +25,7 @@ class IncludeDirectivesSerializerTest extends SerializerSpec {
         def directives = new DefaultIncludeDirectives(ImmutableList.of(), ImmutableList.of(), ImmutableList.of())
 
         expect:
-        serialize(directives, new IncludeDirectivesSerializer()) == directives
+        serialize(directives, IncludeDirectivesSerializer.INSTANCE) == directives
     }
 
     def "serializes include directives"() {
@@ -37,7 +37,7 @@ class IncludeDirectivesSerializerTest extends SerializerSpec {
         def directives = new DefaultIncludeDirectives(ImmutableList.copyOf([include1, include2, include3, include4, include5]), ImmutableList.of(), ImmutableList.of())
 
         expect:
-        serialize(directives, new IncludeDirectivesSerializer()) == directives
+        serialize(directives, IncludeDirectivesSerializer.INSTANCE) == directives
     }
 
     def "serializes nested expression"() {
@@ -48,7 +48,7 @@ class IncludeDirectivesSerializerTest extends SerializerSpec {
         def directives = new DefaultIncludeDirectives(ImmutableList.copyOf([include]), ImmutableList.of(), ImmutableList.of())
 
         expect:
-        serialize(directives, new IncludeDirectivesSerializer()) == directives
+        serialize(directives, IncludeDirectivesSerializer.INSTANCE) == directives
     }
 
     def "replaces common expressions with constants"() {
@@ -61,7 +61,7 @@ class IncludeDirectivesSerializerTest extends SerializerSpec {
         def directives = new DefaultIncludeDirectives(ImmutableList.copyOf([include]), ImmutableList.of(), ImmutableList.of())
 
         expect:
-        def expressions = serialize(directives, new IncludeDirectivesSerializer()).all.first().arguments
+        def expressions = serialize(directives, IncludeDirectivesSerializer.INSTANCE).all.first().arguments
         expressions[0].is(SimpleExpression.EMPTY_EXPRESSIONS)
         expressions[1].is(SimpleExpression.EMPTY_ARGS)
         expressions[2].is(SimpleExpression.COMMA)
@@ -81,7 +81,7 @@ class IncludeDirectivesSerializerTest extends SerializerSpec {
         def directives = new DefaultIncludeDirectives(ImmutableList.of(), ImmutableList.copyOf([macro1, macro2, macro3, macro4, macro5, macro6, macro7, macro8]), ImmutableList.of())
 
         expect:
-        serialize(directives, new IncludeDirectivesSerializer()) == directives
+        serialize(directives, IncludeDirectivesSerializer.INSTANCE) == directives
     }
 
     def "serializes macro function directives"() {
@@ -95,6 +95,6 @@ class IncludeDirectivesSerializerTest extends SerializerSpec {
         def directives = new DefaultIncludeDirectives(ImmutableList.of(), ImmutableList.of(), ImmutableList.copyOf([macro1, macro2, macro3, macro4, macro5, macro6, macro7]))
 
         expect:
-        serialize(directives, new IncludeDirectivesSerializer()) == directives
+        serialize(directives, IncludeDirectivesSerializer.INSTANCE) == directives
     }
 }


### PR DESCRIPTION
Store content information about immutable files in the user home.
This means that things like external dependencies or the gradleApi
jar will only be analyzed once and that this analysis can then be
reused by other builds. This should improve build times after clean
checkouts and will also speed up our own integration tests.