### PR TITLE
Create and wire in a ComponentMetadataRuleExecutor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/action/ConfigurableRules.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/action/ConfigurableRules.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.action;
+
+import java.util.List;
+
+public interface ConfigurableRules<DETAILS> {
+    List<ConfigurableRule<DETAILS>> getConfigurableRules();
+    boolean isCacheable();
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/action/DefaultConfigurableRules.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/action/DefaultConfigurableRules.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.action;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+public class DefaultConfigurableRules<DETAILS> implements ConfigurableRules<DETAILS> {
+
+    public static <T> ConfigurableRules<T> of(ConfigurableRule<T> unique) {
+        return new DefaultConfigurableRules<T>(singletonList(unique));
+    }
+
+    private final List<ConfigurableRule<DETAILS>> configurableRules;
+    private final boolean cacheable;
+
+    public DefaultConfigurableRules(List<ConfigurableRule<DETAILS>> rules) {
+        this.configurableRules = ImmutableList.copyOf(rules);
+
+        cacheable = computeCacheable();
+    }
+
+    private boolean computeCacheable() {
+        boolean isCacheable = false;
+        for (ConfigurableRule<DETAILS> configurableRule : configurableRules) {
+            if (configurableRule.isCacheable()) {
+                isCacheable = true;
+            }
+        }
+        return isCacheable;
+    }
+
+    @Override
+    public List<ConfigurableRule<DETAILS>> getConfigurableRules() {
+        return configurableRules;
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return cacheable;
+    }
+
+    @Override
+    public String toString() {
+        return configurableRules.toString();
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/action/InstantiatingActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/action/InstantiatingActionTest.groovy
@@ -38,19 +38,20 @@ class InstantiatingActionTest extends Specification {
 
         when:
         def action = new InstantiatingAction<Details>(
-            DefaultConfigurableRule.of(RuleWithParams, new Action<ActionConfiguration>() {
-                @Override
-                void execute(ActionConfiguration actionConfiguration) {
-                    actionConfiguration.params(123, "test string")
-                }
-            }, TestUtil.valueSnapshotter()),
+            DefaultConfigurableRules.of(
+                DefaultConfigurableRule.of(RuleWithParams, new Action<ActionConfiguration>() {
+                    @Override
+                    void execute(ActionConfiguration actionConfiguration) {
+                        actionConfiguration.params(123, "test string")
+                    }
+                }, TestUtil.valueSnapshotter())),
             TestUtil.instantiatorFactory().decorate(),
             shouldNotFail
         )
 
         then:
-        action.rule.ruleParams.isolate() == [123, "test string"] as Object[]
-        action.rule.ruleClass == RuleWithParams
+        action.rules.configurableRules[0].ruleParams.isolate() == [123, "test string"] as Object[]
+        action.rules.configurableRules[0].ruleClass == RuleWithParams
 
         when:
         action.execute(details)
@@ -68,14 +69,14 @@ class InstantiatingActionTest extends Specification {
 
         when:
         def action = new InstantiatingAction<Details>(
-            DefaultConfigurableRule.of(RuleWithInjectedParams),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(RuleWithInjectedParams)),
             TestUtil.instantiatorFactory().inject(registry),
             shouldNotFail
         )
 
         then:
-        action.rule.ruleParams.isolate() == [] as Object[]
-        action.rule.ruleClass == RuleWithInjectedParams
+        action.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
+        action.rules.configurableRules[0].ruleClass == RuleWithInjectedParams
 
         when:
         action.execute(details)
@@ -94,19 +95,20 @@ class InstantiatingActionTest extends Specification {
 
         when:
         def action = new InstantiatingAction<Details>(
-            DefaultConfigurableRule.of(RuleWithInjectedAndRegularParams, new Action<ActionConfiguration>() {
-                @Override
-                void execute(ActionConfiguration actionConfiguration) {
-                    actionConfiguration.params(456)
-                }
-            }, TestUtil.valueSnapshotter()),
+            DefaultConfigurableRules.of(
+                DefaultConfigurableRule.of(RuleWithInjectedAndRegularParams, new Action<ActionConfiguration>() {
+                    @Override
+                    void execute(ActionConfiguration actionConfiguration) {
+                        actionConfiguration.params(456)
+                    }
+                }, TestUtil.valueSnapshotter())),
             TestUtil.instantiatorFactory().inject(registry),
             shouldNotFail
         )
 
         then:
-        action.rule.ruleParams.isolate() == [456] as Object[]
-        action.rule.ruleClass == RuleWithInjectedAndRegularParams
+        action.rules.configurableRules[0].ruleParams.isolate() == [456] as Object[]
+        action.rules.configurableRules[0].ruleClass == RuleWithInjectedAndRegularParams
 
         when:
         action.execute(details)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+
+class ComponentMetadataRulesCachingIntegrationTest extends AbstractModuleDependencyResolveTest implements ComponentMetadataRulesSupport {
+    String getDefaultStatus() {
+        GradleMetadataResolveRunner.useIvy()?'integration':'release'
+    }
+
+    def setup() {
+        buildFile << """
+dependencies {
+    conf 'org.test:projectA:1.0'
+}
+
+// implement Sync manually to make sure that task is never up-to-date
+task resolve {
+    doLast {
+        delete 'libs'
+        copy {
+            from configurations.conf
+            into 'libs'
+        }
+    }
+}
+"""
+    }
+
+    def "rule is cached across builds"() {
+        repository {
+            'org.test:projectA:1.0'()
+        }
+        buildFile << """
+
+@CacheableRule
+class CachedRule implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println 'Rule executed'
+    }
+}
+
+dependencies {
+    components {
+        all(CachedRule)
+    }
+}
+"""
+
+        when:
+        repositoryInteractions {
+            'org.test:projectA:1.0' {
+                allowAll()
+            }
+        }
+
+        then:
+        succeeds 'resolve'
+        outputContains('Rule executed')
+
+
+        then:
+        succeeds 'resolve'
+        outputDoesNotContain('Rule executed')
+    }
+
+    def 'rule cache properly differentiates inputs'() {
+        repository {
+            'org.test:projectA:1.0'()
+        }
+        buildFile << """
+
+@CacheableRule
+class CachedRuleA implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println 'Rule A executed'
+            context.details.changing = true
+    }
+}
+
+@CacheableRule
+class CachedRuleB implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println 'Rule B executed - saw changing ' + context.details.changing
+    }
+}
+
+dependencies {
+    components {
+        if (project.hasProperty('cacheA')) {
+            all(CachedRuleA)
+        }
+        all(CachedRuleB)
+    }
+}
+"""
+        when:
+        repositoryInteractions {
+            'org.test:projectA:1.0' {
+                allowAll()
+            }
+        }
+
+        then:
+        succeeds 'resolve'
+        outputContains('Rule B executed - saw changing false')
+
+
+        then:
+        succeeds 'resolve', '-PcacheA'
+        outputContains('Rule A executed')
+        outputContains('Rule B executed - saw changing true')
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -982,7 +982,7 @@ group:projectB:2.2;release
         outputContains 'Providing metadata for group:projectA:1.2'
     }
 
-    def "can cache the result of processing a rule accross projects"() {
+    def "can cache the result of processing a rule across projects"() {
         settingsFile << """
             include 'b'
         """
@@ -1032,8 +1032,8 @@ group:projectB:2.2;release
 
         then:
         noExceptionThrown()
-        outputContains "Found result for rule DefaultConfigurableRule{rule=class MP, ruleParams=[]} and key group:projectB:2.2"
-        outputContains "Found result for rule DefaultConfigurableRule{rule=class MP, ruleParams=[]} and key group:projectB:1.1"
+        result.assertRawOutputContains "Found result for rule [DefaultConfigurableRule{rule=class MP, ruleParams=[]}] and key group:projectB:2.2"
+        result.assertRawOutputContains "Found result for rule [DefaultConfigurableRule{rule=class MP, ruleParams=[]}] and key group:projectB:1.1"
     }
 
     def "changing the implementation of a rule invalidates the cache"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
@@ -16,12 +16,13 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ComponentMetadata;
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
 public interface ComponentMetadataProcessor {
     ComponentMetadataProcessor NO_OP = new ComponentMetadataProcessor() {
         @Override
-        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
+        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata, CachePolicy cachePolicy) {
             return metadata;
         }
 
@@ -31,7 +32,7 @@ public interface ComponentMetadataProcessor {
         }
     };
 
-    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata);
+    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata, CachePolicy cachePolicy);
 
     /**
      * Processes "shallow" metadata, only for selecting a version. This metadata is typically

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -93,6 +93,7 @@ import org.gradle.internal.locking.DefaultDependencyLockingHandler;
 import org.gradle.internal.locking.DefaultDependencyLockingProvider;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resource.cached.ExternalResourceFileStore;
 import org.gradle.internal.resource.local.FileResourceRepository;
@@ -246,8 +247,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory);
         }
 
-        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory) {
-            return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory);
+        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {
+            return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory, componentMetadataRuleExecutor);
         }
 
         DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -38,6 +38,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.DefaultModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCacheProvider;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCaches;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.SuppliedComponentMetadataSerializer;
@@ -101,6 +103,7 @@ import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.TextResourceLoader;
@@ -389,9 +392,21 @@ class DependencyManagementBuildScopeServices {
     }
 
 
+    ModuleComponentResolveMetadataSerializer createModuleComponentResolveMetadataSerializer(AttributeContainerSerializer attributeContainerSerializer, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+        return new ModuleComponentResolveMetadataSerializer(new ModuleMetadataSerializer(attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory), moduleIdentifierFactory);
+    }
+
     SuppliedComponentMetadataSerializer createSuppliedComponentMetadataSerializer(ImmutableModuleIdentifierFactory moduleIdentifierFactory, AttributeContainerSerializer attributeContainerSerializer) {
         ModuleVersionIdentifierSerializer moduleVersionIdentifierSerializer = new ModuleVersionIdentifierSerializer(moduleIdentifierFactory);
         return new SuppliedComponentMetadataSerializer(moduleVersionIdentifierSerializer, attributeContainerSerializer);
+    }
+
+    ComponentMetadataRuleExecutor createComponentMetadataRuleExecutor(ValueSnapshotter valueSnapshotter,
+                                                                      CacheRepository cacheRepository,
+                                                                      InMemoryCacheDecoratorFactory cacheDecoratorFactory,
+                                                                      BuildCommencedTimeProvider timeProvider,
+                                                                      ModuleComponentResolveMetadataSerializer serializer) {
+        return new ComponentMetadataRuleExecutor(cacheRepository, cacheDecoratorFactory, valueSnapshotter, timeProvider, serializer);
     }
 
     ComponentMetadataSupplierRuleExecutor createComponentMetadataSupplierRuleExecutor(ValueSnapshotter snapshotter,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
@@ -23,12 +23,12 @@ import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
-public class DefaultComponentMetadataContext implements ComponentMetadataContext {
+class DefaultComponentMetadataContext implements ComponentMetadataContext {
 
     private final ComponentMetadataDetails details;
     private final ModuleComponentResolveMetadata metadata;
 
-    public DefaultComponentMetadataContext(ComponentMetadataDetails details, ModuleComponentResolveMetadata metadata) {
+    DefaultComponentMetadataContext(ComponentMetadataDetails details, ModuleComponentResolveMetadata metadata) {
         this.details = details;
         this.metadata = metadata;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/SpecConfigurableRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/SpecConfigurableRule.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.specs.Spec;
+import org.gradle.internal.action.ConfigurableRule;
+
+class SpecConfigurableRule {
+
+    private final ConfigurableRule<ComponentMetadataContext> configurableRule;
+    private final Spec<ModuleVersionIdentifier> spec;
+
+    SpecConfigurableRule(ConfigurableRule<ComponentMetadataContext> configurableRule, Spec<ModuleVersionIdentifier> spec) {
+
+        this.configurableRule = configurableRule;
+        this.spec = spec;
+    }
+
+    public ConfigurableRule<ComponentMetadataContext> getConfigurableRule() {
+        return configurableRule;
+    }
+
+    public Spec<ModuleVersionIdentifier> getSpec() {
+        return spec;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
+import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+
+class WrappingComponentMetadataContext implements ComponentMetadataContext {
+
+
+    private final ModuleComponentResolveMetadata metadata;
+    private final Instantiator instantiator;
+    private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
+    private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+
+    private MutableModuleComponentResolveMetadata mutableMetadata;
+    private ComponentMetadataDetails details;
+
+    public WrappingComponentMetadataContext(ModuleComponentResolveMetadata metadata, Instantiator instantiator,
+                                            NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
+                                            NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser) {
+        this.metadata = metadata;
+        this.instantiator = instantiator;
+        this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
+        this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
+    }
+
+    @Override
+    public <T> T getDescriptor(Class<T> descriptorClass) {
+        if (IvyModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
+            if (metadata instanceof IvyModuleResolveMetadata) {
+                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
+                return descriptorClass.cast(new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus()));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ComponentMetadataDetails getDetails() {
+        createMutableMetadataIfNeeded();
+        if (details == null) {
+            details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+
+        }
+        return details;
+    }
+
+    MutableModuleComponentResolveMetadata getMutableMetadata() {
+        createMutableMetadataIfNeeded();
+        return mutableMetadata;
+    }
+
+    private void createMutableMetadataIfNeeded() {
+        if (mutableMetadata == null) {
+            mutableMetadata = metadata.asMutable();
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -230,7 +230,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         private ModuleComponentResolveMetadata getProcessedMetadata(ModuleMetadataCache.CachedMetadata cachedMetadata) {
             ModuleComponentResolveMetadata metadata = cachedMetadata.getProcessedMetadata();
             if (metadata == null) {
-                metadata = metadataProcessor.processMetadata(cachedMetadata.getMetadata());
+                metadata = metadataProcessor.processMetadata(cachedMetadata.getMetadata(), cachePolicy);
                 // Save the processed metadata for next time.
                 cachedMetadata.setProcessedMetadata(metadata);
             }
@@ -385,7 +385,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
                     ModuleComponentResolveMetadata resolvedMetadata = result.getMetaData();
                     ModuleSource moduleSource = resolvedMetadata.getSource();
                     ModuleMetadataCache.CachedMetadata cachedMetadata = moduleMetadataCache.cacheMetaData(delegate, moduleComponentIdentifier, resolvedMetadata);
-                    ModuleComponentResolveMetadata processedMetadata = metadataProcessor.processMetadata(resolvedMetadata);
+                    ModuleComponentResolveMetadata processedMetadata = metadataProcessor.processMetadata(resolvedMetadata, cachePolicy);
                     cachedMetadata.setProcessedMetadata(processedMetadata);
                     moduleSource = new CachingModuleSource(processedMetadata.getContentHash().asBigInteger(), requestMetaData.isChanging() || processedMetadata.isChanging(), moduleSource);
                     result.resolved(processedMetadata.withSource(moduleSource));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
@@ -42,10 +43,12 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
     private final ComponentMetadataProcessor metadataProcessor;
     private final LocalAccess localAccess = new LocalAccess();
     private final RemoteAccess remoteAccess = new RemoteAccess();
+    private final CachePolicy cachePolicy;
 
-    public LocalModuleComponentRepository(ModuleComponentRepository delegate, ComponentMetadataProcessor metadataProcessor) {
+    public LocalModuleComponentRepository(ModuleComponentRepository delegate, ComponentMetadataProcessor metadataProcessor, CachePolicy cachePolicy) {
         super(delegate);
         this.metadataProcessor = metadataProcessor;
+        this.cachePolicy = cachePolicy;
     }
 
     public ModuleComponentRepositoryAccess getLocalAccess() {
@@ -78,7 +81,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
             }
 
             if (result.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved) {
-                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData()));
+                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData(), cachePolicy));
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -104,7 +104,7 @@ public class ResolveIvyFactory {
             if (baseRepository.isLocal()) {
                 moduleComponentRepository = new CachingModuleComponentRepository(moduleComponentRepository, cacheProvider.getInMemoryCaches(),
                     cachePolicy, timeProvider, metadataProcessor, moduleIdentifierFactory);
-                moduleComponentRepository = new LocalModuleComponentRepository(moduleComponentRepository, metadataProcessor);
+                moduleComponentRepository = new LocalModuleComponentRepository(moduleComponentRepository, metadataProcessor, cachePolicy);
             } else {
                 moduleComponentRepository = startParameterResolutionOverride.overrideModuleVersionRepository(moduleComponentRepository);
                 moduleComponentRepository = new CachingModuleComponentRepository(moduleComponentRepository, cacheProvider.getCaches(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache;
+
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.serialize.AbstractSerializer;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+
+import java.io.EOFException;
+
+public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer<ModuleComponentResolveMetadata> {
+
+    private final ModuleMetadataSerializer delegate;
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+
+    public ModuleComponentResolveMetadataSerializer(ModuleMetadataSerializer delegate, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+        this.delegate = delegate;
+        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata read(Decoder decoder) throws EOFException, Exception {
+
+        return delegate.read(decoder, moduleIdentifierFactory).asImmutable();
+    }
+
+    @Override
+    public void write(Encoder encoder, ModuleComponentResolveMetadata value) throws Exception {
+        delegate.write(encoder, value);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRule;
+import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ImplicitInputsCapturingInstantiator;
@@ -132,7 +133,7 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
 
 
     private static <T> InstantiatingAction<T> createRuleAction(final Instantiator instantiator, final ConfigurableRule<T> rule) {
-        return new InstantiatingAction<T>(rule, instantiator, new InstantiatingAction.ExceptionHandler<T>() {
+        return new InstantiatingAction<T>(DefaultConfigurableRules.of(rule), instantiator, new InstantiatingAction.ExceptionHandler<T>() {
             @Override
             public void handleException(T target, Throwable throwable) {
                 throw UncheckedException.throwAsUncheckedException(throwable);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.CompatibilityRuleChain;
 import org.gradle.internal.action.DefaultConfigurableRule;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory;
+import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.type.ModelType;
@@ -54,12 +55,14 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
 
     @Override
     public void add(Class<? extends AttributeCompatibilityRule<T>> rule, Action<? super ActionConfiguration> configureAction) {
-        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule, configureAction, isolatableFactory), instantiator, new ExceptionHandler<T>(rule)));
+        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule, configureAction, isolatableFactory)),
+                    instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override
     public void add(final Class<? extends AttributeCompatibilityRule<T>> rule) {
-        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule), instantiator, new ExceptionHandler<T>(rule)));
+        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule)),
+                    instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
@@ -26,6 +26,7 @@ import org.gradle.api.attributes.DisambiguationRuleChain;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.internal.action.DefaultConfigurableRule;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory;
+import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.type.ModelType;
@@ -46,12 +47,14 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
 
     @Override
     public void add(final Class<? extends AttributeDisambiguationRule<T>> rule, Action<? super ActionConfiguration> configureAction) {
-        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule, configureAction, isolatableFactory), instantiator, new ExceptionHandler<T>(rule)));
+        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule, configureAction, isolatableFactory)),
+                        instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override
     public void add(final Class<? extends AttributeDisambiguationRule<T>> rule) {
-        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule), instantiator, new ExceptionHandler<T>(rule)));
+        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule)),
+                        instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resolve.caching;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedModuleVersion;
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
+import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
+import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
+import org.gradle.cache.CacheRepository;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.serialize.Serializer;
+import org.gradle.util.BuildCommencedTimeProvider;
+
+import java.io.Serializable;
+
+public class ComponentMetadataRuleExecutor extends CrossBuildCachingRuleExecutor<ModuleComponentResolveMetadata, ComponentMetadataContext, ModuleComponentResolveMetadata> {
+
+    private final static Transformer<Serializable, ModuleComponentResolveMetadata> KEY_TO_SNAPSHOTTABLE = new Transformer<Serializable, ModuleComponentResolveMetadata>() {
+        @Override
+        public Serializable transform(ModuleComponentResolveMetadata moduleMetadata) {
+            return moduleMetadata.getContentHash().asBigInteger();
+        }
+    };
+
+    public ComponentMetadataRuleExecutor(CacheRepository cacheRepository,
+                                         InMemoryCacheDecoratorFactory cacheDecoratorFactory,
+                                         ValueSnapshotter snapshotter,
+                                         BuildCommencedTimeProvider timeProvider,
+                                         Serializer<ModuleComponentResolveMetadata> componentMetadataContextSerializer) {
+        super("md-rule", cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, createValidator(timeProvider), KEY_TO_SNAPSHOTTABLE, componentMetadataContextSerializer);
+    }
+
+    private static EntryValidator<ModuleComponentResolveMetadata> createValidator(final BuildCommencedTimeProvider timeProvider) {
+        return new CrossBuildCachingRuleExecutor.EntryValidator<ModuleComponentResolveMetadata>() {
+            @Override
+            public boolean isValid(CachePolicy policy, final CrossBuildCachingRuleExecutor.CachedEntry<ModuleComponentResolveMetadata> entry) {
+                long age = timeProvider.getCurrentTime() - entry.getTimestamp();
+                final ModuleComponentResolveMetadata result = entry.getResult();
+                boolean mustRefreshModule = policy.mustRefreshModule(new SimpleResolvedModuleVersion(result.getModuleVersionId()), age, result.isChanging());
+                return !mustRefreshModule;
+            }
+        };
+    }
+
+    private static class SimpleResolvedModuleVersion implements ResolvedModuleVersion {
+
+        private final ModuleVersionIdentifier identifier;
+
+        private SimpleResolvedModuleVersion(ModuleVersionIdentifier identifier) {
+            this.identifier = identifier;
+        }
+
+        @Override
+        public ModuleVersionIdentifier getId() {
+            return identifier;
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCa
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
 import org.gradle.cache.CacheRepository
+import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
@@ -164,7 +165,7 @@ class MetadataProviderTest extends Specification {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplier),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )
@@ -191,7 +192,7 @@ class MetadataProviderTest extends Specification {
             }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplier),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )
@@ -213,7 +214,7 @@ class MetadataProviderTest extends Specification {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplier),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )
@@ -240,7 +241,7 @@ class MetadataProviderTest extends Specification {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplierWithInvalidAttributes),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplierWithInvalidAttributes)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry
@@ -52,6 +53,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
         localMavenRepoLocator, fileResolver, transportFactory, locallyAvailableResourceFinder,
@@ -61,7 +63,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
 
     def testCreateFlatDirResolver() {
         expect:
-        def repo =factory.createFlatDirRepository()
+        def repo = factory.createFlatDirRepository()
         repo instanceof DefaultFlatDirArtifactRepository
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.api.internal.model.NamedObjectInstantiator
@@ -56,6 +57,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory, TestUtil.valueSnapshotter())
 
@@ -302,8 +304,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def supplier = repository.createResolver().componentMetadataSupplier
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplier
-        supplier.rule.ruleParams.isolate() == [] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplier
+        supplier.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom metadata rule"() {
@@ -320,8 +322,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def supplier = resolver.getComponentMetadataSupplier()
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplierWithParams
-        supplier.rule.ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplierWithParams
+        supplier.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
     }
 
     def "can set a custom version lister"() {
@@ -337,8 +339,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionLister
-        lister.rule.ruleParams.isolate() == [] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionLister
+        lister.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom version lister"() {
@@ -354,8 +356,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionListerWithParams
-        lister.rule.ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionListerWithParams
+        lister.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
     }
 
     static class CustomVersionLister implements ComponentMetadataVersionLister {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModul
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.resource.ExternalResourceRepository
@@ -51,6 +52,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
         resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory, TestUtil.valueSnapshotter())
@@ -179,8 +181,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def supplier = resolver.componentMetadataSupplier
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplier
-        supplier.rule.ruleParams.isolate() == [] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplier
+        supplier.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom metadata rule"() {
@@ -197,8 +199,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def supplier = resolver.getComponentMetadataSupplier()
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplierWithParams
-        supplier.rule.ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplierWithParams
+        supplier.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
     }
 
     def "can set a custom version lister"() {
@@ -214,8 +216,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionLister
-        lister.rule.ruleParams.isolate() == [] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionLister
+        lister.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom version lister"() {
@@ -231,8 +233,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionListerWithParams
-        lister.rule.ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionListerWithParams
+        lister.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
     }
 
     static class CustomVersionLister implements ComponentMetadataVersionLister {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMeta
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -42,6 +43,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(resolver,
         transportFactory,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadata
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata
 import org.gradle.internal.action.ConfigurableRule
@@ -173,8 +174,8 @@ class IvyResolverTest extends Specification {
             }
         }
 
-        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
-        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
         new IvyResolver(
             "repo",

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadata
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.ComponentVariant
 import org.gradle.internal.component.external.model.FixedComponentArtifacts
@@ -141,8 +142,8 @@ class MavenResolverTest extends Specification {
             }
         }
 
-        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
-        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
         new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), moduleIdentifierFactory, metadataSources, metadataArtifactProvider, Stub(MavenMetadataLoader), supplier, lister)
     }


### PR DESCRIPTION
This enables `ComponentMetadataRule` execution to be cached
Update the `CrossBuildCachingRuleExecutor` to work with a set of rule
instead of a single one. This means we cache or miss on a chain of rules
 instead of single rules.