### PR TITLE
Fix several failed Java/Groovy compile tests for Java 9

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
@@ -7,9 +7,6 @@ import org.gradle.api.JavaVersion.VERSION_1_9
 internal
 val excludedTests = listOf(
     // TODO requires investigation
-    "DaemonGroovyCompilerIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-    "DaemonJavaCompilerIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-    "InProcessJavaCompilerIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
     "JacocoPluginMultiVersionIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
     "JacocoPluginCoverageVerificationIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -17,6 +17,7 @@ package org.gradle.groovy.compile
 
 import com.google.common.collect.Ordering
 import org.gradle.api.Action
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
@@ -28,6 +29,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 @TargetCoverage({GroovyCoverage.ALL})
@@ -384,7 +386,8 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         failure.assertHasCause("Could not execute Groovy compiler configuration script: ${file('groovycompilerconfig.groovy')}")
     }
 
-    @Requires(TestPrecondition.JDK8_OR_LATER)
+    // JavaFx was removed in JDK 10
+    @IgnoreIf({ JavaVersion.current() < JavaVersion.VERSION_1_8 || JavaVersion.current() > JavaVersion.VERSION_1_9 })
     def "compileJavaFx8Code"() {
         expect:
         succeeds("compileGroovy")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -18,11 +18,13 @@
 package org.gradle.java.compile
 
 import org.gradle.api.Action
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.ClassFile
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.IgnoreIf
 
 abstract class BasicJavaCompilerIntegrationSpec extends AbstractIntegrationSpec {
     def setup() {
@@ -123,6 +125,8 @@ compileJava.options.debug = false
         !noDebug.debugIncludesLocalVariables
     }
 
+    // JavaFx was removed in JDK 10
+    @IgnoreIf({ JavaVersion.current() < JavaVersion.VERSION_1_8 || JavaVersion.current() > JavaVersion.VERSION_1_9 })
     @Requires(TestPrecondition.JDK8_OR_LATER)
     def "compileJavaFx8Code"() {
         given:

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
@@ -3,3 +3,10 @@ apply plugin: "groovy"
 repositories {
     mavenCentral()
 }
+
+compileGroovy {
+    if (JavaVersion.current().isJava9()) {
+        options.compilerArgs += ['--add-modules', 'javafx.graphics']
+        groovyOptions.forkOptions.jvmArgs += ['--add-modules', 'javafx.graphics']
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/useConfigurationScript/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/useConfigurationScript/build.gradle
@@ -4,4 +4,9 @@ repositories {
     mavenCentral()
 }
 
+compileGroovy {
+    if (JavaVersion.current().isJava9Compatible()) {
+        groovyOptions.forkOptions.jvmArgs += ['--add-opens', 'java.base/jdk.internal.loader=ALL-UNNAMED']
+    }
+}
 compileGroovy.groovyOptions.configurationScript = file('groovycompilerconfig.groovy')


### PR DESCRIPTION
### Context 

This PR fixes some failed tests on Java 9/10. All of them are requiring some extra `--add-modules`/`--add-opens` arguments.