### PR TITLE
Let gradle --version display Kotlin DSL and Kotlin versions

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -268,6 +268,7 @@ public class CommandLineActionFactory {
     private static class ShowVersionAction implements Runnable {
         public void run() {
             GradleVersion currentVersion = GradleVersion.current();
+            KotlinDslVersion currentKotlinDslVersion = KotlinDslVersion.current();
 
             final StringBuilder sb = new StringBuilder();
             sb.append("%n------------------------------------------------------------%nGradle ");
@@ -276,7 +277,11 @@ public class CommandLineActionFactory {
             sb.append(currentVersion.getBuildTime());
             sb.append("%nRevision:     ");
             sb.append(currentVersion.getRevision());
-            sb.append("%n%nGroovy:       ");
+            sb.append("%n%nKotlin DSL:   ");
+            sb.append(currentKotlinDslVersion.getProviderVersion());
+            sb.append("%nKotlin:       ");
+            sb.append(currentKotlinDslVersion.getKotlinVersion());
+            sb.append("%nGroovy:       ");
             sb.append(GroovySystem.getVersion());
             sb.append("%nAnt:          ");
             sb.append(Main.getAntVersion());

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/KotlinDslVersion.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/KotlinDslVersion.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.launcher.cli;
+
+import org.gradle.util.GUtil;
+
+import java.net.URL;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+final class KotlinDslVersion {
+
+    static KotlinDslVersion current() {
+        ClassLoader loader = KotlinDslVersion.class.getClassLoader();
+        URL resource = loader.getResource("gradle-kotlin-dsl-versions.properties");
+        checkNotNull(resource, "Gradle Kotlin DSL versions manifest was not found");
+        Properties versions = GUtil.loadProperties(resource);
+        return new KotlinDslVersion(versions.getProperty("provider"), versions.getProperty("kotlin"));
+    }
+
+    private final String provider;
+    private final String kotlin;
+
+    private KotlinDslVersion(String provider, String kotlin) {
+        checkNotNull(provider, "Kotlin DSL Provider version was not found");
+        checkNotNull(kotlin, "Kotlin version was not found");
+        this.provider = provider;
+        this.kotlin = kotlin;
+    }
+
+    String getProviderVersion() {
+        return provider;
+    }
+
+    String getKotlinVersion() {
+        return kotlin;
+    }
+}

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/CommandLineActionFactoryTest.groovy
@@ -217,6 +217,7 @@ class CommandLineActionFactoryTest extends Specification {
 
     def "displays version message"() {
         def version = GradleVersion.current()
+        def kotlinDslVersion = KotlinDslVersion.current()
         def expectedText = [
             "",
             "------------------------------------------------------------",
@@ -226,6 +227,8 @@ class CommandLineActionFactoryTest extends Specification {
             "Build time:   $version.buildTime",
             "Revision:     $version.revision",
             "",
+            "Kotlin DSL:   ${kotlinDslVersion.providerVersion}",
+            "Kotlin:       ${kotlinDslVersion.kotlinVersion}",
             "Groovy:       $GroovySystem.version",
             "Ant:          $Main.antVersion",
             "JVM:          ${Jvm.current()}",


### PR DESCRIPTION
```
user@host $ ./gradlew --version

------------------------------------------------------------
Gradle 4.9-20180521174539+0000
------------------------------------------------------------

Build time:   2018-05-21 17:45:39 UTC
Revision:     3c73eb0af4e3ccd4e0e6b5e78fb564d87ca9b039

Kotlin DSL:   0.17.5
Kotlin:       1.2.41
Groovy:       2.4.12
Ant:          Apache Ant(TM) version 1.9.11 compiled on March 23 2018
JVM:          1.8.0_161 (Oracle Corporation 25.161-b12)
OS:           Mac OS X 10.13.4 x86_64
```

See https://github.com/gradle/kotlin-dsl/issues/481