### PR TITLE
Upgrade ktlint-convention plugin in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
 
 plugins {
     `kotlin-dsl` version "0.17.2"
-    id("org.gradle.kotlin.ktlint-convention") version "0.1.7" apply false
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.8" apply false
 }
 
 subprojects {


### PR DESCRIPTION
for `buildSrc/**/src/*/kotlin/*.kt[s]`

New
- relocatable cacheable ktlint check tasks
- *.kts linting

See https://github.com/gradle/build-cache/issues/1126 and https://github.com/gradle/kotlin-dsl/pull/901