### PR TITLE
WIP - Add build ops for task registration / creation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/ExecuteTaskBuildOperationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/ExecuteTaskBuildOperationDetails.java
@@ -47,7 +47,7 @@ public class ExecuteTaskBuildOperationDetails implements ExecuteTaskBuildOperati
 
     @Override
     public long getTaskId() {
-        return (long) System.identityHashCode(task);
+        return task.getInternalTaskInstanceId();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -100,4 +100,7 @@ public interface TaskInternal extends Task, Configurable<Task> {
 
     @Internal
     Path getIdentityPath();
+
+    @Internal
+    long getInternalTaskInstanceId();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -49,6 +49,11 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
         return process(taskFactory.create(name, type, args));
     }
 
+    @Override
+    public <S extends Task> S create(Long internalTaskInstanceId, String name, Class<S> type, Object... args) {
+        return process(taskFactory.create(internalTaskInstanceId, name, type, args));
+    }
+
     private <S extends Task> S process(S task) {
         TaskClassInfo taskClassInfo = taskClassInfoStore.getTaskClassInfo(task.getClass());
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -45,11 +45,6 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
     }
 
     @Override
-    public <S extends Task> S create(String name, Class<S> type, Object... args) {
-        return process(taskFactory.create(name, type, args));
-    }
-
-    @Override
     public <S extends Task> S create(Long internalTaskInstanceId, String name, Class<S> type, Object... args) {
         return process(taskFactory.create(internalTaskInstanceId, name, type, args));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
@@ -23,7 +23,5 @@ import org.gradle.model.internal.core.NamedEntityInstantiator;
 public interface ITaskFactory extends NamedEntityInstantiator<Task> {
     ITaskFactory createChild(ProjectInternal project, Instantiator instantiator);
 
-    <S extends Task> S create(String name, Class<S> type, Object... args);
-
     <S extends Task> S create(Long internalTaskInstanceId, String name, Class<S> type, Object... args);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InternalTaskInstanceIdSequence.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/InternalTaskInstanceIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.internal.project.taskfactory;
 
-import org.gradle.api.Task;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.internal.reflect.Instantiator;
-import org.gradle.model.internal.core.NamedEntityInstantiator;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public interface ITaskFactory extends NamedEntityInstantiator<Task> {
-    ITaskFactory createChild(ProjectInternal project, Instantiator instantiator);
+public final class InternalTaskInstanceIdSequence {
 
-    <S extends Task> S create(String name, Class<S> type, Object... args);
+    private static final AtomicInteger SEQUENCE = new AtomicInteger();
 
-    <S extends Task> S create(Long internalTaskInstanceId, String name, Class<S> type, Object... args);
+    public static long getNextId() {
+        return SEQUENCE.incrementAndGet();
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -56,6 +56,11 @@ public class TaskFactory implements ITaskFactory {
 
     @Override
     public <S extends Task> S create(String name, final Class<S> type, final Object... args) {
+        return create(null, name, type, args);
+    }
+
+    @Override
+    public <S extends Task> S create(Long internalTaskInstanceId, String name, final Class<S> type, final Object... args) {
         if (!Task.class.isAssignableFrom(type)) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task of type '%s' as it does not implement the Task interface.",
@@ -70,7 +75,8 @@ public class TaskFactory implements ITaskFactory {
             generatedType = generator.generate(type);
         }
 
-        return type.cast(AbstractTask.injectIntoNewInstance(project, name, type, new Callable<Task>() {
+        long id = internalTaskInstanceId == null ? InternalTaskInstanceIdSequence.getNextId() : internalTaskInstanceId;
+        return type.cast(AbstractTask.injectIntoNewInstance(id, project, name, type, new Callable<Task>() {
             public Task call() throws Exception {
                 try {
                     return instantiator.newInstance(generatedType, args);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -51,12 +51,7 @@ public class TaskFactory implements ITaskFactory {
 
     @Override
     public <S extends Task> S create(String name, Class<S> type) {
-        return create(name, type, NO_ARGS);
-    }
-
-    @Override
-    public <S extends Task> S create(String name, final Class<S> type, final Object... args) {
-        return create(null, name, type, args);
+        return create(null, name, type, NO_ARGS);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CreateTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CreateTaskBuildOperationType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+/**
+ * Represents a creation request for a task. Actual task may be realized later.
+ *
+ * @since 4.9
+ */
+public final class CreateTaskBuildOperationType implements BuildOperationType<CreateTaskBuildOperationType.Details, CreateTaskBuildOperationType.Result> {
+
+    @UsedByScanPlugin
+    public interface Details {
+        String getBuildPath();
+
+        String getTaskPath();
+
+        /**
+         * An ID for the task, that disambiguates it from other tasks with the same path.
+         *
+         * Due to a bug in Gradle, two tasks with the same path can be executed.
+         * This is very problematic for build scans.
+         * As such, scans need to be able to differentiate between different tasks with the same path.
+         * The combination of the path and ID does this.
+         *
+         * In later versions of Gradle, executing two tasks with the same path will be prevented
+         * and this value can be noop-ed.
+         */
+        long getTaskId();
+
+        boolean isReplacement();
+
+        boolean isEager();
+    }
+
+    @UsedByScanPlugin
+    public interface Result {
+    }
+
+    private CreateTaskBuildOperationType() {
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CreateTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/CreateTaskBuildOperationType.java
@@ -28,26 +28,26 @@ public final class CreateTaskBuildOperationType implements BuildOperationType<Cr
 
     @UsedByScanPlugin
     public interface Details {
-        String getBuildPath();
-
-        String getTaskPath();
-
-        /**
-         * An ID for the task, that disambiguates it from other tasks with the same path.
-         *
-         * Due to a bug in Gradle, two tasks with the same path can be executed.
-         * This is very problematic for build scans.
-         * As such, scans need to be able to differentiate between different tasks with the same path.
-         * The combination of the path and ID does this.
-         *
-         * In later versions of Gradle, executing two tasks with the same path will be prevented
-         * and this value can be noop-ed.
-         */
-        long getTaskId();
-
-        boolean isReplacement();
-
-        boolean isEager();
+//        String getBuildPath();
+//
+//        String getTaskPath();
+//
+//        /**
+//         * An ID for the task, that disambiguates it from other tasks with the same path.
+//         *
+//         * Due to a bug in Gradle, two tasks with the same path can be executed.
+//         * This is very problematic for build scans.
+//         * As such, scans need to be able to differentiate between different tasks with the same path.
+//         * The combination of the path and ID does this.
+//         *
+//         * In later versions of Gradle, executing two tasks with the same path will be prevented
+//         * and this value can be noop-ed.
+//         */
+//        long getTaskId();
+//
+//        boolean isReplacement();
+//
+//        boolean isEager();
     }
 
     @UsedByScanPlugin

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -268,14 +268,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                 T task = factory.apply(taskId);
                 addTask(task, replacement);
                 statistics.eagerTask(type);
-                context.setResult(new CreateTaskBuildOperationType.Result(){});
+//                context.setResult(new CreateTaskBuildOperationType.Result(){});
                 return task;
             }
 
             @Override
             public BuildOperationDescriptor.Builder description() {
 //                return new CreateTaskBuildOperationDetails(name, taskId, replacement, true).descriptor();
-                return new CreateTaskBuildOperationDetails().descriptor();
+                return BuildOperationDescriptor.displayName("create task " + taskId);
             }
         });
     }
@@ -286,14 +286,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             @Override
             public TaskCreatingProvider<T> call(BuildOperationContext context) {
                 TaskCreatingProvider<T> provider = new TaskCreatingProvider<T>(taskId, type, name, configurationAction);
-                context.setResult(new RegisterTaskBuildOperationType.Result(){});
+//                context.setResult(new RegisterTaskBuildOperationType.Result(){});
                 return provider;
             }
 
             @Override
             public BuildOperationDescriptor.Builder description() {
 //                return new RegisterTaskBuildOperationDetails(name, taskId, replacement).descriptor();
-                return new RegisterTaskBuildOperationDetails().descriptor();
+                return BuildOperationDescriptor.displayName("register task " + taskId);
             }
         });
     }
@@ -304,14 +304,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             public T call(BuildOperationContext context) {
                 T task = createTask(taskId, name, type, constructorArgs);
                 statistics.lazyTaskRealized(type);
-                context.setResult(new CreateTaskBuildOperationType.Result(){});
+//                context.setResult(new CreateTaskBuildOperationType.Result(){});
                 return task;
             }
 
             @Override
             public BuildOperationDescriptor.Builder description() {
 //                return new CreateTaskBuildOperationDetails(name, taskId, false, false).descriptor();
-                return new CreateTaskBuildOperationDetails().descriptor();
+                return BuildOperationDescriptor.displayName("realize task " + taskId);
             }
         });
     }
@@ -662,8 +662,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 //            return BuildOperationDescriptor.displayName(sb.toString())
             return BuildOperationDescriptor.displayName("create")
 //                .name(taskPath)
-                .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
-                .details(this);
+                .operationType(BuildOperationCategory.CONFIGURE_PROJECT); // or TASK?
+//                .details(this);
         }
     }
 
@@ -711,8 +711,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 //            }
             return BuildOperationDescriptor.displayName("register")
 //                .name(taskPath)
-                .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
-                .details(this);
+                .operationType(BuildOperationCategory.CONFIGURE_PROJECT); // or TASK?
+//                .details(this);
 
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -274,11 +274,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                CreateTaskBuildOperationDetails details = new CreateTaskBuildOperationDetails(name, taskId, replacement, true);
-                return BuildOperationDescriptor.displayName("Create task " + details.taskPath + " of type " + type.getName() + " (eager)")
-                    .name(name)
-                    .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
-                    .details(details);
+                return new CreateTaskBuildOperationDetails(name, taskId, replacement, true).descriptor();
             }
         });
     }
@@ -295,11 +291,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                RegisterTaskBuildOperationDetails details = new RegisterTaskBuildOperationDetails(name, taskId, replacement);
-                return BuildOperationDescriptor.displayName("Register task " + details.taskPath + " of type " + type.getName())
-                    .name(name)
-                    .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
-                    .details(details);
+                return new RegisterTaskBuildOperationDetails(name, taskId, replacement).descriptor();
             }
         });
     }
@@ -316,11 +308,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                CreateTaskBuildOperationDetails details = new CreateTaskBuildOperationDetails(name, taskId, false, false);
-                return BuildOperationDescriptor.displayName("Create task " + details.taskPath + " of type " + type.getName() + " (deferred)")
-                    .name(name)
-                    .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
-                    .details(details);
+                return new CreateTaskBuildOperationDetails(name, taskId, false, false).descriptor();
             }
         });
     }
@@ -660,9 +648,20 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         public boolean isEager() {
             return eager;
         }
+
+        private BuildOperationDescriptor.Builder descriptor() {
+            StringBuilder sb = new StringBuilder("Create task ").append(taskPath).append(" (").append(eager ? "eager" : "deferred").append(")");
+            if (replacement) {
+                sb.append(" (replacement)");
+            }
+            return BuildOperationDescriptor.displayName(sb.toString())
+                .name(taskPath)
+                .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
+                .details(this);
+        }
     }
 
-    private final class RegisterTaskBuildOperationDetails implements RegisterTaskBuildOperationType.Details  {
+    private final class RegisterTaskBuildOperationDetails implements RegisterTaskBuildOperationType.Details {
 
         private final String buildPath;
         private final String taskPath;
@@ -694,6 +693,19 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         @Override
         public boolean isReplacement() {
             return replacement;
+        }
+
+
+        private BuildOperationDescriptor.Builder descriptor() {
+            StringBuilder sb = new StringBuilder("Register task ").append(taskPath);
+            if (replacement) {
+                sb.append(" (replacement)");
+            }
+            return BuildOperationDescriptor.displayName(sb.toString())
+                .name(taskPath)
+                .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
+                .details(this);
+
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -274,7 +274,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return new CreateTaskBuildOperationDetails(name, taskId, replacement, true).descriptor();
+//                return new CreateTaskBuildOperationDetails(name, taskId, replacement, true).descriptor();
+                return new CreateTaskBuildOperationDetails().descriptor();
             }
         });
     }
@@ -291,7 +292,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return new RegisterTaskBuildOperationDetails(name, taskId, replacement).descriptor();
+//                return new RegisterTaskBuildOperationDetails(name, taskId, replacement).descriptor();
+                return new RegisterTaskBuildOperationDetails().descriptor();
             }
         });
     }
@@ -308,7 +310,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return new CreateTaskBuildOperationDetails(name, taskId, false, false).descriptor();
+//                return new CreateTaskBuildOperationDetails(name, taskId, false, false).descriptor();
+                return new CreateTaskBuildOperationDetails().descriptor();
             }
         });
     }
@@ -610,52 +613,55 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     private final class CreateTaskBuildOperationDetails implements CreateTaskBuildOperationType.Details  {
 
-        private final String buildPath;
-        private final String taskPath;
-        private final long taskId;
-        private final boolean replacement;
-        private final boolean eager;
-
-        private CreateTaskBuildOperationDetails(String name, long taskId, boolean replacement, boolean eager) {
-            this.eager = eager;
-            this.buildPath = project.getBuildPath().getPath();
-            this.taskPath = project.getProjectPath().child(name).getPath();
-            this.taskId = taskId;
-            this.replacement = replacement;
+        private CreateTaskBuildOperationDetails() {
         }
-
-        @Override
-        public String getBuildPath() {
-            return buildPath;
-        }
-
-        @Override
-        public String getTaskPath() {
-            return taskPath;
-        }
-
-        @Override
-        public long getTaskId() {
-            return taskId;
-        }
-
-        @Override
-        public boolean isReplacement() {
-            return replacement;
-        }
-
-        @Override
-        public boolean isEager() {
-            return eager;
-        }
+//        private final String buildPath;
+//        private final String taskPath;
+//        private final long taskId;
+//        private final boolean replacement;
+//        private final boolean eager;
+//
+//        private CreateTaskBuildOperationDetails(String name, long taskId, boolean replacement, boolean eager) {
+//            this.eager = eager;
+//            this.buildPath = project.getBuildPath().getPath();
+//            this.taskPath = project.getProjectPath().child(name).getPath();
+//            this.taskId = taskId;
+//            this.replacement = replacement;
+//        }
+//
+//        @Override
+//        public String getBuildPath() {
+//            return buildPath;
+//        }
+//
+//        @Override
+//        public String getTaskPath() {
+//            return taskPath;
+//        }
+//
+//        @Override
+//        public long getTaskId() {
+//            return taskId;
+//        }
+//
+//        @Override
+//        public boolean isReplacement() {
+//            return replacement;
+//        }
+//
+//        @Override
+//        public boolean isEager() {
+//            return eager;
+//        }
 
         private BuildOperationDescriptor.Builder descriptor() {
-            StringBuilder sb = new StringBuilder("Create task ").append(taskPath).append(" (").append(eager ? "eager" : "deferred").append(")");
-            if (replacement) {
-                sb.append(" (replacement)");
-            }
-            return BuildOperationDescriptor.displayName(sb.toString())
-                .name(taskPath)
+//            StringBuilder sb = new StringBuilder("Create task ").append(taskPath).append(" (").append(eager ? "eager" : "deferred").append(")");
+//            if (replacement) {
+//                sb.append(" (replacement)");
+//            }
+//            return BuildOperationDescriptor.displayName(sb.toString())
+            return BuildOperationDescriptor.displayName("create")
+//                .name(taskPath)
                 .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
                 .details(this);
         }
@@ -663,46 +669,48 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     private final class RegisterTaskBuildOperationDetails implements RegisterTaskBuildOperationType.Details {
 
-        private final String buildPath;
-        private final String taskPath;
-        private final long taskId;
-        private final boolean replacement;
-
-        private RegisterTaskBuildOperationDetails(String name, long taskId, boolean replacement) {
-            this.buildPath = project.getBuildPath().getPath();
-            this.taskPath = project.getProjectPath().child(name).getPath();
-            this.taskId = taskId;
-            this.replacement = replacement;
+        private RegisterTaskBuildOperationDetails() {
         }
-
-        @Override
-        public String getBuildPath() {
-            return buildPath;
-        }
-
-        @Override
-        public String getTaskPath() {
-            return taskPath;
-        }
-
-        @Override
-        public long getTaskId() {
-            return taskId;
-        }
-
-        @Override
-        public boolean isReplacement() {
-            return replacement;
-        }
+//        private final String buildPath;
+//        private final String taskPath;
+//        private final long taskId;
+//        private final boolean replacement;
+//
+//        private RegisterTaskBuildOperationDetails(String name, long taskId, boolean replacement) {
+//            this.buildPath = project.getBuildPath().getPath();
+//            this.taskPath = project.getProjectPath().child(name).getPath();
+//            this.taskId = taskId;
+//            this.replacement = replacement;
+//        }
+//
+//        @Override
+//        public String getBuildPath() {
+//            return buildPath;
+//        }
+//
+//        @Override
+//        public String getTaskPath() {
+//            return taskPath;
+//        }
+//
+//        @Override
+//        public long getTaskId() {
+//            return taskId;
+//        }
+//
+//        @Override
+//        public boolean isReplacement() {
+//            return replacement;
+//        }
 
 
         private BuildOperationDescriptor.Builder descriptor() {
-            StringBuilder sb = new StringBuilder("Register task ").append(taskPath);
-            if (replacement) {
-                sb.append(" (replacement)");
-            }
-            return BuildOperationDescriptor.displayName(sb.toString())
-                .name(taskPath)
+//            StringBuilder sb = new StringBuilder("Register task ").append(taskPath);
+//            if (replacement) {
+//                sb.append(" (replacement)");
+//            }
+            return BuildOperationDescriptor.displayName("register")
+//                .name(taskPath)
                 .operationType(BuildOperationCategory.CONFIGURE_PROJECT) // or TASK?
                 .details(this);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -274,20 +274,21 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     private <T extends Task> TaskCreatingProvider<T> registerTask(final boolean replacement, final String name, final Class<T> type, final Action<? super T> configurationAction) {
         final long taskId = InternalTaskInstanceIdSequence.getNextId();
-        return buildOperationExecutor.call(new CallableBuildOperation<TaskCreatingProvider<T>>() {
-            @Override
-            public TaskCreatingProvider<T> call(BuildOperationContext context) {
-                TaskCreatingProvider<T> provider = new TaskCreatingProvider<T>(taskId, type, name, configurationAction);
-//                context.setResult(new RegisterTaskBuildOperationType.Result(){});
-                return provider;
-            }
-
-            @Override
-            public BuildOperationDescriptor.Builder description() {
-//                return new RegisterTaskBuildOperationDetails(name, taskId, replacement).descriptor();
-                return BuildOperationDescriptor.displayName("register task " + taskId);
-            }
-        });
+        return new TaskCreatingProvider<T>(taskId, type, name, configurationAction);
+//        return buildOperationExecutor.call(new CallableBuildOperation<TaskCreatingProvider<T>>() {
+//            @Override
+//            public TaskCreatingProvider<T> call(BuildOperationContext context) {
+//                TaskCreatingProvider<T> provider = new TaskCreatingProvider<T>(taskId, type, name, configurationAction);
+////                context.setResult(new RegisterTaskBuildOperationType.Result(){});
+//                return provider;
+//            }
+//
+//            @Override
+//            public BuildOperationDescriptor.Builder description() {
+////                return new RegisterTaskBuildOperationDetails(name, taskId, replacement).descriptor();
+//                return BuildOperationDescriptor.displayName("register task " + taskId);
+//            }
+//        });
     }
 
     private <T extends Task> T realizeTask(final long taskId, final String name, final Class<T> type, final Object... constructorArgs) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
@@ -25,6 +25,7 @@ import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.BiAction;
 import org.gradle.internal.Factory;
 import org.gradle.internal.model.RuleBasedPluginListener;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.collection.internal.BridgedCollections;
 import org.gradle.model.internal.core.ChildNodeInitializerStrategyAccessors;
@@ -48,18 +49,20 @@ public class DefaultTaskContainerFactory implements Factory<TaskContainerInterna
     private Project project;
     private final ProjectAccessListener projectAccessListener;
     private final TaskStatistics statistics;
+    private final BuildOperationExecutor buildOperationExecutor;
 
-    public DefaultTaskContainerFactory(ModelRegistry modelRegistry, Instantiator instantiator, ITaskFactory taskFactory, Project project, ProjectAccessListener projectAccessListener, TaskStatistics statistics) {
+    public DefaultTaskContainerFactory(ModelRegistry modelRegistry, Instantiator instantiator, ITaskFactory taskFactory, Project project, ProjectAccessListener projectAccessListener, TaskStatistics statistics, BuildOperationExecutor buildOperationExecutor) {
         this.modelRegistry = modelRegistry;
         this.instantiator = instantiator;
         this.taskFactory = taskFactory;
         this.project = project;
         this.projectAccessListener = projectAccessListener;
         this.statistics = statistics;
+        this.buildOperationExecutor = buildOperationExecutor;
     }
 
     public TaskContainerInternal create() {
-        DefaultTaskContainer tasks = instantiator.newInstance(DefaultTaskContainer.class, project, instantiator, taskFactory, projectAccessListener, statistics);
+        DefaultTaskContainer tasks = instantiator.newInstance(DefaultTaskContainer.class, project, instantiator, taskFactory, projectAccessListener, statistics, buildOperationExecutor);
         bridgeIntoSoftwareModelWhenNeeded(tasks);
         return tasks;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+/**
+ * Represents a task realization for a task whose creation was deferred.
+ *
+ * @since 4.9
+ */
+public final class RegisterTaskBuildOperationType implements BuildOperationType<RegisterTaskBuildOperationType.Details, RegisterTaskBuildOperationType.Result> {
+
+    @UsedByScanPlugin
+    public interface Details {
+        String getBuildPath();
+
+        String getTaskPath();
+
+        /**
+         * An ID for the task, that disambiguates it from other tasks with the same path.
+         *
+         * Due to a bug in Gradle, two tasks with the same path can be executed.
+         * This is very problematic for build scans.
+         * As such, scans need to be able to differentiate between different tasks with the same path.
+         * The combination of the path and ID does this.
+         *
+         * In later versions of Gradle, executing two tasks with the same path will be prevented
+         * and this value can be noop-ed.
+         */
+        long getTaskId();
+
+        boolean isReplacement();
+    }
+
+    @UsedByScanPlugin
+    public interface Result {
+    }
+
+    private RegisterTaskBuildOperationType() {
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
@@ -28,24 +28,24 @@ public final class RegisterTaskBuildOperationType implements BuildOperationType<
 
     @UsedByScanPlugin
     public interface Details {
-        String getBuildPath();
-
-        String getTaskPath();
-
-        /**
-         * An ID for the task, that disambiguates it from other tasks with the same path.
-         *
-         * Due to a bug in Gradle, two tasks with the same path can be executed.
-         * This is very problematic for build scans.
-         * As such, scans need to be able to differentiate between different tasks with the same path.
-         * The combination of the path and ID does this.
-         *
-         * In later versions of Gradle, executing two tasks with the same path will be prevented
-         * and this value can be noop-ed.
-         */
-        long getTaskId();
-
-        boolean isReplacement();
+//        String getBuildPath();
+//
+//        String getTaskPath();
+//
+//        /**
+//         * An ID for the task, that disambiguates it from other tasks with the same path.
+//         *
+//         * Due to a bug in Gradle, two tasks with the same path can be executed.
+//         * This is very problematic for build scans.
+//         * As such, scans need to be able to differentiate between different tasks with the same path.
+//         * The combination of the path and ID does this.
+//         *
+//         * In later versions of Gradle, executing two tasks with the same path will be prevented
+//         * and this value can be noop-ed.
+//         */
+//        long getTaskId();
+//
+//        boolean isReplacement();
     }
 
     @UsedByScanPlugin

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -181,8 +181,8 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return parentFactory.createChild(project, get(InstantiatorFactory.class).injectAndDecorate(this));
     }
 
-    protected Factory<TaskContainerInternal> createTaskContainerInternal(TaskStatistics taskStatistics) {
-        return new DefaultTaskContainerFactory(get(ModelRegistry.class), get(Instantiator.class), get(ITaskFactory.class), project, get(ProjectAccessListener.class), taskStatistics);
+    protected Factory<TaskContainerInternal> createTaskContainerInternal(TaskStatistics taskStatistics, BuildOperationExecutor buildOperationExecutor) {
+        return new DefaultTaskContainerFactory(get(ModelRegistry.class), get(Instantiator.class), get(ITaskFactory.class), project, get(ProjectAccessListener.class), taskStatistics, buildOperationExecutor);
     }
 
     protected SoftwareComponentContainer createSoftwareComponentContainer() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -58,11 +58,12 @@ class DefaultTaskTest extends AbstractTaskTest {
 
     def "default task"() {
         given:
-        Task task = AbstractTask.injectIntoNewInstance(project, TEST_TASK_NAME, Task, { new DefaultTask() } as Callable)
+        Task task = AbstractTask.injectIntoNewInstance(99, project, TEST_TASK_NAME, Task, { new DefaultTask() } as Callable)
 
         expect:
         task.dependsOn.isEmpty()
         task.actions == []
+        (task as TaskInternal).internalTaskInstanceId == 99L
     }
 
     def "useful toString()"() {
@@ -72,11 +73,12 @@ class DefaultTaskTest extends AbstractTaskTest {
 
     def "can inject values into task when using no-args constructor"() {
         given:
-        def task = AbstractTask.injectIntoNewInstance(project, TEST_TASK_NAME, Task, { new DefaultTask() } as Callable)
+        def task = AbstractTask.injectIntoNewInstance(99, project, TEST_TASK_NAME, Task, { new DefaultTask() } as Callable)
 
         expect:
         task.project.is(project)
         task.name == TEST_TASK_NAME
+        (task as TaskInternal).internalTaskInstanceId == 99L
     }
 
     def "dependsOn() works"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -743,7 +743,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     private TaskInternal expectTaskCreated(final Class type, final Object... params) {
         final Class decorated = project.getServices().get(ClassGenerator).generate(type)
         final String name = "task"
-        TaskInternal task = (TaskInternal) AbstractTask.injectIntoNewInstance(project, name, type, new Callable<TaskInternal>() {
+        TaskInternal task = (TaskInternal) AbstractTask.injectIntoNewInstance(InternalTaskInstanceIdSequence.nextId, project, name, type, new Callable<TaskInternal>() {
             TaskInternal call() throws Exception {
                 if (params.length > 0) {
                     return type.cast(decorated.constructors[0].newInstance(params))

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -55,6 +55,7 @@ import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resource.TextResourceLoader
@@ -118,6 +119,7 @@ class ProjectScopeServicesTest extends Specification {
         parent.get(FileHasher) >> Mock(FileHasher)
         parent.get(TaskStatistics) >> new TaskStatistics()
         parent.get(TextResourceLoader) >> Mock(TextResourceLoader)
+        parent.get(BuildOperationExecutor) >> Mock(BuildOperationExecutor)
         registry = new ProjectScopeServices(parent, project, loggingManagerInternalFactory)
     }
 

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -15,6 +15,14 @@
             "changes": [
                 "org.gradle.api.artifacts.repositories.MetadataSupplierAware"
             ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Class org.gradle.api.DefaultTask",
+            "acceptation": "Internal decoration method altered to pass in task id",
+            "changes": [
+                "org.gradle.api.internal.AbstractTask.injectIntoNewInstance(org.gradle.api.internal.project.ProjectInternal,java.lang.String,java.lang.Class,java.util.concurrent.Callable)"
+            ]
         }
     ]
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
@@ -275,7 +275,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        events.operation('Configure project :').children.size() <= 3 //only 'Apply plugin org.gradle.help-tasks' and maybe two task registrations
+        events.operation('Configure project :').children.size() <= 3 //only 'Apply plugin org.gradle.help-tasks' and possibly 2 delayed task registrations
     }
 
     def "generates events for applied script plugins"() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/BuildProgressCrossVersionSpec.groovy
@@ -275,7 +275,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        events.operation('Configure project :').children.size() == 1 //only 'Apply plugin org.gradle.help-tasks'
+        events.operation('Configure project :').children.size() <= 3 //only 'Apply plugin org.gradle.help-tasks' and maybe two task registrations
     }
 
     def "generates events for applied script plugins"() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -176,7 +176,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         then:
         thrown(BuildActionFailureException)
-        !events.contains("hello")
+        !events.contains("Task hello")
     }
 
     @TargetGradleVersion(">=4.8")


### PR DESCRIPTION
Capture task eager / lazy creation stats to diagnose unnecessarily eager task creation and unnecessarily created lazy tasks. Ops to be used by build scan plugin.