### PR TITLE
Keep hashes for immutable in user home scope

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultResourceSnapshotterCacheService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultResourceSnapshotterCacheService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import org.gradle.cache.PersistentIndexedCache;
+import org.gradle.caching.internal.BuildCacheHasher;
+import org.gradle.caching.internal.DefaultBuildCacheHasher;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
+
+public class DefaultResourceSnapshotterCacheService implements ResourceSnapshotterCacheService {
+    private static final HashCode NO_HASH = Hashing.md5().hashString(CachingResourceHasher.class.getName() + " : no hash");
+    private final PersistentIndexedCache<HashCode, HashCode> persistentCache;
+
+    public DefaultResourceSnapshotterCacheService(PersistentIndexedCache<HashCode, HashCode> persistentCache) {
+        this.persistentCache = persistentCache;
+    }
+
+    @Override
+    public HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileHasher hasher, HashCode configurationHash) {
+        HashCode resourceHashCacheKey = resourceHashCacheKey(fileSnapshot, configurationHash);
+
+        HashCode resourceHash = persistentCache.get(resourceHashCacheKey);
+        if (resourceHash != null) {
+            if (resourceHash.equals(NO_HASH)) {
+                return null;
+            }
+            return resourceHash;
+        }
+
+        resourceHash = hasher.hash(fileSnapshot);
+
+        if (resourceHash != null) {
+            persistentCache.put(resourceHashCacheKey, resourceHash);
+        } else {
+            persistentCache.put(resourceHashCacheKey, NO_HASH);
+        }
+        return resourceHash;
+    }
+
+    private static HashCode resourceHashCacheKey(RegularFileSnapshot fileSnapshot, HashCode configurationHash) {
+        BuildCacheHasher hasher = new DefaultBuildCacheHasher();
+        hasher.putHash(configurationHash);
+        hasher.putHash(fileSnapshot.getContent().getContentMd5());
+        return hasher.hash();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceSnapshotterCacheService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceSnapshotterCacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,45 +16,8 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import org.gradle.cache.PersistentIndexedCache;
-import org.gradle.caching.internal.BuildCacheHasher;
-import org.gradle.caching.internal.DefaultBuildCacheHasher;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hashing;
 
-public class ResourceSnapshotterCacheService {
-    private static final HashCode NO_HASH = Hashing.md5().hashString(CachingResourceHasher.class.getName() + " : no hash");
-    private final PersistentIndexedCache<HashCode, HashCode> persistentCache;
-
-    public ResourceSnapshotterCacheService(PersistentIndexedCache<HashCode, HashCode> persistentCache) {
-        this.persistentCache = persistentCache;
-    }
-
-    public HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileHasher hasher, HashCode configurationHash) {
-        HashCode resourceHashCacheKey = resourceHashCacheKey(fileSnapshot, configurationHash);
-
-        HashCode resourceHash = persistentCache.get(resourceHashCacheKey);
-        if (resourceHash != null) {
-            if (resourceHash.equals(NO_HASH)) {
-                return null;
-            }
-            return resourceHash;
-        }
-
-        resourceHash = hasher.hash(fileSnapshot);
-
-        if (resourceHash != null) {
-            persistentCache.put(resourceHashCacheKey, resourceHash);
-        } else {
-            persistentCache.put(resourceHashCacheKey, NO_HASH);
-        }
-        return resourceHash;
-    }
-
-    private static HashCode resourceHashCacheKey(RegularFileSnapshot fileSnapshot, HashCode configurationHash) {
-        BuildCacheHasher hasher = new DefaultBuildCacheHasher();
-        hasher.putHash(configurationHash);
-        hasher.putHash(fileSnapshot.getContent().getContentMd5());
-        return hasher.hash();
-    }
+public interface ResourceSnapshotterCacheService {
+    HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileHasher hasher, HashCode configurationHash);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SplitFileHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SplitFileHasher.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import org.gradle.api.file.FileTreeElement;
+import org.gradle.internal.file.FileMetadataSnapshot;
+import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.hash.HashCode;
+
+import java.io.File;
+
+/**
+ * A {@link FileHasher} that delegates to the global hasher for immutable files
+ * and uses the local hasher for all other files. This ensures optimal cache utilization.
+ */
+public class SplitFileHasher implements FileHasher {
+    private final FileHasher globalHasher;
+    private final FileHasher localHasher;
+    private final WellKnownFileLocations wellKnownFileLocations;
+
+    public SplitFileHasher(FileHasher globalHasher, FileHasher localHasher, WellKnownFileLocations wellKnownFileLocations) {
+        this.globalHasher = globalHasher;
+        this.localHasher = localHasher;
+        this.wellKnownFileLocations = wellKnownFileLocations;
+    }
+
+    @Override
+    public HashCode hash(File file) {
+        if (wellKnownFileLocations.isImmutable(file.getPath())) {
+            return globalHasher.hash(file);
+        } else {
+            return localHasher.hash(file);
+        }
+    }
+
+    @Override
+    public HashCode hash(FileTreeElement fileDetails) {
+        if (wellKnownFileLocations.isImmutable(fileDetails.getFile().getPath())) {
+            return globalHasher.hash(fileDetails);
+        } else {
+            return localHasher.hash(fileDetails);
+        }
+    }
+
+    @Override
+    public HashCode hash(File file, FileMetadataSnapshot fileDetails) {
+        if (wellKnownFileLocations.isImmutable(file.getPath())) {
+            return globalHasher.hash(file, fileDetails);
+        } else {
+            return localHasher.hash(file, fileDetails);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SplitResourceSnapshotterCacheService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SplitResourceSnapshotterCacheService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import org.gradle.internal.hash.HashCode;
+
+/**
+ * A {@link ResourceSnapshotterCacheService} that delegates to the global service for immutable files
+ * and uses the local service for all other files. This ensures optimal cache utilization.
+ */
+public class SplitResourceSnapshotterCacheService implements ResourceSnapshotterCacheService {
+    private final ResourceSnapshotterCacheService globalCache;
+    private final ResourceSnapshotterCacheService localCache;
+    private final WellKnownFileLocations wellKnownFileLocations;
+
+    public SplitResourceSnapshotterCacheService(ResourceSnapshotterCacheService globalCache, ResourceSnapshotterCacheService localCache, WellKnownFileLocations wellKnownFileLocations) {
+        this.globalCache = globalCache;
+        this.localCache = localCache;
+        this.wellKnownFileLocations = wellKnownFileLocations;
+    }
+
+    @Override
+    public HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileHasher hasher, HashCode configurationHash) {
+        if (wellKnownFileLocations.isImmutable(fileSnapshot.getPath())) {
+            return globalCache.hashFile(fileSnapshot, hasher, configurationHash);
+        } else {
+            return localCache.hashFile(fileSnapshot, hasher, configurationHash);
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
@@ -27,7 +27,7 @@ import java.util.zip.ZipEntry
 class CachingResourceHasherTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def fileSnapshot = new RegularFileSnapshot("path", RelativePath.parse(true, "path"), false, new FileHashSnapshot(HashCode.fromInt(456)))
-    def cachingHasher = new CachingResourceHasher(delegate, new ResourceSnapshotterCacheService(new InMemoryIndexedCache(new HashCodeSerializer())))
+    def cachingHasher = new CachingResourceHasher(delegate, new DefaultResourceSnapshotterCacheService(new InMemoryIndexedCache(new HashCodeSerializer())))
 
     def "returns result from delegate"() {
         def expectedHash = HashCode.fromInt(123)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotterTest.groovy
@@ -46,7 +46,7 @@ class DefaultClasspathSnapshotterTest extends Specification {
     def fileHasher = new TestFileHasher()
     def fileSystemSnapshotter = new DefaultFileSystemSnapshotter(fileHasher, stringInterner, fileSystem, directoryFileTreeFactory, fileSystemMirror)
     InMemoryIndexedCache<HashCode, HashCode> resourceHashesCache = new InMemoryIndexedCache<>(new HashCodeSerializer())
-    def cacheService = new ResourceSnapshotterCacheService(resourceHashesCache)
+    def cacheService = new DefaultResourceSnapshotterCacheService(resourceHashesCache)
     def snapshotter = new DefaultClasspathSnapshotter(
         cacheService,
         directoryFileTreeFactory,


### PR DESCRIPTION
These files never change, so there is no reason to throw
their resource hashes away after every build. This also
speeds up clean checkout builds as the persistent hashes
are now in the user home instead of the project dir.