### PR TITLE
Make sample runner test stderr output as well as stdout

### DIFF
--- a/subprojects/docs/src/samples/userguideOutput/buildProjectEvaluateEvents.out
+++ b/subprojects/docs/src/samples/userguideOutput/buildProjectEvaluateEvents.out
@@ -1,3 +1,19 @@
 Evaluation of root project 'buildProjectEvaluateEvents' succeeded
 Evaluation of project ':projectA' succeeded
 Evaluation of project ':projectB' FAILED
+
+FAILURE: Build failed with an exception.
+
+* Where:
+Build file '/home/user/gradle/samples/userguide/buildlifecycle/buildProjectEvaluateEvents/projectB.gradle' line: 1
+
+* What went wrong:
+A problem occurred evaluating project ':projectB'.
+> broken
+
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 0s

--- a/subprojects/docs/src/samples/userguideOutput/completeCUnitExample.out
+++ b/subprojects/docs/src/samples/userguideOutput/completeCUnitExample.out
@@ -3,3 +3,16 @@ There were test failures:
   1. /home/user/gradle/samples/native-binaries/cunit/src/operatorsTest/c/test_plus.c:6  - plus(0, -2) == -2
   2. /home/user/gradle/samples/native-binaries/cunit/src/operatorsTest/c/test_plus.c:7  - plus(2, 2) == 4
 
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':runOperatorsTestFailingCUnitExe'.
+> There were failing tests. See the results at: file:///home/user/gradle/samples/native-binaries/cunit/build/test-results/operatorsTest/failing/
+
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 0s

--- a/subprojects/docs/src/samples/userguideOutput/taskExecutionEvents.out
+++ b/subprojects/docs/src/samples/userguideOutput/taskExecutionEvents.out
@@ -2,3 +2,19 @@ executing task ':ok' ...
 done
 executing task ':broken' ...
 FAILED
+
+FAILURE: Build failed with an exception.
+
+* Where:
+Build file '/home/user/gradle/samples/userguide/buildlifecycle/taskExecutionEvents/build.gradle' line: 5
+
+* What went wrong:
+Execution failed for task ':broken'.
+> broken
+
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 0s

--- a/subprojects/docs/src/samples/userguideOutput/taskFinalizersWithFailure.out
+++ b/subprojects/docs/src/samples/userguideOutput/taskFinalizersWithFailure.out
@@ -1,2 +1,18 @@
 taskX
 taskY
+
+FAILURE: Build failed with an exception.
+
+* Where:
+Build file '/home/user/gradle/samples/userguide/tasks/finalizersWithFailure/build.gradle' line: 4
+
+* What went wrong:
+Execution failed for task ':taskX'.
+> java.lang.RuntimeException (no error message)
+
+* Try:
+Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+BUILD FAILED in 0s

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesRunner.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesRunner.groovy
@@ -155,6 +155,7 @@ class UserGuideSamplesRunner extends Runner {
                 .inDirectory(run.executionDir)
                 .withArguments(run.args as String[])
                 .withEnvironmentVars(run.envs)
+                .withTestConsoleAttached()
 
             if (!GradleContextualExecuter.longLivingProcess) {
                 //suppress daemon usage suggestions

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesRunner.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesRunner.groovy
@@ -21,6 +21,7 @@ import org.apache.tools.ant.taskdefs.Delete
 import org.apache.tools.ant.types.FileSet
 import org.gradle.api.JavaVersion
 import org.gradle.api.Transformer
+import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.api.reporting.components.NativeComponentReportOutputFormatter
 import org.gradle.api.reporting.components.PlayComponentReportOutputFormatter
 import org.gradle.integtests.fixtures.AvailableJavaHomes
@@ -155,6 +156,7 @@ class UserGuideSamplesRunner extends Runner {
                 .inDirectory(run.executionDir)
                 .withArguments(run.args as String[])
                 .withEnvironmentVars(run.envs)
+                .withConsole(ConsoleOutput.Plain)
                 .withTestConsoleAttached()
 
             if (!GradleContextualExecuter.longLivingProcess) {


### PR DESCRIPTION
This changes the user guide sample runner to capture (and check) error output for user guide samples that fail.