### PR TITLE
Create and cleanup TAPI test directories in ${project}/build/tmp

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -64,6 +64,17 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
         return cleanup;
     }
 
+    public void cleanup() {
+        if (cleanup && dir != null && dir.exists()) {
+            ConcurrentTestUtil.poll(new Closure(null, null) {
+                @SuppressWarnings("UnusedDeclaration")
+                void doCall() throws IOException {
+                    FileUtils.forceDelete(dir);
+                }
+            });
+        }
+    }
+
     public Statement apply(final Statement base, Description description) {
         init(description.getMethodName(), description.getTestClass().getSimpleName());
 
@@ -85,14 +96,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
             base.evaluate();
 
             try {
-                if (cleanup && dir != null && dir.exists()) {
-                    ConcurrentTestUtil.poll(new Closure(null, null) {
-                        @SuppressWarnings("UnusedDeclaration")
-                        void doCall() throws IOException {
-                            FileUtils.forceDelete(dir);
-                        }
-                    });
-                }
+                cleanup();
             } catch (Exception e) {
                 if (suppressCleanupErrors()) {
                     System.err.println(cleanupErrorMessage());

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiCompatibilitySuiteRunner.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiCompatibilitySuiteRunner.groovy
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 package org.gradle.integtests.tooling.fixture
+
 import org.gradle.integtests.fixtures.AbstractCompatibilityTestRunner
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import org.junit.runner.notification.RunNotifier
 
 class ToolingApiCompatibilitySuiteRunner extends AbstractCompatibilityTestRunner {
+    private List<ToolingApiDistributionResolver> distributionResolvers = []
+
     ToolingApiCompatibilitySuiteRunner(Class<? extends ToolingApiSpecification> target) {
         super(target)
     }
@@ -32,20 +36,27 @@ class ToolingApiCompatibilitySuiteRunner extends AbstractCompatibilityTestRunner
     }
 
     @Override
+    void run(RunNotifier notifier) {
+        try {
+            super.run(notifier)
+        }
+        finally {
+            distributionResolvers*.cleanup()
+        }
+    }
+
+    @Override
     protected void createExecutions() {
         def resolver = new ToolingApiDistributionResolver().withDefaultRepository()
-        try {
-            if (implicitVersion) {
-                add(new ToolingApiExecution(resolver.resolve(current.version.version), current))
-            }
-            previous.each {
-                if (it.toolingApiSupported) {
-                    add(new ToolingApiExecution(resolver.resolve(current.version.version), it))
-                    add(new ToolingApiExecution(resolver.resolve(it.version.version), current))
-                }
-            }
-        } finally {
-            resolver.stop()
+        if (implicitVersion) {
+            add(new ToolingApiExecution(resolver.resolve(current.version.version), current))
         }
+        previous.each {
+            if (it.toolingApiSupported) {
+                add(new ToolingApiExecution(resolver.resolve(current.version.version), it))
+                add(new ToolingApiExecution(resolver.resolve(it.version.version), current))
+            }
+        }
+        distributionResolvers.add(resolver)
     }
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.TestUtil
+import org.gradle.testfixtures.ProjectBuilder
 
 class ToolingApiDistributionResolver {
     private final DependencyResolutionServices resolutionServices
@@ -67,7 +67,10 @@ class ToolingApiDistributionResolver {
 
     private DependencyResolutionServices createResolutionServices() {
         // Create a dummy project and use its services
-        ProjectInternal project = TestUtil.createRootProject(temporaryFolder.getTestDirectory())
+        ProjectInternal project = ProjectBuilder.builder()
+            .withProjectDir(temporaryFolder.getTestDirectory())
+            .withGradleUserHomeDir(buildContext.gradleUserHomeDir)
+            .build()
         return project.services.get(DependencyResolutionServices)
     }
 
@@ -79,4 +82,6 @@ class ToolingApiDistributionResolver {
     void cleanup() {
         temporaryFolder.cleanup()
     }
+
+    void stop() { }
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -22,13 +22,15 @@ import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
-import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 
 class ToolingApiDistributionResolver {
     private final DependencyResolutionServices resolutionServices
     private final Map<String, ToolingApiDistribution> distributions = [:]
     private final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
-    private boolean useExternalToolingApiDistribution = false;
+    private final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    private boolean useExternalToolingApiDistribution = false
 
     ToolingApiDistributionResolver() {
         resolutionServices = createResolutionServices()
@@ -65,7 +67,7 @@ class ToolingApiDistributionResolver {
 
     private DependencyResolutionServices createResolutionServices() {
         // Create a dummy project and use its services
-        ProjectInternal project = ProjectBuilder.builder().build()
+        ProjectInternal project = TestUtil.createRootProject(temporaryFolder.getTestDirectory())
         return project.services.get(DependencyResolutionServices)
     }
 
@@ -74,6 +76,7 @@ class ToolingApiDistributionResolver {
         this
     }
 
-    void stop() {
+    void cleanup() {
+        temporaryFolder.cleanup()
     }
 }


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/1290

Previously TAPI test temp directories were created in /tmp and they didn't get cleaned up
at all, which caused /tmp to be filled up quickly. This PR creates temp directories in the
same way as other tests - under `${project}/build/tmp/test files` and cleans up them at last.