### PR TITLE
Remove file leaks in Java/Groovy compiler

### DIFF
--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -72,7 +72,8 @@ open class BuildScanPlugin : Plugin<Project> {
                         codenarcPackage.getElementsByTag("File").flatMap { file ->
                             file.getElementsByTag("Violation").map { violation ->
                                 val filePath = rootProject.relativePath(file.attr("name"))
-                                "$filePath:${violation.attr("lineNumber")} \u2192 ${violation.getElementsByTag("Message").first().text()}"
+                                val message = violation.getElementsByTag("Message").first() ?: violation.getElementsByTag("SourceLine").first()
+                                "$filePath:${violation.attr("lineNumber")} \u2192 ${message.text()}"
                             }
                         }
                     }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesGroovyMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesGroovyMultiProjectIntegrationTest.groovy
@@ -29,8 +29,8 @@ class SamplesGroovyMultiProjectIntegrationTest extends AbstractIntegrationSpec {
     @Rule public final Sample sample = new Sample(temporaryFolder)
     private final static String TEST_PROJECT_NAME = "testproject"
 
+    @LeaksFileHandles("Workaround till https://github.com/apache/groovy/pull/735 is merged")
     @UsesSample("groovy/multiproject")
-    @LeaksFileHandles
     void groovyProjectSamples() {
         def groovySources = ["GroovyPerson", "GroovyJavaPerson"]
         def javaSources = ["JavaPerson"]

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -257,6 +257,11 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                 void suppressCleanup() {
 
                 }
+
+                @Override
+                void suppressCleanupErrors() {
+
+                }
             }
         }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -44,6 +44,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
     private TestFile dir;
     private String prefix;
     private boolean cleanup = true;
+    private boolean suppressCleanupErrors = false;
 
     private String determinePrefix() {
         StackTraceElement[] stackTrace = new RuntimeException().getStackTrace();
@@ -58,6 +59,10 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
     @Override
     public void suppressCleanup() {
         cleanup = false;
+    }
+
+    public void suppressCleanupErrors() {
+        suppressCleanupErrors = true;
     }
 
     public boolean isCleanup() {
@@ -108,7 +113,8 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
         }
 
         private boolean suppressCleanupErrors() {
-            return testClass().getAnnotation(LeaksFileHandles.class) != null
+            return suppressCleanupErrors
+                || testClass().getAnnotation(LeaksFileHandles.class) != null
                 || description.getAnnotation(LeaksFileHandles.class) != null;
         }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestDirectoryProvider.java
@@ -32,4 +32,6 @@ public interface TestDirectoryProvider {
 
     void suppressCleanup();
 
+    void suppressCleanupErrors();
+
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -40,6 +40,7 @@ import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.VersionNumber;
 
@@ -187,6 +188,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
             compilerGroovyLoader.discardTypesFrom(astTransformClassLoader);
             //Discard the compile loader
             compileClasspathLoader.shutdown();
+            CompositeStoppable.stoppable(classPathLoader, astTransformClassLoader).stop();
         }
 
         return WorkResults.didWork(true);

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -59,7 +59,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
             workerFactory = inProcessWorkerFactory;
         }
         Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(project.getServices().get(WorkerDirectoryProvider.class).getIdleWorkingDirectory(), new DaemonSideCompiler(), project.getServices().get(ClassPathRegistry.class), workerFactory, fileResolver);
-        return new AnnotationProcessingCompiler<GroovyJavaJointCompileSpec>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
+        return new AnnotationProcessorDiscoveringCompiler<GroovyJavaJointCompileSpec>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
     }
 
     private static class DaemonSideCompiler implements Compiler<GroovyJavaJointCompileSpec>, Serializable {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.IdentityFileResolver;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.compile.daemon.DaemonGroovyCompiler;
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.GroovyCompileOptions;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -38,12 +39,14 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
     private final WorkerDaemonFactory workerDaemonFactory;
     private final IsolatedClassloaderWorkerFactory inProcessWorkerFactory;
     private final FileResolver fileResolver;
+    private AnnotationProcessorDetector processorDetector;
 
-    public GroovyCompilerFactory(ProjectInternal project, WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, FileResolver fileResolver) {
+    public GroovyCompilerFactory(ProjectInternal project, WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, FileResolver fileResolver, AnnotationProcessorDetector processorDetector) {
         this.project = project;
         this.workerDaemonFactory = workerDaemonFactory;
         this.inProcessWorkerFactory = inProcessWorkerFactory;
         this.fileResolver = fileResolver;
+        this.processorDetector = processorDetector;
     }
 
     @Override
@@ -56,7 +59,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
             workerFactory = inProcessWorkerFactory;
         }
         Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(project.getServices().get(WorkerDirectoryProvider.class).getIdleWorkingDirectory(), new DaemonSideCompiler(), project.getServices().get(ClassPathRegistry.class), workerFactory, fileResolver);
-        return new NormalizingGroovyCompiler(groovyCompiler);
+        return new AnnotationProcessingCompiler<GroovyJavaJointCompileSpec>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
     }
 
     private static class DaemonSideCompiler implements Compiler<GroovyJavaJointCompileSpec>, Serializable {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.tasks.compile.DefaultGroovyJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.compile.DefaultGroovyJavaJointCompileSpecFactory;
 import org.gradle.api.internal.tasks.compile.GroovyCompilerFactory;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorPathFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.CacheableTask;
@@ -84,7 +85,8 @@ public class GroovyCompile extends AbstractCompile {
             WorkerDaemonFactory workerDaemonFactory = getServices().get(WorkerDaemonFactory.class);
             IsolatedClassloaderWorkerFactory inProcessWorkerFactory = getServices().get(IsolatedClassloaderWorkerFactory.class);
             FileResolver fileResolver = getServices().get(FileResolver.class);
-            GroovyCompilerFactory groovyCompilerFactory = new GroovyCompilerFactory(projectInternal, workerDaemonFactory, inProcessWorkerFactory, fileResolver);
+            AnnotationProcessorDetector processorDetector = getServices().get(AnnotationProcessorDetector.class);
+            GroovyCompilerFactory groovyCompilerFactory = new GroovyCompilerFactory(projectInternal, workerDaemonFactory, inProcessWorkerFactory, fileResolver, processorDetector);
             Compiler<GroovyJavaJointCompileSpec> delegatingCompiler = groovyCompilerFactory.newCompiler(spec);
             compiler = new CleaningGroovyCompiler(delegatingCompiler, getOutputs());
         }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -93,6 +93,6 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
 
         expect:
         fails("compileJava")
-        failure.assertHasCause("java.lang.ClassNotFoundException: unknown.Processor")
+        failure.assertHasCause("Annotation processor 'unknown.Processor' not found")
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -54,7 +54,6 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
             
             compileJava {
                 compileJava.options.incremental = true
-                options.fork = true
             }
         """
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -169,7 +169,12 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
 
     def "all files are recompiled if compiler does not support incremental annotation processing"() {
         given:
-        buildFile << "compileJava.options.forkOptions.executable = '${TextUtil.escapeString(AvailableJavaHomes.getJdk(JavaVersion.current()).javacExecutable)}'"
+        buildFile << """
+            compileJava {
+                options.fork = true
+                options.forkOptions.executable = '${TextUtil.escapeString(AvailableJavaHomes.getJdk(JavaVersion.current()).javacExecutable)}'
+            }
+        """
         def a = java "@Helper class A {}"
         java "class Unrelated {}"
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
@@ -34,11 +34,6 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile << """
             apply plugin: 'java'
-            
-            compileJava {
-                // Use forking to work around javac's jar cache
-                options.fork = true
-            }
         """
 
         annotationProjectDir.file("build.gradle") << """

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
@@ -87,7 +87,6 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
         buildFile << '''
             allprojects {
                 apply plugin: 'java'
-                compileJava.options.fork = true // Use forking to work around javac's jar cache
             }
         '''
         file('a/build.gradle') << '''

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -35,7 +35,6 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
                 apply plugin: 'java'
                 tasks.withType(JavaCompile) {
                     options.incremental = true
-                    options.fork = true
                 }
                 ${mavenCentralRepository()}
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaLanguageIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/language/java/JavaLanguageIntegrationTest.groovy
@@ -22,11 +22,9 @@ import org.gradle.integtests.language.AbstractJvmLanguageIntegrationTest
 import org.gradle.jvm.platform.internal.DefaultJavaPlatform
 import org.gradle.language.fixtures.BadJavaComponent
 import org.gradle.language.fixtures.TestJavaComponent
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
-@LeaksFileHandles
 class JavaLanguageIntegrationTest extends AbstractJvmLanguageIntegrationTest {
     TestJvmComponent app = new TestJavaComponent()
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
@@ -45,7 +45,7 @@ import java.util.Set;
  * It replaces the normal processor discovery, which suffers from file descriptor leaks
  * on Java 8 and below. Our own discovery mechanism does not have that issue.
  */
-class IncrementalAnnotationProcessingCompileTask implements JavaCompiler.CompilationTask {
+class AnnotationProcessingCompileTask implements JavaCompiler.CompilationTask {
 
     private final JavaCompiler.CompilationTask delegate;
     private final Set<AnnotationProcessorDeclaration> processorDeclarations;
@@ -55,7 +55,7 @@ class IncrementalAnnotationProcessingCompileTask implements JavaCompiler.Compila
     private URLClassLoader processorClassloader;
     private boolean called;
 
-    IncrementalAnnotationProcessingCompileTask(JavaCompiler.CompilationTask delegate, Set<AnnotationProcessorDeclaration> processorDeclarations, List<File> annotationProcessorPath, AnnotationProcessingResult result) {
+    AnnotationProcessingCompileTask(JavaCompiler.CompilationTask delegate, Set<AnnotationProcessorDeclaration> processorDeclarations, List<File> annotationProcessorPath, AnnotationProcessingResult result) {
         this.delegate = delegate;
         this.processorDeclarations = processorDeclarations;
         this.annotationProcessorPath = annotationProcessorPath;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompiler.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.compile.incremental;
+package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
-import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.internal.tasks.compile.processing.IncrementalAnnotationProcessorType;
@@ -31,20 +30,20 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Sets up incremental annotation processing before delegating to the actual Java compiler.
+ * Sets up annotation processing before delegating to the actual Java compiler.
  */
-class IncrementalAnnotationProcessingCompiler implements Compiler<JavaCompileSpec> {
+public class AnnotationProcessingCompiler<T extends JavaCompileSpec> implements Compiler<T> {
 
-    private final Compiler<JavaCompileSpec> delegate;
+    private final Compiler<T> delegate;
     private final AnnotationProcessorDetector annotationProcessorDetector;
 
-    IncrementalAnnotationProcessingCompiler(Compiler<JavaCompileSpec> delegate, AnnotationProcessorDetector annotationProcessorDetector) {
+    public AnnotationProcessingCompiler(Compiler<T> delegate, AnnotationProcessorDetector annotationProcessorDetector) {
         this.delegate = delegate;
         this.annotationProcessorDetector = annotationProcessorDetector;
     }
 
     @Override
-    public WorkResult execute(JavaCompileSpec spec) {
+    public WorkResult execute(T spec) {
         Set<AnnotationProcessorDeclaration> annotationProcessors = getEffectiveAnnotationProcessors(spec);
         spec.setEffectiveAnnotationProcessors(annotationProcessors);
         return delegate.execute(spec);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessorDiscoveringCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessorDiscoveringCompiler.java
@@ -32,12 +32,12 @@ import java.util.Set;
 /**
  * Sets up annotation processing before delegating to the actual Java compiler.
  */
-public class AnnotationProcessingCompiler<T extends JavaCompileSpec> implements Compiler<T> {
+public class AnnotationProcessorDiscoveringCompiler<T extends JavaCompileSpec> implements Compiler<T> {
 
     private final Compiler<T> delegate;
     private final AnnotationProcessorDetector annotationProcessorDetector;
 
-    public AnnotationProcessingCompiler(Compiler<T> delegate, AnnotationProcessorDetector annotationProcessorDetector) {
+    public AnnotationProcessorDiscoveringCompiler(Compiler<T> delegate, AnnotationProcessorDetector annotationProcessorDetector) {
         this.delegate = delegate;
         this.annotationProcessorDetector = annotationProcessorDetector;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.internal.Factory;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -31,13 +32,15 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
     private final Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory;
     private final FileResolver fileResolver;
     private final ExecHandleFactory execHandleFactory;
+    private AnnotationProcessorDetector processorDetector;
 
-    public DefaultJavaCompilerFactory(WorkerDirectoryProvider workingDirProvider, WorkerDaemonFactory workerDaemonFactory, Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory, FileResolver fileResolver, ExecHandleFactory execHandleFactory) {
+    public DefaultJavaCompilerFactory(WorkerDirectoryProvider workingDirProvider, WorkerDaemonFactory workerDaemonFactory, Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory, FileResolver fileResolver, ExecHandleFactory execHandleFactory, AnnotationProcessorDetector processorDetector) {
         this.workingDirProvider = workingDirProvider;
         this.workerDaemonFactory = workerDaemonFactory;
         this.javaHomeBasedJavaCompilerFactory = javaHomeBasedJavaCompilerFactory;
         this.fileResolver = fileResolver;
         this.execHandleFactory = execHandleFactory;
+        this.processorDetector = processorDetector;
     }
 
     @Override
@@ -48,7 +51,7 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
     @Override
     public Compiler<JavaCompileSpec> create(Class<? extends CompileSpec> type) {
         Compiler<JavaCompileSpec> result = createTargetCompiler(type, false);
-        return new NormalizingJavaCompiler(result);
+        return new AnnotationProcessingCompiler<JavaCompileSpec>(new NormalizingJavaCompiler(result), processorDetector);
     }
 
     private Compiler<JavaCompileSpec> createTargetCompiler(Class<? extends CompileSpec> type, boolean jointCompilation) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
@@ -51,7 +51,7 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
     @Override
     public Compiler<JavaCompileSpec> create(Class<? extends CompileSpec> type) {
         Compiler<JavaCompileSpec> result = createTargetCompiler(type, false);
-        return new AnnotationProcessingCompiler<JavaCompileSpec>(new NormalizingJavaCompiler(result), processorDetector);
+        return new AnnotationProcessorDiscoveringCompiler<JavaCompileSpec>(new NormalizingJavaCompiler(result), processorDetector);
     }
 
     private Compiler<JavaCompileSpec> createTargetCompiler(Class<? extends CompileSpec> type, boolean jointCompilation) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -68,6 +68,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
 
         Set<AnnotationProcessorDeclaration> annotationProcessors = spec.getEffectiveAnnotationProcessors();
         task = new IncrementalAnnotationProcessingCompileTask(task, annotationProcessors, spec.getAnnotationProcessorPath(), result.getAnnotationProcessingResult());
+        task = new ResourceCleaningCompilationTask(task, fileManager);
         return task;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -67,9 +67,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, null, options, spec.getClasses(), compilationUnits);
 
         Set<AnnotationProcessorDeclaration> annotationProcessors = spec.getEffectiveAnnotationProcessors();
-        if (annotationProcessors != null) {
-            task = new IncrementalAnnotationProcessingCompileTask(task, annotationProcessors, spec.getAnnotationProcessorPath(), result.getAnnotationProcessingResult());
-        }
+        task = new IncrementalAnnotationProcessingCompileTask(task, annotationProcessors, spec.getAnnotationProcessorPath(), result.getAnnotationProcessingResult());
         return task;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -67,7 +67,7 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
         JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, null, options, spec.getClasses(), compilationUnits);
 
         Set<AnnotationProcessorDeclaration> annotationProcessors = spec.getEffectiveAnnotationProcessors();
-        task = new IncrementalAnnotationProcessingCompileTask(task, annotationProcessors, spec.getAnnotationProcessorPath(), result.getAnnotationProcessingResult());
+        task = new AnnotationProcessingCompileTask(task, annotationProcessors, spec.getAnnotationProcessorPath(), result.getAnnotationProcessingResult());
         task = new ResourceCleaningCompilationTask(task, fileManager);
         return task;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ResourceCleaningCompilationTask.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ResourceCleaningCompilationTask.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile;
+
+import org.gradle.internal.concurrent.CompositeStoppable;
+
+import javax.annotation.processing.Processor;
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import java.util.Locale;
+
+public class ResourceCleaningCompilationTask implements JavaCompiler.CompilationTask {
+    private final JavaCompiler.CompilationTask delegate;
+    private final StandardJavaFileManager fileManager;
+
+    public ResourceCleaningCompilationTask(JavaCompiler.CompilationTask delegate, StandardJavaFileManager fileManager) {
+        this.delegate = delegate;
+        this.fileManager = fileManager;
+    }
+
+    @Override
+    public void setProcessors(Iterable<? extends Processor> processors) {
+        delegate.setProcessors(processors);
+    }
+
+    @Override
+    public void setLocale(Locale locale) {
+        delegate.setLocale(locale);
+    }
+
+    @Override
+    public Boolean call() {
+        try {
+            return delegate.call();
+        } finally {
+            CompositeStoppable.stoppable(fileManager).stop();
+        }
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotMaker;
 import org.gradle.api.internal.tasks.compile.incremental.jar.PreviousCompilation;
-import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
@@ -42,14 +41,13 @@ public class IncrementalCompilerDecorator {
     private final RecompilationSpecProvider staleClassDetecter;
     private final ClassSetAnalysisUpdater classSetAnalysisUpdater;
     private final CompilationSourceDirs sourceDirs;
-    private final AnnotationProcessorDetector annotationProcessorDetector;
     private final Compiler<JavaCompileSpec> rebuildAllCompiler;
     private final IncrementalCompilationInitializer compilationInitializer;
 
     public IncrementalCompilerDecorator(JarClasspathSnapshotMaker jarClasspathSnapshotMaker, CompileCaches compileCaches,
                                         IncrementalCompilationInitializer compilationInitializer, CleaningJavaCompiler cleaningCompiler, String displayName,
                                         RecompilationSpecProvider staleClassDetecter, ClassSetAnalysisUpdater classSetAnalysisUpdater,
-                                        CompilationSourceDirs sourceDirs, AnnotationProcessorDetector annotationProcessorDetector, Compiler<JavaCompileSpec> rebuildAllCompiler) {
+                                        CompilationSourceDirs sourceDirs, Compiler<JavaCompileSpec> rebuildAllCompiler) {
         this.jarClasspathSnapshotMaker = jarClasspathSnapshotMaker;
         this.compileCaches = compileCaches;
         this.compilationInitializer = compilationInitializer;
@@ -58,14 +56,12 @@ public class IncrementalCompilerDecorator {
         this.staleClassDetecter = staleClassDetecter;
         this.classSetAnalysisUpdater = classSetAnalysisUpdater;
         this.sourceDirs = sourceDirs;
-        this.annotationProcessorDetector = annotationProcessorDetector;
         this.rebuildAllCompiler = rebuildAllCompiler;
     }
 
     public Compiler<JavaCompileSpec> prepareCompiler(IncrementalTaskInputs inputs) {
         Compiler<JavaCompileSpec> compiler = getCompiler(inputs, sourceDirs);
-        IncrementalResultStoringDecorator compilationFinalizer = new IncrementalResultStoringDecorator(compiler, jarClasspathSnapshotMaker, classSetAnalysisUpdater, compileCaches.getAnnotationProcessorPathStore());
-        return new IncrementalAnnotationProcessingCompiler(compilationFinalizer, annotationProcessorDetector);
+        return new IncrementalResultStoringDecorator(compiler, jarClasspathSnapshotMaker, classSetAnalysisUpdater, compileCaches.getAnnotationProcessorPathStore());
     }
 
     private Compiler<JavaCompileSpec> getCompiler(IncrementalTaskInputs inputs, CompilationSourceDirs sourceDirs) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
@@ -36,7 +36,6 @@ import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotter;
 import org.gradle.api.internal.tasks.compile.incremental.jar.LocalJarClasspathSnapshotStore;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
-import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.hash.FileHasher;
@@ -48,14 +47,12 @@ public class IncrementalCompilerFactory {
     private final FileOperations fileOperations;
     private final StreamHasher streamHasher;
     private final FileHasher fileHasher;
-    private final AnnotationProcessorDetector annotationProcessorDetector;
     private final GeneralCompileCaches generalCompileCaches;
 
-    public IncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, AnnotationProcessorDetector annotationProcessorDetector, GeneralCompileCaches generalCompileCaches) {
+    public IncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, GeneralCompileCaches generalCompileCaches) {
         this.fileOperations = fileOperations;
         this.streamHasher = streamHasher;
         this.fileHasher = fileHasher;
-        this.annotationProcessorDetector = annotationProcessorDetector;
         this.generalCompileCaches = generalCompileCaches;
     }
 
@@ -70,7 +67,7 @@ public class IncrementalCompilerFactory {
         RecompilationSpecProvider recompilationSpecProvider = new RecompilationSpecProvider(sourceToNameConverter, fileOperations);
         ClassSetAnalysisUpdater classSetAnalysisUpdater = new ClassSetAnalysisUpdater(compileCaches.getLocalClassSetAnalysisStore(), fileOperations, analyzer, fileHasher);
         IncrementalCompilationInitializer compilationInitializer = new IncrementalCompilationInitializer(fileOperations, sources);
-        IncrementalCompilerDecorator incrementalSupport = new IncrementalCompilerDecorator(jarClasspathSnapshotMaker, compileCaches, compilationInitializer, cleaningJavaCompiler, compileDisplayName, recompilationSpecProvider, classSetAnalysisUpdater, sourceDirs, annotationProcessorDetector, rebuildAllCompiler);
+        IncrementalCompilerDecorator incrementalSupport = new IncrementalCompilerDecorator(jarClasspathSnapshotMaker, compileCaches, compilationInitializer, cleaningJavaCompiler, compileDisplayName, recompilationSpecProvider, classSetAnalysisUpdater, sourceDirs, rebuildAllCompiler);
         return incrementalSupport.prepareCompiler(inputs);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
@@ -62,8 +62,8 @@ public class JavaLanguagePluginServiceRegistry extends AbstractPluginServiceRegi
     }
 
     private static class JavaProjectScopeServices {
-        public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, AnnotationProcessorDetector annotationProcessorDetector, GeneralCompileCaches compileCaches) {
-            return new IncrementalCompilerFactory(fileOperations, streamHasher, fileHasher, annotationProcessorDetector, compileCaches);
+        public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, GeneralCompileCaches compileCaches) {
+            return new IncrementalCompilerFactory(fileOperations, streamHasher, fileHasher, compileCaches);
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaToolChainServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaToolChainServiceRegistry.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.tasks.JavaToolChainFactory;
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompilerFactory;
 import org.gradle.api.internal.tasks.compile.JavaCompilerFactory;
 import org.gradle.api.internal.tasks.compile.JavaHomeBasedJavaCompilerFactory;
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.internal.Factory;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.service.ServiceRegistration;
@@ -52,8 +53,8 @@ public class JavaToolChainServiceRegistry extends AbstractPluginServiceRegistry 
     }
 
     private static class ProjectScopeCompileServices {
-        JavaCompilerFactory createJavaCompilerFactory(GradleInternal gradle, WorkerDaemonFactory workerDaemonFactory, Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory, FileResolver fileResolver, WorkerDirectoryProvider workerDirectoryProvider, ExecHandleFactory execHandleFactory) {
-            return new DefaultJavaCompilerFactory(workerDirectoryProvider, workerDaemonFactory, javaHomeBasedJavaCompilerFactory, fileResolver, execHandleFactory);
+        JavaCompilerFactory createJavaCompilerFactory(GradleInternal gradle, WorkerDaemonFactory workerDaemonFactory, Factory<JavaCompiler> javaHomeBasedJavaCompilerFactory, FileResolver fileResolver, WorkerDirectoryProvider workerDirectoryProvider, ExecHandleFactory execHandleFactory, AnnotationProcessorDetector processorDetector) {
+            return new DefaultJavaCompilerFactory(workerDirectoryProvider, workerDaemonFactory, javaHomeBasedJavaCompilerFactory, fileResolver, execHandleFactory, processorDetector);
         }
 
         JavaToolChainInternal createJavaToolChain(JavaCompilerFactory compilerFactory, ExecActionFactory execActionFactory) {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompilerTest.groovy
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.compile.incremental
+package org.gradle.api.internal.tasks.compile
 
-import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec
-import org.gradle.api.internal.tasks.compile.JavaCompileSpec
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector
 import org.gradle.api.internal.tasks.compile.processing.IncrementalAnnotationProcessorType
@@ -26,7 +24,7 @@ import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
-class IncrementalAnnotationProcessingCompilerTest extends Specification {
+class AnnotationProcessingCompilerTest extends Specification {
     JavaCompileSpec spec = new DefaultJavaCompileSpec().with {
         compileOptions = new CompileOptions(TestUtil.objectFactory())
         it
@@ -34,7 +32,7 @@ class IncrementalAnnotationProcessingCompilerTest extends Specification {
     AnnotationProcessorDetector detector = Stub(AnnotationProcessorDetector)
     Compiler<JavaCompileSpec> delegate = Stub(Compiler)
 
-    IncrementalAnnotationProcessingCompiler compiler = new IncrementalAnnotationProcessingCompiler(delegate, detector)
+    AnnotationProcessingCompiler compiler = new AnnotationProcessingCompiler(delegate, detector)
 
     def "when neither processor path nor processor option are given, no processors are used"() {
         when:

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/AnnotationProcessorDiscoveringCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/AnnotationProcessorDiscoveringCompilerTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.language.base.internal.compile.Compiler
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
-class AnnotationProcessingCompilerTest extends Specification {
+class AnnotationProcessorDiscoveringCompilerTest extends Specification {
     JavaCompileSpec spec = new DefaultJavaCompileSpec().with {
         compileOptions = new CompileOptions(TestUtil.objectFactory())
         it
@@ -32,7 +32,7 @@ class AnnotationProcessingCompilerTest extends Specification {
     AnnotationProcessorDetector detector = Stub(AnnotationProcessorDetector)
     Compiler<JavaCompileSpec> delegate = Stub(Compiler)
 
-    AnnotationProcessingCompiler compiler = new AnnotationProcessingCompiler(delegate, detector)
+    AnnotationProcessorDiscoveringCompiler compiler = new AnnotationProcessorDiscoveringCompiler(delegate, detector)
 
     def "when neither processor path nor processor option are given, no processors are used"() {
         when:

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.compile
 
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector
 import org.gradle.internal.Factory
 import org.gradle.process.internal.ExecHandleFactory
 import org.gradle.workers.internal.WorkerDaemonFactory
@@ -25,13 +26,14 @@ import javax.tools.JavaCompiler
 
 class DefaultJavaCompilerFactoryTest extends Specification {
     Factory<JavaCompiler> javaCompilerFinder = Mock()
-    def factory = new DefaultJavaCompilerFactory({new File("daemon-work-dir")}, Mock(WorkerDaemonFactory), javaCompilerFinder, Mock(FileResolver), Mock(ExecHandleFactory))
+    def factory = new DefaultJavaCompilerFactory({ new File("daemon-work-dir") }, Mock(WorkerDaemonFactory), javaCompilerFinder, Mock(FileResolver), Mock(ExecHandleFactory), Stub(AnnotationProcessorDetector))
 
     def "creates in-process compiler when JavaCompileSpec is provided"() {
         expect:
         def compiler = factory.create(JavaCompileSpec.class)
-        compiler instanceof NormalizingJavaCompiler
-        compiler.delegate instanceof JdkJavaCompiler
+        compiler instanceof AnnotationProcessingCompiler
+        compiler.delegate instanceof NormalizingJavaCompiler
+        compiler.delegate.delegate instanceof JdkJavaCompiler
     }
 
     def "creates in-process compiler when JavaCompileSpec is provided and joint compilation"() {
@@ -43,8 +45,9 @@ class DefaultJavaCompilerFactoryTest extends Specification {
     def "creates command line compiler when CommandLineJavaCompileSpec is provided"() {
         expect:
         def compiler = factory.create(TestCommandLineJavaSpec.class)
-        compiler instanceof NormalizingJavaCompiler
-        compiler.delegate instanceof CommandLineJavaCompiler
+        compiler instanceof AnnotationProcessingCompiler
+        compiler.delegate instanceof NormalizingJavaCompiler
+        compiler.delegate.delegate instanceof CommandLineJavaCompiler
     }
 
     def "creates command line compiler when CommandLineJavaCompileSpec is provided and joint compilation"() {
@@ -56,9 +59,10 @@ class DefaultJavaCompilerFactoryTest extends Specification {
     def "creates daemon compiler when ForkingJavaCompileSpec"() {
         expect:
         def compiler = factory.create(TestForkingJavaCompileSpec)
-        compiler instanceof NormalizingJavaCompiler
-        compiler.delegate instanceof DaemonJavaCompiler
-        compiler.delegate.delegate instanceof JdkJavaCompiler
+        compiler instanceof AnnotationProcessingCompiler
+        compiler.delegate instanceof NormalizingJavaCompiler
+        compiler.delegate.delegate instanceof DaemonJavaCompiler
+        compiler.delegate.delegate.delegate instanceof JdkJavaCompiler
     }
 
     def "creates in-process compiler when ForkingJavaCompileSpec is provided and joint compilation"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -31,7 +31,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
     def "creates in-process compiler when JavaCompileSpec is provided"() {
         expect:
         def compiler = factory.create(JavaCompileSpec.class)
-        compiler instanceof AnnotationProcessingCompiler
+        compiler instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate instanceof NormalizingJavaCompiler
         compiler.delegate.delegate instanceof JdkJavaCompiler
     }
@@ -45,7 +45,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
     def "creates command line compiler when CommandLineJavaCompileSpec is provided"() {
         expect:
         def compiler = factory.create(TestCommandLineJavaSpec.class)
-        compiler instanceof AnnotationProcessingCompiler
+        compiler instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate instanceof NormalizingJavaCompiler
         compiler.delegate.delegate instanceof CommandLineJavaCompiler
     }
@@ -59,7 +59,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
     def "creates daemon compiler when ForkingJavaCompileSpec"() {
         expect:
         def compiler = factory.create(TestForkingJavaCompileSpec)
-        compiler instanceof AnnotationProcessingCompiler
+        compiler instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate instanceof NormalizingJavaCompiler
         compiler.delegate.delegate instanceof DaemonJavaCompiler
         compiler.delegate.delegate.delegate instanceof JdkJavaCompiler

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -610,7 +610,7 @@ ${compilerConfiguration()}
                             @Override
                             public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
                                 if (${gradleLeaksIntoAnnotationProcessor() ? '!' : ''}isClasspathContaminated()) {
-                                    throw new RuntimeException("Annotation Processor Classpath is ${gradleLeaksIntoAnnotationProcessor() ? 'not ' : ''}}contaminated by Gradle ClassLoader");
+                                    throw new RuntimeException("Annotation Processor Classpath is ${gradleLeaksIntoAnnotationProcessor() ? 'not ' : ''}contaminated by Gradle ClassLoader");
                                 }
 
                                 for (final Element classElement : roundEnv.getElementsAnnotatedWith(SimpleAnnotation.class)) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
@@ -15,13 +15,11 @@
  */
 package org.gradle.groovy.compile
 
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import spock.lang.Timeout
 
 @Timeout(300)
-@LeaksFileHandles
 class InProcessGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
 
     String compilerConfiguration() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
@@ -22,6 +22,12 @@ import spock.lang.Timeout
 @Timeout(300)
 class InProcessGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
 
+    def setup() {
+        if (groovyVersionNumber < "2.0") {
+            testDirectoryProvider.suppressCleanupErrors()
+        }
+    }
+
     String compilerConfiguration() {
 '''
     tasks.withType(GroovyCompile) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InvokeDynamicGroovyCompilerSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InvokeDynamicGroovyCompilerSpec.groovy
@@ -17,12 +17,10 @@
 package org.gradle.groovy.compile
 
 import org.gradle.integtests.fixtures.TargetVersions
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 
 @TargetVersions(['2.4.10:indy'])
-@LeaksFileHandles
 class InvokeDynamicGroovyCompilerSpec extends ApiGroovyCompilerIntegrationSpec {
     def canEnableAndDisableInvokeDynamicOptimization() {
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractJavaCompileAvoidanceIntegrationSpec.groovy
@@ -51,10 +51,6 @@ include 'a', 'b'
     def useJar() {
         buildFile << """
             allprojects {
-                tasks.withType(JavaCompile) {
-                    // Use forking to work around javac's jar cache
-                    options.fork = true
-                }
                 jar {
                     from emptyDirs
                 }
@@ -791,7 +787,6 @@ public class ToolImpl {
                     processor project(':b')
                 }
                 compileJava.options.annotationProcessorPath = configurations.processor
-                compileJava.options.fork = true
                 task run(type: JavaExec) {
                     main = 'TestApp'
                     classpath = sourceSets.main.runtimeClasspath

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -20,7 +20,6 @@ package org.gradle.java.compile
 import org.gradle.api.Action
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.ClassFile
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -263,7 +262,6 @@ class Main {
         return new ClassFile(javaClassFile(path))
     }
 
-    @LeaksFileHandles("holds processor.jar open for in process compiler")
     def "can use annotation processor"() {
         when:
         buildFile << """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -323,7 +323,7 @@ class Main {
                             @Override
                             public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
                                 if (${gradleLeaksIntoAnnotationProcessor() ? '!' : ''}isClasspathContaminated()) {
-                                    throw new RuntimeException("Annotation Processor Classpath is ${gradleLeaksIntoAnnotationProcessor() ? 'not ' : ''}}contaminated by Gradle ClassLoader");
+                                    throw new RuntimeException("Annotation Processor Classpath is ${gradleLeaksIntoAnnotationProcessor() ? 'not ' : ''}contaminated by Gradle ClassLoader");
                                 }
 
                                 for (final Element classElement : roundEnv.getElementsAnnotatedWith(SimpleAnnotation.class)) {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
@@ -37,6 +37,11 @@ class PluginUnderTest {
         void suppressCleanup() {
 
         }
+
+        @Override
+        void suppressCleanupErrors() {
+
+        }
     }
 
     private final int num


### PR DESCRIPTION
This fixes a bunch of file leaks in our Java and Groovy compiler, which were probably giving a lot of users trouble. My suspicion is that users either switched off the Gradle daemon at that point or used `fork = true`, which adds significant overhead for starting up a new compiler for each build. Also, our mid term goal is to reuse compiler daemons by default, so making them not leak files is a prerequisite for that as well.