### PR TITLE
[WIP] Use visitor based file system mirror

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/file/RelativePath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/file/RelativePath.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.ListIterator;
 
 /**
@@ -31,7 +32,7 @@ import java.util.ListIterator;
  *
  * <p>{@code RelativePath} instances are immutable.</p>
  */
-public class RelativePath implements Serializable, Comparable<RelativePath>, CharSequence {
+public class RelativePath implements Serializable, Comparable<RelativePath>, CharSequence, Iterable<String> {
     public static final RelativePath EMPTY_ROOT = new RelativePath(false);
     private static final StringInterner PATH_SEGMENT_STRING_INTERNER = new StringInterner();
     private static final String FILE_PATH_SEPARATORS = File.separatorChar != '/' ? ("/" + File.separator) : File.separator;
@@ -300,5 +301,10 @@ public class RelativePath implements Serializable, Comparable<RelativePath>, Cha
             k++;
         }
         return 0;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return segmentIterator();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractClasspathSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractClasspathSnapshotBuilder.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.mirror.FileSnapshotHelper;
 import org.gradle.api.internal.changedetection.state.mirror.PhysicalFileVisitor;
@@ -72,7 +70,7 @@ public abstract class AbstractClasspathSnapshotBuilder implements VisitingFileCo
             public void visit(String basePath, String name, Iterable<String> relativePath, FileContentSnapshot content) {
                 if (content.getType() == FileType.RegularFile) {
                     RegularFileSnapshot fileSnapshot = Cast.uncheckedCast(FileSnapshotHelper.create(
-                        Joiner.on("/").skipNulls().join(Strings.emptyToNull(basePath), Strings.emptyToNull(Joiner.on('/').join(relativePath))),
+                        basePath,
                         relativePath,
                         content
                     ));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbstractFileCollectionSnapshotter.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.api.internal.changedetection.state.mirror.VisitableDirectoryTree;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
@@ -27,8 +28,6 @@ import org.gradle.internal.serialize.SerializerRegistry;
 import org.gradle.internal.serialize.Serializers;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Responsible for calculating a {@link FileCollectionSnapshot} for a particular {@link FileCollection}.
@@ -91,15 +90,14 @@ public abstract class AbstractFileCollectionSnapshotter implements FileCollectio
 
         @Override
         public void visitTree(FileTreeInternal fileTree) {
-            List<FileSnapshot> descendants = fileSystemSnapshotter.snapshotTree(fileTree);
-            fileSnapshotVisitor.visitFileTreeSnapshot(descendants);
+            VisitableDirectoryTree treeSnapshot = fileSystemSnapshotter.snapshotTree(fileTree);
+            fileSnapshotVisitor.visitFileTreeSnapshot(treeSnapshot);
         }
 
         @Override
         public void visitDirectoryTree(DirectoryFileTree directoryTree) {
-            FileTreeSnapshot treeSnapshot = fileSystemSnapshotter.snapshotDirectoryTree(directoryTree);
-            Collection<FileSnapshot> descendants = treeSnapshot.getDescendants();
-            fileSnapshotVisitor.visitFileTreeSnapshot(descendants);
+            VisitableDirectoryTree treeSnapshot = fileSystemSnapshotter.snapshotDirectoryTree(directoryTree);
+            fileSnapshotVisitor.visitFileTreeSnapshot(treeSnapshot);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
@@ -62,6 +63,7 @@ import java.util.List;
  */
 @NonNullApi
 public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
+    private static final Joiner PATH_JOINER = Joiner.on(File.separatorChar);
     private final FileHasher hasher;
     private final StringInterner stringInterner;
     private final FileSystem fileSystem;
@@ -197,8 +199,8 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
                     @Override
                     public void visitFile(FileVisitDetails fileDetails) {
                         String absolutePath = internPath(fileDetails.getFile());
-                        String relativePath = fileDetails.getPath();
-                        if (absolutePath.endsWith(relativePath) && (absolutePath.charAt(absolutePath.length() - relativePath.length() - 1) == '/')) {
+                        String relativePath = PATH_JOINER.join(fileDetails.getRelativePath());
+                        if (absolutePath.endsWith(relativePath) && (absolutePath.charAt(absolutePath.length() - relativePath.length() - 1) == File.separatorChar)) {
                             absolutePath =  stringInterner.intern(absolutePath.substring(0, absolutePath.length() - relativePath.length() - 1));
                             visitor.visit(absolutePath, fileDetails.getName(), fileDetails.getRelativePath(), fileSnapshot(fileDetails));
                         } else {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -196,7 +196,14 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
 
                     @Override
                     public void visitFile(FileVisitDetails fileDetails) {
-                        visitor.visit(internPath(fileDetails.getFile()), fileDetails.getName(), RelativePath.EMPTY_ROOT, fileSnapshot(fileDetails));
+                        String absolutePath = internPath(fileDetails.getFile());
+                        String relativePath = fileDetails.getPath();
+                        if (absolutePath.endsWith(relativePath) && (absolutePath.charAt(absolutePath.length() - relativePath.length() - 1) == '/')) {
+                            absolutePath =  stringInterner.intern(absolutePath.substring(0, absolutePath.length() - relativePath.length() - 1));
+                            visitor.visit(absolutePath, fileDetails.getName(), fileDetails.getRelativePath(), fileSnapshot(fileDetails));
+                        } else {
+                            visitor.visit(absolutePath, fileDetails.getName(), RelativePath.EMPTY_ROOT, fileSnapshot(fileDetails));
+                        }
                     }
                 });
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DirectoryTreeDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DirectoryTreeDetails.java
@@ -16,11 +16,15 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.changedetection.state.mirror.PhysicalFileVisitor;
+
 import java.util.Collection;
 
 /**
  * Represents the state of a directory tree.
  */
+@NonNullApi
 public class DirectoryTreeDetails implements FileTreeSnapshot {
     // Interned path
     private final String path;
@@ -47,4 +51,10 @@ public class DirectoryTreeDetails implements FileTreeSnapshot {
         return path + " (" + descendants.size() + " descendants)";
     }
 
+    @Override
+    public void visit(PhysicalFileVisitor visitor) {
+        for (FileSnapshot descendant : descendants) {
+            visitor.visit(path, descendant.getName(), descendant.getRelativePath(), descendant.getContent());
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionVisitingSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileCollectionVisitingSnapshotBuilder.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.changedetection.state.mirror.FileSnapshotHelper;
 import org.gradle.api.internal.changedetection.state.mirror.PhysicalFileVisitor;
@@ -39,8 +37,7 @@ public class FileCollectionVisitingSnapshotBuilder implements VisitingFileCollec
         tree.visit(new PhysicalFileVisitor() {
             @Override
             public void visit(String basePath, String name, Iterable<String> relativePath, FileContentSnapshot content) {
-                String absolutePath = Joiner.on("/").skipNulls().join(Strings.emptyToNull(basePath), Strings.emptyToNull(Joiner.on('/').join(relativePath)));
-                builder.collectFileSnapshot(FileSnapshotHelper.create(absolutePath, relativePath, content));
+                builder.collectFileSnapshot(FileSnapshotHelper.create(basePath, relativePath, content));
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileSnapshotVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileSnapshotVisitor.java
@@ -16,16 +16,17 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import java.util.Collection;
+import org.gradle.api.internal.changedetection.state.mirror.VisitableDirectoryTree;
 
 /**
  * A {@link FileSnapshotVisitor} is used to visit all snapshots created by the {@link FileSystemSnapshotter} for a {@link org.gradle.api.file.FileCollection}.
  */
 public interface FileSnapshotVisitor {
+
     /**
      * Visits the descendants of a {@link org.gradle.api.file.FileTree} or a {@link org.gradle.api.internal.file.collections.DirectoryFileTree}.
      */
-    void visitFileTreeSnapshot(Collection<FileSnapshot> descendants);
+    void visitFileTreeSnapshot(VisitableDirectoryTree tree);
 
     /**
      * Visits a {@link DirectoryFileSnapshot} in the root of the {@link org.gradle.api.file.FileCollection}.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileSystemSnapshotter.java
@@ -56,12 +56,6 @@ public interface FileSystemSnapshotter {
     Snapshot snapshotAll(File file);
 
     /**
-     * Returns the current snapshot of the contents and meta-data of the given directory.
-     * The provided directory must exist and be a directory.
-     */
-    FileTreeSnapshot snapshotDirectoryTree(File dir);
-
-    /**
      * Returns the current snapshot of the contents and meta-data of the given directory tree.
      */
     VisitableDirectoryTree snapshotDirectoryTree(DirectoryFileTree dirTree);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileSystemSnapshotter.java
@@ -17,11 +17,11 @@
 package org.gradle.api.internal.changedetection.state;
 
 import net.jcip.annotations.ThreadSafe;
+import org.gradle.api.internal.changedetection.state.mirror.VisitableDirectoryTree;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 
 import java.io.File;
-import java.util.List;
 
 /**
  * Provides access to snapshots of the content and metadata of the file system.
@@ -64,11 +64,11 @@ public interface FileSystemSnapshotter {
     /**
      * Returns the current snapshot of the contents and meta-data of the given directory tree.
      */
-    FileTreeSnapshot snapshotDirectoryTree(DirectoryFileTree dirTree);
+    VisitableDirectoryTree snapshotDirectoryTree(DirectoryFileTree dirTree);
 
     /**
      * Returns the current snapshot of the contents and meta-data of the given file tree.
      * Note: currently does not include the root elements, if any.
      */
-    List<FileSnapshot> snapshotTree(FileTreeInternal tree);
+    VisitableDirectoryTree snapshotTree(FileTreeInternal tree);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileTreeSnapshot.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileTreeSnapshot.java
@@ -16,12 +16,14 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.api.internal.changedetection.state.mirror.VisitableDirectoryTree;
+
 import java.util.Collection;
 
 /**
  * An immutable snapshot of the content and meta-data of some part of the file system based at some root directory.
  */
-public interface FileTreeSnapshot {
+public interface FileTreeSnapshot extends VisitableDirectoryTree {
     /**
      * The absolute path of the root directory of the tree. Can safely be used as a cache key.
      */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/FileSnapshotHelper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/FileSnapshotHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state.mirror;
+
+import com.google.common.collect.Iterables;
+import org.gradle.api.file.RelativePath;
+import org.gradle.api.internal.changedetection.state.DirectoryFileSnapshot;
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
+import org.gradle.api.internal.changedetection.state.FileSnapshot;
+import org.gradle.api.internal.changedetection.state.MissingFileSnapshot;
+import org.gradle.api.internal.changedetection.state.RegularFileSnapshot;
+
+public class FileSnapshotHelper {
+    public static FileSnapshot create(String absolutePath, Iterable<String> relativePath, FileContentSnapshot content) {
+        String[] segments = Iterables.toArray(relativePath, String.class);
+        FileSnapshot snapshot;
+        switch (content.getType()) {
+            case Directory:
+                snapshot = new DirectoryFileSnapshot(absolutePath, new RelativePath(false, segments), false);
+                break;
+            case Missing:
+                snapshot = new MissingFileSnapshot(absolutePath, new RelativePath(true, segments));
+                break;
+            case RegularFile:
+                snapshot = new RegularFileSnapshot(absolutePath, new RelativePath(true, segments), false, content);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported file type: " + content.getType());
+        }
+        return snapshot;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/FileSnapshotHelper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/FileSnapshotHelper.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.changedetection.state.mirror;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.changedetection.state.DirectoryFileSnapshot;
@@ -24,10 +26,15 @@ import org.gradle.api.internal.changedetection.state.FileSnapshot;
 import org.gradle.api.internal.changedetection.state.MissingFileSnapshot;
 import org.gradle.api.internal.changedetection.state.RegularFileSnapshot;
 
+import java.io.File;
+
 public class FileSnapshotHelper {
-    public static FileSnapshot create(String absolutePath, Iterable<String> relativePath, FileContentSnapshot content) {
+    private static final Joiner JOINER =Joiner.on(File.separatorChar).skipNulls();
+
+    public static FileSnapshot create(String basePath, Iterable<String> relativePath, FileContentSnapshot content) {
         String[] segments = Iterables.toArray(relativePath, String.class);
         FileSnapshot snapshot;
+        String absolutePath = JOINER.join(Strings.emptyToNull(basePath), Strings.emptyToNull(JOINER.join(relativePath)));
         switch (content.getType()) {
             case Directory:
                 snapshot = new DirectoryFileSnapshot(absolutePath, new RelativePath(false, segments), false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/PhysicalFileVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/PhysicalFileVisitor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state.mirror;
+
+import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
+
+public interface PhysicalFileVisitor {
+    void visit(String basePath, String name, Iterable<String> relativePath, FileContentSnapshot content);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/VisitableDirectoryTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/VisitableDirectoryTree.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state.mirror;
+
+public interface VisitableDirectoryTree {
+    void visit(PhysicalFileVisitor visitor);
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotterTest.groovy
@@ -87,11 +87,11 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         d.createDir("d2")
 
         expect:
-        def snapshot = snapshotter.snapshotDirectoryTree(d)
+        def snapshot = snapshotter.snapshotDirectoryTree(dirTree(d))
         snapshot.path == d.path
         snapshot.descendants.size() == 4
 
-        def snapshot2 = snapshotter.snapshotDirectoryTree(d)
+        def snapshot2 = snapshotter.snapshotDirectoryTree(dirTree(d))
         snapshot2.is(snapshot)
     }
 
@@ -99,11 +99,11 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         def d = tmpDir.createDir("d")
 
         expect:
-        def snapshot = snapshotter.snapshotDirectoryTree(d)
+        def snapshot = snapshotter.snapshotDirectoryTree(dirTree(d))
         snapshot.path == d.path
         snapshot.descendants.empty
 
-        def snapshot2 = snapshotter.snapshotDirectoryTree(d)
+        def snapshot2 = snapshotter.snapshotDirectoryTree(dirTree(d))
         snapshot2.is(snapshot)
     }
 
@@ -112,7 +112,7 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         d.createFile("f1")
         d.createFile("d1/f2")
         d.createDir("d2")
-        def tree = TestFiles.directoryFileTreeFactory().create(d)
+        def tree = dirTree(d)
 
         expect:
         def snapshot = snapshotter.snapshotDirectoryTree(tree)
@@ -122,7 +122,7 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         def snapshot2 = snapshotter.snapshotDirectoryTree(tree)
         snapshot2.is(snapshot)
 
-        def snapshot3 = snapshotter.snapshotDirectoryTree(d)
+        def snapshot3 = snapshotter.snapshotDirectoryTree(dirTree(d))
         snapshot3.is(snapshot)
     }
 
@@ -146,11 +146,11 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         def snapshot2 = snapshotter.snapshotDirectoryTree(tree)
         !snapshot2.is(snapshot)
 
-        def snapshot3 = snapshotter.snapshotDirectoryTree(d)
+        def snapshot3 = snapshotter.snapshotDirectoryTree(dirTree(d))
         !snapshot3.is(snapshot)
         snapshot3.descendants.size() == 7
 
-        def snapshot4 = snapshotter.snapshotDirectoryTree(TestFiles.directoryFileTreeFactory().create(d))
+        def snapshot4 = snapshotter.snapshotDirectoryTree(dirTree(d))
         !snapshot4.is(snapshot)
         snapshot4.is(snapshot3)
     }
@@ -161,7 +161,7 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         d.createFile("f1")
         d.createFile("d1/f2")
         d.createFile("d1/f1")
-        def unfilteredTree = TestFiles.directoryFileTreeFactory().create(d)
+        def unfilteredTree = dirTree(d)
         snapshotter.snapshotDirectoryTree(unfilteredTree)
 
         and: "A filtered tree over the same directory"
@@ -254,5 +254,9 @@ class DefaultFileSystemSnapshotterTest extends Specification {
         def builder = new DefaultBuildCacheHasher()
         snapshot.appendToHasher(builder)
         return builder.hash()
+    }
+
+    private static DirectoryFileTree dirTree(File dir) {
+        TestFiles.directoryFileTreeFactory().create(dir)
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/changedetection/state/TestFileSnapshotter.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/changedetection/state/TestFileSnapshotter.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state
 
+import org.gradle.api.internal.changedetection.state.mirror.VisitableDirectoryTree
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTree
 import org.gradle.internal.hash.Hashing
@@ -45,12 +46,12 @@ class TestFileSnapshotter implements FileSystemSnapshotter {
     }
 
     @Override
-    FileTreeSnapshot snapshotDirectoryTree(DirectoryFileTree dirTree) {
+    VisitableDirectoryTree snapshotDirectoryTree(DirectoryFileTree dirTree) {
         throw new UnsupportedOperationException()
     }
 
     @Override
-    List<FileSnapshot> snapshotTree(FileTreeInternal tree) {
+    VisitableDirectoryTree snapshotTree(FileTreeInternal tree) {
         throw new UnsupportedOperationException()
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/changedetection/state/TestFileSnapshotter.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/changedetection/state/TestFileSnapshotter.groovy
@@ -40,10 +40,6 @@ class TestFileSnapshotter implements FileSystemSnapshotter {
         throw new UnsupportedOperationException()
     }
 
-    @Override
-    FileTreeSnapshot snapshotDirectoryTree(File dir) {
-        throw new UnsupportedOperationException()
-    }
 
     @Override
     VisitableDirectoryTree snapshotDirectoryTree(DirectoryFileTree dirTree) {


### PR DESCRIPTION
Instead of returning a full list of files in a directory tree, we return something which can be visited.
This allows for changing the file system mirror to a different data structure where all the file collection snapshots are not determined up front.
Only the visitor should then decide how much information it needs.