### PR TITLE
Make Play! tests faster

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
@@ -98,7 +98,7 @@ class DefaultModuleRegistryTest extends Specification {
 
     def "locates module using manifest from runtime ClassLoader when run from build"() {
         given:
-        def classesDir = tmpDir.createDir("some-module/build/classes/main")
+        def classesDir = tmpDir.createDir("some-module/build/classes/main/java")
         def staticResourcesDir = tmpDir.createDir("some-module/src/main/resources")
         def cl = classLoaderFor([classesDir, resourcesDir, staticResourcesDir, runtimeDep])
         def registry = new DefaultModuleRegistry(cl, ClassPath.EMPTY, null)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -37,6 +37,7 @@ import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
@@ -91,6 +92,16 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         .parent(NativeServicesTestFixture.getInstance())
         .provider(new GlobalScopeServices(true))
         .build();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                CompositeStoppable.stoppable(GLOBAL_SERVICES).stop();
+            }
+        }));
+    }
+
     protected final static Set<String> PROPAGATED_SYSTEM_PROPERTIES = Sets.newHashSet();
     private static final List<String> JDK7_PATHS = Arrays.asList("1.7", "jdk7", "-7-", "jdk-7", "7u");
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -820,7 +820,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         FOREGROUND
     }
 
-    private CliDaemonArgument resolveCliDaemonArgument() {
+    protected CliDaemonArgument resolveCliDaemonArgument() {
         for (int i = args.size() - 1; i >= 0; i--) {
             final String arg = args.get(i);
             if (arg.equals("--daemon")) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -41,6 +41,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
+import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.DefaultLoggingManagerFactory;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
@@ -86,12 +87,15 @@ import static org.gradle.util.CollectionUtils.collect;
 import static org.gradle.util.CollectionUtils.join;
 
 public abstract class AbstractGradleExecuter implements GradleExecuter {
+
     protected static final ServiceRegistry GLOBAL_SERVICES = ServiceRegistryBuilder.builder()
         .displayName("Global services")
         .parent(newCommandLineProcessLogging())
         .parent(NativeServicesTestFixture.getInstance())
         .provider(new GlobalScopeServices(true))
         .build();
+
+    private static final JvmVersionDetector JVM_VERSION_DETECTOR = GLOBAL_SERVICES.get(JvmVersionDetector.class);
 
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
@@ -541,6 +545,18 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (isProfile()) {
             buildJvmOpts.add(profiler);
         }
+
+        if (isUseDaemon() && isSharedDaemons()) {
+            if (JVM_VERSION_DETECTOR.getJavaVersion(Jvm.forHome(getJavaHome())).compareTo(JavaVersion.VERSION_1_8) < 0) {
+                buildJvmOpts.add("-XX:MaxPermSize=320m");
+            }
+            buildJvmOpts.add("-Xmx4g");
+        } else {
+            buildJvmOpts.add("-Xmx1g");
+        }
+
+        buildJvmOpts.add("-XX:+HeapDumpOnOutOfMemoryError");
+        buildJvmOpts.add("-XX:HeapDumpPath=" + getGradleUserHomeDir().getAbsolutePath());
         return buildJvmOpts;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -31,19 +31,33 @@ import static org.apache.commons.collections.CollectionUtils.containsAny;
 public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     private static final JvmVersionDetector JVM_VERSION_DETECTOR = GLOBAL_SERVICES.get(JvmVersionDetector.class);
 
+    private boolean daemonExplicitlyRequired;
+
     public DaemonGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider) {
         super(distribution, testDirectoryProvider);
-        requireDaemon();
+        super.requireDaemon();
     }
 
     public DaemonGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider, GradleVersion gradleVersion, IntegrationTestBuildContext buildContext) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext);
-        requireDaemon();
+        super.requireDaemon();
+    }
+
+    @Override
+    public GradleExecuter requireDaemon() {
+        daemonExplicitlyRequired = true;
+        return super.requireDaemon();
     }
 
     @Override
     protected void validateDaemonVisibility() {
-        // Ignore. Should really ignore only when daemon has not been explicitly enabled or disabled
+        if (isDaemonExplicitlyRequired()) {
+            super.validateDaemonVisibility();
+        }
+    }
+
+    protected boolean isDaemonExplicitlyRequired() {
+        return daemonExplicitlyRequired || resolveCliDaemonArgument() == CliDaemonArgument.DAEMON;
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -15,9 +15,6 @@
  */
 package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.api.JavaVersion;
-import org.gradle.internal.jvm.Jvm;
-import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.util.GradleVersion;
@@ -29,7 +26,6 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.collections.CollectionUtils.containsAny;
 
 public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
-    private static final JvmVersionDetector JVM_VERSION_DETECTOR = GLOBAL_SERVICES.get(JvmVersionDetector.class);
 
     private boolean daemonExplicitlyRequired;
 
@@ -75,24 +71,6 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
         }
 
         return args;
-    }
-
-    @Override
-    protected List<String> getImplicitBuildJvmArgs() {
-        if (!isUseDaemon() || !isSharedDaemons()) {
-            return super.getImplicitBuildJvmArgs();
-        }
-
-        // Add JVM heap settings only for shared daemons
-        List<String> buildJvmOpts = new ArrayList<String>(super.getImplicitBuildJvmArgs());
-
-        if (JVM_VERSION_DETECTOR.getJavaVersion(Jvm.forHome(getJavaHome())).compareTo(JavaVersion.VERSION_1_8) < 0) {
-            buildJvmOpts.add("-XX:MaxPermSize=320m");
-        }
-
-        buildJvmOpts.add("-XX:+HeapDumpOnOutOfMemoryError");
-        buildJvmOpts.add("-XX:HeapDumpPath=" + buildContext.getGradleUserHomeDir().getAbsolutePath());
-        return buildJvmOpts;
     }
 
     @Override

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -27,7 +27,6 @@ import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DaemonForkOptionsBuilder;
-import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerFactory;
 
 import java.io.File;
@@ -64,7 +63,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
             .javaForkOptions(javaForkOptions)
             .classpath(groovyFiles)
             .sharedPackages(SHARED_PACKAGES)
-            .keepAliveMode(KeepAliveMode.SESSION)
+            .keepAliveMode(getKeepAliveMode())
             .build();
 
         return new InvocationContext(invocationWorkingDir, daemonForkOptions);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -17,13 +17,12 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
-import org.gradle.process.JavaForkOptions;
-import org.gradle.workers.internal.DaemonForkOptionsBuilder;
-import org.gradle.workers.internal.KeepAliveMode;
-import org.gradle.workers.internal.WorkerDaemonFactory;
-import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.process.JavaForkOptions;
+import org.gradle.workers.internal.DaemonForkOptions;
+import org.gradle.workers.internal.DaemonForkOptionsBuilder;
+import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
 import java.util.Collections;
@@ -49,7 +48,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         DaemonForkOptions daemonForkOptions = new DaemonForkOptionsBuilder(fileResolver)
             .javaForkOptions(javaForkOptions)
             .sharedPackages(SHARED_PACKAGES)
-            .keepAliveMode(KeepAliveMode.SESSION)
+            .keepAliveMode(getKeepAliveMode())
             .build();
 
         return new InvocationContext(invocationWorkingDir, daemonForkOptions);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -41,6 +41,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
     @Override
     protected InvocationContext toInvocationContext(JavaCompileSpec spec) {
         ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        limitHeapSize(forkOptions);
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(fileResolver).transform(forkOptions);
         File invocationWorkingDir = javaForkOptions.getWorkingDir();
         javaForkOptions.setWorkingDir(daemonWorkingDir);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ResourceCleaningCompilationTask.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ResourceCleaningCompilationTask.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 /**
  * Cleans up resources (e.g. file handles) after compilation has finished.
  */
-class ResourceCleaningCompilationTask implements JavaCompiler.CompilationTask {
+public class ResourceCleaningCompilationTask implements JavaCompiler.CompilationTask {
     private final JavaCompiler.CompilationTask delegate;
     private final StandardJavaFileManager fileManager;
 
@@ -64,7 +64,7 @@ class ResourceCleaningCompilationTask implements JavaCompiler.CompilationTask {
      * method does not take arguments, so the cache can't be turned off.
      * So instead we clean it ourselves using reflection.
      */
-    private void cleanupZipCache() {
+    public static void cleanupZipCache() {
         try {
             Class<?> zipFileIndexCache = Class.forName("com.sun.tools.javac.file.ZipFileIndexCache");
             Object instance = zipFileIndexCache.getMethod("getSharedInstance").invoke(null);

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -23,6 +23,7 @@ import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DefaultWorkResult;
+import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.SimpleActionExecutionSpec;
 import org.gradle.workers.internal.Worker;
 import org.gradle.workers.internal.WorkerFactory;
@@ -36,6 +37,8 @@ import static org.gradle.process.internal.util.MergeOptionsUtil.mergeHeapSize;
 import static org.gradle.process.internal.util.MergeOptionsUtil.normalized;
 
 public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements Compiler<T> {
+    public static final String REUSE_COMPILERS_PROPERTY = "org.gradle.internal.reuse.compilers";
+
     private final Compiler<T> delegate;
     private final WorkerFactory workerFactory;
 
@@ -46,6 +49,14 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
 
     public Compiler<T> getDelegate() {
         return delegate;
+    }
+
+    protected KeepAliveMode getKeepAliveMode() {
+        if (Boolean.getBoolean(REUSE_COMPILERS_PROPERTY)) {
+            return KeepAliveMode.DAEMON;
+        } else {
+            return KeepAliveMode.SESSION;
+        }
     }
 
     @Override

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.BaseForkOptions;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.workers.internal.DaemonForkOptions;
@@ -61,6 +62,7 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
 
     @Override
     public WorkResult execute(T spec) {
+        ClassLoaderUtils.disableUrlConnectionCaching();
         InvocationContext invocationContext = toInvocationContext(spec);
         DaemonForkOptions daemonForkOptions = invocationContext.getDaemonForkOptions();
         Worker worker = workerFactory.getWorker(daemonForkOptions);

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -78,10 +78,21 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
         BaseForkOptions merged = new BaseForkOptions();
         merged.setMemoryInitialSize(mergeHeapSize(left.getMemoryInitialSize(), right.getMemoryInitialSize()));
         merged.setMemoryMaximumSize(mergeHeapSize(left.getMemoryMaximumSize(), right.getMemoryMaximumSize()));
+        limitHeapSize(merged);
         Set<String> mergedJvmArgs = normalized(left.getJvmArgs());
         mergedJvmArgs.addAll(normalized(right.getJvmArgs()));
         merged.setJvmArgs(Lists.newArrayList(mergedJvmArgs));
         return merged;
+    }
+
+    protected void limitHeapSize(BaseForkOptions forkOptions) {
+        if (forkOptions.getMemoryMaximumSize() == null) {
+            if (forkOptions.getMemoryInitialSize() == null) {
+                forkOptions.setMemoryMaximumSize("1g");
+            } else {
+                forkOptions.setMemoryMaximumSize(forkOptions.getMemoryInitialSize());
+            }
+        }
     }
 
     private static class CompilerCallable<T extends CompileSpec> implements Callable<WorkResult> {

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
@@ -22,6 +22,7 @@ abstract class AbstractCompilerContinuousIntegrationTest extends Java7RequiringC
 
     def setup() {
         executer.withWorkerDaemonsExpirationDisabled()
+        executer.requireIsolatedDaemons()
     }
 
     def cleanup() {

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/CompilerReuseFixture.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/CompilerReuseFixture.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.compile
+
+import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+
+class CompilerReuseFixture {
+
+    static void enableCompilerReuse(GradleExecuter executer) {
+        executer.beforeExecute {
+            executer.withArgument("-D$AbstractDaemonCompiler.REUSE_COMPILERS_PROPERTY=true")
+        }
+    }
+
+    static void disableCompilerReuse(GradleExecuter executer) {
+        executer.beforeExecute {
+            executer.withArgument("-D$AbstractDaemonCompiler.REUSE_COMPILERS_PROPERTY=false")
+        }
+    }
+}

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -35,14 +35,13 @@ package org.gradle.api.internal.tasks.scala;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.tasks.compile.BaseForkOptionsConverter;
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
-import org.gradle.process.JavaForkOptions;
-import org.gradle.workers.internal.DaemonForkOptionsBuilder;
-import org.gradle.workers.internal.KeepAliveMode;
-import org.gradle.workers.internal.WorkerDaemonFactory;
-import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.api.tasks.scala.ScalaForkOptions;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.process.JavaForkOptions;
+import org.gradle.workers.internal.DaemonForkOptions;
+import org.gradle.workers.internal.DaemonForkOptionsBuilder;
+import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
 import java.util.Arrays;
@@ -73,7 +72,7 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
             .javaForkOptions(javaForkOptions)
             .classpath(zincClasspath)
             .sharedPackages(SHARED_PACKAGES)
-            .keepAliveMode(KeepAliveMode.SESSION)
+            .keepAliveMode(getKeepAliveMode())
             .build();
 
         return new InvocationContext(invocationWorkingDir, daemonForkOptions);

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -21,6 +21,7 @@ import com.typesafe.zinc.IncOptions;
 import com.typesafe.zinc.Inputs;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
 import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
+import org.gradle.api.internal.tasks.compile.ResourceCleaningCompilationTask;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
@@ -84,6 +85,7 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec>, S
             }
             LOGGER.info("Completed Scala compilation: {}", timer.getElapsed());
 
+            ResourceCleaningCompilationTask.cleanupZipCache();
             return WorkResults.didWork(true);
         }
 

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -84,15 +84,11 @@ public class ZincScalaCompilerFactory {
     }
 
     private static Compiler createCompiler(final Setup setup, final PersistentCache zincCache, final xsbti.Logger logger) {
-        return Compiler.compilerCache().get(setup, new scala.runtime.AbstractFunction0<Compiler>() {
-            public Compiler apply() {
-                ScalaInstance instance = Compiler.scalaInstance(setup);
-                File interfaceJar = getCompilerInterface(setup, instance, zincCache, logger);
-                AnalyzingCompiler scalac = Compiler.newScalaCompiler(instance, interfaceJar, logger);
-                JavaCompiler javac = Compiler.newJavaCompiler(instance, setup.javaHome(), setup.forkJava());
-                return new Compiler(scalac, javac);
-            }
-        });
+        ScalaInstance instance = Compiler.scalaInstance(setup);
+        File interfaceJar = getCompilerInterface(setup, instance, zincCache, logger);
+        AnalyzingCompiler scalac = Compiler.newScalaCompiler(instance, interfaceJar, logger);
+        JavaCompiler javac = Compiler.newJavaCompiler(instance, setup.javaHome(), setup.forkJava());
+        return new Compiler(scalac, javac);
     }
 
     // parallel safe version of Compiler.compilerInterface()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -30,6 +30,7 @@ import java.nio.charset.Charset
 class SingleUseDaemonIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
+        executer.withArgument("--no-daemon")
         executer.requireIsolatedDaemons()
     }
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/AutoTestedSamplePlatformPlayIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/AutoTestedSamplePlatformPlayIntegrationTest.groovy
@@ -17,9 +17,15 @@
 package org.gradle.play.integtest
 
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.junit.Test
 
 class AutoTestedSamplePlatformPlayIntegrationTest extends AbstractAutoTestedSamplesTest {
+
+    def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
+    }
+
     @Test
     void runSamples() {
         runSamplesFrom("subprojects/platform-play/src/main")

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/MixedPlayAndJvmLibraryProjectIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/MixedPlayAndJvmLibraryProjectIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.play.integtest
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.jvm.TestJvmComponent
 import org.gradle.language.fixtures.TestJavaComponent
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.integtest.fixtures.app.BasicPlayApp
 import org.gradle.play.integtest.fixtures.PlayApp
 import org.gradle.test.fixtures.archive.JarTestFixture
@@ -29,6 +30,7 @@ class MixedPlayAndJvmLibraryProjectIntegrationTest extends AbstractIntegrationSp
     PlayApp playApp = new BasicPlayApp()
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         playApp.writeSources(testDirectory)
         jvmApp.writeSources(file("src/jvmLib"))
         jvmApp.writeResources(file("src/jvmLib/resources"))

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/MixedPlayAndLegacyJavaProjectIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/MixedPlayAndLegacyJavaProjectIntegrationTest.groovy
@@ -16,9 +16,13 @@
 
 package org.gradle.play.integtest
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import spock.lang.Issue
 
 class MixedPlayAndLegacyJavaProjectIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
+    }
 
     @Issue("GRADLE-3356")
     def "can apply both java and play plugins"() {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayApplicationBinariesIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayApplicationBinariesIntegrationTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.play.integtest
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.hamcrest.Matchers
 
 class PlayApplicationBinariesIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         buildFile << """
             plugins {
                 id 'play-application'

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayMultiProjectApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayMultiProjectApplicationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.play.integtest
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.integtest.fixtures.DistributionTestExecHandleBuilder
 import org.gradle.play.integtest.fixtures.MultiProjectRunningPlayApp
 import org.gradle.play.integtest.fixtures.RunningPlayApp
@@ -35,6 +36,7 @@ class PlayMultiProjectApplicationIntegrationTest extends AbstractIntegrationSpec
     RunningPlayApp runningApp = new MultiProjectRunningPlayApp(testDirectory)
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         playApp.writeSources(testDirectory)
     }
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformComponentReportIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformComponentReportIntegrationTest.groovy
@@ -16,12 +16,17 @@
 package org.gradle.play.integtest
 import org.gradle.api.reporting.components.AbstractComponentReportIntegrationTest
 import org.gradle.platform.base.internal.DefaultPlatformRequirement
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.internal.DefaultPlayPlatform
 import org.gradle.play.internal.PlayPlatformResolver
 
 class PlayPlatformComponentReportIntegrationTest extends AbstractComponentReportIntegrationTest {
     private String defaultPlayPlatformName = String.format("play-%s", DefaultPlayPlatform.DEFAULT_PLAY_VERSION);
     private def defaultPlayPlatform = new PlayPlatformResolver().resolve(DefaultPlatformRequirement.create(defaultPlayPlatformName));
+
+    def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
+    }
 
     def "shows details of Play application"() {
         given:

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/PlayPlatformIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.play.integtest
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.integtest.fixtures.PlayApp
 import org.gradle.play.integtest.fixtures.app.BasicPlayApp
 import org.gradle.play.internal.DefaultPlayPlatform
@@ -33,6 +34,7 @@ public class PlayPlatformIntegrationTest extends AbstractIntegrationSpec {
     PlayApp playApp = new BasicPlayApp()
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         playApp.writeSources(testDirectory)
     }
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/dependencies/PlayJavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/dependencies/PlayJavaAnnotationProcessingIntegrationTest.groovy
@@ -17,12 +17,17 @@
 package org.gradle.play.integtest.dependencies
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import spock.lang.Issue
 
 import static org.gradle.play.integtest.fixtures.Repositories.PLAY_REPOSITORIES
 
 @Issue("https://github.com/gradle/gradle/issues/2337")
 class PlayJavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
+    }
 
     def "can compile Java class incorporating annotation processing"() {
         given:

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/AbstractPlaySampleIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/AbstractPlaySampleIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.integtest.fixtures.RunningPlayApp
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import spock.lang.IgnoreIf
@@ -41,6 +42,7 @@ abstract class AbstractPlaySampleIntegrationTest extends AbstractIntegrationSpec
 
     def setup() {
         executer.usingInitScript(RepoScriptBlockUtil.createMirrorInitScript())
+        CompilerReuseFixture.enableCompilerReuse(executer)
         initScript = file("initFile") << """
             gradle.allprojects {
                 tasks.withType(PlayRun) {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/UserGuidePlaySamplesIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/UserGuidePlaySamplesIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.play.integtest.samples
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.test.fixtures.archive.ArchiveTestFixture
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.archive.TarTestFixture
@@ -38,6 +39,7 @@ class UserGuidePlaySamplesIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
         executer.usingInitScript(RepoScriptBlockUtil.createMirrorInitScript())
+        CompilerReuseFixture.enableCompilerReuse(executer)
     }
 
     def "sourcesets sample is buildable" () {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/AbstractJavaScriptMinifyIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/AbstractJavaScriptMinifyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.TextUtil
@@ -24,6 +25,7 @@ import org.gradle.util.TextUtil
 abstract class AbstractJavaScriptMinifyIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         settingsFile << """ rootProject.name = 'js-play-app' """
     }
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/AbstractRoutesCompileIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/AbstractRoutesCompileIntegrationTest.groovy
@@ -19,6 +19,7 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.VersionNumber
@@ -51,6 +52,7 @@ abstract class AbstractRoutesCompileIntegrationTest extends MultiVersionIntegrat
     }
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         settingsFile << """ rootProject.name = 'routes-play-app' """
         buildFile <<"""
 plugins {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/DistributionZipIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/DistributionZipIntegrationTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.test.fixtures.archive.ZipTestFixture
 import static org.gradle.play.integtest.fixtures.Repositories.*
 
 class DistributionZipIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         settingsFile << """ rootProject.name = 'dist-play-app' """
         buildFile << """
             plugins {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/PlayAssetsJarIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/PlayAssetsJarIntegrationTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.integtest.fixtures.app.BasicPlayApp
 import org.gradle.test.fixtures.archive.JarTestFixture
 
 class PlayAssetsJarIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         new BasicPlayApp().writeSources(file("."))
         settingsFile << """ rootProject.name = 'play-app' """
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/TwirlVersionIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/tasks/TwirlVersionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.play.internal.DefaultPlayPlatform
 import static org.gradle.play.integtest.fixtures.Repositories.*
 
@@ -32,6 +33,7 @@ class TwirlVersionIntegrationTest extends AbstractIntegrationSpec {
     def twirlOutputDir = "build/src/play/binary/twirlTemplatesScalaSources"
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         settingsFile << """ rootProject.name = 'twirl-play-app' """
     }
 

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -25,7 +25,6 @@ import org.gradle.play.internal.spec.PlayCompileSpec;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DaemonForkOptionsBuilder;
-import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
@@ -55,7 +54,7 @@ public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemo
             .javaForkOptions(javaForkOptions)
             .classpath(compilerClasspath)
             .sharedPackages(classLoaderPackages)
-            .keepAliveMode(KeepAliveMode.SESSION)
+            .keepAliveMode(getKeepAliveMode())
             .build();
 
         return new InvocationContext(invocationWorkingDir, daemonForkOptions);

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -46,6 +46,7 @@ public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemo
     @Override
     protected InvocationContext toInvocationContext(PlayCompileSpec spec) {
         BaseForkOptions forkOptions = spec.getForkOptions();
+        limitHeapSize(forkOptions);
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(fileResolver).transform(forkOptions);
         File invocationWorkingDir = javaForkOptions.getWorkingDir();
         javaForkOptions.setWorkingDir(daemonWorkingDir);

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/toolchain/DaemonPlayCompilerTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/internal/toolchain/DaemonPlayCompilerTest.groovy
@@ -53,8 +53,8 @@ class DaemonPlayCompilerTest extends Specification {
         given:
         def compiler = new DaemonPlayCompiler(workingDirectory, delegate, workerDaemonFactory, someClasspath(), [], fileResolver)
         when:
-        1 * forkOptions.getMemoryInitialSize() >> "256m"
-        1 * forkOptions.getMemoryMaximumSize() >> "512m"
+        _ * forkOptions.getMemoryInitialSize() >> "256m"
+        _ * forkOptions.getMemoryMaximumSize() >> "512m"
         then:
         def context = compiler.toInvocationContext(spec)
         context.daemonForkOptions.javaForkOptions.getMinHeapSize() == "256m"

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractPlayContinuousBuildIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractPlayContinuousBuildIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.play.integtest.fixtures
 
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.launcher.continuous.Java7RequiringContinuousIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
@@ -25,6 +26,7 @@ abstract class AbstractPlayContinuousBuildIntegrationTest extends Java7Requiring
     abstract RunningPlayApp getRunningApp()
 
     def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
         writeSources()
         buildTimeout = 90
     }

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.integtest.fixtures
 
 import org.gradle.api.JavaVersion
+import org.gradle.api.tasks.compile.CompilerReuseFixture
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
@@ -24,6 +25,10 @@ import org.gradle.integtests.fixtures.executer.ExecutionResult
 
 @TargetCoverage({ JavaVersion.current().isJava8Compatible() ? PlayCoverage.ALL : PlayCoverage.PLAY23_OR_EARLIER })
 abstract class PlayMultiVersionIntegrationTest extends MultiVersionIntegrationSpec {
+
+    def setup() {
+        CompilerReuseFixture.enableCompilerReuse(executer)
+    }
 
     static boolean isPlay22(def version) {
         return version.toString().startsWith('2.2')

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.jvm.Jvm
-
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Assume
@@ -58,7 +57,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         gradle.standardOutput.contains("Execution working dir: " + testDirectory.getAbsolutePath())
 
         and:
-        GradleContextualExecuter.daemon || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        GradleContextualExecuter.isLongLivingProcess() || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     def "sets the working directory to the specified directory during worker execution"() {
@@ -90,7 +89,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         gradle.standardOutput.contains("Execution working dir: " + testDirectory.file("workerDir").getAbsolutePath())
 
         and:
-        GradleContextualExecuter.daemon || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        GradleContextualExecuter.isLongLivingProcess() || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     @Requires(TestPrecondition.JDK_ORACLE)


### PR DESCRIPTION
Reuse compiler daemons and use the Gradle daemon when forking from the embedded executor. See more details in the commit messages. This makes the Play! tests twice as fast.