### PR TITLE
Don't use ClassLoader.getDefinedPackages() on Java 9

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -39,7 +39,8 @@ public abstract class ClassLoaderUtils {
 
     static {
         CLASS_DEFINER = JavaVersion.current().isJava9Compatible() ? new LookupClassDefiner() : new ReflectionClassDefiner();
-        GET_PACKAGES_METHOD = getMethodWithFallback(Package[].class, new Class[0], "getDefinedPackages", "getPackages");
+        GET_PACKAGES_METHOD = method(ClassLoader.class, Package[].class, "getPackages");
+        // Since Java 9, getPackage() is deprecated, so we use getDefinedPackage() instead
         GET_PACKAGE_METHOD = getMethodWithFallback(Package.class, new Class[]{String.class}, "getDefinedPackage", "getPackage");
     }
 
@@ -48,7 +49,6 @@ public abstract class ClassLoaderUtils {
         try {
             method = method(ClassLoader.class, clazz, firstChoice, params);
         } catch (Throwable e) {
-            // We must not be on Java 9 where the getDefinedPackages() method exists. Fall back to getPackages()
             method = method(ClassLoader.class, clazz, fallback, params);
         }
         return method;

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/FilteringClassLoaderTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/FilteringClassLoaderTest.groovy
@@ -23,7 +23,6 @@ import org.junit.runners.BlockJUnit4ClassRunner
 import spock.lang.Issue
 import spock.lang.Specification
 
-import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
 import static org.junit.Assert.fail
 
 class FilteringClassLoaderTest extends Specification {
@@ -38,14 +37,12 @@ class FilteringClassLoaderTest extends Specification {
         canLoadClass(String)
     }
 
-    @Requires(FIX_TO_WORK_ON_JAVA9)
     void passesThroughSystemPackages() {
         expect:
         canSeePackage('java.lang')
     }
 
     @Issue("gradle/core-issues#115")
-    @Requires(FIX_TO_WORK_ON_JAVA9)
     void passesThroughSystemResources() {
         expect:
         canSeeResource('com/sun/jndi/ldap/jndiprovider.properties')
@@ -70,7 +67,6 @@ class FilteringClassLoaderTest extends Specification {
         e2.message == "$Test.name not found."
     }
 
-    @Requires(TestPrecondition.JDK8_OR_EARLIER)
     void filtersPackagesByDefault() {
         given:
         assert classLoader.parent.getPackage('org.junit') != null


### PR DESCRIPTION
Prior to this change, `FilteringClassLoader` invokes
`ClassLoader.getSystemClassLoader().getParent().getDefinedPackages()`
to get all system packages on Java 9, which is not correct.
`ClassLoader.getDefinedPackages()` only fetches packages defined by
the `ClassLoader` itself, not including its parent's. The consequence is,
on Java 9, most Java SE and JDK packages (e.g. `java.lang`) are not included in
`FilteringClassLoader.SYSTEM_PACKAGES`.

This PR fixes this problem by using `ClassLoader.getPackages()` all the time.

@melix I guess you used `getDefinedPackages` to keep consistence with `getDefinedPackage`. However, the difference is, `getPackage(String)` is deprecated by `getPackages()` isn't.

