### PR TITLE
Use `ModuleComponentIdentifier` to represent a locked dependency

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingState.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
-import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 
 import java.util.Set;
 
@@ -26,7 +26,13 @@ import java.util.Set;
 public interface DependencyLockingState {
 
     /**
-     * Indicates if the lock state must be validated
+     * Indicates if the lock state must be strictly validated.
+     *
+     * If {@code true}, each locked dependency is added as a strict constraint,
+     * and the resolution result must exactly match the set of locked dependencies.
+     *
+     * If {@code false}, each locked dependency is added a regular (lenient) constraint,
+     * and the resolution result is not verified against the set of locked dependencies.
      *
      * @return {@code true} if lock state was found, {@code false} otherwise
      */
@@ -37,8 +43,8 @@ public interface DependencyLockingState {
      * Note that an empty set can mean either that lock state was not defined or that lock state is an empty set.
      * Disambiguation can be done by calling {@link #mustValidateLockState()}.
      *
-     * @return a set of constraints
+     * @return The set of module versions to lock.
      * @see #mustValidateLockState()
      */
-    Set<DependencyConstraint> getLockedDependencies();
+    Set<ModuleComponentIdentifier> getLockedDependencies();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolveException;
@@ -95,8 +94,8 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
             DependencyLockingState lockingState = dependencyLockingProvider.loadLockState(configuration.getName());
             if (lockingState.mustValidateLockState() && !lockingState.getLockedDependencies().isEmpty()) {
                 ArrayList<String> errors = Lists.newArrayListWithCapacity(lockingState.getLockedDependencies().size());
-                for (DependencyConstraint lockedDependency : lockingState.getLockedDependencies()) {
-                    errors.add("Did not resolve '" + lockedDependency.getGroup() + ":" + lockedDependency.getName() + ":" + lockedDependency.getVersion() + "' which is part of the lock state");
+                for (ModuleComponentIdentifier lockedDependency : lockingState.getLockedDependencies()) {
+                    errors.add("Did not resolve '" + lockedDependency.getGroup() + ":" + lockedDependency.getModule() + ":" + lockedDependency.getVersion() + "' which is part of the lock state");
                 }
                 throw LockOutOfDateException.createLockOutOfDateException(configuration.getName(), errors);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -19,7 +19,6 @@ package org.gradle.internal.locking;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.StartParameter;
-import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
@@ -51,7 +50,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
             LOGGER.debug("Write locks is enabled");
         }
         List<String> lockedDependenciesToUpdate = startParameter.getLockedDependenciesToUpdate();
-        this.partialUpdate = !lockedDependenciesToUpdate.isEmpty();
+        partialUpdate = !lockedDependenciesToUpdate.isEmpty();
         lockEntryFilter = LockEntryFilterFactory.forParameter(lockedDependenciesToUpdate);
         converter = new DependencyLockingNotationConverter(!lockedDependenciesToUpdate.isEmpty());
     }
@@ -61,13 +60,13 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         if (!writeLocks || partialUpdate) {
             List<String> lockedModules = lockFileReaderWriter.readLockFile(configurationName);
             if (lockedModules != null) {
-                Set<DependencyConstraint> results = Sets.newHashSetWithExpectedSize(lockedModules.size());
+                Set<ModuleComponentIdentifier> results = Sets.newHashSetWithExpectedSize(lockedModules.size());
                 for (String module : lockedModules) {
                     if (lockEntryFilter.filters(module)) {
                         continue;
                     }
                     try {
-                        results.add(converter.convertToDependencyConstraint(module));
+                        results.add(converter.convertFromLockNotation(module));
                     } catch (IllegalArgumentException e) {
                         throw new InvalidLockFileException(configurationName, e);
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -37,7 +37,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private static final Logger LOGGER = Logging.getLogger(DefaultDependencyLockingProvider.class);
     private static final DocumentationRegistry DOC_REG = new DocumentationRegistry();
 
-    private final DependencyLockingNotationConverter converter;
+    private final DependencyLockingNotationConverter converter = new DependencyLockingNotationConverter();
     private final LockFileReaderWriter lockFileReaderWriter;
     private final boolean writeLocks;
     private final boolean partialUpdate;
@@ -52,7 +52,6 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         List<String> lockedDependenciesToUpdate = startParameter.getLockedDependenciesToUpdate();
         partialUpdate = !lockedDependenciesToUpdate.isEmpty();
         lockEntryFilter = LockEntryFilterFactory.forParameter(lockedDependenciesToUpdate);
-        converter = new DependencyLockingNotationConverter(!lockedDependenciesToUpdate.isEmpty());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -62,13 +62,9 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
             if (lockedModules != null) {
                 Set<ModuleComponentIdentifier> results = Sets.newHashSetWithExpectedSize(lockedModules.size());
                 for (String module : lockedModules) {
-                    if (lockEntryFilter.filters(module)) {
-                        continue;
-                    }
-                    try {
-                        results.add(converter.convertFromLockNotation(module));
-                    } catch (IllegalArgumentException e) {
-                        throw new InvalidLockFileException(configurationName, e);
+                    ModuleComponentIdentifier lockedIdentifier = parseLockNotation(configurationName, module);
+                    if (!lockEntryFilter.isSatisfiedBy(lockedIdentifier)) {
+                        results.add(lockedIdentifier);
                     }
                 }
                 if (LOGGER.isDebugEnabled()) {
@@ -80,6 +76,16 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
             }
         }
         return DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT;
+    }
+
+    private ModuleComponentIdentifier parseLockNotation(String configurationName, String module) {
+        ModuleComponentIdentifier lockedIdentifier;
+        try {
+            lockedIdentifier = converter.convertFromLockNotation(module);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidLockFileException(configurationName, e);
+        }
+        return lockedIdentifier;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingState.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.locking;
 
-import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 
 import java.util.Set;
@@ -27,29 +27,25 @@ public class DefaultDependencyLockingState implements DependencyLockingState {
 
     public static final DefaultDependencyLockingState EMPTY_LOCK_CONSTRAINT = new DefaultDependencyLockingState();
 
-    private final boolean lockDefined;
-    private final Set<DependencyConstraint> constraints;
+    private final boolean strictlyValidate;
+    private final Set<ModuleComponentIdentifier> constraints;
 
     private DefaultDependencyLockingState() {
-        lockDefined = false;
+        strictlyValidate = false;
         constraints = emptySet();
     }
-    public DefaultDependencyLockingState(boolean partialUpdate, Set<DependencyConstraint> constraints) {
-        if (partialUpdate) {
-            lockDefined = false;
-        } else {
-            lockDefined = true;
-        }
+    public DefaultDependencyLockingState(boolean partialUpdate, Set<ModuleComponentIdentifier> constraints) {
+        strictlyValidate = !partialUpdate;
         this.constraints = constraints;
     }
 
     @Override
     public boolean mustValidateLockState() {
-        return lockDefined;
+        return strictlyValidate;
     }
 
     @Override
-    public Set<DependencyConstraint> getLockedDependencies() {
+    public Set<ModuleComponentIdentifier> getLockedDependencies() {
         return constraints;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -19,6 +19,7 @@ package org.gradle.internal.locking;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 
 class DependencyLockingNotationConverter {
 
@@ -58,6 +59,17 @@ class DependencyLockingNotationConverter {
             module.substring(nameVersionSeparatorIndex + 1));
         constraint.because("dependency was locked to version '" + constraint.getVersion() + "' (update mode)");
         return constraint;
+    }
+
+    ModuleComponentIdentifier convertFromLockNotation(String notation) {
+        int groupNameSeparatorIndex = notation.indexOf(':');
+        int nameVersionSeparatorIndex = notation.lastIndexOf(':');
+        if (groupNameSeparatorIndex < 0 || nameVersionSeparatorIndex == groupNameSeparatorIndex) {
+            throw new IllegalArgumentException("The module notation does not respect the lock file format of 'group:name:version' - received '" + notation + "'");
+        }
+        return DefaultModuleComponentIdentifier.newId(notation.substring(0, groupNameSeparatorIndex),
+            notation.substring(groupNameSeparatorIndex + 1, nameVersionSeparatorIndex),
+            notation.substring(nameVersionSeparatorIndex + 1));
     }
 
     String convertToLockNotation(ModuleComponentIdentifier id) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilter.java
@@ -16,7 +16,8 @@
 
 package org.gradle.internal.locking;
 
-interface LockEntryFilter {
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.specs.Spec;
 
-    boolean filters(String moduleIdentifier);
+interface LockEntryFilter extends Spec<ModuleComponentIdentifier> {
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilterFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockEntryFilterFactory.java
@@ -45,6 +45,9 @@ class LockEntryFilterFactory {
         HashSet<LockEntryFilter> lockEntryFilters = new HashSet<LockEntryFilter>();
         for (String lockExcludes : lockedDependenciesToUpdate) {
             for (String lockExclude : lockExcludes.split(",")) {
+                String[] split = lockExclude.split(MODULE_SEPARATOR);
+                validateNotation(lockExclude, split);
+
                 if (!lockExclude.contains(MODULE_SEPARATOR)) {
                     throwInvalid(lockExclude);
                 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -25,12 +25,12 @@ import org.gradle.api.internal.artifacts.DefaultResolverResults
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
-import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildDependenciesVisitor
 import org.gradle.api.specs.Specs
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.locking.LockOutOfDateException
 import spock.lang.Specification
 
@@ -179,7 +179,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         1 * resolutionStrategy.dependencyLockingProvider >> lockingProvider
         1 * lockingProvider.loadLockState('lockedConf') >> lockingState
         1 * lockingState.mustValidateLockState() >> true
-        3 * lockingState.lockedDependencies >> [DefaultDependencyConstraint.strictConstraint('org', 'foo', '1.0')]
+        3 * lockingState.lockedDependencies >> [DefaultModuleComponentIdentifier.newId('org', 'foo', '1.0')]
     }
 
     def "delegates to backing service to resolve build dependencies when there are one or more dependencies"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.internal.component.local.model
 
-import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.locking.DefaultDependencyLockingState
 
@@ -29,7 +29,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
 
     def 'locking constraints are attached to a configuration and not its children'() {
         given:
-        def constraint = new DefaultDependencyConstraint('org', 'foo', '1.1')
+        def constraint = DefaultModuleComponentIdentifier.newId('org', 'foo', '1.1')
         dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(false, [constraint] as Set)
         dependencyLockingHandler.loadLockState("child") >> DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT
         addConfiguration('conf').enableLocking()
@@ -46,7 +46,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
 
     def 'locking constraints are not transitive'() {
         given:
-        def constraint = new DefaultDependencyConstraint('org', 'foo', '1.1')
+        def constraint = DefaultModuleComponentIdentifier.newId('org', 'foo', '1.1')
         dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(false, [constraint] as Set)
         addConfiguration('conf').enableLocking()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.locking
 
 import org.gradle.StartParameter
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.test.fixtures.file.TestFile
@@ -28,7 +27,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 import static java.util.Collections.emptySet
-import static org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint.strictConstraint
+import static org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId
 
 class DefaultDependencyLockingProviderTest extends Specification {
     @Rule
@@ -74,7 +73,7 @@ org:foo:1.0
 
         then:
         result.mustValidateLockState()
-        result.getLockedDependencies() == [strictConstraint('org', 'bar', '1.3'), strictConstraint('org', 'foo', '1.0')] as Set
+        result.getLockedDependencies() == [newId('org', 'bar', '1.3'), newId('org', 'foo', '1.0')] as Set
     }
 
     def 'can load lockfile as prefer constraints in update mode'() {
@@ -91,7 +90,7 @@ org:foo:1.0
 
         then:
         !result.mustValidateLockState()
-        result.getLockedDependencies() == [new DefaultDependencyConstraint('org', 'bar', '1.3')] as Set
+        result.getLockedDependencies() == [newId('org', 'bar', '1.3')] as Set
     }
 
     def 'can filter lock entries using module update patterns'() {
@@ -125,7 +124,7 @@ com:foo:1.0
 
         then:
         !result.mustValidateLockState()
-        result.getLockedDependencies() == [new DefaultDependencyConstraint('com', 'foo', '1.0')] as Set
+        result.getLockedDependencies() == [newId('com', 'foo', '1.0')] as Set
     }
 
     def 'fails with invalid content in lock file'() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.locking
 
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -28,11 +30,11 @@ class LockEntryFilterFactoryTest extends Specification {
 
         then:
         filteredValues.each {
-            assert filter.filters(it)
+            assert filter.isSatisfiedBy(id(it))
         }
         if (!acceptedValues.empty) {
             acceptedValues.each {
-                assert !filter.filters(it)
+                assert !filter.isSatisfiedBy(id(it))
             }
         }
 
@@ -50,6 +52,11 @@ class LockEntryFilterFactoryTest extends Specification {
         ['*:*']                 | ['org:foo:1.1', 'com:bar:2.1']    | []
     }
 
+    private static ModuleComponentIdentifier id(String notation) {
+        String[] parts = notation.split(':')
+        DefaultModuleComponentIdentifier.newId(parts[0], parts[1], parts[2])
+    }
+
     @Unroll
     def "fails for invalid filter #filters"() {
         when:
@@ -59,6 +66,6 @@ class LockEntryFilterFactoryTest extends Specification {
         thrown(IllegalArgumentException)
 
         where:
-        filters << [['*org:foo'], ['org:*foo'], ['org'], [',org:foo'], [','], ['org:foo:1.0']]
+        filters << [['*org:foo'], ['org:*foo'], ['or*g:foo'], ['org:fo*o'], ['org'], [',org:foo'], [','], ['org:foo:1.0']]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
@@ -59,6 +59,6 @@ class LockEntryFilterFactoryTest extends Specification {
         thrown(IllegalArgumentException)
 
         where:
-        filters << [['*org:foo'], ['org:*foo'], ['org'], [',org:foo'], [',']]
+        filters << [['*org:foo'], ['org:*foo'], ['org'], [',org:foo'], [','], ['org:foo:1.0']]
     }
 }


### PR DESCRIPTION
Refactoring and simplification of the dependency locking implementation, primarily to avoid a reliance on `VersionConstraint.getPreferredVersion()`. A few other things were tidied up on the way.