### PR TITLE
Make xctest task fail when there are errors during test execution

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -213,7 +213,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         }
 
         TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher) {
-            String failureMethodName = "execution failure"
+            String failureMethodName = EXECUTION_FAILURE
             def testCase = testsFailures.find { it.name == failureMethodName }
             assert testCase
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -23,6 +23,7 @@ import org.hamcrest.Matchers
 import org.junit.Assert
 
 import static org.gradle.integtests.fixtures.DefaultTestExecutionResult.removeParentheses
+import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
 
 class JUnitTestClassExecutionResult implements TestClassExecutionResult {
     GPathResult testClassNode
@@ -124,7 +125,7 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
 
     TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher) {
         Map<String, Node> testMethods = findTests()
-        String failureMethodName = "execution failure"
+        String failureMethodName = EXECUTION_FAILURE
         Assert.assertThat(testMethods.keySet(), Matchers.hasItem(failureMethodName))
 
         String causeLinePrefix = "Caused by: "

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestExecutionResult.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestExecutionResult.java
@@ -17,6 +17,8 @@
 package org.gradle.integtests.fixtures;
 
 public interface TestExecutionResult {
+    String EXECUTION_FAILURE = "failed to execute tests";
+
     /**
      * Asserts that the given test classes (and only the given test classes) were executed.
      */

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftAppWithLibraries.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftAppWithLibraries.groovy
@@ -39,8 +39,8 @@ class SwiftAppWithLibraries implements AppElement {
         return greeter
     }
 
-    SourceElement getApplication() {
-        return new SourceElement() {
+    SwiftSourceElement getApplication() {
+        return new SwiftSourceElement('app') {
             @Override
             List<SourceFile> getFiles() {
                 return [main.sourceFile].collect {

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftAppWithLibrariesAndXCTest.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftAppWithLibrariesAndXCTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+import com.google.common.collect.Iterables
+import com.google.common.collect.Lists
+import org.gradle.integtests.fixtures.SourceFile
+
+class SwiftAppWithLibrariesAndXCTest extends MainWithXCTestSourceElement implements AppElement {
+    final SwiftAppWithLibraries app = new SwiftAppWithLibraries()
+    final SwiftSourceElement main = app.application
+    final SwiftSum sum = new SwiftSum()
+    final SwiftMultiply multiply = new SwiftMultiply()
+    final XCTestSourceElement test = new SwiftAppTest(main, app.greeter, sum, multiply)
+
+    String expectedOutput = main.expectedOutput
+
+    SwiftAppWithLibrariesAndXCTest() {
+        super('app')
+    }
+
+    SourceElement getGreeter() {
+        return app.greeter
+    }
+
+    SourceElement getLogger() {
+        return app.logger
+    }
+
+    @Override
+    List<SourceFile> getFiles() {
+        return Lists.newArrayList(Iterables.concat(super.getFiles(), app.greeter.files, app.logger.files, sum.files, multiply.files))
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -62,4 +62,9 @@ public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     public String getClassDisplayName() {
         return getClassName();
     }
+
+    @Override
+    public boolean isRoot() {
+        return false;
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
@@ -76,4 +76,9 @@ public class DecoratingTestDescriptor implements TestDescriptorInternal {
     public boolean isComposite() {
         return descriptor.isComposite();
     }
+
+    @Override
+    public boolean isRoot() {
+        return descriptor.isRoot();
+    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -48,4 +48,9 @@ public interface TestDescriptorInternal extends TestDescriptor {
      * @return the class name for display.
      */
     String getClassDisplayName();
+
+    /**
+     * Whether or not this is the test execution root test suite.
+     */
+    boolean isRoot();
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit.result;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.tasks.testing.*;
 import org.gradle.internal.serialize.PlaceholderException;
@@ -23,6 +24,7 @@ import org.gradle.internal.serialize.PlaceholderException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,6 +35,7 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
     private final Map<String, TestClassResult> results;
     private final TestOutputStore.Writer outputWriter;
     private final Map<TestDescriptor, TestMethodResult> currentTestMethods = new HashMap<TestDescriptor, TestMethodResult>();
+    private final List<TestOutputEvent> rootOutputEvents = Lists.newArrayList();
     private long internalIdCounter = 1;
 
     public TestReportDataCollector(Map<String, TestClassResult> results, TestOutputStore.Writer outputWriter) {
@@ -50,11 +53,17 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
             //there are some exceptions attached to the suite. Let's make sure they are reported to the user.
             //this may happen for example when suite initialisation fails and no tests are executed
             TestMethodResult methodResult = new TestMethodResult(internalIdCounter++, "execution failure");
+            TestClassResult classResult = new TestClassResult(internalIdCounter++, suite.getName(), result.getStartTime());
             for (Throwable throwable : result.getExceptions()) {
                 methodResult.addFailure(failureMessage(throwable), stackTrace(throwable), exceptionClassName(throwable));
             }
+            if (((TestDescriptorInternal)suite).isRoot() && !rootOutputEvents.isEmpty()) {
+                for (TestOutputEvent outputEvent : rootOutputEvents) {
+                    outputWriter.onOutput(classResult.getId(), methodResult.getId(), outputEvent);
+                }
+                rootOutputEvents.clear();
+            }
             methodResult.completed(result);
-            TestClassResult classResult = new TestClassResult(internalIdCounter++, suite.getName(), result.getStartTime());
             classResult.add(methodResult);
             results.put(suite.getName(), classResult);
         }
@@ -120,6 +129,9 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
     public void onOutput(TestDescriptor testDescriptor, TestOutputEvent outputEvent) {
         String className = testDescriptor.getClassName();
         if (className == null) {
+            if (((TestDescriptorInternal)testDescriptor).isRoot()) {
+                rootOutputEvents.add(outputEvent);
+            }
             //this means that we receive an output before even starting any class (or too late).
             //we don't have a place for such output in any of the reports so skipping.
             //Unfortunately, this happens pretty often with current level of TestNG support

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
@@ -32,6 +32,7 @@ import java.util.Map;
  */
 public class TestReportDataCollector implements TestListener, TestOutputListener {
 
+    public static final String EXECUTION_FAILURE = "failed to execute tests";
     private final Map<String, TestClassResult> results;
     private final TestOutputStore.Writer outputWriter;
     private final Map<TestDescriptor, TestMethodResult> currentTestMethods = new HashMap<TestDescriptor, TestMethodResult>();
@@ -52,7 +53,7 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
         if (result.getResultType() == TestResult.ResultType.FAILURE && !result.getExceptions().isEmpty()) {
             //there are some exceptions attached to the suite. Let's make sure they are reported to the user.
             //this may happen for example when suite initialisation fails and no tests are executed
-            TestMethodResult methodResult = new TestMethodResult(internalIdCounter++, "execution failure");
+            TestMethodResult methodResult = new TestMethodResult(internalIdCounter++, EXECUTION_FAILURE);
             TestClassResult classResult = new TestClassResult(internalIdCounter++, suite.getName(), result.getStartTime());
             for (Throwable throwable : result.getExceptions()) {
                 methodResult.addFailure(failureMessage(throwable), stackTrace(throwable), exceptionClassName(throwable));

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
@@ -79,5 +79,10 @@ public class TestMainAction implements Runnable {
         public String toString() {
             return getName();
         }
+
+        @Override
+        public boolean isRoot() {
+            return true;
+        }
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
@@ -61,4 +61,9 @@ public class UnknownTestDescriptor implements TestDescriptorInternal {
     public String getClassDisplayName() {
         return getClassName();
     }
+
+    @Override
+    public boolean isRoot() {
+        return false;
+    }
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
@@ -23,6 +23,7 @@ class SimpleTestDescriptor implements TestDescriptorInternal {
     String className = "ClassName"
     String classDisplayName = "ClassName"
     boolean composite = false
+    boolean root = false
     TestDescriptorInternal parent = null
     Object ownerBuildOperationId = null
     Object getId() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import spock.lang.Issue
 
+import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
 import static org.hamcrest.Matchers.startsWith
 
 class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
@@ -47,7 +48,7 @@ class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
         fails("test")
 
         def result = new DefaultTestExecutionResult(testDirectory)
-        result.testClassStartsWith("Gradle Test Executor").assertTestFailed("execution failure",
+        result.testClassStartsWith("Gradle Test Executor").assertTestFailed(EXECUTION_FAILURE,
                 startsWith("org.gradle.api.internal.tasks.testing.TestSuiteExecutionException"))
     }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -110,9 +110,9 @@ class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChain
             List<XCTestCaseElement> getTestCases() {
                 return [testCase("testForceUnwrapOptional",
                     """
-                                let string: String? = nil
-                                XCTAssert((string?.lengthOfBytes(using: .utf8))! > 0)
-                            """)]
+                        let string: String? = nil
+                        XCTAssert((string?.lengthOfBytes(using: .utf8))! > 0)
+                    """)]
             }
         }
         XCTestSourceElement sourceElement = new XCTestSourceElement('app') {

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.test.xctest
+
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.nativeplatform.fixtures.app.SwiftAppWithLibrariesAndXCTest
+import org.gradle.nativeplatform.fixtures.app.XCTestCaseElement
+import org.gradle.nativeplatform.fixtures.app.XCTestSourceFileElement
+
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+
+    def "fails when application cannot load shared library at runtime"() {
+        buildWithApplicationAndDependencies()
+        buildFile << """
+            project(':app') {
+                tasks.withType(XCTest).configureEach {
+                    doFirst {
+                        delete project(':hello').layout.buildDir.get()
+                    }
+                }
+            }
+        """
+
+        expect:
+        fails(':app:test')
+
+        and:
+        failure.assertHasErrorOutput("The bundle “AppTest.xctest” couldn’t be loaded because it is damaged or missing necessary resources")
+        failure.assertHasCause("Failure while running xctest executable")
+    }
+
+    def "fails when force-unwrapping an optional results in an error"() {
+        buildWithApplicationAndDependencies()
+        addForceUnwrappedOptionalTest()
+
+        expect:
+        fails(':app:test')
+
+        and:
+        failure.assertHasErrorOutput("Test Case '-[AppTest.ForceUnwrapTestSuite testForceUnwrapOptional]' started.")
+        failure.assertHasCause("Failure while running xctest executable")
+    }
+
+    void buildWithApplicationAndDependencies() {
+        def app = new SwiftAppWithLibrariesAndXCTest()
+        app.test.greeterTest.withTestableImport("Hello")
+        app.test.greeterTest.withTestableImport("Log")
+
+        app.writeToProject(file("app"))
+        app.sum.writeToProject(file("app"))
+        app.multiply.writeToProject(file("app"))
+        app.greeter.writeToProject(file("hello"))
+        app.logger.writeToProject(file("log"))
+
+        settingsFile.text =  """
+            include 'app', 'log', 'hello'
+            rootProject.name = "app"
+        """
+        file("app/build.gradle") << """
+            apply plugin: 'xctest'
+            apply plugin: 'swift-application'
+            dependencies {
+                implementation project(':hello')
+            }
+        """
+        file("hello/build.gradle") << """
+            apply plugin: 'swift-library'
+            dependencies {
+                implementation project(':log')
+            }
+        """
+        file("log/build.gradle") << """
+            apply plugin: 'swift-library'
+        """
+    }
+
+    void addForceUnwrappedOptionalTest() {
+        XCTestSourceFileElement sourceElement = new XCTestSourceFileElement("ForceUnwrapTestSuite") {
+            @Override
+            List<XCTestCaseElement> getTestCases() {
+                return [testCase("testForceUnwrapOptional",
+                    """
+                                let string: String? = nil
+                                XCTAssert((string?.lengthOfBytes(using: .utf8))! > 0)
+                            """)]
+            }
+        }
+        sourceElement.writeToProject(file("app"))
+    }
+}

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.nativeplatform.fixtures.app.XCTestCaseElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceFileElement
 
+import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
 import static org.gradle.util.Matchers.containsText
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
@@ -50,13 +51,12 @@ class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChain
         and:
         failure.assertHasCause("There were failing tests.")
         def testFailure = testExecutionResult.testClass("Gradle Test Run :app:xcTest")
-        testFailure.assertTestFailed("execution failure", containsText("Failure while running xctest executable"))
+        testFailure.assertTestFailed(EXECUTION_FAILURE, containsText("Failure while running xctest executable"))
         if (OperatingSystem.current().isMacOsX()) {
             testFailure.assertStderr(containsText("The bundle “AppTest.xctest” couldn’t be loaded because it is damaged or missing necessary resources"))
         } else {
             testFailure.assertStderr(containsText("cannot open shared object file"))
         }
-
     }
 
     def "fails when force-unwrapping an optional results in an error"() {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
@@ -156,8 +156,7 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
             if (result.getExitValue() != 0 && result.getExitValue() != 1) {
                 Exception failure = new ExecException("Failure while running xctest executable (exit code: " + result.getExitValue() + ").");
                 stdOut.endOfStream(failure);
-                stdErr.endOfStream(failure);
-                resultProcessor.failure(rootTestSuiteId, failure);
+                stdErr.endOfStream(null);
             }
         }
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestScraper.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestScraper.java
@@ -175,10 +175,16 @@ class XCTestScraper implements TextStream {
     @Override
     public void endOfStream(@Nullable Throwable failure) {
         if (failure != null) {
-            while (!testDescriptors.isEmpty()) {
-                processor.failure(testDescriptors.pop().getDescriptorInternal().getId(), failure);
+            synchronized (testDescriptors) {
+                Object testId;
+                if (!testDescriptors.isEmpty()) {
+                    testId = testDescriptors.pop().getDescriptorInternal().getId();
+                } else {
+                    testId = rootTestSuiteId;
+                }
+                processor.failure(testId, failure);
+                testDescriptors.clear();
             }
         }
     }
-
 }


### PR DESCRIPTION
Previously, when xctest test execution failed, the task would appear successful.  This fixes the issue by failing the task and printing test execution output when test execution fails.