### PR TITLE
Include S3 publishing tests on JDK >= 9

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
@@ -92,14 +92,6 @@ val excludedTests = listOf(
     // Test compiles for Java 5
     "ToolingApiUnsupportedClientJvmCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10),
 
-    // Missing class javax/xml/bind/DatatypeConverter on PUT to S3
-    // These tests need jvmArgs '-addmods', 'java.xml.bind'
-    // At some point Gradle should import this module automatically
-    "IvyPublishS3IntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-    "IvyS3UploadArchivesIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-    "MavenPublishS3IntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-    "MavenPublishS3ErrorsIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-
     // Various problems, eg scala compile
     "UserGuideSamplesIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
 

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/AddJavaXmBindModulesTrait.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/AddJavaXmBindModulesTrait.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resource.s3.fixtures
+
+import groovy.transform.CompileStatic
+import groovy.transform.SelfType
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
+@CompileStatic
+@SelfType(AbstractIntegrationSpec)
+trait AddJavaXmBindModulesTrait {
+    def addJavaXmlBindModuleIfNecessary() {
+        if (!GradleContextualExecuter.embedded && JavaVersion.current().isJava9Compatible()) {
+            executer.withBuildJvmOpts('--add-modules', 'java.xml.bind')
+        }
+    }
+}

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
@@ -17,14 +17,16 @@
 package org.gradle.integtests.resource.s3.ivy
 
 import org.gradle.api.publish.ivy.AbstractIvyPublishIntegTest
+import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.junit.Rule
 
-class IvyPublishS3IntegrationTest extends AbstractIvyPublishIntegTest {
+class IvyPublishS3IntegrationTest extends AbstractIvyPublishIntegTest implements AddJavaXmBindModulesTrait{
     @Rule
     public S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
+        addJavaXmlBindModuleIfNecessary()
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.getUri()}")
     }
 

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3UploadArchivesIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3UploadArchivesIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.integtests.resource.s3.ivy
 
 import org.gradle.api.publish.ivy.AbstractIvyRemoteLegacyPublishIntegrationTest
+import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.gradle.test.fixtures.server.RepositoryServer
 import org.junit.Rule
 
-class IvyS3UploadArchivesIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest {
+class IvyS3UploadArchivesIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest implements AddJavaXmBindModulesTrait{
     @Rule
     public S3Server server = new S3Server(temporaryFolder)
 
@@ -31,6 +32,7 @@ class IvyS3UploadArchivesIntegrationTest extends AbstractIvyRemoteLegacyPublishI
     }
 
     def setup() {
+        addJavaXmlBindModuleIfNecessary()
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.uri}")
     }
 }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
@@ -18,11 +18,12 @@
 package org.gradle.integtests.resource.s3.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
 import org.gradle.integtests.resource.s3.fixtures.MavenS3Repository
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.junit.Rule
 
-class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest {
+class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest implements AddJavaXmBindModulesTrait {
 
     String mavenVersion = "1.45"
     String projectName = "publishS3Test"
@@ -33,6 +34,7 @@ class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest 
     public final S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
+        addJavaXmlBindModuleIfNecessary()
         disableModuleMetadataPublishing()
         executer.withArgument('-i')
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.uri}")

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3IntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3IntegrationTest.groovy
@@ -17,16 +17,18 @@
 package org.gradle.integtests.resource.s3.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
 import org.gradle.integtests.resource.s3.fixtures.MavenS3Repository
 import org.gradle.integtests.resource.s3.fixtures.S3Artifact
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.junit.Rule
 
-class MavenPublishS3IntegrationTest extends AbstractMavenPublishIntegTest {
+class MavenPublishS3IntegrationTest extends AbstractMavenPublishIntegTest implements AddJavaXmBindModulesTrait {
     @Rule
     public S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
+        addJavaXmlBindModuleIfNecessary()
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.getUri()}")
         .withArgument("-Daws.accessKeyId=someKey")
         .withArgument("-Daws.secretKey=someSecret");


### PR DESCRIPTION
Include the recently fixed S3 resources tests when executing tests on JDK >= 9.