### PR TITLE
Run init scripts from client distribution in buildSrc

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -223,7 +223,6 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.searchUpwards = searchUpwards;
         p.projectProperties = new HashMap<String, String>(projectProperties);
         p.systemPropertiesArgs = new HashMap<String, String>(systemPropertiesArgs);
-        p.gradleHomeDir = gradleHomeDir;
         p.initScripts = new ArrayList<File>(initScripts);
         p.includedBuilds = new ArrayList<File>(includedBuilds);
         p.dryRun = dryRun;
@@ -243,6 +242,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     protected StartParameter prepareNewBuild(StartParameter p) {
         p.gradleUserHomeDir = gradleUserHomeDir;
+        p.gradleHomeDir = gradleHomeDir;
         p.setLogLevel(getLogLevel());
         p.setConsoleOutput(getConsoleOutput());
         p.setShowStacktrace(getShowStacktrace());

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonInitScriptHandlingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonInitScriptHandlingIntegrationTest.groovy
@@ -61,6 +61,7 @@ class DaemonInitScriptHandlingIntegrationTest extends DaemonIntegrationSpec {
         def distro2Result = runWithGradleHome(distro2)
 
         then:
+        distro2Result.assertNotOutput "from distro 1"
         distro2Result.assertOutputContains "from distro 2"
         distro2Result.assertOutputContains "buildSrc: runtime gradle home: ${distro1.absolutePath}"
         distro2Result.assertOutputContains "main build: runtime gradle home: ${distro1.absolutePath}"


### PR DESCRIPTION
The gradleHome was not passed on to nested builds,
meaning they would use the wrong directory and not
run init scripts from the client distribution.

@big-guy This got lost in transition from my PR to yours. 
The test wasn't checking that buildSrc uses the right script.