### PR TITLE
Fix failed sample tests on Java 9

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
@@ -101,8 +101,5 @@ val excludedTests = listOf(
     "MavenPublishS3ErrorsIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
 
     // Various problems, eg scala compile
-    "UserGuideSamplesIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-
-    //Changes in Javadoc generation
-    "SamplesJavaMultiProjectIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10)
+    "UserGuideSamplesIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10)
 )

--- a/subprojects/docs/src/samples/java/multiproject/api/build.gradle
+++ b/subprojects/docs/src/samples/java/multiproject/api/build.gradle
@@ -3,8 +3,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'commons-math:commons-math:1.1'
+        classpath 'org.apache.commons:commons-math3:3.6.1'
     }
+
 }
 
 configurations {
@@ -17,8 +18,8 @@ dependencies {
     compile project(':shared')
 // END SNIPPET project-dependencies
 // END SNIPPET dependencies
-    compile module("commons-lang:commons-lang:2.4") {
-        dependency("commons-io:commons-io:1.2")
+    compile module("org.apache.commons:commons-lang3:3.7") {
+        dependency("commons-io:commons-io:2.6")
     }
 // START SNIPPET dependencies
 // START SNIPPET project-dependencies
@@ -55,7 +56,7 @@ artifacts {
 // END SNIPPET dists
 
 // We want to test if commons-math was properly added to the build script classpath
-org.apache.commons.math.fraction.Fraction lhs = new org.apache.commons.math.fraction.Fraction(1, 3);
+org.apache.commons.math3.fraction.Fraction lhs = new org.apache.commons.math3.fraction.Fraction(1, 3);
 org.gradle.buildsrc.BuildSrcClass bsc = new org.gradle.buildsrc.BuildSrcClass()
 
 task checkProjectDependency(dependsOn: project(':shared').jar) {

--- a/subprojects/docs/src/samples/java/multiproject/api/src/main/java/org/gradle/api/PersonList.java
+++ b/subprojects/docs/src/samples/java/multiproject/api/src/main/java/org/gradle/api/PersonList.java
@@ -9,7 +9,7 @@ public class PersonList {
     private ArrayList<Person> persons = new ArrayList<Person>();
 
     public void doSomethingWithImpl() {
-        org.apache.commons.lang.builder.ToStringBuilder stringBuilder;
+        org.apache.commons.lang3.builder.ToStringBuilder stringBuilder;
         try {
              Class.forName("org.apache.commons.io.FileUtils");
         } catch (ClassNotFoundException e) {

--- a/subprojects/docs/src/samples/java/multiproject/api/src/main/java/org/gradle/api/package-info.java
+++ b/subprojects/docs/src/samples/java/multiproject/api/src/main/java/org/gradle/api/package-info.java
@@ -1,0 +1,4 @@
+/**
+* These are the API classes.
+*/
+package org.gradle.api;

--- a/subprojects/docs/src/samples/java/multiproject/api/src/main/java/org/gradle/api/package.html
+++ b/subprojects/docs/src/samples/java/multiproject/api/src/main/java/org/gradle/api/package.html
@@ -1,3 +1,0 @@
-<html>
-    <body><p>These are the API classes</p></body>
-</html>

--- a/subprojects/docs/src/samples/java/multiproject/services/webservice/build.gradle
+++ b/subprojects/docs/src/samples/java/multiproject/services/webservice/build.gradle
@@ -4,8 +4,8 @@ version = '2.5'
 
 // START SNIPPET dependency-configurations
 dependencies {
-// END SNIPPET dependency-configurations    
-    compile project(':shared'), 'commons-collections:commons-collections:3.2.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+// END SNIPPET dependency-configurations
+    compile project(':shared'), 'commons-collections:commons-collections:3.2.2@jar', 'commons-io:commons-io:2.6', 'org.apache.commons:commons-lang3:3.7@jar'
 // START SNIPPET dependency-configurations
     compile project(path: ':api', configuration: 'spi')
 // END SNIPPET dependency-configurations

--- a/subprojects/docs/src/samples/java/multiproject/services/webservice/src/main/java/org/gradle/webservice/TestTest.java
+++ b/subprojects/docs/src/samples/java/multiproject/services/webservice/src/main/java/org/gradle/webservice/TestTest.java
@@ -1,7 +1,7 @@
 package org.gradle.webservice;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.collections.list.GrowthList;
 import org.gradle.shared.Person;
 import org.gradle.api.PersonList;

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -124,8 +124,8 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationTest {
                 "WEB-INF/lib/$API_NAME-1.0.jar".toString(),
                 "WEB-INF/lib/$API_NAME-spi-1.0.jar".toString(),
                 'WEB-INF/lib/commons-collections-3.2.2.jar',
-                'WEB-INF/lib/commons-io-1.2.jar',
-                'WEB-INF/lib/commons-lang-2.4.jar'
+                'WEB-INF/lib/commons-io-2.6.jar',
+                'WEB-INF/lib/commons-lang3-3.7.jar'
         )
 
         // Check contents of dist zip
@@ -135,8 +135,8 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationTest {
                 'README.txt',
                 "libs/$API_NAME-spi-1.0.jar".toString(),
                 "libs/$SHARED_NAME-1.0.jar".toString(),
-                'libs/commons-io-1.2.jar',
-                'libs/commons-lang-2.4.jar'
+                'libs/commons-io-2.6.jar',
+                'libs/commons-lang3-3.7.jar'
         )
     }
 


### PR DESCRIPTION
These sample tests were disabled previously because of the failures observed
on Java 9. This PR fixes the problems:

- Upgrade dependencies to newer version which supports Java 9 version schema (JEP-223)
- Prefer usage of `package-info.java` over `package.html` because it's recommended by JLS
