### PR TITLE
Restore semantics of ProjectState.executed

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -750,7 +750,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     }
 
     private Project evaluationDependsOn(DefaultProject projectToEvaluate) {
-        if (projectToEvaluate.getState().getExecuting()) {
+        if (projectToEvaluate.getState().isConfiguring()) {
             throw new CircularReferenceException(String.format("Circular referencing during evaluation for %s.",
                 projectToEvaluate));
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.Project
 import org.gradle.api.ProjectEvaluationListener
-import org.gradle.api.ProjectState
 import org.gradle.api.Task
 import org.gradle.api.UnknownProjectException
 import org.gradle.api.artifacts.ConfigurationContainer
@@ -96,8 +95,19 @@ import java.awt.*
 import java.lang.reflect.Type
 import java.text.FieldPosition
 
-import static org.hamcrest.Matchers.*
-import static org.junit.Assert.*
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.lessThan
+import static org.hamcrest.Matchers.notNullValue
+import static org.hamcrest.Matchers.sameInstance
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertSame
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.fail
 
 @RunWith(JMock.class)
 class DefaultProjectTest {
@@ -451,16 +461,18 @@ class DefaultProjectTest {
 
     @Test(expected = CircularReferenceException)
     void testEvaluationDependsOnWithCircularDependency() {
-        final ProjectEvaluator mockReader1 = [evaluate: { DefaultProject project, ProjectState state ->
-            state.executing()
+        final ProjectEvaluator mockReader1 = { project, state ->
+            state.toBeforeEvaluate()
+            state.toEvaluate()
             project.evaluationDependsOn(child1.path)
             testScript
-        }] as ProjectEvaluator
-        final ProjectEvaluator mockReader2 = [evaluate: { DefaultProject project, ProjectState state ->
-            state.executing()
+        } as ProjectEvaluator
+        final ProjectEvaluator mockReader2 = { project, state ->
+            state.toBeforeEvaluate()
+            state.toEvaluate()
             project.evaluationDependsOn(project.path)
             testScript
-        }] as ProjectEvaluator
+        } as ProjectEvaluator
         project.projectEvaluator = mockReader1
         child1.projectEvaluator = mockReader2
         project.evaluate()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectStateInternalSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectStateInternalSpec.groovy
@@ -15,23 +15,26 @@
  */
 package org.gradle.api.internal.project
 
-import spock.lang.*
 import org.gradle.util.ConfigureUtil
+import spock.lang.Specification
 
 class ProjectStateInternalSpec extends Specification {
 
-	def "to string representation"() {
-		expect:
-		stateString {} == "NOT EXECUTED"
-		stateString { executed() } == "EXECUTED"
-		stateString { executed(new Error("bang")) } == "FAILED (bang)"
-	}
+    def "to string representation"() {
+        expect:
+        stateString {} == "NOT EXECUTED"
+        stateString { toBeforeEvaluate() } == "EXECUTING"
+        stateString { toBeforeEvaluate(); toEvaluate() } == "EXECUTING"
+        stateString { toBeforeEvaluate(); toEvaluate(); toAfterEvaluate() } == "EXECUTING"
+        stateString { configured() } == "EXECUTED"
+        stateString { failed(new Error("bang")); configured() } == "FAILED (bang)"
+    }
 
-	String stateString(Closure closure) {
-		def state = ConfigureUtil.configure(closure, new ProjectStateInternal())
-		def matcher = state.toString() =~ /^project state '(.*?)'$/
-		assert matcher
-		matcher[0][1]
-	}
+    String stateString(@DelegatesTo(ProjectStateInternal) Closure closure) {
+        def state = ConfigureUtil.configure(closure, new ProjectStateInternal())
+        def matcher = state.toString() =~ /^project state '(.*?)'$/
+        assert matcher
+        matcher[0][1]
+    }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorTest.groovy
@@ -57,7 +57,7 @@ class LifecycleProjectEvaluatorTest extends Specification {
 
     void "nothing happens if project was already configured"() {
         given:
-        state.executed()
+        state.configured()
 
         when:
         evaluate()
@@ -72,13 +72,13 @@ class LifecycleProjectEvaluatorTest extends Specification {
 
     void "nothing happens if project is being configured now"() {
         given:
-        state.executing()
+        state.toBeforeEvaluate()
 
         when:
         evaluate()
 
         then:
-        state.executing
+        state.configuring
         0 * delegate._
 
         and:
@@ -91,17 +91,24 @@ class LifecycleProjectEvaluatorTest extends Specification {
 
         then:
         1 * listener.beforeEvaluate(project) >> {
-            assert state.executing
+            assert !state.unconfigured
+            assert !state.executed
+            assert state.configuring
         }
 
         then:
         1 * delegate.evaluate(project, state) >> {
-            assert state.executing
+            assert !state.unconfigured
+            assert !state.executed
+            assert state.configuring
+
         }
 
         then:
         1 * listener.afterEvaluate(project, state) >> {
-            assert state.executing
+            assert !state.unconfigured
+            assert state.executed
+            assert state.configuring
         }
 
         and:


### PR DESCRIPTION
The Android plugin is relying on this being true when in afterEvaluate.