### PR TITLE
Put DeferredConfigurable back in place

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ExtensionsStorage.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ExtensionsStorage.java
@@ -132,8 +132,10 @@ public class ExtensionsStorage {
     }
 
     private <T> ExtensionHolder<T> wrap(String name, TypeOf<T> publicType, T extension) {
-        if (isDeferredConfigurable(extension) && !extension.getClass().getName().startsWith("org.gradle.api.publish.internal.DeferredConfigurablePublishingExtension")) {
-            DeprecationLogger.nagUserOfDeprecated("@DeferredConfigurable");
+        if (isDeferredConfigurable(extension)) {
+            if (!extension.getClass().getName().startsWith("org.gradle.api.publish.internal.DeferredConfigurablePublishingExtension")) {
+                DeprecationLogger.nagUserOfDeprecated("@DeferredConfigurable");
+            }
             return new DeferredConfigurableExtensionHolder<T>(name, publicType, extension);
         }
         return new ExtensionHolder<T>(name, publicType, extension);

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
@@ -200,7 +200,7 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
         fails 'publish'
 
         then:
-        failure.assertHasDescription("A problem occurred evaluating root project 'publish'.")
+        failure.assertHasDescription("A problem occurred configuring root project 'publish'.")
         failure.assertHasCause("Invalid ivy extra info element name: '${name}'")
 
         where:
@@ -229,7 +229,7 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
         fails 'publish'
 
         then:
-        failure.assertHasDescription("A problem occurred evaluating root project 'publish'.")
+        failure.assertHasDescription("A problem occurred configuring root project 'publish'.")
         failure.assertHasFileName("Build file '${buildFile}'")
         failure.assertHasLineNumber(23)
         failure.assertHasCause("Cannot add an extra info element with null ")

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.cpp
 
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrariesWithApiDependencies
@@ -480,7 +481,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractInstalledToolChainInte
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
-    def "can adjust publication coordiantes"() {
+    def "can adjust main publication coordinates"() {
         def lib = new CppLib()
 
         given:
@@ -495,7 +496,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractInstalledToolChainInte
             }
             publishing {
                 repositories { maven { url 'repo' } }
-                publications.withType(MavenPublication) {
+                publications.main {
                     artifactId = "\${artifactId}-adjusted"
                 }
             }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -266,6 +266,25 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         outputContains(DEFERRED_CONFIGURATION_WARNING)
     }
 
+    def "uses old deferred configuration logic if feature preview is not activated"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            def mode = "Deferred"
+            publishing {
+                mode = "Eager"
+            }
+            println mode
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputDoesNotContain("Eager")
+    }
+
     def "no warning if the user already activated the stable feature preview"() {
 
         given:

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -105,12 +105,16 @@ public class PublishingPlugin implements Plugin<Project> {
     }
 
     private void bridgeToSoftwareModelIfNeeded(ProjectInternal project) {
-        project.addRuleBasedPluginListener(new RuleBasedPluginListener() {
-            @Override
-            public void prepareForRuleBasedPlugins(Project project) {
-                project.getPluginManager().apply(PublishingPluginRules.class);
-            }
-        });
+        if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_PUBLISHING)) {
+            project.addRuleBasedPluginListener(new RuleBasedPluginListener() {
+                @Override
+                public void prepareForRuleBasedPlugins(Project project) {
+                    project.getPluginManager().apply(PublishingPluginRules.class);
+                }
+            });
+        } else {
+            project.getPluginManager().apply(PublishingPluginRules.class);
+        }
     }
 
 }


### PR DESCRIPTION
Only the warning message should have been conditional,
the old extension should still behave as deferred.

Suprised so few people complained ;)