### PR TITLE
Add dedicated DSL to customize Ivy descriptor to ivy-publish plugin

### DIFF
--- a/subprojects/docs/src/docs/dsl/dsl.xml
+++ b/subprojects/docs/src/docs/dsl/dsl.xml
@@ -222,6 +222,15 @@
                 <td>org.gradle.api.publish.ivy.IvyModuleDescriptorSpec</td>
             </tr>
             <tr>
+                <td>org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor</td>
+            </tr>
+            <tr>
+                <td>org.gradle.api.publish.ivy.IvyModuleDescriptorLicense</td>
+            </tr>
+            <tr>
+                <td>org.gradle.api.publish.ivy.IvyModuleDescriptorDescription</td>
+            </tr>
+            <tr>
                 <td>org.gradle.api.publish.maven.MavenPublication</td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>name</td>
+            </tr>
+            <tr>
+                <td>url</td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorDescription.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorDescription.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>text</td>
+            </tr>
+            <tr>
+                <td>homepage</td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorLicense.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorLicense.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>name</td>
+            </tr>
+            <tr>
+                <td>url</td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorSpec.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorSpec.xml
@@ -32,6 +32,15 @@
             <tr>
                 <td>extraInfo</td>
             </tr>
+            <tr>
+                <td>author</td>
+            </tr>
+            <tr>
+                <td>license</td>
+            </tr>
+            <tr>
+                <td>description</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -7,6 +7,7 @@ The publishing plugins get some much-needed improvements in this release:
 
  * The Signing Plugin now supports [signing all artifacts of a publication](#signing-publications).
  * The Maven Publish Plugin now provides a dedicated, type-safe [DSL to customize the POM generated](#customizing-the-generated-pom) as part of a Maven publication.
+ * The Ivy Publish Plugin now provides a dedicated, type-safe [DSL to customize the Ivy module descriptor generated](#customizing-the-generated-ivy-module-descriptor) as part of an Ivy publication.
  * Configuration-wide [dependency excludes are now published](#configuration-wide-dependency-excludes-are-now-published)
 
 The `maven-publish` and `ivy-publish` plugins are now considered stable and use of the `maven` plugin is discouraged as it will eventually be deprecated — please migrate.
@@ -123,6 +124,32 @@ The [Maven Publish Plugin](userguide/publishing_maven.html) now provides a dedic
       }
     }
 
+### Customizing the generated Ivy module descriptor
+
+The [Ivy Publish Plugin](userguide/publishing_ivy.html) now provides a dedicated, type safe DSL to customize the Ivy module descriptor generated as part of an Ivy publication. The following sample demonstrates the new properties and methods. Please see the [DSL Reference](dsl/org.gradle.api.publish.ivy.IvyModuleDescriptorSpec.html) for the complete documentation.
+
+    publishing {
+      publications {
+        ivyJava(IvyPublication) {
+          from components.java
+          descriptor {
+            license {
+              name = "The Apache License, Version 2.0"
+              url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+            author {
+              name = "Jane Doe"
+              url = "http://example.com/users/jane"
+            }
+            description {
+              text = "A concise description of my library"
+              homepage = "http://www.example.com/library"
+            }
+          }
+        }
+      }
+    }
+
 ### Configuration-wide dependency excludes are now published
 
 The [Ivy Publish Plugin](userguide/publishing_ivy.html) now writes dependency exclude rules defined on a configuration (instead of on an individual dependency) into the generated Ivy module descriptor; the [Maven Publish Plugin](userguide/publishing_maven.html) now repeats them for each dependency in the generated POM.
@@ -212,7 +239,7 @@ The following are the features that have been promoted in this Gradle release.
 
 ### Ivy Publish and Maven Publish Plugins marked stable
 
-The [Ivy Publish Plugin](userguide/publishing_ivy.html) and [Maven Publish Plugin](userguide/publishing_maven.html) that have been _incubating_ since Gradle 1.3 are now marked as stable. Both plugins now [support signing](#signing-publications) and [publish configuration-wide dependency excludes](#configuration-wide-dependency-excludes-are-now-published). The [Maven Publish Plugin](userguide/publishing_maven.html) introduces a new dedicated DSL for [customizing the generated POM](#customizing-the-generated-pom). In addition, some usage quirks with the `publishing` extension have been addressed which now [behaves like other extension objects](https://github.com/gradle/gradle/issues/4945). Thus, these plugins are now the preferred option for publishing artifacts to Ivy and Maven repositories, respectively.
+The [Ivy Publish Plugin](userguide/publishing_ivy.html) and [Maven Publish Plugin](userguide/publishing_maven.html) that have been _incubating_ since Gradle 1.3 are now marked as stable. Both plugins now [support signing](#signing-publications), [publish configuration-wide dependency excludes](#configuration-wide-dependency-excludes-are-now-published), and provide new dedicated DSLs for customizing generated [POMs](#customizing-the-generated-pom) or [Ivy module descriptors](#customizing-the-generated-ivy-module-descriptor). In addition, some usage quirks with the `publishing` extension have been addressed which now [behaves like other extension objects](https://github.com/gradle/gradle/issues/4945). Thus, these plugins are now the preferred option for publishing artifacts to Ivy and Maven repositories, respectively.
 
 ## Fixed issues
 

--- a/subprojects/docs/src/docs/userguide/publishingIvy.adoc
+++ b/subprojects/docs/src/docs/userguide/publishingIvy.adoc
@@ -135,23 +135,15 @@ Certain repositories are not able to handle all supported characters. For exampl
 Gradle will handle any valid Unicode character for organisation, module and revision (as well as artifact name, extension and classifier). The only values that are explicitly prohibited are `\`, `/` and any ISO control character. The supplied values are validated early during publication.
 
 [[sec:modifying_the_generated_module_descriptor]]
-==== Modifying the generated module descriptor
+==== Customizing the generated module descriptor
 
-At times, the module descriptor file generated from the project information will need to be tweaked before publishing. The Ivy Publish Plugin provides a hook to allow such modification.
+At times, the module descriptor file generated from the project information will need to be tweaked before publishing. The Ivy Publish Plugin provides a DSL for that purpose. Please see api:org.gradle.api.publish.ivy.IvyModuleDescriptorSpec[] in the DSL Reference for the complete documentation of available properties and methods. The following sample shows how to use the most common ones:
 
 ++++
 <sample dir="ivy-publish/descriptor-customization" id="publishing_ivy:descriptor-customization-snippet" title="Customizing the module descriptor file">
     <sourcefile file="build.gradle" snippet="customize-descriptor"/>
 </sample>
 ++++
-
-In this example we are simply adding a 'description' element to the generated Ivy dependency descriptor, but this hook allows you to modify any aspect of the generated descriptor. For example, you could replace the version range for a dependency with the actual version used to produce the build.
-
-See api:org.gradle.api.publish.ivy.IvyModuleDescriptorSpec#withXml(org.gradle.api.Action)[] in the API documentation for more information.
-
-It is possible to modify virtually any aspect of the created descriptor should you need to. This means that it is also possible to modify the descriptor in such a way that it is no longer a valid Ivy module descriptor, so care must be taken when using this feature.
-
-The identifier (organisation, module, revision) of the published module is an exception; these values cannot be modified in the descriptor using the `withXML` hook.
 
 [[sec:publishing_multiple_modules_to_ivy]]
 ==== Publishing multiple modules

--- a/subprojects/docs/src/samples/ivy-publish/descriptor-customization/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/descriptor-customization/build.gradle
@@ -7,9 +7,19 @@ publishing {
 // START SNIPPET customize-descriptor
     publications {
         ivyCustom(IvyPublication) {
-            descriptor.withXml {
-                asNode().info[0].appendNode('description',
-                                            'A demonstration of ivy descriptor customization')
+            descriptor {
+                license {
+                    name = 'The Apache License, Version 2.0'
+                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+                author {
+                    name = 'Jane Doe'
+                    url = 'http://example.com/users/jane'
+                }
+                description {
+                    text = 'A concise description of my library'
+                    homepage = 'http://www.example.com/library'
+                }
             }
         }
     }

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/build.gradle
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/build.gradle
@@ -51,8 +51,8 @@ subprojects {
                     conf "compile"
                 }
 // END SNIPPET publish-custom-artifact
-                descriptor.withXml {
-                    asNode().info[0].appendNode('description', description)
+                descriptor.description {
+                    text = description
                 }
 // START SNIPPET publish-custom-artifact
             }

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/output-ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/output-ivy.xml
@@ -1,7 +1,7 @@
 <!-- This file is an example of the Ivy module descriptor that this build will produce -->
 <!-- START SNIPPET content -->
 <?xml version="1.0" encoding="UTF-8"?>
-<ivy-module version="2.0">
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
   <info organisation="org.gradle.sample" module="project1" revision="1.0" status="integration" publication="«PUBLICATION-TIME-STAMP»">
     <description>The first project</description>
   </info>
@@ -11,7 +11,7 @@
     <conf name="runtime" visibility="public"/>
   </configurations>
   <publications>
-    <artifact name="project1" type="source" ext="jar" conf="compile" m:classifier="source" xmlns:m="http://ant.apache.org/ivy/maven"/>
+    <artifact name="project1" type="source" ext="jar" conf="compile" m:classifier="source"/>
     <artifact name="project1" type="jar" ext="jar" conf="compile"/>
   </publications>
   <dependencies>

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
@@ -27,9 +27,11 @@ class IvyDescriptor {
     String module
     String revision
     String status
-    String description
+    Node description
     String branch
     String resolver
+    NodeList licenses
+    NodeList authors
     Map<QName, String> extraInfo
 
     IvyDescriptor(File ivyFile) {
@@ -40,7 +42,9 @@ class IvyDescriptor {
         status = ivy.info[0].@status
         branch = ivy.info[0].@branch
         resolver = ivy.info[0].@resolver
-        description = ivy.info[0].description[0]?.text()
+        description = ivy.info[0].description[0]
+        licenses = ivy.info[0].license
+        authors = ivy.info[0].ivyauthor
 
         extraInfo = [:]
         ivy.info[0].children().findAll { it.name() instanceof QName }.each {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
@@ -71,6 +71,18 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
                         descriptor {
                             status "custom-status"
                             branch "custom-branch"
+                            license {
+                                name = 'The Apache License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                            author {
+                                name = 'Jane Doe'
+                                url = 'http://example.com/users/jane'
+                            }
+                            description {
+                                text = 'A concise description of my library'
+                                homepage = 'http://www.example.com/library'
+                            }
                             extraInfo 'http://my.extra.info1', 'foo', 'fooValue'
                             extraInfo 'http://my.extra.info2', 'bar', 'barValue'
                             withXml {
@@ -83,17 +95,26 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
         """
         succeeds 'publish'
 
-
         then:
         ":jar" in skippedTasks
 
         and:
-        module.parsedIvy.resolver == "test"
-        module.parsedIvy.status == "custom-status"
-        module.parsedIvy.branch == "custom-branch"
-        module.parsedIvy.extraInfo.size() == 2
-        module.parsedIvy.extraInfo[new QName('http://my.extra.info1', 'foo')] == 'fooValue'
-        module.parsedIvy.extraInfo[new QName('http://my.extra.info2', 'bar')] == 'barValue'
+        with (module.parsedIvy) {
+            resolver == "test"
+            status == "custom-status"
+            branch == "custom-branch"
+            licenses.size() == 1
+            licenses[0].@name == 'The Apache License, Version 2.0'
+            licenses[0].@url == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            authors.size() == 1
+            authors[0].@name == 'Jane Doe'
+            authors[0].@url == 'http://example.com/users/jane'
+            description.text() == "A concise description of my library"
+            description.@homepage == 'http://www.example.com/library'
+            extraInfo.size() == 2
+            extraInfo[new QName('http://my.extra.info1', 'foo')] == 'fooValue'
+            extraInfo[new QName('http://my.extra.info2', 'bar')] == 'barValue'
+        }
     }
 
     def "can generate ivy.xml without publishing"() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationKotlinDslIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationKotlinDslIntegTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
+
+import javax.xml.namespace.QName
+
+import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
+
+@Requires([KOTLIN_SCRIPT])
+class IvyPublishDescriptorCustomizationKotlinDslIntegTest extends AbstractIvyPublishIntegTest {
+
+    @Override
+    protected String getDefaultBuildFileName() {
+        'build.gradle.kts'
+    }
+
+    @Override
+    protected TestFile getSettingsFile() {
+        testDirectory.file('settings.gradle.kts')
+    }
+
+    def setup() {
+        requireOwnGradleUserHomeDir() // Isolate Kotlin DSL extensions API jar
+    }
+
+    def "can customize Ivy descriptor using Kotlin DSL"() {
+        given:
+        settingsFile << 'rootProject.name = "customizeIvy"'
+        buildFile << """
+            plugins {
+                `ivy-publish`
+            }
+
+            group = "org.gradle.test"
+            version = "1.0"
+
+            publishing {
+                repositories {
+                    ivy(url = "${ivyRepo.uri}")
+                }
+                publications {
+                    create<IvyPublication>("mavenCustom") {
+                        descriptor {
+                            status = "custom-status"
+                            branch = "custom-branch"
+                            license {
+                                name.set("The Apache License, Version 2.0")
+                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            }
+                            author {
+                                name.set("Jane Doe")
+                                url.set("http://example.com/users/jane")
+                            }
+                            description {
+                                text.set("A concise description of my library")
+                                homepage.set("http://www.example.com/library")
+                            }
+                            extraInfo("http://my.extra.info1", "foo", "fooValue")
+                            extraInfo("http://my.extra.info2", "bar", "barValue")
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module("org.gradle.test", "customizeIvy", "1.0")
+        with (module.parsedIvy) {
+            status == "custom-status"
+            branch == "custom-branch"
+            licenses.size() == 1
+            licenses[0].@name == 'The Apache License, Version 2.0'
+            licenses[0].@url == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            authors.size() == 1
+            authors[0].@name == 'Jane Doe'
+            authors[0].@url == 'http://example.com/users/jane'
+            description.text() == "A concise description of my library"
+            description.@homepage == 'http://www.example.com/library'
+            extraInfo.size() == 2
+            extraInfo[new QName('http://my.extra.info1', 'foo')] == 'fooValue'
+            extraInfo[new QName('http://my.extra.info2', 'bar')] == 'barValue'
+        }
+    }
+}

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultipleRepositoriesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultipleRepositoriesIntegTest.groovy
@@ -50,8 +50,8 @@ class IvyPublishMultipleRepositoriesIntegTest extends AbstractIntegrationSpec {
                 publications {
                     ivy(IvyPublication) {
                         from components.java
-                        descriptor.withXml {
-                            asNode().info[0].appendNode('description', 'test module')
+                        descriptor.description {
+                            text = 'test module'
                         }
                     }
                 }
@@ -81,8 +81,8 @@ class IvyPublishMultipleRepositoriesIntegTest extends AbstractIntegrationSpec {
         repo2Module.jarFile.exists()
 
         and: // Modification applied to both
-        repo1Module.parsedIvy.description == "test module"
-        repo2Module.parsedIvy.description == "test module"
+        repo1Module.parsedIvy.description.text() == "test module"
+        repo2Module.parsedIvy.description.text() == "test module"
     }
 
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
@@ -59,7 +59,7 @@ class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
         project1module.assertArtifactsPublished("project1-1.0.jar", "project1-1.0-source.jar", "ivy-1.0.xml")
 
         project1module.parsedIvy.configurations.keySet() == ['default', 'compile', 'runtime'] as Set
-        project1module.parsedIvy.description == "The first project"
+        project1module.parsedIvy.description.text() == "The first project"
         project1module.parsedIvy.assertDependsOn("junit:junit:4.12@compile", "org.gradle.sample:project2:1.0@compile")
 
         and:
@@ -67,7 +67,7 @@ class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
         project2module.assertArtifactsPublished("project2-1.0.jar", "project2-1.0-source.jar", "ivy-1.0.xml")
 
         project2module.parsedIvy.configurations.keySet() == ['default', 'compile', 'runtime'] as Set
-        project2module.parsedIvy.description == "The second project"
+        project2module.parsedIvy.description.text() == "The second project"
         project2module.parsedIvy.assertDependsOn('commons-collections:commons-collections:3.2.2@compile')
 
         def actualIvyXmlText = project1module.ivyFile.text.replaceFirst('publication="\\d+"', 'publication="«PUBLICATION-TIME-STAMP»"').trim()
@@ -88,7 +88,14 @@ class SamplesIvyPublishIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         module.assertPublished()
-        module.parsedIvy.description == "A demonstration of ivy descriptor customization"
+        with (module.parsedIvy) {
+            licenses[0].@name == 'The Apache License, Version 2.0'
+            licenses[0].@url == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            authors[0].@name == 'Jane Doe'
+            authors[0].@url == 'http://example.com/users/jane'
+            description.text() == "A concise description of my library"
+            description.@homepage == 'http://www.example.com/library'
+        }
         sampleProject.dir.file("build/generated-ivy.xml").assertExists()
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorAuthor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorAuthor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
+
+/**
+ * An author of an Ivy publication.
+ *
+ * @since 4.8
+ * @see IvyModuleDescriptorSpec
+ */
+@Incubating
+public interface IvyModuleDescriptorAuthor {
+
+    /**
+     * The name of this author.
+     */
+    Property<String> getName();
+
+    /**
+     * The URL of this author.
+     */
+    Property<String> getUrl();
+
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorDescription.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorDescription.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
+
+/**
+ * The description of an Ivy publication.
+ *
+ * @since 4.8
+ * @see IvyModuleDescriptorSpec
+ */
+@Incubating
+public interface IvyModuleDescriptorDescription {
+
+    /**
+     * The text of this description.
+     */
+    Property<String> getText();
+
+    /**
+     * The homepage of the publication of this description.
+     */
+    Property<String> getHomepage();
+
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorLicense.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorLicense.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
+
+/**
+ * A license of an Ivy publication.
+ *
+ * @since 4.8
+ * @see IvyModuleDescriptorSpec
+ */
+@Incubating
+public interface IvyModuleDescriptorLicense {
+
+    /**
+     * The name of this license.
+     */
+    Property<String> getName();
+
+    /**
+     * The URL of this license.
+     */
+    Property<String> getUrl();
+
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorSpec.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.XmlProvider;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -28,6 +29,8 @@ import javax.annotation.Nullable;
  * Corresponds to the <a href="http://ant.apache.org/ivy/history/latest-milestone/ivyfile.html">XML version of the Ivy Module Descriptor</a>.
  * <p>
  * The {@link #withXml(org.gradle.api.Action)} method can be used to modify the descriptor after it has been generated according to the publication data.
+ * However, the preferred way to customize the project information to be published is to use the dedicated configuration methods exposed by this class, e.g.
+ * {@link #description(Action)}.
  *
  * @since 1.3
  */
@@ -100,4 +103,29 @@ public interface IvyModuleDescriptorSpec {
      * Adds a new extra info element to the publication
      */
     void extraInfo(String namespace, String elementName, String value);
+
+    /**
+     * Creates, configures and adds a license to this publication.
+     *
+     * @since 4.8
+     */
+    @Incubating
+    void license(Action<? super IvyModuleDescriptorLicense> action);
+
+    /**
+     * Creates, configures and adds an author to this publication.
+     *
+     * @since 4.8
+     */
+    @Incubating
+    void author(Action<? super IvyModuleDescriptorAuthor> action);
+
+    /**
+     * Configures the description for this publication.
+     *
+     * @since 4.8
+     */
+    @Incubating
+    void description(Action<? super IvyModuleDescriptorDescription> action);
+
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -55,6 +55,8 @@ import org.gradle.internal.HasInternalProtocol;
  * You can also completely replace the set of published artifacts using {@link #setArtifacts(Iterable)}.
  * Together, these methods give you full control over the artifacts to be published.
  * </p><p>
+ * In addition, {@link IvyModuleDescriptorSpec} provides configuration methods to customize licenses, authors, and the description to be published in the Ivy module descriptor.
+ * </p><p>
  * For any other tweaks to the publication, it is possible to modify the generated Ivy descriptor file prior to publication. This is done using
  * the {@link IvyModuleDescriptorSpec#withXml(org.gradle.api.Action)} method, normally via a Closure passed to the {@link #descriptor(org.gradle.api.Action)} method.
  * </p>
@@ -77,8 +79,16 @@ import org.gradle.internal.HasInternalProtocol;
  *         extension "src.jar"
  *         conf "runtime"
  *       }
- *       descriptor.withXml {
- *         asNode().info[0].appendNode("description", "custom-description")
+ *       descriptor {
+ *         license {
+ *           name = "Custom License"
+ *         }
+ *         author {
+ *           name = "Custom Name"
+ *         }
+ *         description {
+ *           text = "Custom Description"
+ *         }
  *       }
  *     }
  *   }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorAuthor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorAuthor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy.internal.publication;
+
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor;
+
+public class DefaultIvyModuleDescriptorAuthor implements IvyModuleDescriptorAuthor {
+
+    private final Property<String> name;
+    private final Property<String> url;
+
+    public DefaultIvyModuleDescriptorAuthor(ObjectFactory objectFactory) {
+        name = objectFactory.property(String.class);
+        url = objectFactory.property(String.class);
+    }
+
+    @Override
+    public Property<String> getName() {
+        return name;
+    }
+
+    @Override
+    public Property<String> getUrl() {
+        return url;
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorDescription.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorDescription.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy.internal.publication;
+
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorDescription;
+
+public class DefaultIvyModuleDescriptorDescription implements IvyModuleDescriptorDescription {
+
+    private final Property<String> text;
+    private final Property<String> homepage;
+
+    public DefaultIvyModuleDescriptorDescription(ObjectFactory objectFactory) {
+        text = objectFactory.property(String.class);
+        homepage = objectFactory.property(String.class);
+    }
+
+    @Override
+    public Property<String> getText() {
+        return text;
+    }
+
+    @Override
+    public Property<String> getHomepage() {
+        return homepage;
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorLicense.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorLicense.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy.internal.publication;
+
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorLicense;
+
+public class DefaultIvyModuleDescriptorLicense implements IvyModuleDescriptorLicense {
+
+    private final Property<String> name;
+    private final Property<String> url;
+
+    public DefaultIvyModuleDescriptorLicense(ObjectFactory objectFactory) {
+        name = objectFactory.property(String.class);
+        url = objectFactory.property(String.class);
+    }
+
+    @Override
+    public Property<String> getName() {
+        return name;
+    }
+
+    @Override
+    public Property<String> getUrl() {
+        return url;
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpec.java
@@ -21,27 +21,40 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.internal.UserCodeAction;
 import org.gradle.api.internal.artifacts.Module;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.ivy.IvyArtifact;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor;
 import org.gradle.api.publish.ivy.IvyConfiguration;
-
+import org.gradle.api.publish.ivy.IvyModuleDescriptorDescription;
 import org.gradle.api.publish.ivy.IvyExtraInfoSpec;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorLicense;
 import org.gradle.api.publish.ivy.internal.dependency.IvyDependencyInternal;
 import org.gradle.api.publish.ivy.internal.dependency.IvyExcludeRule;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 import org.gradle.internal.MutableActionSet;
+import org.gradle.internal.reflect.Instantiator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class DefaultIvyModuleDescriptorSpec implements IvyModuleDescriptorSpecInternal {
 
     private final MutableActionSet<XmlProvider> xmlActions = new MutableActionSet<XmlProvider>();
     private final IvyPublicationInternal ivyPublication;
+    private final Instantiator instantiator;
+    private final ObjectFactory objectFactory;
     private String status = Module.DEFAULT_STATUS;
     private String branch;
     private IvyExtraInfoSpec extraInfo = new DefaultIvyExtraInfoSpec();
+    private final List<IvyModuleDescriptorAuthor> authors = new ArrayList<IvyModuleDescriptorAuthor>();
+    private final List<IvyModuleDescriptorLicense> licenses = new ArrayList<IvyModuleDescriptorLicense>();
+    private IvyModuleDescriptorDescription description;
 
-    public DefaultIvyModuleDescriptorSpec(IvyPublicationInternal ivyPublication) {
+    public DefaultIvyModuleDescriptorSpec(IvyPublicationInternal ivyPublication, Instantiator instantiator, ObjectFactory objectFactory) {
         this.ivyPublication = ivyPublication;
+        this.instantiator = instantiator;
+        this.objectFactory = objectFactory;
     }
 
     public String getStatus() {
@@ -101,5 +114,44 @@ public class DefaultIvyModuleDescriptorSpec implements IvyModuleDescriptorSpecIn
     @Override
     public Set<IvyExcludeRule> getGlobalExcludes() {
         return ivyPublication.getGlobalExcludes();
+    }
+
+    @Override
+    public void license(Action<? super IvyModuleDescriptorLicense> action) {
+        configureAndAdd(DefaultIvyModuleDescriptorLicense.class, action, licenses);
+    }
+
+    @Override
+    public List<IvyModuleDescriptorLicense> getLicenses() {
+        return licenses;
+    }
+
+    @Override
+    public void author(Action<? super IvyModuleDescriptorAuthor> action) {
+        configureAndAdd(DefaultIvyModuleDescriptorAuthor.class, action, authors);
+    }
+
+    @Override
+    public List<IvyModuleDescriptorAuthor> getAuthors() {
+        return authors;
+    }
+
+    @Override
+    public void description(Action<? super IvyModuleDescriptorDescription> action) {
+        if (description == null) {
+            description = instantiator.newInstance(DefaultIvyModuleDescriptorDescription.class, objectFactory);
+        }
+        action.execute(description);
+    }
+
+    @Override
+    public IvyModuleDescriptorDescription getDescription() {
+        return description;
+    }
+
+    private <T> void configureAndAdd(Class<? extends T> clazz, Action<? super T> action, List<T> items) {
+        T item = instantiator.newInstance(clazz, objectFactory);
+        action.execute(item);
+        items.add(item);
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -44,6 +44,7 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
 import org.gradle.api.publish.internal.DefaultPublicationArtifactSet;
 import org.gradle.api.publish.internal.PublicationArtifactSet;
@@ -116,7 +117,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private boolean artifactsOverridden;
 
     public DefaultIvyPublication(
-        String name, Instantiator instantiator, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
+        String name, Instantiator instantiator, ObjectFactory objectFactory, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
         ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
         ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews) {
         this.name = name;
@@ -130,7 +131,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         derivedArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory);
         publishableArtifacts = new CompositePublicationArtifactSet<IvyArtifact>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class);
-        descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this);
+        descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
     }
 
     public String getName() {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyModuleDescriptorSpecInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyModuleDescriptorSpecInternal.java
@@ -19,12 +19,16 @@ package org.gradle.api.publish.ivy.internal.publication;
 import org.gradle.api.Action;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.publish.ivy.IvyArtifact;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor;
 import org.gradle.api.publish.ivy.IvyConfiguration;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorDescription;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorLicense;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorSpec;
 import org.gradle.api.publish.ivy.internal.dependency.IvyDependencyInternal;
 import org.gradle.api.publish.ivy.internal.dependency.IvyExcludeRule;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 
+import java.util.List;
 import java.util.Set;
 
 public interface IvyModuleDescriptorSpecInternal extends IvyModuleDescriptorSpec {
@@ -40,4 +44,10 @@ public interface IvyModuleDescriptorSpecInternal extends IvyModuleDescriptorSpec
     Set<IvyExcludeRule> getGlobalExcludes();
 
     Action<XmlProvider> getXmlAction();
+
+    List<IvyModuleDescriptorAuthor> getAuthors();
+
+    List<IvyModuleDescriptorLicense> getLicenses();
+
+    IvyModuleDescriptorDescription getDescription();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
@@ -19,7 +19,9 @@ package org.gradle.api.publish.ivy.tasks;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.publish.ivy.IvyArtifact;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor;
 import org.gradle.api.publish.ivy.IvyConfiguration;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorLicense;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorSpec;
 import org.gradle.api.publish.ivy.internal.dependency.IvyDependencyInternal;
 import org.gradle.api.publish.ivy.internal.dependency.IvyExcludeRule;
@@ -107,6 +109,16 @@ public class GenerateIvyDescriptor extends DefaultTask {
         ivyGenerator.setStatus(descriptorInternal.getStatus());
         ivyGenerator.setBranch(descriptorInternal.getBranch());
         ivyGenerator.setExtraInfo(descriptorInternal.getExtraInfo().asMap());
+
+        for (IvyModuleDescriptorAuthor ivyAuthor : descriptorInternal.getAuthors()) {
+            ivyGenerator.addAuthor(ivyAuthor);
+        }
+
+        for (IvyModuleDescriptorLicense ivyLicense : descriptorInternal.getLicenses()) {
+            ivyGenerator.addLicense(ivyLicense);
+        }
+
+        ivyGenerator.setDescription(descriptorInternal.getDescription());
 
         for (IvyConfiguration ivyConfiguration : descriptorInternal.getConfigurations()) {
             ivyGenerator.addConfiguration(ivyConfiguration);

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpecTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpecTest.groovy
@@ -16,14 +16,18 @@
 
 package org.gradle.api.publish.ivy.internal.publication
 
-import javax.xml.namespace.QName
 import org.gradle.api.InvalidUserDataException
+import org.gradle.internal.reflect.DirectInstantiator
 import spock.lang.Specification
 
-class DefaultIvyModuleDescriptorSpecTest extends Specification {
-    def "getExtraInfo returns IvyExtraInfo with immutable map" () {
-        def spec = new DefaultIvyModuleDescriptorSpec(Stub(IvyPublicationInternal))
+import javax.xml.namespace.QName
 
+import static org.gradle.util.TestUtil.objectFactory
+
+class DefaultIvyModuleDescriptorSpecTest extends Specification {
+    def spec = new DefaultIvyModuleDescriptorSpec(Stub(IvyPublicationInternal), DirectInstantiator.INSTANCE, objectFactory())
+
+    def "getExtraInfo returns IvyExtraInfo with immutable map" () {
         when:
         spec.getExtraInfo().asMap().put(new QName('http://some.namespace', 'foo'), 'fooValue')
 
@@ -32,8 +36,6 @@ class DefaultIvyModuleDescriptorSpecTest extends Specification {
     }
 
     def "can add extra info elements" () {
-        def spec = new DefaultIvyModuleDescriptorSpec(Stub(IvyPublicationInternal))
-
         when:
         spec.extraInfo 'http://some.namespace', 'foo', 'fooValue'
 
@@ -42,8 +44,6 @@ class DefaultIvyModuleDescriptorSpecTest extends Specification {
     }
 
     def "cannot add extra info elements with null values" () {
-        def spec = new DefaultIvyModuleDescriptorSpec(Stub(IvyPublicationInternal))
-
         when:
         spec.extraInfo namespace, name, 'fooValue'
 

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -37,6 +37,8 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.model.DefaultObjectFactory
+import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.ivy.IvyArtifact
 import org.gradle.api.tasks.TaskOutputs
@@ -53,6 +55,7 @@ class DefaultIvyPublicationTest extends Specification {
     TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
 
     Instantiator instantiator = new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE)
+    def objectFactory = new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE)
     def projectIdentity = new DefaultIvyPublicationIdentity("organisation", "module", "revision")
     def notationParser = Mock(NotationParser)
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
@@ -281,6 +284,7 @@ class DefaultIvyPublicationTest extends Specification {
         def publication = instantiator.newInstance(DefaultIvyPublication,
             "pub-name",
             instantiator,
+            objectFactory,
             projectIdentity,
             notationParser,
             projectDependencyResolver,
@@ -364,6 +368,7 @@ class DefaultIvyPublicationTest extends Specification {
         def publication = instantiator.newInstance(DefaultIvyPublication,
             "pub-name",
             instantiator,
+            objectFactory,
             projectIdentity,
             notationParser,
             projectDependencyResolver,

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
@@ -23,6 +23,9 @@ import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.publish.ivy.internal.artifact.FileBasedIvyArtifact
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyDependency
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyConfiguration
+import org.gradle.api.publish.ivy.internal.publication.DefaultIvyModuleDescriptorAuthor
+import org.gradle.api.publish.ivy.internal.publication.DefaultIvyModuleDescriptorDescription
+import org.gradle.api.publish.ivy.internal.publication.DefaultIvyModuleDescriptorLicense
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublicationIdentity
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -31,6 +34,8 @@ import org.junit.Rule
 import spock.lang.Specification
 
 import javax.xml.namespace.QName
+
+import static org.gradle.util.TestUtil.objectFactory
 
 class IvyDescriptorFileGeneratorTest extends Specification {
     @Rule
@@ -92,6 +97,83 @@ class IvyDescriptorFileGeneratorTest extends Specification {
 
         then:
         ivyXml.info.@branch == "someBranch"
+    }
+
+    def "writes supplied licenses" () {
+        given:
+        def objectFactory = objectFactory()
+        def license1 = new DefaultIvyModuleDescriptorLicense(objectFactory)
+        license1.name.set("EPL v2.0")
+        def license2 = new DefaultIvyModuleDescriptorLicense(objectFactory)
+        license2.name.set("Apache v2.0")
+        license2.url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+
+        when:
+        generator.addLicense(license1)
+        generator.addLicense(license2)
+
+        then:
+        with (ivyXml.info) {
+            license.size() == 2
+            license[0].@name == "EPL v2.0"
+            license[0].@url.isEmpty()
+            license[1].@name == "Apache v2.0"
+            license[1].@url == "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+    }
+
+    def "writes supplied authors" () {
+        given:
+        def objectFactory = objectFactory()
+        def author1 = new DefaultIvyModuleDescriptorAuthor(objectFactory)
+        author1.name.set("Alice")
+        def author2 = new DefaultIvyModuleDescriptorAuthor(objectFactory)
+        author2.name.set("Bob")
+        author2.url.set("http://example.com/bob/")
+
+        when:
+        generator.addAuthor(author1)
+        generator.addAuthor(author2)
+
+        then:
+        with (ivyXml.info) {
+            ivyauthor.size() == 2
+            ivyauthor[0].@name == "Alice"
+            ivyauthor[0].@url.isEmpty()
+            ivyauthor[1].@name == "Bob"
+            ivyauthor[1].@url == "http://example.com/bob/"
+        }
+    }
+
+    def "writes supplied description" () {
+        given:
+        def description = new DefaultIvyModuleDescriptorDescription(objectFactory())
+        description.text.set("Some lengthy description.")
+        description.homepage.set("http://example.com")
+
+        when:
+        generator.description = description
+
+        then:
+        with (ivyXml) {
+            info.description[0].text() == "Some lengthy description."
+            info.description[0].@homepage == "http://example.com"
+        }
+    }
+
+    def "writes supplied description without text" () {
+        given:
+        def description = new DefaultIvyModuleDescriptorDescription(objectFactory())
+        description.homepage.set("http://example.com")
+
+        when:
+        generator.description = description
+
+        then:
+        with (ivyXml) {
+            info.description[0].text() == ""
+            info.description[0].@homepage == "http://example.com"
+        }
     }
 
     def "writes supplied extra info elements" () {


### PR DESCRIPTION
This PR adds a type safe DSL for customizing the generated Ivy module descriptor of an IvyPublication to the ivy-publish plugin:

```gradle
descriptor {
  license {
    name = 'The Apache License, Version 2.0'
    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
  }
  author {
    name = 'Jane Doe'
    url = 'http://example.com/users/jane'
  }
  description {
    text = 'A concise description of my library'
    homepage = 'http://www.example.com/library'
  }
}
```

Only interfaces are exposed as part of the public API, all of them are prefixed with `IvyModuleDescriptor`. The exposed properties make use of the Provider API.

In addition, the new DSL is documented in the User Guide, DSL Reference and Release Notes.

Resolves #5193.