### PR TITLE
Switch to NoDaemonExecuter when setting environment variables on Java 9+

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 
 package org.gradle.buildinit.plugins
+
 import org.gradle.buildinit.plugins.fixtures.WrapperTestFixture
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
@@ -24,9 +25,7 @@ import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.PomHttpArtifact
-import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
-import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Issue
 
@@ -267,7 +266,6 @@ it.exclude group: '*', module: 'badArtifact'
         file("build/libs/util-2.5.jar").exists()
     }
 
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
     @Issue("GRADLE-2872")
     def "expandProperties"() {
         setup:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1408,6 +1408,17 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         }
     }
 
+    @Override
+    public void assertCanExecute() throws AssertionError {
+        if (JavaVersion.current().isJava9Compatible() && !environmentVars.isEmpty() && !supportResettingEnvVariablesOnJava9Plus()) {
+            throw new AssertionError("Setting environment variables are not supported by Java 9+! Env: " + environmentVars);
+        }
+    }
+
+    private boolean supportResettingEnvVariablesOnJava9Plus() {
+        return getClass() == NoDaemonGradleExecuter.class;
+    }
+
     private boolean errorsShouldAppearOnStdout() {
         // If stderr is attached to the console or if we'll use the fallback console
         return (consoleAttachment.isStderrAttached() && consoleAttachment.isStdoutAttached()) || (consoleAttachment == ConsoleAttachment.NOT_ATTACHED && (consoleType == ConsoleOutput.Rich || consoleType == ConsoleOutput.Verbose));

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -49,7 +49,7 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     @Override
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>(super.getAllArgs());
-        if(!isQuiet() && isAllowExtraLogging()) {
+        if (!isQuiet() && isAllowExtraLogging()) {
             if (!containsAny(args, asList("-i", "--info", "-d", "--debug", "-w", "--warn", "-q", "--quiet"))) {
                 args.add(0, "-i");
             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -53,7 +53,9 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext);
     }
 
+    @Override
     public void assertCanExecute() throws AssertionError {
+        super.assertCanExecute();
         if (!getDistribution().isSupportsSpacesInGradleAndJavaOpts()) {
             Map<String, String> environmentVars = buildInvocation().environmentVars;
             for (String envVarName : Arrays.asList("JAVA_OPTS", "GRADLE_OPTS")) {


### PR DESCRIPTION
On Java 9+ environment variables can't be set for `InProcessGradleExecuter` and `DaemonGradleExecuter`, so we switch to `NoDaemonExecuter` to avoid accidental build failure.

For example, some maven tests depend on `M2_HOME` env variable but `InProcessGradleExecuter` will ignore these environment variables silently on Java 9, which cause tricky build failures. 