### PR TITLE
Re-enable Jacoco test for Java9

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/excluded-tests.kt
@@ -6,10 +6,6 @@ import org.gradle.api.JavaVersion.VERSION_1_9
 
 internal
 val excludedTests = listOf(
-    // TODO requires investigation
-    "JacocoPluginMultiVersionIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-    "JacocoPluginCoverageVerificationIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),
-
     // Caused by: java.lang.IncompatibleClassChangeError: Method Person.getName()Ljava/lang/String; must be InterfaceMethodref constant
     // Fail since build 125
     "InterfaceBackedManagedTypeIntegrationTest" to listOf(VERSION_1_9, VERSION_1_10),

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.testing.jacoco.plugins.fixtures.JacocoCoverage
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
-@TargetCoverage({ JacocoCoverage.SUPPORTS_JDK_8_OR_HIGHER })
+@TargetCoverage({ JacocoCoverage.DEFAULT_COVERAGE })
 class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrationTest {
 
     private static final String REPORTING_BASE = "${Project.DEFAULT_BUILD_DIR_NAME}/${ReportingExtension.DEFAULT_REPORTS_DIR_NAME}"

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.jacoco.plugins.fixtures
 
+import org.gradle.api.JavaVersion
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 
 final class JacocoCoverage {
@@ -24,11 +25,7 @@ final class JacocoCoverage {
 
     final static String[] ALL = ['0.6.0.201210061924', '0.6.2.201302030002', '0.6.3.201306030806', '0.7.1.201405082137', '0.7.6.201602180812', JacocoPlugin.DEFAULT_JACOCO_VERSION].asImmutable()
 
-    final static List<String> COVERAGE_CHECK_SUPPORTED = ALL.findAll {
-        def jacocoVersion = new JacocoVersion(it)
-        def supportedJacocoVersion = JacocoVersion.CHECK_INTRODUCED
-        jacocoVersion.compareTo(supportedJacocoVersion) >= 0
-    }.asImmutable()
+    final static List<String> COVERAGE_CHECK_SUPPORTED = filter(JacocoVersion.CHECK_INTRODUCED)
 
     final static List<String> COVERAGE_CHECK_UNSUPPORTED = ALL.findAll {
         def jacocoVersion = new JacocoVersion(it)
@@ -36,15 +33,19 @@ final class JacocoCoverage {
         jacocoVersion.compareTo(supportedJacocoVersion) == -1
     }.asImmutable()
 
-    final static List<String> SUPPORTS_JDK_8_OR_HIGHER = ALL.findAll {
-        def jacocoVersion = new JacocoVersion(it)
-        def supportedJacocoVersion = JacocoVersion.SUPPORTS_JDK_8
-        jacocoVersion.compareTo(supportedJacocoVersion) >= 0
-    }.asImmutable()
+    final static List<String> SUPPORTS_JDK_8_OR_HIGHER = filter(JacocoVersion.SUPPORTS_JDK_8)
+    final static List<String> SUPPORTS_JDK_9_OR_HIGHER = filter(JacocoVersion.SUPPORTS_JDK_9)
+
+    final static List<String> DEFAULT_COVERAGE = JavaVersion.current().isJava9Compatible() ? SUPPORTS_JDK_9_OR_HIGHER : SUPPORTS_JDK_8_OR_HIGHER
+
+    static List<String> filter(JacocoVersion threshold) {
+        ALL.findAll { new JacocoVersion(it) >= threshold }
+    }
 
     private static class JacocoVersion implements Comparable<JacocoVersion> {
         final static CHECK_INTRODUCED = new JacocoVersion(0, 6, 3)
         final static SUPPORTS_JDK_8 = new JacocoVersion(0, 7, 0)
+        final static SUPPORTS_JDK_9 = new JacocoVersion(0, 7, 8)
         private final Integer major
         private final Integer minor
         private final Integer patch

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
@@ -39,7 +39,7 @@ final class JacocoCoverage {
     final static List<String> DEFAULT_COVERAGE = JavaVersion.current().isJava9Compatible() ? SUPPORTS_JDK_9_OR_HIGHER : SUPPORTS_JDK_8_OR_HIGHER
 
     static List<String> filter(JacocoVersion threshold) {
-        ALL.findAll { new JacocoVersion(it) >= threshold }
+        ALL.findAll { new JacocoVersion(it) >= threshold }.asImmutable()
     }
 
     private static class JacocoVersion implements Comparable<JacocoVersion> {

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/rules/JacocoPluginCoverageVerificationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/rules/JacocoPluginCoverageVerificationIntegrationTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 import static org.gradle.testing.jacoco.plugins.rules.JacocoViolationRulesLimit.Insufficient
 import static org.gradle.testing.jacoco.plugins.rules.JacocoViolationRulesLimit.Sufficient
 
-@TargetCoverage({ JacocoCoverage.SUPPORTS_JDK_8_OR_HIGHER })
+@TargetCoverage({ JacocoCoverage.DEFAULT_COVERAGE })
 class JacocoPluginCoverageVerificationIntegrationTest extends JacocoMultiVersionIntegrationTest {
 
     private final static String[] TEST_TASK_PATH = [':test'] as String[]


### PR DESCRIPTION
### Context

Since Jacoco 0.7.8 supports Java 9+, we should re-enable related tests.