### PR TITLE
Move worker daemon expiration to WorkerDaemonClientsManager

### DIFF
--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -29,6 +29,8 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.events.LogLevelChangeEvent;
 import org.gradle.internal.logging.events.OutputEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
+import org.gradle.process.internal.health.memory.MemoryManager;
+import org.gradle.process.internal.health.memory.TotalPhysicalMemoryProvider;
 import org.gradle.util.CollectionUtils;
 
 import java.util.ArrayList;
@@ -49,9 +51,11 @@ public class WorkerDaemonClientsManager implements Stoppable {
     private final LoggingManagerInternal loggingManager;
     private final SessionLifecycleListener stopSessionScopeWorkers;
     private final OutputEventListener logLevelChangeEventListener;
+    private final WorkerDaemonExpiration workerDaemonExpiration;
+    private final MemoryManager memoryManager;
     private LogLevel currentLogLevel;
 
-    public WorkerDaemonClientsManager(WorkerDaemonStarter workerDaemonStarter, ListenerManager listenerManager, LoggingManagerInternal loggingManager) {
+    public WorkerDaemonClientsManager(WorkerDaemonStarter workerDaemonStarter, ListenerManager listenerManager, LoggingManagerInternal loggingManager, MemoryManager memoryManager) {
         this.workerDaemonStarter = workerDaemonStarter;
         this.listenerManager = listenerManager;
         this.loggingManager = loggingManager;
@@ -60,6 +64,9 @@ public class WorkerDaemonClientsManager implements Stoppable {
         this.logLevelChangeEventListener = new LogLevelChangeEventListener();
         loggingManager.addOutputEventListener(logLevelChangeEventListener);
         this.currentLogLevel = loggingManager.getLevel();
+        this.memoryManager = memoryManager;
+        this.workerDaemonExpiration = new WorkerDaemonExpiration(this, getTotalPhysicalMemory());
+        memoryManager.addMemoryHolder(workerDaemonExpiration);
     }
 
     // TODO - should supply and check for the same parameters as passed to reserveNewClient()
@@ -110,6 +117,15 @@ public class WorkerDaemonClientsManager implements Stoppable {
             idleClients.clear();
             listenerManager.removeListener(stopSessionScopeWorkers);
             loggingManager.removeOutputEventListener(logLevelChangeEventListener);
+            memoryManager.removeMemoryHolder(workerDaemonExpiration);
+        }
+    }
+
+    private static long getTotalPhysicalMemory() {
+        try {
+            return TotalPhysicalMemoryProvider.getTotalPhysicalMemory();
+        } catch (UnsupportedOperationException e) {
+            return -1;
         }
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -17,31 +17,23 @@
 package org.gradle.workers.internal;
 
 import net.jcip.annotations.ThreadSafe;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRef;
-import org.gradle.process.internal.health.memory.MemoryManager;
-import org.gradle.process.internal.health.memory.TotalPhysicalMemoryProvider;
 import org.gradle.workers.IsolationMode;
 
 /**
  * Controls the lifecycle of the worker daemon and provides access to it.
  */
 @ThreadSafe
-public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
+public class WorkerDaemonFactory implements WorkerFactory {
     private final WorkerDaemonClientsManager clientsManager;
-    private final MemoryManager memoryManager;
-    private final WorkerDaemonExpiration workerDaemonExpiration;
     private final BuildOperationExecutor buildOperationExecutor;
 
-    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, MemoryManager memoryManager, BuildOperationExecutor buildOperationExecutor) {
+    public WorkerDaemonFactory(WorkerDaemonClientsManager clientsManager, BuildOperationExecutor buildOperationExecutor) {
         this.clientsManager = clientsManager;
-        this.memoryManager = memoryManager;
-        this.workerDaemonExpiration = new WorkerDaemonExpiration(clientsManager, getTotalPhysicalMemory());
-        memoryManager.addMemoryHolder(workerDaemonExpiration);
         this.buildOperationExecutor = buildOperationExecutor;
     }
 
@@ -85,18 +77,5 @@ public class WorkerDaemonFactory implements WorkerFactory, Stoppable {
     @Override
     public IsolationMode getIsolationMode() {
         return IsolationMode.PROCESS;
-    }
-
-    @Override
-    public void stop() {
-        memoryManager.removeMemoryHolder(workerDaemonExpiration);
-    }
-
-    private static long getTotalPhysicalMemory() {
-        try {
-            return TotalPhysicalMemoryProvider.getTotalPhysicalMemory();
-        } catch (UnsupportedOperationException e) {
-            return -1;
-        }
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -57,7 +57,7 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     private static class BuildSessionScopeServices {
 
         WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
-            return new WorkerDaemonFactory(workerDaemonClientsManager, memoryManager, buildOperationExecutor);
+            return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationExecutor);
         }
 
         IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(ClassLoaderFactory classLoaderFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
@@ -73,8 +73,9 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     private static class GradleUserHomeServices {
         WorkerDaemonClientsManager createWorkerDaemonClientsManager(WorkerProcessFactory workerFactory,
                                                                     LoggingManagerInternal loggingManager,
-                                                                    ListenerManager listenerManager) {
-            return new WorkerDaemonClientsManager(new WorkerDaemonStarter(workerFactory, loggingManager), listenerManager, loggingManager);
+                                                                    ListenerManager listenerManager,
+                                                                    MemoryManager memoryManager) {
+            return new WorkerDaemonClientsManager(new WorkerDaemonStarter(workerFactory, loggingManager), listenerManager, loggingManager, memoryManager);
         }
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.process.internal.DefaultJavaForkOptions
 import org.gradle.process.internal.health.memory.JvmMemoryStatus
 import org.gradle.process.internal.health.memory.MaximumHeapHelper
 import org.gradle.process.internal.health.memory.MemoryAmount
+import org.gradle.process.internal.health.memory.MemoryManager
 import spock.lang.Specification
 
 import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
@@ -57,7 +58,7 @@ class WorkerDaemonExpirationTest extends Specification {
             }
         }
     }
-    def clientsManager = new WorkerDaemonClientsManager(daemonStarter, Mock(ListenerManager), Mock(LoggingManagerInternal))
+    def clientsManager = new WorkerDaemonClientsManager(daemonStarter, Mock(ListenerManager), Mock(LoggingManagerInternal), Mock(MemoryManager))
     def expiration = new WorkerDaemonExpiration(clientsManager, MemoryAmount.ofGigaBytes(OS_MEMORY_GB).bytes)
 
     def "expires least recently used idle worker daemon to free system memory when requested to release some memory"() {


### PR DESCRIPTION
This resolves some flakiness in our tests and fixes an issue where worker daemon expiration can only occur during a build (and not while the build daemon is idle).