### PR TITLE
Re-enable ignored TAPI tests

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
@@ -14,11 +14,6 @@ val excludedTests = listOf(
     // Fail since build 125
     "InterfaceBackedManagedTypeIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
 
-    // Cannot obtain Jvm arguments via java.lang.management.ManagementFactory.runtimeMXBean.inputArguments module java.management does not export sun.management to unnamed module @6427ecb
-    "BuildEnvironmentModelCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10), // "informs about java args as in the build script"
-    "JavaConfigurabilityCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10), // "customized java args are reflected in the inputArguments and the build model", "tooling api provided jvm args take precedence over gradle.properties"
-    "GradlePropertiesToolingApiCrossVersionSpec" to listOf(VERSION_1_9, VERSION_1_10), // "tooling api honours jvm args specified in gradle.properties"
-
     // Broken scala and twirl compilation
     // Play does not fully support Java 9 yet (https://github.com/playframework/playframework/issues/7879)
     "MixedPlayAndJvmLibraryProjectIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),


### PR DESCRIPTION
### Context

This PR is simply re-enabling several tests. Not sure why they're disabled before, but they look compatible with Java 9 now.