### PR TITLE
gradlew: use `readlink` to read a link instead of attempting to parse `ls`

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -11,8 +11,7 @@
 PRG="\$0"
 # Need this for relative symlinks.
 while [ -h "\$PRG" ] ; do
-    ls=`ls -ld "\$PRG"`
-    link=`expr "\$ls" : '.*-> \\(.*\\)\$'`
+    link=`readlink "\$PRG"`
     if expr "\$link" : '/.*' > /dev/null; then
         PRG="\$link"
     else


### PR DESCRIPTION
Parsing `ls` is notoriously fragile and should be avoided when possible.
Let's use `readlink` (part of coreutils, just like `printf` which is
already used in this file) to read links instead of a fragile parsing of
`ls`.

The current code breaks if any part of the link or its derefs contains
`-> ` (uncommon, granted). You can test that breakage with:
$ ln -s 'bar -> baz' foo