### PR TITLE
Suppress redundant warning message.

### DIFF
--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompilerFactory.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/routes/RoutesCompilerFactory.java
@@ -38,7 +38,7 @@ public class RoutesCompilerFactory {
             case PLAY_2_3_X:
                 return new RoutesCompilerAdapterV23X(playVersion);
             case PLAY_2_4_X:
-                if (VersionNumber.parse(playVersion).getMicro() < 6) {
+                if (VersionNumber.parse(playVersion).getMicro() < 6 && !"2.10".equals(scalaVersion)) {
                     LOGGER.warn("Asked to use scala version " + scalaVersion
                         + " on play < 2.4.6. Will have to use the 2.10 routes compiler");
                     scalaVersion = "2.10";


### PR DESCRIPTION
Issue: #5514

RoutesCompilerFactory forces the scala version being used in Play 2.4
to 2.10 and emits a warning message about this. This adds a check to
suppress this message if the scala version is already 2.10.

### Context
This is a minor distraction in our logs noticed by one of our internal developers.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
