### PR TITLE
Make `JavaExec` support `--args`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.tasks;
 
+import org.apache.tools.ant.types.Commandline;
+import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.tasks.options.Option;
@@ -31,6 +33,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -277,6 +280,18 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     public List<String> getArgs() {
         return javaExecHandleBuilder.getArgs();
+    }
+
+    /**
+     * Command line arguments passed to the main class.
+     * @param args the command line arguments as a single string. Will be parsed to argument list.
+     * @return this
+     * @since 4.9
+     */
+    @Incubating
+    @Option(option = "args", description = "Command line arguments passed to the main class. [INCUBATING]")
+    public JavaExec setArgs(String args) {
+        return setArgs(Arrays.asList(Commandline.translateCommandline(args)));
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -290,7 +290,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Incubating
     @Option(option = "args", description = "Command line arguments passed to the main class. [INCUBATING]")
-    public JavaExec setArgs(String args) {
+    public JavaExec setArgsString(String args) {
         return setArgs(Arrays.asList(Commandline.translateCommandline(args)));
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -2,6 +2,11 @@
 
 Here are the new features introduced in this Gradle release.
 
+### Command line args supported by JavaExec
+
+Since Gradle 4.9, the command line arguments can be passed to `JavaExec` with `--args`. For example, if you want to launch the application with command line arguments `foo --bar`, 
+you don't need to hardcode it into build script - you can just run `gradle run --args 'foo --bar'` (see [application plugin](userguide/application_plugin.html) for more information).
+
 <!--
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -5,7 +5,7 @@ Here are the new features introduced in this Gradle release.
 ### Command line args supported by JavaExec
 
 Since Gradle 4.9, the command line arguments can be passed to `JavaExec` with `--args`. For example, if you want to launch the application with command line arguments `foo --bar`, 
-you don't need to hardcode it into build script - you can just run `gradle run --args 'foo --bar'` (see [application plugin](userguide/application_plugin.html) for more information).
+you don't need to hardcode it into the build script - you can just run `gradle run --args 'foo --bar'` (see [application plugin](userguide/application_plugin.html) for more information).
 
 <!--
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.

--- a/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
@@ -43,6 +43,8 @@ The only mandatory configuration for the plugin is the specification of the main
 
 You can run the application by executing the `run` task (type: api:org.gradle.api.tasks.JavaExec[]). This will compile the main source set, and launch a new JVM with its classes (along with all runtime dependencies) as the classpath and using the specified main class. You can launch the application in debug mode with `gradle run --debug-jvm` (see api:org.gradle.api.tasks.JavaExec#setDebug(boolean)[]).
 
+Since Gradle 4.9, the command line arguments can be passed with `--args`. For example, if you want to launch the application with command line arguments `foo --bar`, you can use `gradle run --args 'foo --bar'` (see api:org.gradle.api.tasks.JavaExec#setArgs(java.lang.String)[]).
+
 If your application requires a specific set of JVM settings or system properties, you can configure the `applicationDefaultJvmArgs` property. These JVM arguments are applied to the `run` task and also considered in the generated start scripts of your distribution.
 
 ++++

--- a/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
+++ b/subprojects/docs/src/docs/userguide/applicationPlugin.adoc
@@ -43,7 +43,7 @@ The only mandatory configuration for the plugin is the specification of the main
 
 You can run the application by executing the `run` task (type: api:org.gradle.api.tasks.JavaExec[]). This will compile the main source set, and launch a new JVM with its classes (along with all runtime dependencies) as the classpath and using the specified main class. You can launch the application in debug mode with `gradle run --debug-jvm` (see api:org.gradle.api.tasks.JavaExec#setDebug(boolean)[]).
 
-Since Gradle 4.9, the command line arguments can be passed with `--args`. For example, if you want to launch the application with command line arguments `foo --bar`, you can use `gradle run --args 'foo --bar'` (see api:org.gradle.api.tasks.JavaExec#setArgs(java.lang.String)[]).
+Since Gradle 4.9, the command line arguments can be passed with `--args`. For example, if you want to launch the application with command line arguments `foo --bar`, you can use `gradle run --args 'foo --bar'` (see api:org.gradle.api.tasks.JavaExec#setArgsString(java.lang.String)[]).
 
 If your application requires a specific set of JVM settings or system properties, you can configure the `applicationDefaultJvmArgs` property. These JVM arguments are applied to the `run` task and also considered in the generated start scripts of your distribution.
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -84,20 +83,9 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ":run"
     }
 
-    private void runCommandWithQuotes() {
-        if (TestPrecondition.WINDOWS.fulfilled) {
-            // On Windows, "5" passed to ProcessBuilder will be stripped quotes:
-            // https://bugs.openjdk.java.net/browse/JDK-8131908
-            // https://msdn.microsoft.com/en-us/library/17w5ykft.aspx
-            run("run", "--args", "2 '3' \"4\" '\\\"5\\\"'")
-        } else {
-            run("run", "--args", "2 '3' \"4\" '\"5\"'")
-        }
-    }
-
     def 'arguments can be passed via command line and take precedence'() {
         when:
-        runCommandWithQuotes()
+        run("run", "--args", "2 '3' \"4\"")
 
         then:
         executedAndNotSkipped ":run"
@@ -105,11 +93,10 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         2
         3
         4
-        "5"
         '''.stripIndent())
 
         when:
-        runCommandWithQuotes()
+        run("run", "--args", "2 '3' \"4\"")
 
         then:
         executedAndNotSkipped ":run"
@@ -117,7 +104,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         2
         3
         4
-        "5"
         '''.stripIndent())
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -83,7 +83,7 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ":run"
     }
 
-    def 'arguments can be passed via command line and take precedence'() {
+    def 'arguments passed via command line take precedence and is not incremental by default'() {
         when:
         run("run", "--args", "2 '3' \"4\"")
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -159,11 +159,11 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         file("out.txt").delete()
 
         and:
-        run("run", "--args", "3")
+        run("run", "--args", "2")
 
         then:
         executedAndNotSkipped ":run"
-        assertOutputFileIs("3\n")
+        assertOutputFileIs("2\n")
     }
 
     def "arguments can be passed by using argument providers"() {


### PR DESCRIPTION
### Context

Also see https://github.com/gradle/gradle/issues/1743 

Previously, all arguments of `JavaExec` task can only be configured in build script. This PR adds `--args` support to `JavaExec`, which makes `gradle run --args "--foo --bar"` possible. `org.apache.tools.ant.types.Commandline` is used to parse single argument string (e.g. `-a -b -c`) to argument list (`['-a', '-b', '-c']`). Corresponding documentations are updated.

