### PR TITLE
Re-enable cross version test for Java 9+

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -87,8 +87,12 @@ public class DefaultGradleDistribution implements GradleDistribution {
             return javaVersion.compareTo(JavaVersion.VERSION_1_6) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
         }
 
-        // 3.x works on Java 7 - 8
-        return javaVersion.compareTo(JavaVersion.VERSION_1_7) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
+        // 3.x - 4.6 works on Java 7 - 8
+        if(isSameOrOlder("4.6")) {
+            return javaVersion.compareTo(JavaVersion.VERSION_1_7) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_8) <= 0;
+        }
+
+        return javaVersion.compareTo(JavaVersion.VERSION_1_7) >= 0 && javaVersion.compareTo(JavaVersion.VERSION_1_10) <= 0;
     }
 
     public boolean worksWith(OperatingSystem os) {


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle/issues/2116 for more context. TL;DR:

Once upon a time we disabled cross version tests on Java 9 because at that time we were not ready for Java 9. Now it's time to re-enable them.

In addition, this PR fixed a little issue of `JAVA_ILLEGAL_ACCESS_WARNING_PATTERN` - a newline character was missing in this pattern.