### PR TITLE
Rename TaskContainer.get(Class, String) to TaskCollection.named(String)

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
@@ -193,7 +193,7 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
 
     private void configureCheckTaskDependents() {
         final String taskBaseName = getTaskBaseName();
-        project.getTasks().get(Task.class, JavaBasePlugin.CHECK_TASK_NAME).configure(new Action<Task>() {
+        project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 task.dependsOn(new Callable() {

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
@@ -17,9 +17,11 @@ package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 
 /**
@@ -76,4 +78,16 @@ public interface TaskCollection<T extends Task> extends NamedDomainObjectSet<T> 
      * {@inheritDoc}
      */
     T getAt(String name) throws UnknownTaskException;
+
+    /**
+     * Locates a task by name, without triggering its creation or configuration, failing if there is no such object.
+     *
+     *
+     * @param name The task name
+     * @return A {@link Provider} that will return the task when queried. The task may be created and configured at this point, if not already.
+     * @throws UnknownTaskException If a task with the given name is not defined.
+     * @since 4.9
+     */
+    @Incubating
+    TaskProvider<T> named(String name) throws UnknownTaskException;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -59,20 +59,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
     Task getByPath(String path) throws UnknownTaskException;
 
     /**
-     * Locates a task by type and name, without triggering its creation or configuration, failing if there is no such object.
-     *
-     *
-     * @param type The task type
-     * @param name The task name
-     * @param <T> The task type
-     * @return A {@link Provider} that will return the task when queried. The task may be created and configured at this point, if not already.
-     * @throws InvalidUserDataException If a task with the given name and type is not defined.
-     * @since 4.9
-     */
-    @Incubating
-    <T extends Task> TaskProvider<T> get(Class<T> type, String name) throws InvalidUserDataException;
-
-    /**
      * <p>Creates a {@link Task} and adds it to this container. A map of creation options can be passed to this method
      * to control how the task is created. The following options are available:</p>
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Project;
@@ -31,11 +30,8 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.internal.NamedDomainObjectContainerConfigureDelegate;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
-import org.gradle.api.internal.provider.AbstractProvider;
-import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.TaskReference;
@@ -331,32 +327,6 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return project.getTasks().findByName(StringUtils.substringAfterLast(path, Project.PATH_SEPARATOR));
     }
 
-    @Override
-    public <T extends Task> TaskProvider<T> get(Class<T> type, String name) throws InvalidUserDataException {
-        Task task = findByNameWithoutRules(name);
-        if (task == null) {
-            ProviderInternal<? extends Task> taskProvider = findByNameLaterWithoutRules(name);
-            if (taskProvider == null) {
-                throw createNotFoundException(name);
-            } else if (!type.isAssignableFrom(taskProvider.getType())) {
-                return createTypeMismatchException(name, taskProvider.getType(), type);
-            }
-            return (TaskProvider<T>)taskProvider;
-        } else if(!type.isAssignableFrom(task.getClass())) {
-            return createTypeMismatchException(name, getDeclaredTaskType(task), type);
-        }
-
-        return new TaskLookupProvider<T>(type, name);
-    }
-
-    private <T extends Task> TaskProvider<T> createTypeMismatchException(String name, Class<?> actualType, Class<?> expectedType) {
-        throw new IllegalArgumentException(String.format("Task with name '%s' exists in %s, but task does not have requested type. Found %s expected %s.", name, project, actualType.getName(), expectedType.getName()));
-    }
-
-    private Class getDeclaredTaskType(Task original) {
-        return new DslObject(original).getDeclaredType();
-    }
-
     public Task resolveTask(String path) {
         if (Strings.isNullOrEmpty(path)) {
             throw new InvalidUserDataException("A path must be specified!");
@@ -516,53 +486,6 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return Cast.uncheckedCast(instantiator.newInstance(RealizableTaskCollection.class, type, super.withType(type), modelNode, instantiator));
     }
 
-    private abstract class DefaultTaskProvider<T extends Task> extends AbstractProvider<T> implements Named, TaskProvider<T> {
-        final Class<T> type;
-        final String name;
-        boolean removed = false;
-
-        DefaultTaskProvider(Class<T> type, String name) {
-            this.type = type;
-            this.name = name;
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public Class<T> getType() {
-            return type;
-        }
-
-        @Override
-        public boolean isPresent() {
-            return findByNameWithoutRules(name) != null;
-        }
-
-        @Override
-        public void configure(final Action<? super T> action) {
-            configureEach(new Action<Task>() {
-                private boolean alreadyExecuted = false;
-
-                @Override
-                public void execute(Task task) {
-                    // Task specific configuration action should only be executed once
-                    if (task.getName().equals(name) && !removed && !alreadyExecuted) {
-                        alreadyExecuted = true;
-                        action.execute((T)task);
-                    }
-                }
-            });
-        }
-
-        @Override
-        public String toString() {
-            return String.format("provider(task %s, %s)", name, type);
-        }
-    }
-
     private class TaskCreatingProvider<T extends Task> extends DefaultTaskProvider<T> {
         T task;
         boolean failed = false;
@@ -589,22 +512,6 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                         throw ex;
                     }
                 }
-            }
-            return task;
-        }
-    }
-
-    private class TaskLookupProvider<T extends Task> extends DefaultTaskProvider<T> {
-        T task;
-
-        public TaskLookupProvider(Class<T> type, String name) {
-            super(type, name);
-        }
-
-        @Override
-        public T getOrNull() {
-            if (task == null) {
-                task = type.cast(findByName(name));
             }
             return task;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RealizableTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RealizableTaskCollection.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Namer;
 import org.gradle.api.Rule;
 import org.gradle.api.Task;
@@ -26,6 +27,7 @@ import org.gradle.api.UnknownTaskException;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.core.ModelNode;
@@ -275,5 +277,10 @@ public class RealizableTaskCollection<T extends Task> implements TaskCollection<
     @Override
     public void clear() {
         delegate.clear();
+    }
+
+    @Override
+    public TaskProvider<T> named(String name) throws InvalidUserDataException {
+        return delegate.named(name);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -569,7 +569,7 @@ class DefaultTaskContainerTest extends Specification {
         container.createLater("task", DefaultTask, action)
 
         when:
-        def provider = container.get(Task, "task")
+        def provider = container.named("task")
 
         then:
         !provider.present
@@ -598,7 +598,7 @@ class DefaultTaskContainerTest extends Specification {
         container.createLater("task", DefaultTask, action)
 
         when:
-        def provider = container.get(Task, "task")
+        def provider = container.named("task")
         and:
         provider.configure(deferredAction)
         then:
@@ -638,8 +638,8 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == task
 
         and:
-        container.get(DefaultTask, "task").isPresent()
-        container.get(DefaultTask, "task").get() == task
+        container.withType(DefaultTask).named("task").isPresent()
+        container.withType(DefaultTask).named("task").get() == task
 
         and:
         1 * taskFactory.create("task", DefaultTask) >> task
@@ -668,8 +668,8 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == task
 
         and:
-        container.get(DefaultTask, "task").isPresent()
-        container.get(DefaultTask, "task").get() == task
+        container.withType(DefaultTask).named("task").isPresent()
+        container.withType(DefaultTask).named("task").get() == task
 
         and:
         1 * taskFactory.create("task", DefaultTask) >> task
@@ -688,7 +688,7 @@ class DefaultTaskContainerTest extends Specification {
 
         given:
         def creationProvider = container.createLater("task", DefaultTask, action)
-        def provider = container.get(DefaultTask, "task")
+        def provider = container.withType(DefaultTask).named("task")
 
         when:
         provider.get()
@@ -754,7 +754,7 @@ class DefaultTaskContainerTest extends Specification {
         !provider.isPresent()
 
         and:
-        !container.get(DefaultTask, "task").isPresent()
+        !container.withType(DefaultTask).named("task").isPresent()
 
         and:
         container.findByName("task") == null
@@ -775,7 +775,7 @@ class DefaultTaskContainerTest extends Specification {
 
         given:
         def creationProvider = container.createLater("task", DefaultTask, action)
-        def provider = container.get(DefaultTask, "task")
+        def provider = container.withType(DefaultTask).named("task")
 
         when:
         provider.get()
@@ -823,8 +823,8 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == task
 
         and:
-        container.get(DefaultTask, "task").isPresent()
-        container.get(DefaultTask, "task").get() == task
+        container.withType(DefaultTask).named("task").isPresent()
+        container.withType(DefaultTask).named("task").get() == task
 
         and:
         1 * taskFactory.create("task", DefaultTask) >> task
@@ -851,8 +851,8 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == task
 
         and:
-        container.get(DefaultTask, "task").isPresent()
-        container.get(DefaultTask, "task").get() == task
+        container.withType(DefaultTask).named("task").isPresent()
+        container.withType(DefaultTask).named("task").get() == task
 
         and:
         1 * taskFactory.create("task", DefaultTask) >> task
@@ -878,8 +878,8 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == task
 
         and:
-        container.get(DefaultTask, "task").isPresent()
-        container.get(DefaultTask, "task").get() == task
+        container.withType(DefaultTask).named("task").isPresent()
+        container.withType(DefaultTask).named("task").get() == task
 
         and:
         1 * taskFactory.create("task", DefaultTask) >> task
@@ -909,8 +909,8 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == task
 
         and:
-        container.get(DefaultTask, "task").isPresent()
-        container.get(DefaultTask, "task").get() == task
+        container.withType(DefaultTask).named("task").isPresent()
+        container.withType(DefaultTask).named("task").get() == task
 
         and:
         1 * taskFactory.create("task", DefaultTask) >> task
@@ -930,7 +930,7 @@ class DefaultTaskContainerTest extends Specification {
         given:
         container.withType(DefaultTask).configureEach(action)
         def creationProvider = container.createLater("task", DefaultTask)
-        def provider = container.get(DefaultTask, "task")
+        def provider = container.withType(DefaultTask).named("task")
 
         when:
         provider.get()
@@ -969,7 +969,7 @@ class DefaultTaskContainerTest extends Specification {
         container.create("task")
 
         when:
-        def provider = container.get(Task, "task")
+        def provider = container.named("task")
 
         then:
         provider.present
@@ -1062,7 +1062,7 @@ class DefaultTaskContainerTest extends Specification {
 
     void "get() fails if unknown task is requested"() {
         when:
-        container.get(DefaultTask, "unknown")
+        container.withType(DefaultTask).named("unknown")
 
         then:
         def ex = thrown(UnknownTaskException)
@@ -1075,22 +1075,22 @@ class DefaultTaskContainerTest extends Specification {
         container.create("task", DefaultTask)
 
         when:
-        container.get(CustomTask, "task")
+        container.withType(CustomTask).named("task")
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == "Task with name 'task' exists in Mock for type 'ProjectInternal' named '<project>', but task does not have requested type. Found ${DefaultTask.name} expected ${CustomTask.name}."
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
     }
 
     void "get() fails if lazily created task type is not a subtype"() {
         container.createLater("task", DefaultTask)
 
         when:
-        container.get(CustomTask, "task")
+        container.withType(CustomTask).named("task")
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == "Task with name 'task' exists in Mock for type 'ProjectInternal' named '<project>', but task does not have requested type. Found ${DefaultTask.name} expected ${CustomTask.name}."
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
         0 * taskFactory.create("task", DefaultTask)
     }
 
@@ -1100,7 +1100,7 @@ class DefaultTaskContainerTest extends Specification {
         container.create("task", CustomTask)
 
         when:
-        container.get(Task, "task")
+        container.named("task")
 
         then:
         noExceptionThrown()
@@ -1110,7 +1110,7 @@ class DefaultTaskContainerTest extends Specification {
         container.createLater("task", CustomTask)
 
         when:
-        container.get(Task, "task")
+        container.named("task")
 
         then:
         noExceptionThrown()
@@ -1123,7 +1123,7 @@ class DefaultTaskContainerTest extends Specification {
         container.create("task", DefaultTask)
 
         when:
-        container.get(DefaultTask, "task")
+        container.withType(DefaultTask).named("task")
 
         then:
         noExceptionThrown()
@@ -1134,7 +1134,7 @@ class DefaultTaskContainerTest extends Specification {
         container.createLater("task", DefaultTask)
 
         when:
-        container.get(DefaultTask, "task")
+        container.withType(DefaultTask).named("task")
 
         then:
         noExceptionThrown()
@@ -1149,15 +1149,15 @@ class DefaultTaskContainerTest extends Specification {
         container.create("task", CustomTask)
 
         when:
-        container.get(DefaultTask, "task")
+        container.withType(DefaultTask).named("task")
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == "Task with name 'task' exists in Mock for type 'ProjectInternal' named '<project>', but task does not have requested type. Found ${customTask.class.name} expected ${DefaultTask.name}."
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
 
         when:
         container.create([name: "task", type: DefaultTask, overwrite: true])
-        container.get(DefaultTask, "task")
+        container.withType(DefaultTask).named("task")
 
         then:
         noExceptionThrown()
@@ -1168,16 +1168,16 @@ class DefaultTaskContainerTest extends Specification {
         container.createLater("task", CustomTask)
 
         when:
-        container.get(DefaultTask, "task")
+        container.withType(DefaultTask).named("task")
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == "Task with name 'task' exists in Mock for type 'ProjectInternal' named '<project>', but task does not have requested type. Found ${CustomTask.name} expected ${DefaultTask.name}."
+        def ex = thrown(UnknownTaskException)
+        ex.message == "Task with name 'task' not found in Mock for type 'ProjectInternal' named '<project>'."
         0 * taskFactory.create("task", CustomTask)
 
         when:
         container.create([name: "task", type: DefaultTask, overwrite: true])
-        container.get(DefaultTask, "task")
+        container.withType(DefaultTask).named("task")
 
         then:
         noExceptionThrown()

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -174,7 +174,7 @@ public class BasePlugin implements Plugin<Project> {
     }
 
     private void configureAssemble(final ProjectInternal project) {
-        project.getTasks().get(Task.class, ASSEMBLE_TASK_NAME).configure(new Action<Task>() {
+        project.getTasks().named(ASSEMBLE_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 task.dependsOn(project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getAllArtifacts().getBuildDependencies());

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -115,7 +115,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
 
                 // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin
                 // doesn't need to do this.
-                project.getTasks().get(Task.class, sourceSet.getClassesTaskName()).configure(new Action<Task>() {
+                project.getTasks().named(sourceSet.getClassesTaskName()).configure(new Action<Task>() {
                     @Override
                     public void execute(Task task) {
                         task.dependsOn(compileTask);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
@@ -87,9 +87,8 @@ class JavaBasePluginRules implements Plugin<Project> {
         pluginConvention.getSourceSets().all(new Action<SourceSet>() {
             public void execute(final SourceSet sourceSet) {
 
-                Provider<ProcessResources> resourcesTask = tasks.get(ProcessResources.class, sourceSet.getProcessResourcesTaskName());
-                Provider<JavaCompile> compileTask = tasks.get(JavaCompile.class, sourceSet.getCompileJavaTaskName());
-                Provider<Task> classesTask = tasks.get(Task.class, sourceSet.getClassesTaskName());
+                Provider<ProcessResources> resourcesTask = tasks.withType(ProcessResources.class).named(sourceSet.getProcessResourcesTaskName());
+                Provider<JavaCompile> compileTask = tasks.withType(JavaCompile.class).named(sourceSet.getCompileJavaTaskName());
 
                 DefaultComponentSpecIdentifier binaryId = new DefaultComponentSpecIdentifier(project.getPath(), sourceSet.getName());
                 ClassDirectoryBinarySpecInternal binary = instantiator.newInstance(DefaultClassDirectoryBinarySpec.class, binaryId, sourceSet, javaToolChain, DefaultJavaPlatform.current(), instantiator, taskFactory);
@@ -101,6 +100,7 @@ class JavaBasePluginRules implements Plugin<Project> {
                 binary.addSourceSet(javaSourceSet);
                 binary.addSourceSet(resourceSet);
 
+                Provider<Task> classesTask = tasks.named(sourceSet.getClassesTaskName());
                 attachTasksToBinary(binary, compileTask, resourcesTask, classesTask);
                 binaries.add(binary);
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -70,7 +70,7 @@ public class JavaLibraryPlugin implements Plugin<Project> {
         Configuration apiElementsConfiguration = configurations.getByName(sourceSet.getApiElementsConfigurationName());
         apiElementsConfiguration.extendsFrom(apiConfiguration);
 
-        final Provider<JavaCompile> javaCompile = project.getTasks().get(JavaCompile.class, COMPILE_JAVA_TASK_NAME);
+        final Provider<JavaCompile> javaCompile = project.getTasks().withType(JavaCompile.class).named(COMPILE_JAVA_TASK_NAME);
 
         // Define a classes variant to use for compilation
         ConfigurationPublications publications = apiElementsConfiguration.getOutgoing();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -317,8 +317,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
         project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(jarArtifact);
 
-        Provider<JavaCompile> javaCompile = project.getTasks().get(JavaCompile.class, COMPILE_JAVA_TASK_NAME);
-        Provider<ProcessResources> processResources = project.getTasks().get(ProcessResources.class, PROCESS_RESOURCES_TASK_NAME);
+        Provider<JavaCompile> javaCompile = project.getTasks().withType(JavaCompile.class).named(COMPILE_JAVA_TASK_NAME);
+        Provider<ProcessResources> processResources = project.getTasks().withType(ProcessResources.class).named(PROCESS_RESOURCES_TASK_NAME);
 
         addJar(apiElementConfiguration, jarArtifact);
         addJar(runtimeConfiguration, jarArtifact);
@@ -364,14 +364,14 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
     }
 
     private void configureBuild(Project project) {
-        project.getTasks().get(Task.class, JavaBasePlugin.BUILD_NEEDED_TASK_NAME).configure(new Action<Task>() {
+        project.getTasks().named(JavaBasePlugin.BUILD_NEEDED_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 addDependsOnTaskInOtherProjects(task, true,
                     JavaBasePlugin.BUILD_NEEDED_TASK_NAME, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             }
         });
-        project.getTasks().get(Task.class, JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME).configure(new Action<Task>() {
+        project.getTasks().named(JavaBasePlugin.BUILD_DEPENDENTS_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 addDependsOnTaskInOtherProjects(task, false,
@@ -403,7 +403,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
                 test.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             }
         });
-        project.getTasks().get(Task.class, JavaBasePlugin.CHECK_TASK_NAME).configure(new Action<Task>() {
+        project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
                 task.dependsOn(test);


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
