### PR TITLE
Show rejected versions when resolution passes

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -397,7 +397,6 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
       - By conflict resolution
       - Selected by rule : A replaced with B
 
-
 org:a:1 -> org:b:1""")
 
         when:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -388,13 +388,17 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         run 'dependencyInsight', '--configuration=conf', '--dependency=a'
 
         then:
-        result.groupedOutput.task(':dependencyInsight').output.contains("""org:b:1 (A replaced with B)
+        result.groupedOutput.task(':dependencyInsight').output.contains("""org:b:1
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+   Selection reasons:
+      - Was requested
+      - By conflict resolution
+      - Selected by rule : A replaced with B
 
-org:a:1 -> org:b:1
-\\--- conf""")
+
+org:a:1 -> org:b:1""")
 
         when:
         run 'check'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -229,9 +229,9 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:bar:1.0") {
-                    edge("org:foo:[1.0,1.2]", "org:foo:1.1").byReason('tested versions')
+                    edge("org:foo:[1.0,1.2]", "org:foo:1.1").byReason('didn\'t match version 1.2 because tested versions')
                 }
-                edgeFromConstraint("org:foo:[1.0,1.1]", "org:foo:1.1").byReason('tested versions')
+                edgeFromConstraint("org:foo:[1.0,1.1]", "org:foo:1.1").byReason('didn\'t match version 1.2 because tested versions')
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -567,7 +567,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:$notation", "org:foo:1.0")
+                edge("org:foo:$notation", "org:foo:1.0").byReason("rejected version 1.1")
             }
         }
 
@@ -656,7 +656,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:[1.0,)", "org:foo:1.1")
+                edge("org:foo:[1.0,)", "org:foo:1.1").byReason("rejected versions 1.5, 1.4, 1.3, 1.2")
             }
         }
     }
@@ -738,7 +738,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:$notation", "org:foo:1.$selected")
+                String rejectedVersions = (selected+1..5).collect { "1.${it}" }.reverse().join(", ")
+                edge("org:foo:$notation", "org:foo:1.$selected").byReason("rejected versions ${rejectedVersions}")
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -57,7 +57,7 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
         checkDependencies {
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org.utils:api:${selector}", "org.utils:${chosenModule}:${chosenVersion}")
+                    edge("org.utils:api:${selector}", "org.utils:${chosenModule}:${chosenVersion}").byReasons(reasons)
                 }
             }
         }
@@ -72,17 +72,17 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
         resetExpectations()
 
         where:
-        selector             | rule            | chosenVersion | candidates       | downloadedMetadata | mavenCompatible | gradleCompatible
-        "1.+"                | "select 1.1"    | "1.1"         | '["1.2", "1.1"]' | ['1.1']            | true            | true
-        "1.+"                | "select status" | "1.1"         | '["1.2", "1.1"]' | ['1.2', '1.1']     | false           | true
-        "1.+"                | "select branch" | "1.1"         | '["1.2", "1.1"]' | ['1.2', '1.1']     | false           | false
-        "latest.integration" | "select 2.1"    | "2.1"         | '["2.1"]'        | ['2.1']            | true            | true
-        "latest.milestone"   | "select 2.0"    | "2.0"         | '["2.0"]'        | ['2.1', '2.0']     | false           | true
-        "latest.milestone"   | "select status" | "2.0"         | '["2.0"]'        | ['2.1', '2.0']     | false           | true
-        "latest.milestone"   | "select branch" | "2.0"         | '["2.0"]'        | ['2.1', '2.0']     | false           | false
-        "1.1"                | "select 1.1"    | "1.1"         | '["1.1"]'        | ['1.1']            | true            | true
-        "1.1"                | "select status" | "1.1"         | '["1.1"]'        | ['1.1']            | false           | true
-        "1.1"                | "select branch" | "1.1"         | '["1.1"]'        | ['1.1']            | false           | false
+        selector             | rule            | chosenVersion | candidates       | downloadedMetadata | mavenCompatible | gradleCompatible | reasons
+        "1.+"                | "select 1.1"    | "1.1"         | '["1.2", "1.1"]' | ['1.1']            | true            | true             | ["didn't match versions 2.1, 2.0", "1.2 by rule because not 1.1"]
+        "1.+"                | "select status" | "1.1"         | '["1.2", "1.1"]' | ['1.2', '1.1']     | false           | true             | ["didn't match versions 2.1, 2.0", "1.2 by rule because not milestone"]
+        "1.+"                | "select branch" | "1.1"         | '["1.2", "1.1"]' | ['1.2', '1.1']     | false           | false            | ["didn't match versions 2.1, 2.0", "1.2 by rule because not branch"]
+        "latest.integration" | "select 2.1"    | "2.1"         | '["2.1"]'        | ['2.1']            | true            | true             | []
+        "latest.milestone"   | "select 2.0"    | "2.0"         | '["2.0"]'        | ['2.1', '2.0']     | false           | true             | ["didn't match version 2.1"]
+        "latest.milestone"   | "select status" | "2.0"         | '["2.0"]'        | ['2.1', '2.0']     | false           | true             | ["didn't match version 2.1"]
+        "latest.milestone"   | "select branch" | "2.0"         | '["2.0"]'        | ['2.1', '2.0']     | false           | false            | ["didn't match version 2.1"]
+        "1.1"                | "select 1.1"    | "1.1"         | '["1.1"]'        | ['1.1']            | true            | true             | []
+        "1.1"                | "select status" | "1.1"         | '["1.1"]'        | ['1.1']            | false           | true             | []
+        "1.1"                | "select branch" | "1.1"         | '["1.1"]'        | ['1.1']            | false           | false            | []
     }
 
     private String setupInterations(String selector, String chosenVersion, List<String> downloadedMetadata, Closure<Void> more = {}) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionMultiRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionMultiRepoResolveIntegrationTest.groovy
@@ -58,7 +58,7 @@ class IvyDynamicRevisionMultiRepoResolveIntegrationTest extends AbstractDependen
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1").byReason("didn't match version 1.2")
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -191,7 +191,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1").byReason("didn't match version 1.3")
             }
         }
 
@@ -221,7 +221,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2").byReason("didn't match version 1.3")
             }
         }
 
@@ -252,7 +252,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2").byReason("didn't match version 1.3")
             }
         }
     }
@@ -345,7 +345,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.release", "org.test:projectA:1.1")
+                edge("org.test:projectA:latest.release", "org.test:projectA:1.1").byReason("didn't match versions 1.3, 1.2")
             }
         }
 
@@ -386,7 +386,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.release", "org.test:projectA:1.1")
+                edge("org.test:projectA:latest.release", "org.test:projectA:1.1").byReason("didn't match versions 1.3, 1.2, 1.1.1")
             }
         }
     }
@@ -435,7 +435,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.1")
+                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.1").byReason("didn't match version 2.0")
             }
         }
 
@@ -458,7 +458,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.9")
+                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.9").byReason("didn't match version 2.0")
             }
         }
 
@@ -481,7 +481,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.10")
+                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.10").byReason("didn't match version 2.0")
             }
         }
     }
@@ -531,7 +531,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.2.1")
+                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.2.1").byReason("didn't match version 2.1")
             }
         }
 
@@ -554,7 +554,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.3")
+                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.3").byReason("didn't match version 2.1")
             }
         }
     }
@@ -606,7 +606,7 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:[1.2,2.0)", "org.test:projectA:1.2.1:default")
+                edge("org.test:projectA:[1.2,2.0)", "org.test:projectA:1.2.1:default").byReason("didn't match version 2.0")
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import spock.lang.Ignore
 
 class DependencyLockingIntegrationTest extends AbstractDependencyResolutionTest {
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
-import spock.lang.Ignore
 
 class DependencyLockingIntegrationTest extends AbstractDependencyResolutionTest {
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -136,7 +136,7 @@ dependencies {
             root(":", ":test:") {
                 edge("org.test:child:1.0", "org.test:child:1.0") {
                     edge("org.test:imported:[2.0,3.0)", "org.test:imported:2.1") {
-                        artifact(group: 'org.test', module: 'imported', version: '2.1', type: 'pom')
+                        artifact(group: 'org.test', module: 'imported', version: '2.1', type: 'pom').byReason("didn't match version 3.0")
                         edge("org.test:dep:2.1", "org.test:dep:2.1")
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -77,7 +77,8 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"],
+            "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
         outputContains 'Providing metadata for group:projectB:2.2'
         outputContains 'Providing metadata for group:projectB:1.1'
         !output.contains('Providing metadata for group:projectA:1.1')
@@ -115,12 +116,12 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then:
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         and: "re-execute the same build"
         resetExpectations()
         supplierInteractions.refresh('group:projectB:2.2', 'group:projectB:1.1')
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
     }
 
@@ -153,7 +154,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then:
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         when: "publish a new integration version"
         resetExpectations()
@@ -180,7 +181,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
             }
         }
         supplierInteractions.refresh('group:projectB:2.2', 'group:projectB:1.1')
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match versions 2.3, 2.2"]
     }
 
     def "publishing new release version incurs get status file of new release version only"() {
@@ -212,7 +213,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then:
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         when: "publish a new integration version"
         resetExpectations()
@@ -239,7 +240,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
                 }
             }
         }
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:2.3"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": "group:projectB:2.3"
     }
 
     def "can use --offline to use cached result after remote failure"() {
@@ -271,7 +272,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         when:
         server.expectHeadBroken('/repo/group/projectB/2.2/status.txt')
@@ -287,7 +288,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         executer.withArgument('--offline')
 
         then: "will used cached status resources"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
     }
 
     def "can recover from --offline mode"() {
@@ -329,7 +330,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then: "recovers from previous --offline mode"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
     }
 
     def "will not make network requests when run with --offline"() {
@@ -383,7 +384,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then:
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         when: "Fails without making network request when offline"
         resetExpectations()
@@ -444,7 +445,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then: "recovers from previous failure to get status file"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
     }
 
     def "can inject configuration into metadata provider"() {
@@ -625,7 +626,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         }
 
         then:
-        checkResolve "group:projectA:1.+": "group:projectA:1.2",
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"],
             "group:projectB:latest.release": "group:projectB:3.3"
     }
 
@@ -691,7 +692,7 @@ group:projectB:2.2;integration
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
         outputContains 'Providing metadata for group:projectB:2.2'
         outputContains 'Providing metadata for group:projectB:1.1'
         outputDoesNotContain('Providing metadata for group:projectA:1.1')
@@ -702,7 +703,7 @@ group:projectB:2.2;integration
 
         when: "resolving the same dependencies"
         server.expectHead("/repo/status.txt", statusFile)
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         then: "should get the result from cache"
         outputDoesNotContain('Parsing status file call count')
@@ -736,7 +737,7 @@ group:projectB:2.2;release
 
         then: "shouldn't use the cached resource"
         executer.withArguments('--refresh-dependencies')
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:2.2"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": "group:projectB:2.2"
         outputContains 'Providing metadata for group:projectB:2.2'
         outputDoesNotContain('Providing metadata for group:projectB:1.1')
         outputDoesNotContain('Providing metadata for group:projectA:1.1')
@@ -773,7 +774,7 @@ group:projectB:2.2;release
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         when:
         executer.withArgument('--refresh-dependencies')
@@ -797,7 +798,7 @@ group:projectB:2.2;release
             }
         }
         supplierInteractions.refresh('group:projectB:2.2', 'group:projectB:1.1')
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":  ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
     }
 
     def "component metadata rules are executed after metadata supplier is called"() {
@@ -842,7 +843,7 @@ group:projectB:2.2;release
                 }
             }
         }
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
 
         then:
         outputContains 'Providing metadata for group:projectB:1.1'
@@ -879,7 +880,7 @@ group:projectB:2.2;release
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "didn't match version 2.2"]
         outputContains 'Providing metadata for group:projectB:2.2'
         outputContains 'Providing metadata for group:projectB:1.1'
     }
@@ -920,7 +921,7 @@ group:projectB:2.2;release
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+":["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "version 2.2: Attribute 'custom string' didn't match. Requested 'v2', was: 'v1'"]
         outputContains 'Providing metadata for group:projectB:2.2'
         outputContains 'Providing metadata for group:projectB:1.1'
 
@@ -973,7 +974,7 @@ group:projectB:2.2;release
         }
 
         then: "custom metadata rule prevented parsing of ivy descriptor"
-        checkResolve "group:projectA:1.+": "group:projectA:1.2", "group:projectB:latest.release": "group:projectB:1.1"
+        checkResolve "group:projectA:1.+": ["group:projectA:1.2", "didn't match version 2.0"], "group:projectB:latest.release": ["group:projectB:1.1", "version 2.2: Attribute 'custom' didn't match. Requested 'v2', was: 'v1'"]
         outputContains 'Providing metadata for group:projectB:2.2'
         outputContains 'Providing metadata for group:projectB:1.1'
 
@@ -1317,7 +1318,11 @@ group:projectB:2.2;release
         resolve.expectGraph {
             root(":", ":test:") {
                 edges.each { from, to ->
-                    edge(from, to)
+                    if (to instanceof List) {
+                        edge(from, to[0]).byReason(to[1])
+                    } else {
+                        edge(from, to)
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentMetaDataResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentMetaDataResolveState.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.resolve.RejectedByRuleVersion;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
@@ -65,7 +66,8 @@ class ComponentMetaDataResolveState {
     protected void process(ModuleComponentRepositoryAccess moduleAccess) {
         moduleAccess.resolveComponentMetaData(componentIdentifier, componentOverrideMetadata, resolveResult);
         if (resolveResult.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved) {
-            if (versionedComponentChooser.isRejectedComponent(componentIdentifier, new MetadataProvider(resolveResult))) {
+            RejectedByRuleVersion rejectedComponent = versionedComponentChooser.isRejectedComponent(componentIdentifier, new MetadataProvider(resolveResult));
+            if (rejectedComponent != null) {
                 resolveResult.missing();
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -89,7 +89,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
 
             ModuleComponentIdentifier candidateId = candidate.getId();
             if (!versionMatches) {
-                result.notMatched(candidateId);
+                result.notMatched(candidateId, requestedVersionMatcher);
                 continue;
             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -95,9 +95,9 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
             RejectedByAttributesVersion maybeRejectByAttributes = tryRejectByAttributes(candidateId, metadataProvider, consumerAttributes);
             if (maybeRejectByAttributes != null) {
                 result.doesNotMatchConsumerAttributes(maybeRejectByAttributes);
-            } else if (isRejectedByConstraint(candidateId, rejectedVersionSelector)) {
+            } else if (isRejectedBySelector(candidateId, rejectedVersionSelector)) {
                 // Mark this version as rejected
-                result.rejectedByConstraint(candidateId);
+                result.rejectedBySelector(candidateId);
             } else if (isRejectedByRules(candidateId, rules, metadataProvider)) {
                 // Mark this version as rejected
                 result.rejectedByRule(candidateId);
@@ -194,7 +194,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
         return selection.isRejected();
     }
 
-    private boolean isRejectedByConstraint(ModuleComponentIdentifier candidateIdentifier, VersionSelector rejectedVersionSelector) {
+    private boolean isRejectedBySelector(ModuleComponentIdentifier candidateIdentifier, VersionSelector rejectedVersionSelector) {
         return rejectedVersionSelector != null && rejectedVersionSelector.accept(candidateIdentifier.getVersion());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -43,6 +43,8 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.RejectedByAttributesVersion;
+import org.gradle.internal.resolve.RejectedByRuleVersion;
+import org.gradle.internal.resolve.RejectedBySelectorVersion;
 import org.gradle.internal.resolve.RejectedVersion;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
@@ -323,8 +325,8 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public void rejectedByRule(ModuleComponentIdentifier id) {
-            rejectedVersions.add(new RejectedVersion(id));
+        public void rejectedByRule(RejectedByRuleVersion id) {
+            rejectedVersions.add(id);
         }
 
         @Override
@@ -333,11 +335,11 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public void rejectedBySelector(ModuleComponentIdentifier id) {
+        public void rejectedBySelector(ModuleComponentIdentifier id, VersionSelector versionSelector) {
             if (firstRejected == null) {
                 firstRejected = id;
             }
-            rejectedVersions.add(new RejectedVersion(id));
+            rejectedVersions.add(new RejectedBySelectorVersion(id, versionSelector));
         }
 
         private List<CandidateResult> candidates() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +141,11 @@ public class DynamicVersionResolver {
             // (after conflict resolution), so it is not a failure at this stage.
             return;
         }
-        result.failed(new ModuleVersionNotFoundException(requested, result.getAttempted(), result.getUnmatchedVersions(), result.getRejectedVersions()));
+        Set<String> unmatched = new LinkedHashSet<String>();
+        for (RejectedBySelectorVersion rejected : result.getUnmatchedVersions()) {
+            unmatched.add(rejected.getId().getVersion());
+        }
+        result.failed(new ModuleVersionNotFoundException(requested, result.getAttempted(), unmatched, result.getRejectedVersions()));
     }
 
     private RepositoryChainModuleResolution findLatestModule(List<RepositoryResolveState> resolveStates, Collection<Throwable> failures) {
@@ -238,7 +243,7 @@ public class DynamicVersionResolver {
         private final VersionedComponentChooser versionedComponentChooser;
         private final BuildableModuleComponentMetaDataResolveResult resolvedVersionMetadata = new DefaultBuildableModuleComponentMetaDataResolveResult();
         private final Map<String, CandidateResult> candidateComponents = new LinkedHashMap<String, CandidateResult>();
-        private final Set<String> unmatchedVersions = Sets.newLinkedHashSet();
+        private final Set<RejectedBySelectorVersion> unmatchedVersions = Sets.newLinkedHashSet();
         private final Set<RejectedVersion> rejectedVersions = Sets.newLinkedHashSet();
         private final VersionListResult versionListingResult;
         private final ModuleComponentRepository repository;
@@ -320,8 +325,8 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public void notMatched(ModuleComponentIdentifier id) {
-            unmatchedVersions.add(id.getVersion());
+        public void notMatched(ModuleComponentIdentifier id, VersionSelector requestedVersionMatcher) {
+            unmatchedVersions.add(new RejectedBySelectorVersion(id, requestedVersionMatcher));
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -112,7 +112,7 @@ public class DynamicVersionResolver {
                 LOGGER.debug("Discarding resolve failure.", error);
             }
 
-            result.resolved(metaDataFactory.transform(latestResolved));
+            found(result, resolveStates, latestResolved);
             return;
         }
         if (!errors.isEmpty()) {
@@ -120,6 +120,13 @@ public class DynamicVersionResolver {
         } else {
             notFound(result, requested, resolveStates);
         }
+    }
+
+    private void found(BuildableComponentIdResolveResult result, List<RepositoryResolveState> resolveStates, RepositoryChainModuleResolution latestResolved) {
+        for (RepositoryResolveState resolveState : resolveStates) {
+            resolveState.registerAttempts(result);
+        }
+        result.resolved(metaDataFactory.transform(latestResolved));
     }
 
     private void notFound(BuildableComponentIdResolveResult result, ModuleComponentSelector requested, List<RepositoryResolveState> resolveStates) {
@@ -326,7 +333,7 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public void rejectedByConstraint(ModuleComponentIdentifier id) {
+        public void rejectedBySelector(ModuleComponentIdentifier id) {
             if (firstRejected == null) {
                 firstRejected = id;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionedComponentChooser.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.resolve.RejectedByRuleVersion;
 import org.gradle.internal.resolve.result.ComponentSelectionContext;
 
 import java.util.Collection;
@@ -28,5 +29,5 @@ public interface VersionedComponentChooser {
 
     void selectNewestMatchingComponent(Collection<? extends ModuleComponentResolveState> versions, ComponentSelectionContext result, VersionSelector versionSelector, VersionSelector rejectedVersionSelector, ImmutableAttributes consumerAttributes);
 
-    boolean isRejectedComponent(ModuleComponentIdentifier candidateIdentifier, MetadataProvider metadataProvider);
+    RejectedByRuleVersion isRejectedComponent(ModuleComponentIdentifier candidateIdentifier, MetadataProvider metadataProvider);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StringVersioned;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.resolve.RejectedBySelectorVersion;
 import org.gradle.internal.resolve.RejectedVersion;
 
 import javax.annotation.Nullable;
@@ -47,7 +48,7 @@ public interface ComponentResolutionState extends StringVersioned {
 
     boolean isRejected();
 
-    void unmatched(Collection<String> unmatchedVersions);
+    void unmatched(Collection<RejectedBySelectorVersion> unmatchedVersions);
 
     void rejected(Collection<RejectedVersion> rejectedVersions);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -21,8 +21,10 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StringVersioned;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.resolve.RejectedVersion;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 
 public interface ComponentResolutionState extends StringVersioned {
     ComponentIdentifier getComponentId();
@@ -44,4 +46,8 @@ public interface ComponentResolutionState extends StringVersioned {
     void reject();
 
     boolean isRejected();
+
+    void unmatched(Collection<String> unmatchedVersions);
+
+    void rejected(Collection<RejectedVersion> rejectedVersions);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -34,11 +35,13 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedVersion;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Resolution state for a given component
@@ -53,6 +56,9 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private final ModuleResolveState module;
     private final List<ComponentSelectionDescriptorInternal> selectionCauses = Lists.newArrayList();
     private final ImmutableCapability implicitCapability;
+    private final Set<String> unmatchedVersions = Sets.newLinkedHashSet();
+    private final Set<RejectedVersion> rejectedVersions = Sets.newLinkedHashSet();
+
     private volatile ComponentResolveMetadata metadata;
 
     private ComponentSelectionState state = ComponentSelectionState.Selectable;
@@ -289,6 +295,18 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     @Override
     public boolean isRejected() {
         return rejected;
+    }
+
+    @Override
+    public void unmatched(Collection<String> unmatchedVersions) {
+        // so nothing for them yet
+    }
+
+    @Override
+    public void rejected(Collection<RejectedVersion> rejectedVersions) {
+        for (RejectedVersion rejectedVersion : rejectedVersions) {
+            addCause(VersionSelectionReasons.REJECTION.withReason("version " + rejectedVersion.getId().getVersion() + " was rejected"));
+        }
     }
 
     public void removeOutgoingEdges() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
@@ -92,7 +92,7 @@ public class DefaultConflictHandler implements ModuleConflictHandler {
             if (replacement != null) {
                 String reason = replacement.getReason();
                 if (reason != null) {
-                    selected.addCause(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONFLICT_RESOLUTION, reason));
+                    selected.addCause(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.SELECTED_BY_RULE, reason));
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -68,6 +68,8 @@ class SelectorStateResolverResults {
     public static <T extends ComponentResolutionState> T componentForIdResolveResult(ComponentStateFactory<T> componentFactory, ComponentIdResolveResult idResolveResult, ResolvableSelectorState selector) {
         T component = componentFactory.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId(), idResolveResult.getMetadata());
         component.selectedBy(selector);
+        component.unmatched(idResolveResult.getUnmatchedVersions());
+        component.rejected(idResolveResult.getRejectedVersions());
         if (idResolveResult.isRejected()) {
             component.reject();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 import java.util.ArrayDeque;
 import java.util.Collections;
@@ -46,7 +45,7 @@ public class VersionSelectionReasons {
         return new DefaultComponentSelectionReason(Collections.<ComponentSelectionDescriptor>emptyList());
     }
 
-    public static ComponentSelectionReason root() {
+    public static ComponentSelectionReasonInternal root() {
         return new DefaultComponentSelectionReason(ROOT);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -129,13 +129,9 @@ public class VersionSelectionReasons {
 
         @Override
         public ComponentSelectionReasonInternal addCause(ComponentSelectionDescriptor description) {
-            if (!descriptions.contains(description)) {
-                ComponentSelectionCause cause = description.getCause();
-                if (descriptions.isEmpty() && cause != ComponentSelectionCause.REQUESTED && cause != ComponentSelectionCause.ROOT) {
-                    // initial reason must always be either root or requested
-                    descriptions.add(REQUESTED);
-                }
-                descriptions.add((ComponentSelectionDescriptorInternal) description);
+            ComponentSelectionDescriptorInternal descriptor = (ComponentSelectionDescriptorInternal) description;
+            if (!descriptions.contains(descriptor)) {
+                descriptions.add(descriptor);
             }
             return this;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -36,6 +36,7 @@ public class VersionSelectionReasons {
     public static final ComponentSelectionDescriptorInternal SELECTED_BY_RULE = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.SELECTED_BY_RULE);
     public static final ComponentSelectionDescriptorInternal COMPOSITE_BUILD = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.COMPOSITE_BUILD);
     public static final ComponentSelectionDescriptorInternal CONSTRAINT = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT);
+    public static final ComponentSelectionDescriptorInternal REJECTION = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.REJECTION);
 
     public static ComponentSelectionReasonInternal requested() {
         return new DefaultComponentSelectionReason(REQUESTED);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedByAttributesVersion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedByAttributesVersion.java
@@ -21,9 +21,17 @@ import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.text.TreeFormatter;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class RejectedByAttributesVersion extends RejectedVersion {
+    private static final Comparator<AttributeMatcher.MatchingDescription> DESCRIPTION_COMPARATOR = new Comparator<AttributeMatcher.MatchingDescription>() {
+        @Override
+        public int compare(AttributeMatcher.MatchingDescription o1, AttributeMatcher.MatchingDescription o2) {
+            return o1.getRequestedAttribute().getName().compareTo(o2.getRequestedAttribute().getName());
+        }
+    };
     private final List<AttributeMatcher.MatchingDescription> matchingDescription;
 
     public RejectedByAttributesVersion(ModuleComponentIdentifier id, List<AttributeMatcher.MatchingDescription> matchingDescription) {
@@ -33,6 +41,7 @@ public class RejectedByAttributesVersion extends RejectedVersion {
 
     @Override
     public void describeTo(TreeFormatter builder) {
+        Collections.sort(matchingDescription, DESCRIPTION_COMPARATOR);
         builder.node(getId().getVersion());
         builder.startChildren();
         for (AttributeMatcher.MatchingDescription description : matchingDescription) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedByRuleVersion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedByRuleVersion.java
@@ -17,21 +17,22 @@ package org.gradle.internal.resolve;
 
 import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.internal.text.TreeFormatter;
 
-public abstract class RejectedVersion {
-    private final ModuleComponentIdentifier id;
+public class RejectedByRuleVersion extends RejectedVersion {
+    private final String reason;
 
-    public RejectedVersion(ModuleComponentIdentifier id) {
-        this.id = id;
+    public RejectedByRuleVersion(ModuleComponentIdentifier id, String reason) {
+        super(id);
+        this.reason = reason;
     }
 
-    public ModuleComponentIdentifier getId() {
-        return id;
+    public String getReason() {
+        return reason;
     }
 
-    public void describeTo(TreeFormatter builder) {
-        builder.node(id.getVersion());
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId(), reason);
     }
 
     @Override
@@ -42,12 +43,8 @@ public abstract class RejectedVersion {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RejectedVersion that = (RejectedVersion) o;
-        return Objects.equal(id, that.id);
-    }
 
-    @Override
-    public int hashCode() {
-        return id.hashCode();
+        RejectedByRuleVersion that = (RejectedByRuleVersion) o;
+        return getId().equals(that.getId()) && Objects.equal(reason, that.reason);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedBySelectorVersion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/RejectedBySelectorVersion.java
@@ -15,23 +15,24 @@
  */
 package org.gradle.internal.resolve;
 
-import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.internal.text.TreeFormatter;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 
-public abstract class RejectedVersion {
-    private final ModuleComponentIdentifier id;
+public class RejectedBySelectorVersion extends RejectedVersion {
+    private final VersionSelector rejectionSelector;
 
-    public RejectedVersion(ModuleComponentIdentifier id) {
-        this.id = id;
+    public RejectedBySelectorVersion(ModuleComponentIdentifier id, VersionSelector rejectionSelector) {
+        super(id);
+        this.rejectionSelector = rejectionSelector;
     }
 
-    public ModuleComponentIdentifier getId() {
-        return id;
+    public VersionSelector getRejectionSelector() {
+        return rejectionSelector;
     }
 
-    public void describeTo(TreeFormatter builder) {
-        builder.node(id.getVersion());
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
     }
 
     @Override
@@ -42,12 +43,8 @@ public abstract class RejectedVersion {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RejectedVersion that = (RejectedVersion) o;
-        return Objects.equal(id, that.id);
-    }
 
-    @Override
-    public int hashCode() {
-        return id.hashCode();
+        RejectedBySelectorVersion that = (RejectedBySelectorVersion) o;
+        return getId().equals(that.getId());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentIdResolveResult.java
@@ -60,14 +60,4 @@ public interface BuildableComponentIdResolveResult extends ComponentIdResolveRes
      * @param rejections a collection of rejected versions
      */
     void rejections(Collection<RejectedVersion> rejections);
-
-    /**
-     * @return the list of unmatched versions, that is to say versions which were listed but didn't match the selector
-     */
-    Collection<String> getUnmatchedVersions();
-
-    /**
-     * @return the list of versions which were considered for this module but rejected.
-     */
-    Collection<RejectedVersion> getRejectedVersions();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentIdResolveResult.java
@@ -20,6 +20,9 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedVersion;
+
+import java.util.Collection;
 
 public interface BuildableComponentIdResolveResult extends ComponentIdResolveResult, ResourceAwareResolveResult {
     /**
@@ -42,4 +45,29 @@ public interface BuildableComponentIdResolveResult extends ComponentIdResolveRes
      */
     void failed(ModuleVersionResolveException failure);
 
+    // The following methods are used for dynamic modules, when there's often more than one version
+    // which can match, but we actually select (or reject) more before selecting.
+
+
+    /**
+     * Registers the list of versions that were attempted for this module, but didn't match
+     * the selector
+     */
+    void unmatched(Collection<String> unmatchedVersions);
+
+    /**
+     * Registers the list of rejections that happened during resolution for this module
+     * @param rejections a collection of rejected versions
+     */
+    void rejections(Collection<RejectedVersion> rejections);
+
+    /**
+     * @return the list of unmatched versions, that is to say versions which were listed but didn't match the selector
+     */
+    Collection<String> getUnmatchedVersions();
+
+    /**
+     * @return the list of versions which were considered for this module but rejected.
+     */
+    Collection<RejectedVersion> getRejectedVersions();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentIdResolveResult.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedBySelectorVersion;
 import org.gradle.internal.resolve.RejectedVersion;
 
 import java.util.Collection;
@@ -45,18 +46,21 @@ public interface BuildableComponentIdResolveResult extends ComponentIdResolveRes
      */
     void failed(ModuleVersionResolveException failure);
 
-    // The following methods are used for dynamic modules, when there's often more than one version
-    // which can match, but we actually select (or reject) more before selecting.
-
 
     /**
      * Registers the list of versions that were attempted for this module, but didn't match
-     * the selector
+     * the selector. This method is used for dynamic modules, when there's often more than one
+     * version which can match, but we actually select (or reject) more before selecting.
+     *
+     * @param unmatchedVersions a collection of unmatched versions
      */
-    void unmatched(Collection<String> unmatchedVersions);
+    void unmatched(Collection<RejectedBySelectorVersion> unmatchedVersions);
 
     /**
-     * Registers the list of rejections that happened during resolution for this module
+     * Registers the list of rejections that happened during resolution for this module.
+     * This method is used for dynamic modules, when there's often more than one
+     * version which can match, but we actually select (or reject) more before selecting.
+     *
      * @param rejections a collection of rejected versions
      */
     void rejections(Collection<RejectedVersion> rejections);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentIdResolveResult.java
@@ -20,8 +20,10 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedVersion;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 
 /**
  * The result of resolving a module version selector to a particular component id.
@@ -60,5 +62,15 @@ public interface ComponentIdResolveResult extends ResolveResult {
      * Returns true if the component id was resolved, but it was rejected by constraint.
      */
     boolean isRejected();
+
+    /**
+     * @return the list of unmatched versions, that is to say versions which were listed but didn't match the selector
+     */
+    Collection<String> getUnmatchedVersions();
+
+    /**
+     * @return the list of versions which were considered for this module but rejected.
+     */
+    Collection<RejectedVersion> getRejectedVersions();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentIdResolveResult.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedBySelectorVersion;
 import org.gradle.internal.resolve.RejectedVersion;
 
 import javax.annotation.Nullable;
@@ -66,7 +67,7 @@ public interface ComponentIdResolveResult extends ResolveResult {
     /**
      * @return the list of unmatched versions, that is to say versions which were listed but didn't match the selector
      */
-    Collection<String> getUnmatchedVersions();
+    Collection<RejectedBySelectorVersion> getUnmatchedVersions();
 
     /**
      * @return the list of versions which were considered for this module but rejected.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
@@ -44,7 +44,7 @@ public interface ComponentSelectionContext {
     /**
      * Adds a candidate version that did not match the provided selector.
      */
-    void notMatched(ModuleComponentIdentifier id);
+    void notMatched(ModuleComponentIdentifier id, VersionSelector requestedVersionMatcher);
 
     /**
      * Adds a candidate version that matched the provided selector, but was rejected by some rule.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
@@ -52,7 +52,7 @@ public interface ComponentSelectionContext {
     /**
      * Adds a candidate version that matched the provided selector, but was rejected by some constraint.
      */
-    void rejectedByConstraint(ModuleComponentIdentifier id);
+    void rejectedBySelector(ModuleComponentIdentifier id);
 
     /**
      * Adds a candidate that matched the provided selector, but was rejected because it didn't match the consumer attributes.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
@@ -17,8 +17,10 @@
 package org.gradle.internal.resolve.result;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.RejectedByAttributesVersion;
+import org.gradle.internal.resolve.RejectedByRuleVersion;
 
 /**
  * The result of resolving some dynamic version selector to a particular component id.
@@ -47,12 +49,12 @@ public interface ComponentSelectionContext {
     /**
      * Adds a candidate version that matched the provided selector, but was rejected by some rule.
      */
-    void rejectedByRule(ModuleComponentIdentifier id);
+    void rejectedByRule(RejectedByRuleVersion id);
 
     /**
      * Adds a candidate version that matched the provided selector, but was rejected by some constraint.
      */
-    void rejectedBySelector(ModuleComponentIdentifier id);
+    void rejectedBySelector(ModuleComponentIdentifier id, VersionSelector versionSelector);
 
     /**
      * Adds a candidate that matched the provided selector, but was rejected because it didn't match the consumer attributes.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedBySelectorVersion;
 import org.gradle.internal.resolve.RejectedVersion;
 
 import java.util.Collection;
@@ -32,7 +33,7 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
     private ComponentIdentifier id;
     private ModuleVersionIdentifier moduleVersionId;
     private boolean rejected;
-    private ImmutableSet.Builder<String> unmatchedVersions;
+    private ImmutableSet.Builder<RejectedBySelectorVersion> unmatchedVersions;
     private ImmutableSet.Builder<RejectedVersion> rejections;
 
     public boolean hasResult() {
@@ -86,12 +87,12 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
     }
 
     @Override
-    public void unmatched(Collection<String> unmatchedVersions) {
+    public void unmatched(Collection<RejectedBySelectorVersion> unmatchedVersions) {
         if (unmatchedVersions.isEmpty()) {
             return;
         }
         if (this.unmatchedVersions == null) {
-            this.unmatchedVersions = new ImmutableSet.Builder<String>();
+            this.unmatchedVersions = new ImmutableSet.Builder<RejectedBySelectorVersion>();
         }
         this.unmatchedVersions.addAll(unmatchedVersions);
     }
@@ -108,7 +109,7 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
     }
 
     @Override
-    public Collection<String> getUnmatchedVersions() {
+    public Collection<RejectedBySelectorVersion> getUnmatchedVersions() {
         return safeBuild(unmatchedVersions);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
@@ -16,10 +16,16 @@
 
 package org.gradle.internal.resolve.result;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.RejectedVersion;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwareResolveResult implements BuildableComponentIdResolveResult {
     private ModuleVersionResolveException failure;
@@ -27,6 +33,8 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
     private ComponentIdentifier id;
     private ModuleVersionIdentifier moduleVersionId;
     private boolean rejected;
+    private List<String> unmatchedVersions = Collections.emptyList();
+    private List<RejectedVersion> rejections = Collections.emptyList();
 
     public boolean hasResult() {
         return id != null || failure != null;
@@ -76,6 +84,26 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
     public void failed(ModuleVersionResolveException failure) {
         reset();
         this.failure = failure;
+    }
+
+    @Override
+    public void unmatched(Collection<String> unmatchedVersions) {
+        this.unmatchedVersions = ImmutableList.copyOf(unmatchedVersions);
+    }
+
+    @Override
+    public void rejections(Collection<RejectedVersion> rejections) {
+        this.rejections = ImmutableList.copyOf(rejections);
+    }
+
+    @Override
+    public Collection<String> getUnmatchedVersions() {
+        return unmatchedVersions;
+    }
+
+    @Override
+    public Collection<RejectedVersion> getRejectedVersions() {
+        return rejections;
     }
 
     private void assertResolved() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -135,7 +135,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * componentSelectionRules.rules >> []
         1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.rejectedByConstraint(b.id)
+        1 * selectedComponentResult.rejectedBySelector(b.id)
         0 * selectedComponentResult.notMatched(d.id) // versions are checked latest first
         1 * selectedComponentResult.matches(a.id)
         0 * _
@@ -173,7 +173,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * componentSelectionRules.rules >> []
         1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.rejectedByConstraint(b.id)
+        1 * selectedComponentResult.rejectedBySelector(b.id)
         1 * selectedComponentResult.matches(a.id)
         0 * _
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -114,8 +114,8 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
-        0 * selectedComponentResult.notMatched(a.id) // versions are checked latest first
+        1 * selectedComponentResult.notMatched(c.id, _)
+        0 * selectedComponentResult.notMatched(a.id, _) // versions are checked latest first
         1 * selectedComponentResult.matches(b.id)
         0 * _
 
@@ -134,9 +134,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
         1 * selectedComponentResult.rejectedBySelector(b.id, _)
-        0 * selectedComponentResult.notMatched(d.id) // versions are checked latest first
+        0 * selectedComponentResult.notMatched(d.id, _) // versions are checked latest first
         1 * selectedComponentResult.matches(a.id)
         0 * _
 
@@ -154,7 +154,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
         1 * selectedComponentResult.matches(b.id)
         0 * _
 
@@ -172,7 +172,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
         1 * selectedComponentResult.rejectedBySelector(b.id, _)
         1 * selectedComponentResult.matches(a.id)
         0 * _
@@ -196,7 +196,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
                 selection.reject("rejected")
             }
         })
-        1 * selectedComponentResult.notMatched(c.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
         1 * selectedComponentResult.rejectedByRule({it.id == d.id}) // 1.2 won't be rejected because of latest first sorting
         1 * selectedComponentResult.matches(b.id)
         0 * _
@@ -218,7 +218,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
                 selection.reject("rejected")
             }
         })
-        1 * selectedComponentResult.notMatched(c.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
         1 * selectedComponentResult.rejectedByRule({it.id == b.id})
         1 * selectedComponentResult.noMatchFound()
         0 * _
@@ -241,7 +241,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         1 * componentSelectionRules.getRules() >> []
         if (notation.indexOf('+') > 0) {
-            1 * selectedComponentResult.notMatched(d.id)
+            1 * selectedComponentResult.notMatched(d.id, _)
         } else {
             1 * selectedComponentResult.doesNotMatchConsumerAttributes({
                 it.id == d.id &&
@@ -282,9 +282,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.notMatched(b.id)
-        1 * selectedComponentResult.notMatched(a.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
+        1 * selectedComponentResult.notMatched(b.id, _)
+        1 * selectedComponentResult.notMatched(a.id, _)
         1 * selectedComponentResult.noMatchFound()
         0 * _
 
@@ -302,9 +302,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
 
         then:
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.notMatched(b.id)
-        1 * selectedComponentResult.notMatched(a.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
+        1 * selectedComponentResult.notMatched(b.id, _)
+        1 * selectedComponentResult.notMatched(a.id, _)
         1 * selectedComponentResult.noMatchFound()
         0 * _
 
@@ -351,7 +351,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
         1 * b.getAttributesFactory() >> TestUtil.attributesFactory()
 
         _ * componentSelectionRules.rules >> []
-        1 * selectedComponentResult.notMatched(c.id)
+        1 * selectedComponentResult.notMatched(c.id, _)
         1 * selectedComponentResult.failed(_ as ModuleVersionResolveException)
         0 * _
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -135,7 +135,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * componentSelectionRules.rules >> []
         1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.rejectedBySelector(b.id)
+        1 * selectedComponentResult.rejectedBySelector(b.id, _)
         0 * selectedComponentResult.notMatched(d.id) // versions are checked latest first
         1 * selectedComponentResult.matches(a.id)
         0 * _
@@ -173,7 +173,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
         then:
         _ * componentSelectionRules.rules >> []
         1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.rejectedBySelector(b.id)
+        1 * selectedComponentResult.rejectedBySelector(b.id, _)
         1 * selectedComponentResult.matches(a.id)
         0 * _
 
@@ -197,7 +197,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
             }
         })
         1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.rejectedByRule(d.id) // 1.2 won't be rejected because of latest first sorting
+        1 * selectedComponentResult.rejectedByRule({it.id == d.id}) // 1.2 won't be rejected because of latest first sorting
         1 * selectedComponentResult.matches(b.id)
         0 * _
     }
@@ -219,7 +219,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
             }
         })
         1 * selectedComponentResult.notMatched(c.id)
-        1 * selectedComponentResult.rejectedByRule(b.id)
+        1 * selectedComponentResult.rejectedByRule({it.id == b.id})
         1 * selectedComponentResult.noMatchFound()
         0 * _
 
@@ -324,9 +324,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
         _ * componentSelectionRules.rules >> rules({ ComponentSelection selection ->
             selection.reject("Rejecting everything")
         })
-        1 * selectedComponentResult.rejectedByRule(c.id)
-        1 * selectedComponentResult.rejectedByRule(b.id)
-        1 * selectedComponentResult.rejectedByRule(a.id)
+        1 * selectedComponentResult.rejectedByRule({it.id == c.id})
+        1 * selectedComponentResult.rejectedByRule({it.id == b.id})
+        1 * selectedComponentResult.rejectedByRule({it.id == a.id})
         1 * selectedComponentResult.noMatchFound()
         0 * _
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentResolveMetadata
+import org.gradle.internal.resolve.RejectedVersion
 import spock.lang.Specification
 
 abstract class AbstractConflictResolverTest extends Specification {
@@ -112,6 +113,16 @@ abstract class AbstractConflictResolverTest extends Specification {
 
         @Override
         void reject() {
+
+        }
+
+        @Override
+        void unmatched(Collection<String> unmatchedVersions) {
+
+        }
+
+        @Override
+        void rejected(Collection<RejectedVersion> rejectedVersions) {
 
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentResolveMetadata
+import org.gradle.internal.resolve.RejectedBySelectorVersion
 import org.gradle.internal.resolve.RejectedVersion
 import spock.lang.Specification
 
@@ -117,7 +118,7 @@ abstract class AbstractConflictResolverTest extends Specification {
         }
 
         @Override
-        void unmatched(Collection<String> unmatchedVersions) {
+        void unmatched(Collection<RejectedBySelectorVersion> unmatchedVersions) {
 
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResol
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.resolve.RejectedBySelectorVersion;
 import org.gradle.internal.resolve.RejectedVersion;
 
 import javax.annotation.Nullable;
@@ -75,7 +76,7 @@ public class TestComponentResolutionState implements ComponentResolutionState {
     }
 
     @Override
-    public void unmatched(Collection<String> unmatchedVersions) {
+    public void unmatched(Collection<RejectedBySelectorVersion> unmatchedVersions) {
 
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
@@ -21,8 +21,10 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResol
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.resolve.RejectedVersion;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 
 public class TestComponentResolutionState implements ComponentResolutionState {
     private ModuleVersionIdentifier id;
@@ -70,5 +72,15 @@ public class TestComponentResolutionState implements ComponentResolutionState {
     @Override
     public boolean isRejected() {
         return rejected;
+    }
+
+    @Override
+    public void unmatched(Collection<String> unmatchedVersions) {
+
+    }
+
+    @Override
+    public void rejected(Collection<RejectedVersion> rejectedVersions) {
+
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionNotFoundExceptionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionNotFoundExceptionTest.groovy
@@ -208,7 +208,7 @@ Searched in the following locations:
 
 
     static RejectedVersion reject(String version) {
-        new RejectedVersion(DefaultModuleComponentIdentifier.newId("org", "foo", version))
+        new RejectedVersion(DefaultModuleComponentIdentifier.newId("org", "foo", version)) {}
     }
 
     static RejectedByAttributesVersion rejectedByAttributes(String version, Map<String, List<String>> attributes) {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -307,47 +307,58 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         json.project.configurations[0].moduleInsights.any { it.module == 'foo:bar' }
         json.project.configurations[0].moduleInsights.any { it.module == 'foo:baz' }
         def barInsight = json.project.configurations[0].moduleInsights.find({ it.module == 'foo:bar' }).insight
-        barInsight.size() == 2
+        barInsight.size() == 3
         barInsight[0].name == 'foo:bar:2.0'
         barInsight[0].resolvable == 'RESOLVED'
         barInsight[0].hasConflict == false
         barInsight[0].description == 'conflict resolution'
-        barInsight[0].children.size() == 1
-        barInsight[0].children[0].name == 'compile'
-        barInsight[0].children[0].resolvable == 'RESOLVED'
-        barInsight[0].children[0].hasConflict == false
-        barInsight[0].children[0].isLeaf == true
-        barInsight[0].children[0].alreadyRendered == false
-        barInsight[0].children[0].children.size() == 0
+        barInsight[0].children.size() == 0
 
-        barInsight[1].name == "foo:bar:1.0 \u27A1 2.0"
+        barInsight[1].name == 'foo:bar:2.0'
         barInsight[1].resolvable == 'RESOLVED'
-        barInsight[1].hasConflict == true
+        barInsight[1].hasConflict == false
+        barInsight[1].description == null
         barInsight[1].children.size() == 1
-        barInsight[1].children[0].name == 'foo:baz:1.0'
+        barInsight[1].children[0].name == 'compile'
         barInsight[1].children[0].resolvable == 'RESOLVED'
-        barInsight[1].children[0].isLeaf == false
+        barInsight[1].children[0].hasConflict == false
+        barInsight[1].children[0].isLeaf == true
         barInsight[1].children[0].alreadyRendered == false
-        barInsight[1].children[0].children.size() == 1
-        barInsight[1].children[0].children[0].name == 'compile'
-        barInsight[1].children[0].children[0].resolvable == 'RESOLVED'
-        barInsight[1].children[0].children[0].hasConflict == false
-        barInsight[1].children[0].children[0].isLeaf == true
-        barInsight[1].children[0].children[0].alreadyRendered == false
-        barInsight[1].children[0].children[0].children.size() == 0
+        barInsight[1].children[0].children.size() == 0
+
+        barInsight[2].name == "foo:bar:1.0 \u27A1 2.0"
+        barInsight[2].resolvable == 'RESOLVED'
+        barInsight[2].hasConflict == true
+        barInsight[2].children.size() == 1
+        barInsight[2].children[0].name == 'foo:baz:1.0'
+        barInsight[2].children[0].resolvable == 'RESOLVED'
+        barInsight[2].children[0].isLeaf == false
+        barInsight[2].children[0].alreadyRendered == false
+        barInsight[2].children[0].children.size() == 1
+        barInsight[2].children[0].children[0].name == 'compile'
+        barInsight[2].children[0].children[0].resolvable == 'RESOLVED'
+        barInsight[2].children[0].children[0].hasConflict == false
+        barInsight[2].children[0].children[0].isLeaf == true
+        barInsight[2].children[0].children[0].alreadyRendered == false
+        barInsight[2].children[0].children[0].children.size() == 0
 
         def bazInsight = json.project.configurations[0].moduleInsights.find({ it.module == 'foo:baz' }).insight
-        bazInsight.size() == 1
+        bazInsight.size() == 2
         bazInsight[0].name == 'foo:baz:1.0'
         bazInsight[0].resolvable == 'RESOLVED'
         bazInsight[0].hasConflict == false
-        bazInsight[0].children.size() == 1
-        bazInsight[0].children[0].name == 'compile'
-        bazInsight[0].children[0].resolvable == 'RESOLVED'
-        bazInsight[0].children[0].hasConflict == false
-        bazInsight[0].children[0].isLeaf == true
-        bazInsight[0].children[0].alreadyRendered == false
-        bazInsight[0].children[0].children.empty
+        bazInsight[0].children.size() == 0
+
+        bazInsight[1].name == 'foo:baz:1.0'
+        bazInsight[1].resolvable == 'RESOLVED'
+        bazInsight[1].hasConflict == false
+        bazInsight[1].children.size() == 1
+        bazInsight[1].children[0].name == 'compile'
+        bazInsight[1].children[0].resolvable == 'RESOLVED'
+        bazInsight[1].children[0].hasConflict == false
+        bazInsight[1].children[0].isLeaf == true
+        bazInsight[1].children[0].alreadyRendered == false
+        bazInsight[1].children[0].children.empty
     }
 
     def "doesn't add insight for dependency with same prefix"() {
@@ -373,8 +384,9 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         def barInsight = json.project.configurations[0].moduleInsights.find({ it.module == 'foo:bar' }).insight
-        barInsight.size() == 1
+        barInsight.size() == 2
         barInsight[0].name == 'foo:bar:1.0'
+        barInsight[1].name == 'foo:bar:1.0'
     }
 
     @Issue("GRADLE-2979")

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.diagnostics
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.resolve.locking.LockfileFixture
-import org.gradle.util.ToBeImplemented
 import spock.lang.Ignore
 import spock.lang.Unroll
 
@@ -143,12 +142,12 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf
 \\--- org:top:1.0 (*)
-
-(*) - dependencies omitted (listed previously)
 """
     }
 
@@ -190,10 +189,13 @@ org:leaf2:1.0
 
         then:
         outputContains """
+Task :dependencyInsight
 org:leaf2:2.5 (conflict resolution)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:2.5
 \\--- org:toplevel3:1.0
      \\--- conf
 
@@ -259,6 +261,8 @@ org:leaf2:2.5 (conflict resolution)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:2.5
 \\--- org:toplevel3:1.0
      \\--- conf
 
@@ -358,11 +362,22 @@ dependencies {
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:
-        outputContains """org:foo:1.0 (via constraint, dependency was locked to version '1.0') FAILED
+        outputContains """
+org:foo:1.0 FAILED
+   Selection reasons:
+      - Was requested
+      - By constraint : dependency was locked to version '1.0'
+
+
+org:foo:1.0 FAILED
 \\--- lockedConf
 
 org:foo:1.1 (via constraint) FAILED
+
+org:foo:1.1 FAILED
 \\--- lockedConf
+
+org:foo:1.+ FAILED
 
 org:foo:1.+ FAILED
 \\--- lockedConf
@@ -403,6 +418,8 @@ org:leaf:1.0 (forced)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:foo:1.0
      \\--- conf
 
@@ -453,6 +470,8 @@ org:leaf:1.0
    variant "default" [
       org.gradle.status = integration (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
@@ -504,6 +523,8 @@ org:leaf:1.0 (selected by rule)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:foo:1.0
      \\--- conf
 
@@ -556,7 +577,8 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        outputContains """org.test:bar:2.0
+        outputContains """
+org.test:bar:2.0
    variant "default" [
       org.gradle.status = release (not requested)
    ]
@@ -572,6 +594,8 @@ org:baz:1.0 (selected by rule)
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+
+org:baz:1.0
 \\--- conf
 
 org:foo:2.0
@@ -823,6 +847,8 @@ org:leaf:2.0 (forced)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:2.0
 \\--- org:bar:1.0
      \\--- conf
 
@@ -914,6 +940,8 @@ org:leaf:1.0 (forced)
    variant "default+runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 +--- conf
 \\--- org:foo:1.0
      \\--- conf
@@ -1205,12 +1233,18 @@ org:leaf:[1.5,1.9] -> 1.5
         then:
         outputContains """
 org:leaf:1.0 FAILED
+
+org:leaf:1.0 FAILED
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:1.6+ FAILED
+
+org:leaf:1.6+ FAILED
 \\--- org:top:1.0
      \\--- conf
+
+org:leaf:[1.5,2.0] FAILED
 
 org:leaf:[1.5,2.0] FAILED
 \\--- org:top:1.0
@@ -1248,6 +1282,8 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 \\--- org:leaf1:1.0
      +--- conf
      \\--- org:leaf2:1.0 (*)
@@ -1286,6 +1322,8 @@ org:leaf2:1.0
         outputContains """
 project :
    variant "compile+runtimeElements"
+
+project :
 \\--- project :impl
      \\--- project : (*)
 """
@@ -1331,6 +1369,8 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 \\--- org:leaf1:1.0
      \\--- project :impl
           \\--- compile
@@ -1377,6 +1417,8 @@ project :impl
    variant "runtimeElements" [
       org.gradle.usage = java-runtime-jars (not requested)
    ]
+
+project :impl
 \\--- compile
 """
     }
@@ -1426,6 +1468,8 @@ org:leaf4:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf4:1.0
 \\--- project :impl
      \\--- compileClasspath
 """
@@ -1458,6 +1502,8 @@ org:leaf1:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf1:1.0
 \\--- compileClasspath
 """
 
@@ -1472,6 +1518,8 @@ org:leaf2:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf2:1.0
 \\--- compileClasspath
 """
     }
@@ -1519,6 +1567,8 @@ project :api
    variant "apiElements" [
       org.gradle.usage = java-api
    ]
+
+project :api
 \\--- project :impl
      \\--- compileClasspath
 """
@@ -1568,12 +1618,15 @@ org:leaf3:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf3:1.0
 \\--- org:leaf2:1.0
      +--- project :api
      |    \\--- project :impl
      |         \\--- compileClasspath
      \\--- org:leaf1:1.0
           \\--- project :impl (*)
+
 """
     }
 
@@ -1609,12 +1662,16 @@ org:leaf3:1.0
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+
+foo:bar:2.0
 \\--- compile
 
 foo:foo:1.0
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+
+foo:foo:1.0
 \\--- compile
 """)
     }
@@ -1953,11 +2010,14 @@ org:foo:[1.0,) -> 1.1
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        outputContains """org:leaf:1.0 (via constraint)
+        outputContains """
+org:leaf:1.0 (via constraint)
    variant "compile" [
       org.gradle.status = release (not requested)
       org.gradle.usage  = java-api
    ]
+
+org:leaf:1.0
 \\--- org:bom:1.0
      \\--- compileClasspath
 
@@ -1994,14 +2054,21 @@ org:leaf -> 1.0
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        outputContains """org.test:leaf:1.0 (first reason)
+        outputContains """
+org.test:leaf:1.0
    variant "default" [
       org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+   Selection reasons:
+      - Was requested : first reason
+
+
+org.test:leaf:1.0
 \\--- org.test:a:1.0
-     \\--- compileClasspath"""
+     \\--- compileClasspath
+"""
     }
 
     def "mentions web-based dependency insight report available using build scans"() {
@@ -2038,6 +2105,8 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf
@@ -2089,21 +2158,33 @@ A web-based, searchable dependency report is available by adding the --scan opti
         run "dependencyInsight", "--dependency", "org"
 
         then:
-        outputContains """org:bar (via constraint, Nope, you won't use this) FAILED
+        outputContains """
+org:bar: FAILED
+   Selection reasons:
+      - Was requested
+      - By constraint : Nope, you won't use this
+
+
+org:bar FAILED
 \\--- compileClasspath
+
+org:bar:[1.0,) FAILED
 
 org:bar:[1.0,) FAILED
 \\--- compileClasspath
 
-org:foo (via constraint) FAILED
+org:foo: (via constraint) FAILED
+
+org:foo FAILED
 \\--- compileClasspath
+
+org:foo:[1.0,) FAILED
 
 org:foo:[1.0,) FAILED
 \\--- compileClasspath
 """
     }
 
-    @ToBeImplemented("all dependency reasons are not yet collected")
     def "shows all published dependency reasons"() {
         given:
         mavenRepo.with {
@@ -2139,17 +2220,24 @@ org:foo:[1.0,) FAILED
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        outputContains """org.test:leaf:1.0 (first reason)
+        outputContains """org.test:leaf:1.0
    variant "default" [
       org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+   Selection reasons:
+      - Was requested : first reason
+      - Was requested : transitive reason
+
+
+org.test:leaf:1.0
 +--- org.test:a:1.0
 |    \\--- compileClasspath
 \\--- org.test:c:1.0
      \\--- org.test:b:1.0
-          \\--- compileClasspath"""
+          \\--- compileClasspath
+"""
     }
 
     @Unroll

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1761,8 +1761,8 @@ org:foo -> $selected
 
         where:
         version                             | selected | rejected
-        "prefer '[1.0, 2.0)'"               | '1.5'    | ""
-        "strictly '[1.1, 1.4]'"             | '1.4'    | ""
+        "prefer '[1.0, 2.0)'"               | '1.5'    | "didn't match version 2.0"
+        "strictly '[1.1, 1.4]'"             | '1.4'    | "didn't match versions 2.0, 1.5"
         "prefer '[1.0, 1.4]'; reject '1.4'" | '1.3'    | "rejected version 1.4"
     }
 
@@ -1814,8 +1814,8 @@ org:foo -> $selected
 """
         where:
         version                             | reason                                          | selected | rejected
-        "prefer '[1.0, 2.0)'"               | "foo v2+ has an incompatible API for project X" | '1.5'    | ""
-        "strictly '[1.1, 1.4]'"             | "versions of foo verified to run on platform Y" | '1.4'    | ""
+        "prefer '[1.0, 2.0)'"               | "foo v2+ has an incompatible API for project X" | '1.5'    | "didn't match version 2.0 because "
+        "strictly '[1.1, 1.4]'"             | "versions of foo verified to run on platform Y" | '1.4'    | "didn't match versions 2.0, 1.5 because "
         "prefer '[1.0, 1.4]'; reject '1.4'" | "1.4 has a critical bug"                        | '1.3'    | "rejected version 1.4 because "
     }
 
@@ -1863,8 +1863,8 @@ org:foo:${displayVersion} -> $selected
 """
         where:
         version                             | displayVersion | reason                                          | selected | rejected
-        "prefer '[1.0, 2.0)'"               | '[1.0, 2.0)'   | "foo v2+ has an incompatible API for project X" | '1.5'    | ""
-        "strictly '[1.1, 1.4]'"             | '[1.1, 1.4]'   | "versions of foo verified to run on platform Y" | '1.4'    | ""
+        "prefer '[1.0, 2.0)'"               | '[1.0, 2.0)'   | "foo v2+ has an incompatible API for project X" | '1.5'    | "didn't match version 2.0 because "
+        "strictly '[1.1, 1.4]'"             | '[1.1, 1.4]'   | "versions of foo verified to run on platform Y" | '1.4'    | "didn't match versions 2.0, 1.5 because "
         "prefer '[1.0, 1.4]'; reject '1.4'" | '[1.0, 1.4]'   | "1.4 has a critical bug"                        | '1.3'    | "rejected version 1.4 because "
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1650,7 +1650,7 @@ org:foo -> $selected
     }
 
     @Unroll
-    def "renders custom dependency constraint reasons"() {
+    def "renders custom dependency constraint reasons (#version)"() {
         given:
         mavenRepo.module("org", "foo", "1.0").publish()
         mavenRepo.module("org", "foo", "1.1").publish()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -365,9 +365,7 @@ dependencies {
         outputContains """
 org:foo:1.0 FAILED
    Selection reasons:
-      - Was requested
       - By constraint : dependency was locked to version '1.0'
-
 
 org:foo:1.0 FAILED
 \\--- lockedConf
@@ -586,7 +584,6 @@ org.test:bar:2.0
       - Was requested
       - Selected by rule : why not?
 
-
 org:bar:1.0 -> org.test:bar:2.0
 \\--- conf
 
@@ -605,7 +602,6 @@ org:foo:2.0
    Selection reasons:
       - Was requested
       - Selected by rule : because I am in control
-
 
 org:foo:1.0 -> 2.0
 \\--- conf
@@ -651,7 +647,6 @@ org:foo:1.0 -> 2.0
    Selection reasons:
       - Was requested
       - Selected by rule : foo superceded by bar
-
 
 org:foo:1.0 -> org:bar:1.0
 \\--- conf
@@ -746,7 +741,6 @@ org:leaf:2.0 -> org:new-leaf:77
       - Was requested
       - Selected by rule : I am not sure I want to explain
 
-
 org:bar:1.0 -> 2.0
 \\--- conf
 
@@ -757,7 +751,6 @@ org:foo:2.0
    Selection reasons:
       - Was requested
       - Selected by rule : I want to
-
 
 org:foo:1.0 -> 2.0
 \\--- conf
@@ -1730,7 +1723,6 @@ org:foo -> $selected
       - Was requested
       - By constraint : $rejected
 
-
 org:foo -> $selected
 \\--- compileClasspath"""
         }
@@ -1785,7 +1777,6 @@ org:foo -> $selected
       - Was requested
       - By constraint : ${rejected}${reason}
 
-
 org:foo -> $selected
 \\--- compileClasspath
 """
@@ -1834,7 +1825,6 @@ org:foo -> $selected
    ]
    Selection reasons:
       - Was requested : ${rejected}${reason}
-
 
 org:foo:${displayVersion} -> $selected
 \\--- compileClasspath
@@ -1891,7 +1881,6 @@ org:foo:${displayVersion} -> $selected
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
 
-
 org:bar:[1.0,) -> 1.0
 \\--- compileClasspath
 
@@ -1903,7 +1892,6 @@ org:foo:1.1
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
-
 
 org:foo:[1.0,) -> 1.1
 \\--- compileClasspath
@@ -1963,7 +1951,6 @@ org:bar:1.0
       - Rejection : 1.2 by rule because version 1.2 is bad
       - Rejection : 1.1 by rule because version 1.1 is bad
 
-
 org:bar:[1.0,) -> 1.0
 \\--- compileClasspath
 
@@ -1975,7 +1962,6 @@ org:foo:1.1
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
-
 
 org:foo:[1.0,) -> 1.1
 \\--- compileClasspath
@@ -2063,7 +2049,6 @@ org.test:leaf:1.0
    ]
    Selection reasons:
       - Was requested : first reason
-
 
 org.test:leaf:1.0
 \\--- org.test:a:1.0
@@ -2161,9 +2146,7 @@ A web-based, searchable dependency report is available by adding the --scan opti
         outputContains """
 org:bar: FAILED
    Selection reasons:
-      - Was requested
       - By constraint : Nope, you won't use this
-
 
 org:bar FAILED
 \\--- compileClasspath
@@ -2229,7 +2212,6 @@ org:foo:[1.0,) FAILED
    Selection reasons:
       - Was requested : first reason
       - Was requested : transitive reason
-
 
 org.test:leaf:1.0
 +--- org.test:a:1.0
@@ -2298,7 +2280,6 @@ org:foo:1.0
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
-
 
 org:foo:[1.0,) -> 1.0
 \\--- compileClasspath

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -54,6 +54,8 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
    ]
+
+project :$expectedProject
 \\--- $configuration"""
 
         where:
@@ -103,8 +105,11 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
       Requested attributes not found in the selected variant:
          org.gradle.blah   = something
    ]
+
+org.test:leaf:1.0
 \\--- org.test:a:1.0
-     \\--- compileClasspath"""
+     \\--- compileClasspath
+"""
     }
 
     def "Asking for variant details of 'FAILED' modules doesn't break the report"() {
@@ -168,6 +173,8 @@ org:leaf:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:top:1.0
      \\--- conf
 """
@@ -206,6 +213,8 @@ org:leaf:1.0
       Requested attributes not found in the selected variant:
          usage             = dummy
    ]
+
+org:leaf:1.0
 \\--- org:top:1.0
      \\--- conf
 """
@@ -263,6 +272,8 @@ org:testA:1.0
       custom            = dep_value
       org.gradle.status = release (not requested)
    ]
+
+org:testA:1.0
 \\--- conf
 
 org:testB:1.0

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsRenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsRenderableDependency.java
@@ -20,7 +20,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.tasks.diagnostics.internal.graph.nodes.AbstractRenderableDependency;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
 import org.gradle.platform.base.BinarySpec;
 import org.gradle.platform.base.ComponentSpec;
@@ -35,7 +35,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.emptyToNull;
 
-public class DependentComponentsRenderableDependency implements RenderableDependency {
+public class DependentComponentsRenderableDependency extends AbstractRenderableDependency {
 
     public static DependentComponentsRenderableDependency of(ComponentSpec componentSpec, ComponentSpecInternal internalProtocol) {
         return of(componentSpec, internalProtocol, null);
@@ -105,12 +105,6 @@ public class DependentComponentsRenderableDependency implements RenderableDepend
     public String getDescription() {
         return description;
     }
-
-    @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return null;
-    }
-
 
     @Override
     public ResolutionState getResolutionState() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -48,6 +48,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.LegendRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.NodeRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
+import org.gradle.api.tasks.diagnostics.internal.graph.nodes.Section;
 import org.gradle.api.tasks.diagnostics.internal.insight.DependencyInsightReporter;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.initialization.StartParameterBuildOptions;
@@ -383,6 +384,7 @@ public class DependencyInsightReportTask extends DefaultTask {
                 out.withStyle(Description).text(" (" + dependency.getDescription() + ")");
             }
             printVariantDetails(out);
+            printExtraDetails(out);
             switch (dependency.getResolutionState()) {
                 case FAILED:
                     out.withStyle(Failure).text(" FAILED");
@@ -393,6 +395,28 @@ public class DependencyInsightReportTask extends DefaultTask {
                     out.withStyle(Failure).text(" (n)");
                     break;
             }
+        }
+
+        private void printExtraDetails(StyledTextOutput out) {
+            List<Section> extraDetails = dependency.getExtraDetails();
+            if (!extraDetails.isEmpty()) {
+                out.println();
+                printSections(out, extraDetails, 1);
+            }
+        }
+
+        private void printSections(StyledTextOutput out, List<Section> extraDetails, int depth) {
+            for (Section extraDetail : extraDetails) {
+                printSection(out, extraDetail, depth);
+                printSections(out, extraDetail.getChildren(), depth + 1);
+            }
+        }
+
+        private void printSection(StyledTextOutput out, Section extraDetail, int depth) {
+            String indent = StringUtils.leftPad("", 3 * depth) + (depth > 1 ? "- " : "");
+            String appendix = extraDetail.getChildren().isEmpty() ? "" : ":";
+            out.withStyle(Description).text(indent + extraDetail.getDescription() + appendix);
+            out.println();
         }
 
         private void printVariantDetails(StyledTextOutput out) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -383,8 +383,6 @@ public class DependencyInsightReportTask extends DefaultTask {
             if (StringUtils.isNotEmpty(dependency.getDescription())) {
                 out.withStyle(Description).text(" (" + dependency.getDescription() + ")");
             }
-            printVariantDetails(out);
-            printExtraDetails(out);
             switch (dependency.getResolutionState()) {
                 case FAILED:
                     out.withStyle(Failure).text(" FAILED");
@@ -395,6 +393,8 @@ public class DependencyInsightReportTask extends DefaultTask {
                     out.withStyle(Failure).text(" (n)");
                     break;
             }
+            printVariantDetails(out);
+            printExtraDetails(out);
         }
 
         private void printExtraDetails(StyledTextOutput out) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -415,7 +415,10 @@ public class DependencyInsightReportTask extends DefaultTask {
         private void printSection(StyledTextOutput out, Section extraDetail, int depth) {
             String indent = StringUtils.leftPad("", 3 * depth) + (depth > 1 ? "- " : "");
             String appendix = extraDetail.getChildren().isEmpty() ? "" : ":";
-            out.withStyle(Description).text(indent + extraDetail.getDescription() + appendix);
+            String description = extraDetail.getDescription();
+            String padding = "\n" + StringUtils.leftPad("", indent.length());
+            description = description.replaceAll("(?m)(\r?\n)", padding);
+            out.withStyle(Description).text(indent + description + appendix);
             out.println();
         }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -400,7 +400,6 @@ public class DependencyInsightReportTask extends DefaultTask {
         private void printExtraDetails(StyledTextOutput out) {
             List<Section> extraDetails = dependency.getExtraDetails();
             if (!extraDetails.isEmpty()) {
-                out.println();
                 printSections(out, extraDetails, 1);
             }
         }
@@ -413,13 +412,13 @@ public class DependencyInsightReportTask extends DefaultTask {
         }
 
         private void printSection(StyledTextOutput out, Section extraDetail, int depth) {
+            out.println();
             String indent = StringUtils.leftPad("", 3 * depth) + (depth > 1 ? "- " : "");
             String appendix = extraDetail.getChildren().isEmpty() ? "" : ":";
-            String description = extraDetail.getDescription();
+            String description = StringUtils.trim(extraDetail.getDescription());
             String padding = "\n" + StringUtils.leftPad("", indent.length());
             description = description.replaceAll("(?m)(\r?\n)", padding);
             out.withStyle(Description).text(indent + description + appendix);
-            out.println();
         }
 
         private void printVariantDetails(StyledTextOutput out) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,34 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
-public abstract class AbstractRenderableModuleResult extends AbstractRenderableDependency {
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
-    protected final ResolvedComponentResult module;
-
-    public AbstractRenderableModuleResult(ResolvedComponentResult module) {
-        this.module = module;
-    }
-
+public abstract class AbstractRenderableDependency implements RenderableDependency {
     @Override
-    public ComponentIdentifier getId() {
-        return module.getId();
+    public Object getId() {
+        return null;
     }
 
     @Override
     public String getName() {
-        return getId().getDisplayName();
-    }
-
-    @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return module.getVariant();
+        return null;
     }
 
     @Override
@@ -49,12 +38,22 @@ public abstract class AbstractRenderableModuleResult extends AbstractRenderableD
     }
 
     @Override
-    public ResolutionState getResolutionState() {
-        return ResolutionState.RESOLVED;
+    public ResolvedVariantResult getResolvedVariant() {
+        return null;
     }
 
     @Override
-    public String toString() {
-        return module.toString();
+    public ResolutionState getResolutionState() {
+        return ResolutionState.UNRESOLVED;
+    }
+
+    @Override
+    public Set<? extends RenderableDependency> getChildren() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public List<Section> getExtraDetails() {
+        return Collections.emptyList();
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
@@ -19,11 +19,8 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
-import javax.annotation.Nullable;
-
-public abstract class AbstractRenderableDependencyResult implements RenderableDependency {
+public abstract class AbstractRenderableDependencyResult extends AbstractRenderableDependency {
     @Override
     public ComponentIdentifier getId() {
         return getActual();
@@ -50,11 +47,6 @@ public abstract class AbstractRenderableDependencyResult implements RenderableDe
         return getSimpleName() + " -> " + selected.getDisplayName();
     }
 
-    @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return null;
-    }
-
     /**
      * Checks if requested and selected module component differ by version.
      *
@@ -75,12 +67,6 @@ public abstract class AbstractRenderableDependencyResult implements RenderableDe
      */
     private String getSimpleName() {
         return getRequested().getDisplayName();
-    }
-
-    @Override
-    @Nullable
-    public String getDescription() {
-        return null;
     }
 
     protected abstract ComponentSelector getRequested();

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DefaultSection.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DefaultSection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+public class DefaultSection implements Section {
+    private final String description;
+    private final List<Section> children = Lists.newArrayList();
+
+    public DefaultSection(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public List<Section> getChildren() {
+        return children;
+    }
+
+    public void addChild(Section child) {
+        children.add(child);
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
@@ -24,18 +24,19 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
-import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
-public class DependencyReportHeader implements RenderableDependency, HasAttributes {
+public class DependencyReportHeader extends AbstractRenderableDependency implements HasAttributes {
     private final DependencyEdge dependency;
     private final String description;
     private final ResolvedVariantResult selectedVariant;
+    private final List<Section> extraDetails;
 
-    public DependencyReportHeader(DependencyEdge dependency, String description, ResolvedVariantResult extraDetails) {
+    public DependencyReportHeader(DependencyEdge dependency, String description, ResolvedVariantResult resolvedVariantResult, List<Section> extraDetails) {
         this.dependency = dependency;
         this.description = description;
-        this.selectedVariant = extraDetails;
+        this.selectedVariant = resolvedVariantResult;
+        this.extraDetails = extraDetails;
     }
 
     @Override
@@ -59,11 +60,6 @@ public class DependencyReportHeader implements RenderableDependency, HasAttribut
     }
 
     @Override
-    public Set<? extends RenderableDependency> getChildren() {
-        return Collections.emptySet();
-    }
-
-    @Override
     public ResolvedVariantResult getResolvedVariant() {
         return selectedVariant;
     }
@@ -72,7 +68,12 @@ public class DependencyReportHeader implements RenderableDependency, HasAttribut
     public AttributeContainer getAttributes() {
         ComponentSelector requested = dependency.getRequested();
         return requested instanceof ModuleComponentSelector
-            ? ((ModuleComponentSelector) requested).getAttributes()
+            ? requested.getAttributes()
             : ImmutableAttributes.EMPTY;
+    }
+
+    @Override
+    public List<Section> getExtraDetails() {
+        return extraDetails;
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
@@ -18,13 +18,9 @@ package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 
-import java.util.Collections;
-import java.util.Set;
-
-public class RenderableUnresolvedDependencyResult implements RenderableDependency {
+public class RenderableUnresolvedDependencyResult extends AbstractRenderableDependency {
     private final UnresolvedDependencyResult dependency;
 
     public RenderableUnresolvedDependencyResult(UnresolvedDependencyResult dependency) {
@@ -37,23 +33,8 @@ public class RenderableUnresolvedDependencyResult implements RenderableDependenc
     }
 
     @Override
-    public Set<RenderableDependency> getChildren() {
-        return Collections.emptySet();
-    }
-
-    @Override
     public Object getId() {
         return dependency.getAttempted();
-    }
-
-    @Override
-    public String getDescription() {
-        return null;
-    }
-
-    @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return null;
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/Section.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/Section.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
-
 import java.util.List;
-import java.util.Set;
 
-public interface RenderableDependency {
-    Object getId();
-    String getName();
+public interface Section {
     String getDescription();
-    ResolvedVariantResult getResolvedVariant();
-    ResolutionState getResolutionState();
-    Set<? extends RenderableDependency> getChildren();
-    List<Section> getExtraDetails();
-
-    enum ResolutionState {
-        FAILED,
-        RESOLVED,
-        UNRESOLVED
-    }
+    List<Section> getChildren();
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvableConfigurationResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvableConfigurationResult.java
@@ -23,13 +23,12 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
-public class UnresolvableConfigurationResult implements RenderableDependency {
+public class UnresolvableConfigurationResult extends AbstractRenderableDependency {
     private final Configuration configuration;
 
     public UnresolvableConfigurationResult(Configuration configuration) {
@@ -52,11 +51,6 @@ public class UnresolvableConfigurationResult implements RenderableDependency {
     }
 
     @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return null;
-    }
-
-    @Override
     public ResolutionState getResolutionState() {
         return ResolutionState.UNRESOLVED;
     }
@@ -69,7 +63,7 @@ public class UnresolvableConfigurationResult implements RenderableDependency {
         }
         Set<RenderableDependency> children = Sets.newLinkedHashSet();
         for (final Dependency dependency : dependencies) {
-            children.add(new RenderableDependency() {
+            children.add(new AbstractRenderableDependency() {
                 @Override
                 public Object getId() {
                     return dependency;
@@ -86,25 +80,6 @@ public class UnresolvableConfigurationResult implements RenderableDependency {
                     return label;
                 }
 
-                @Override
-                public String getDescription() {
-                    return null;
-                }
-
-                @Override
-                public ResolvedVariantResult getResolvedVariant() {
-                    return null;
-                }
-
-                @Override
-                public ResolutionState getResolutionState() {
-                    return ResolutionState.UNRESOLVED;
-                }
-
-                @Override
-                public Set<? extends RenderableDependency> getChildren() {
-                    return Collections.emptySet();
-                }
             });
         }
         return children;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -38,6 +38,10 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
         actual = DefaultModuleComponentIdentifier.newId(attempted.getGroup(), attempted.getModule(), attempted.getVersionConstraint().getPreferredVersion());
     }
 
+    public Throwable getFailure() {
+        return dependency.getFailure();
+    }
+
     @Override
     public boolean isResolvable() {
         return false;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.tasks.diagnostics.internal.insight;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -43,7 +41,6 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.Section;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge;
 import org.gradle.util.CollectionUtils;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -51,20 +48,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class DependencyInsightReporter {
-
-    private static final Predicate<ComponentSelectionDescriptorInternal> HAS_CUSTOM_DESCRIPTION = new Predicate<ComponentSelectionDescriptorInternal>() {
-        @Override
-        public boolean apply(@Nullable ComponentSelectionDescriptorInternal input) {
-            return input.hasCustomDescription();
-        }
-    };
-    private static final Function<ComponentSelectionDescriptorInternal, String> GET_DESCRIPTION = new Function<ComponentSelectionDescriptorInternal, String>() {
-        @Nullable
-        @Override
-        public String apply(@Nullable ComponentSelectionDescriptorInternal input) {
-            return input.getDescription();
-        }
-    };
 
     public Collection<RenderableDependency> prepare(Collection<DependencyResult> input, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser) {
         LinkedList<RenderableDependency> out = new LinkedList<RenderableDependency>();
@@ -89,20 +72,14 @@ public class DependencyInsightReporter {
             ResolvedVariantResult selectedVariant = dependency.getSelectedVariant();
             //add description only to the first module
             if (annotated.add(dependency.getActual())) {
-                //add a heading dependency with the annotation if the dependency does not exist in the graph
-                if (!dependency.getRequested().matchesStrictly(dependency.getActual())) {
-                    SelectionReasonsSection selectionReasonsSection = buildSelectionReasonSection(dependency.getReason());
-                    if (selectionReasonsSection.replacesShortDescription) {
-                        reasonDescription = null;
-                    }
-                    List<Section> extraDetails = !selectionReasonsSection.replacesShortDescription ? Collections.<Section>emptyList() : Collections.<Section>singletonList(selectionReasonsSection);
-                    out.add(new DependencyReportHeader(dependency, reasonDescription, selectedVariant, extraDetails));
-                    current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), null, null);
-                    out.add(current);
-                } else {
-                    current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), reasonDescription, selectedVariant);
-                    out.add(current);
+                SelectionReasonsSection selectionReasonsSection = buildSelectionReasonSection(dependency.getReason());
+                if (selectionReasonsSection.replacesShortDescription) {
+                    reasonDescription = null;
                 }
+                List<Section> extraDetails = !selectionReasonsSection.replacesShortDescription ? Collections.<Section>emptyList() : Collections.<Section>singletonList(selectionReasonsSection);
+                out.add(new DependencyReportHeader(dependency, reasonDescription, selectedVariant, extraDetails));
+                current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), null, null);
+                out.add(current);
             } else if (!current.getRequested().equals(dependency.getRequested())) {
                 current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), null, null);
                 out.add(current);

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
@@ -61,14 +61,6 @@ class AbstractRenderableDependencyResultSpec extends Specification {
             ComponentIdentifier getActual() {
                 return selected
             }
-
-            RenderableDependency.ResolutionState getResolutionState() {
-                throw new UnsupportedOperationException()
-            }
-
-            Set<RenderableDependency> getChildren() {
-                throw new UnsupportedOperationException()
-            }
         }
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SimpleDependency.java
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SimpleDependency.java
@@ -17,14 +17,13 @@
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId;
 
-public class SimpleDependency implements RenderableDependency {
+public class SimpleDependency extends AbstractRenderableDependency {
 
     private final ModuleComponentIdentifier id;
     private final String name;
@@ -57,11 +56,6 @@ public class SimpleDependency implements RenderableDependency {
 
     public String getDescription() {
         return description;
-    }
-
-    @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return null;
     }
 
     public Set<RenderableDependency> getChildren() {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -46,22 +46,31 @@ class DependencyInsightReporterSpec extends Specification {
         def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
-        sorted.size() == 5
+        sorted.size() == 8
 
         sorted[0].name == 'a:x:2.0'
         !sorted[0].description
 
-        sorted[1].name == 'a:x:1.0 -> 2.0'
+        sorted[1].name == 'a:x:2.0'
         !sorted[1].description
 
-        sorted[2].name == 'a:x:1.5 -> 2.0'
+        sorted[2].name == 'a:x:1.0 -> 2.0'
         !sorted[2].description
 
-        sorted[3].name == 'a:z:1.0'
+        sorted[3].name == 'a:x:1.5 -> 2.0'
         !sorted[3].description
 
-        sorted[4].name == 'b:a:5.0'
+        sorted[4].name == 'a:z:1.0'
         !sorted[4].description
+
+        sorted[5].name == 'a:z:1.0'
+        !sorted[5].description
+
+        sorted[6].name == 'b:a:5.0'
+        !sorted[6].description
+
+        sorted[7].name == 'b:a:5.0'
+        !sorted[7].description
     }
 
     def "adds header dependency if the selected version does not exist in the graph"() {
@@ -71,7 +80,7 @@ class DependencyInsightReporterSpec extends Specification {
         def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
-        sorted.size() == 4
+        sorted.size() == 5
 
         sorted[0].name == 'a:x:2.0'
         sorted[0].description == 'forced'
@@ -84,6 +93,9 @@ class DependencyInsightReporterSpec extends Specification {
 
         sorted[3].name == 'b:a:5.0'
         !sorted[3].description
+
+        sorted[4].name == 'b:a:5.0'
+        !sorted[4].description
     }
 
     def "annotates only first dependency in the group"() {
@@ -93,16 +105,22 @@ class DependencyInsightReporterSpec extends Specification {
         def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
-        sorted.size() == 3
+        sorted.size() == 5
 
         sorted[0].name == 'a:x:2.0'
         sorted[0].description == 'conflict resolution'
 
-        sorted[1].name == 'a:x:1.0 -> 2.0'
-        !sorted[1].description
+        sorted[1].name == 'a:x:2.0'
+        sorted[1].description == null
 
-        sorted[2].name == 'b:a:5.0'
-        sorted[2].description == 'forced'
+        sorted[2].name == 'a:x:1.0 -> 2.0'
+        !sorted[2].description
+
+        sorted[3].name == 'b:a:5.0'
+        sorted[3].description == 'forced'
+
+        sorted[4].name == 'b:a:5.0'
+        sorted[4].description == null
     }
 
     private dep(String group, String name, String requested, String selected = requested, ComponentSelectionReason selectionReason = VersionSelectionReasons.requested()) {

--- a/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
@@ -2,6 +2,8 @@ commons-codec:commons-codec:1.7 (conflict resolution)
    variant "default+runtime" [
       org.gradle.status = release (not requested)
    ]
+
+commons-codec:commons-codec:1.7
 \--- scm
 
 commons-codec:commons-codec:1.6 -> 1.7

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
@@ -1,8 +1,13 @@
-org.ow2.asm:asm:6.0 (we require a JDK 9 compatible bytecode generator)
+org.ow2.asm:asm:6.0
    variant "compile" [
       org.gradle.status = release (not requested)
       org.gradle.usage  = java-api
    ]
+   Selection reasons:
+      - Was requested : we require a JDK 9 compatible bytecode generator
+
+
+org.ow2.asm:asm:6.0
 \--- compileClasspath
 
 A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
@@ -6,7 +6,6 @@ org.ow2.asm:asm:6.0
    Selection reasons:
       - Was requested : we require a JDK 9 compatible bytecode generator
 
-
 org.ow2.asm:asm:6.0
 \--- compileClasspath
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -210,7 +210,7 @@ allprojects {
         String module = line.substring(start, idx) // [mv:
         start = idx + 9
         idx = line.indexOf(']', start) // [reason:
-        List<String> reasons = line.substring(start, idx).split(',') as List<String>
+        List<String> reasons = line.substring(start, idx).split('!!') as List<String>
         start = idx + 15
         String variant = null
         Map<String, String> attributes = [:]
@@ -534,7 +534,7 @@ allprojects {
         }
 
         String getReason() {
-            reasons.empty ? (this == graph.root ? 'root' : 'requested') : reasons.join(',')
+            reasons.empty ? (this == graph.root ? 'root' : 'requested') : reasons.join('!!')
         }
 
         private NodeBuilder addNode(String id, String moduleVersionId = id) {
@@ -821,7 +821,7 @@ class GenerateGraphTask extends DefaultTask {
     }
 
     def formatReason(ComponentSelectionReason reason) {
-        def reasons = reason.descriptions.collect { it.description }.join(',')
+        def reasons = reason.descriptions.collect { it.description }.join('!!')
         return reasons
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -698,6 +698,14 @@ allprojects {
             this
         }
 
+        /**
+         * Marks that this node was selected by the given reason
+         */
+        NodeBuilder byReasons(List<String> reasons) {
+            this.reasons.addAll(reasons)
+            this
+        }
+
         NodeBuilder variant(String name, Map<String, ?> attributes = [:]) {
             checkVariant = true
             variantName = name


### PR DESCRIPTION
### Context

This pull requests adds support for showing the rejected versions whenever a version is selected **and** that resolution passes. Previously, there wasn't any information about the versions which were tried during dynamic version resolution.

