### PR TITLE
Collect all dependency reasons

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -397,7 +397,6 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
       - By conflict resolution
       - Selected by rule : A replaced with B
 
-
 org:a:1 -> org:b:1""")
 
         when:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -129,13 +129,9 @@ public class VersionSelectionReasons {
 
         @Override
         public ComponentSelectionReasonInternal addCause(ComponentSelectionDescriptor description) {
-            if (!descriptions.contains(description)) {
-                ComponentSelectionCause cause = description.getCause();
-                if (descriptions.isEmpty() && cause != ComponentSelectionCause.REQUESTED && cause != ComponentSelectionCause.ROOT) {
-                    // initial reason must always be either root or requested
-                    descriptions.add(REQUESTED);
-                }
-                descriptions.add((ComponentSelectionDescriptorInternal) description);
+            ComponentSelectionDescriptorInternal descriptor = (ComponentSelectionDescriptorInternal) description;
+            if (!descriptions.contains(descriptor)) {
+                descriptions.add(descriptor);
             }
             return this;
         }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -307,47 +307,58 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         json.project.configurations[0].moduleInsights.any { it.module == 'foo:bar' }
         json.project.configurations[0].moduleInsights.any { it.module == 'foo:baz' }
         def barInsight = json.project.configurations[0].moduleInsights.find({ it.module == 'foo:bar' }).insight
-        barInsight.size() == 2
+        barInsight.size() == 3
         barInsight[0].name == 'foo:bar:2.0'
         barInsight[0].resolvable == 'RESOLVED'
         barInsight[0].hasConflict == false
         barInsight[0].description == 'conflict resolution'
-        barInsight[0].children.size() == 1
-        barInsight[0].children[0].name == 'compile'
-        barInsight[0].children[0].resolvable == 'RESOLVED'
-        barInsight[0].children[0].hasConflict == false
-        barInsight[0].children[0].isLeaf == true
-        barInsight[0].children[0].alreadyRendered == false
-        barInsight[0].children[0].children.size() == 0
+        barInsight[0].children.size() == 0
 
-        barInsight[1].name == "foo:bar:1.0 \u27A1 2.0"
+        barInsight[1].name == 'foo:bar:2.0'
         barInsight[1].resolvable == 'RESOLVED'
-        barInsight[1].hasConflict == true
+        barInsight[1].hasConflict == false
+        barInsight[1].description == null
         barInsight[1].children.size() == 1
-        barInsight[1].children[0].name == 'foo:baz:1.0'
+        barInsight[1].children[0].name == 'compile'
         barInsight[1].children[0].resolvable == 'RESOLVED'
-        barInsight[1].children[0].isLeaf == false
+        barInsight[1].children[0].hasConflict == false
+        barInsight[1].children[0].isLeaf == true
         barInsight[1].children[0].alreadyRendered == false
-        barInsight[1].children[0].children.size() == 1
-        barInsight[1].children[0].children[0].name == 'compile'
-        barInsight[1].children[0].children[0].resolvable == 'RESOLVED'
-        barInsight[1].children[0].children[0].hasConflict == false
-        barInsight[1].children[0].children[0].isLeaf == true
-        barInsight[1].children[0].children[0].alreadyRendered == false
-        barInsight[1].children[0].children[0].children.size() == 0
+        barInsight[1].children[0].children.size() == 0
+
+        barInsight[2].name == "foo:bar:1.0 \u27A1 2.0"
+        barInsight[2].resolvable == 'RESOLVED'
+        barInsight[2].hasConflict == true
+        barInsight[2].children.size() == 1
+        barInsight[2].children[0].name == 'foo:baz:1.0'
+        barInsight[2].children[0].resolvable == 'RESOLVED'
+        barInsight[2].children[0].isLeaf == false
+        barInsight[2].children[0].alreadyRendered == false
+        barInsight[2].children[0].children.size() == 1
+        barInsight[2].children[0].children[0].name == 'compile'
+        barInsight[2].children[0].children[0].resolvable == 'RESOLVED'
+        barInsight[2].children[0].children[0].hasConflict == false
+        barInsight[2].children[0].children[0].isLeaf == true
+        barInsight[2].children[0].children[0].alreadyRendered == false
+        barInsight[2].children[0].children[0].children.size() == 0
 
         def bazInsight = json.project.configurations[0].moduleInsights.find({ it.module == 'foo:baz' }).insight
-        bazInsight.size() == 1
+        bazInsight.size() == 2
         bazInsight[0].name == 'foo:baz:1.0'
         bazInsight[0].resolvable == 'RESOLVED'
         bazInsight[0].hasConflict == false
-        bazInsight[0].children.size() == 1
-        bazInsight[0].children[0].name == 'compile'
-        bazInsight[0].children[0].resolvable == 'RESOLVED'
-        bazInsight[0].children[0].hasConflict == false
-        bazInsight[0].children[0].isLeaf == true
-        bazInsight[0].children[0].alreadyRendered == false
-        bazInsight[0].children[0].children.empty
+        bazInsight[0].children.size() == 0
+
+        bazInsight[1].name == 'foo:baz:1.0'
+        bazInsight[1].resolvable == 'RESOLVED'
+        bazInsight[1].hasConflict == false
+        bazInsight[1].children.size() == 1
+        bazInsight[1].children[0].name == 'compile'
+        bazInsight[1].children[0].resolvable == 'RESOLVED'
+        bazInsight[1].children[0].hasConflict == false
+        bazInsight[1].children[0].isLeaf == true
+        bazInsight[1].children[0].alreadyRendered == false
+        bazInsight[1].children[0].children.empty
     }
 
     def "doesn't add insight for dependency with same prefix"() {
@@ -373,8 +384,9 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         def barInsight = json.project.configurations[0].moduleInsights.find({ it.module == 'foo:bar' }).insight
-        barInsight.size() == 1
+        barInsight.size() == 2
         barInsight[0].name == 'foo:bar:1.0'
+        barInsight[1].name == 'foo:bar:1.0'
     }
 
     @Issue("GRADLE-2979")

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.diagnostics
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.resolve.locking.LockfileFixture
-import org.gradle.util.ToBeImplemented
 import spock.lang.Ignore
 import spock.lang.Unroll
 
@@ -143,12 +142,12 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf
 \\--- org:top:1.0 (*)
-
-(*) - dependencies omitted (listed previously)
 """
     }
 
@@ -190,10 +189,13 @@ org:leaf2:1.0
 
         then:
         outputContains """
+Task :dependencyInsight
 org:leaf2:2.5 (conflict resolution)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:2.5
 \\--- org:toplevel3:1.0
      \\--- conf
 
@@ -259,6 +261,8 @@ org:leaf2:2.5 (conflict resolution)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:2.5
 \\--- org:toplevel3:1.0
      \\--- conf
 
@@ -358,11 +362,22 @@ dependencies {
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:
-        outputContains """org:foo:1.0 (via constraint, dependency was locked to version '1.0') FAILED
+        outputContains """
+org:foo:1.0 FAILED
+   Selection reasons:
+      - Was requested
+      - By constraint : dependency was locked to version '1.0'
+
+
+org:foo:1.0 FAILED
 \\--- lockedConf
 
 org:foo:1.1 (via constraint) FAILED
+
+org:foo:1.1 FAILED
 \\--- lockedConf
+
+org:foo:1.+ FAILED
 
 org:foo:1.+ FAILED
 \\--- lockedConf
@@ -403,6 +418,8 @@ org:leaf:1.0 (forced)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:foo:1.0
      \\--- conf
 
@@ -453,6 +470,8 @@ org:leaf:1.0
    variant "default" [
       org.gradle.status = integration (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:middle:1.0
      \\--- org:top:1.0
           \\--- conf
@@ -504,6 +523,8 @@ org:leaf:1.0 (selected by rule)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:foo:1.0
      \\--- conf
 
@@ -556,7 +577,8 @@ org:leaf:2.0 -> 1.0
         run "insight"
 
         then:
-        outputContains """org.test:bar:2.0
+        outputContains """
+org.test:bar:2.0
    variant "default" [
       org.gradle.status = release (not requested)
    ]
@@ -572,6 +594,8 @@ org:baz:1.0 (selected by rule)
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+
+org:baz:1.0
 \\--- conf
 
 org:foo:2.0
@@ -823,6 +847,8 @@ org:leaf:2.0 (forced)
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:2.0
 \\--- org:bar:1.0
      \\--- conf
 
@@ -914,6 +940,8 @@ org:leaf:1.0 (forced)
    variant "default+runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 +--- conf
 \\--- org:foo:1.0
      \\--- conf
@@ -1205,12 +1233,18 @@ org:leaf:[1.5,1.9] -> 1.5
         then:
         outputContains """
 org:leaf:1.0 FAILED
+
+org:leaf:1.0 FAILED
 \\--- org:top:1.0
      \\--- conf
 
 org:leaf:1.6+ FAILED
+
+org:leaf:1.6+ FAILED
 \\--- org:top:1.0
      \\--- conf
+
+org:leaf:[1.5,2.0] FAILED
 
 org:leaf:[1.5,2.0] FAILED
 \\--- org:top:1.0
@@ -1248,6 +1282,8 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 \\--- org:leaf1:1.0
      +--- conf
      \\--- org:leaf2:1.0 (*)
@@ -1286,6 +1322,8 @@ org:leaf2:1.0
         outputContains """
 project :
    variant "compile+runtimeElements"
+
+project :
 \\--- project :impl
      \\--- project : (*)
 """
@@ -1331,6 +1369,8 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 \\--- org:leaf1:1.0
      \\--- project :impl
           \\--- compile
@@ -1377,6 +1417,8 @@ project :impl
    variant "runtimeElements" [
       org.gradle.usage = java-runtime-jars (not requested)
    ]
+
+project :impl
 \\--- compile
 """
     }
@@ -1426,6 +1468,8 @@ org:leaf4:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf4:1.0
 \\--- project :impl
      \\--- compileClasspath
 """
@@ -1458,6 +1502,8 @@ org:leaf1:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf1:1.0
 \\--- compileClasspath
 """
 
@@ -1472,6 +1518,8 @@ org:leaf2:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf2:1.0
 \\--- compileClasspath
 """
     }
@@ -1519,6 +1567,8 @@ project :api
    variant "apiElements" [
       org.gradle.usage = java-api
    ]
+
+project :api
 \\--- project :impl
      \\--- compileClasspath
 """
@@ -1568,12 +1618,15 @@ org:leaf3:1.0
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+
+org:leaf3:1.0
 \\--- org:leaf2:1.0
      +--- project :api
      |    \\--- project :impl
      |         \\--- compileClasspath
      \\--- org:leaf1:1.0
           \\--- project :impl (*)
+
 """
     }
 
@@ -1609,12 +1662,16 @@ org:leaf3:1.0
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+
+foo:bar:2.0
 \\--- compile
 
 foo:foo:1.0
    variant "default" [
       org.gradle.status = release (not requested)
    ]
+
+foo:foo:1.0
 \\--- compile
 """)
     }
@@ -1953,11 +2010,14 @@ org:foo:[1.0,) -> 1.1
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        outputContains """org:leaf:1.0 (via constraint)
+        outputContains """
+org:leaf:1.0 (via constraint)
    variant "compile" [
       org.gradle.status = release (not requested)
       org.gradle.usage  = java-api
    ]
+
+org:leaf:1.0
 \\--- org:bom:1.0
      \\--- compileClasspath
 
@@ -1994,14 +2054,21 @@ org:leaf -> 1.0
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        outputContains """org.test:leaf:1.0 (first reason)
+        outputContains """
+org.test:leaf:1.0
    variant "default" [
       org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+   Selection reasons:
+      - Was requested : first reason
+
+
+org.test:leaf:1.0
 \\--- org.test:a:1.0
-     \\--- compileClasspath"""
+     \\--- compileClasspath
+"""
     }
 
     def "mentions web-based dependency insight report available using build scans"() {
@@ -2038,6 +2105,8 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf2:1.0
 +--- org:middle:1.0
 |    \\--- org:top:1.0
 |         \\--- conf
@@ -2089,21 +2158,33 @@ A web-based, searchable dependency report is available by adding the --scan opti
         run "dependencyInsight", "--dependency", "org"
 
         then:
-        outputContains """org:bar (via constraint, Nope, you won't use this) FAILED
+        outputContains """
+org:bar: FAILED
+   Selection reasons:
+      - Was requested
+      - By constraint : Nope, you won't use this
+
+
+org:bar FAILED
 \\--- compileClasspath
+
+org:bar:[1.0,) FAILED
 
 org:bar:[1.0,) FAILED
 \\--- compileClasspath
 
-org:foo (via constraint) FAILED
+org:foo: (via constraint) FAILED
+
+org:foo FAILED
 \\--- compileClasspath
+
+org:foo:[1.0,) FAILED
 
 org:foo:[1.0,) FAILED
 \\--- compileClasspath
 """
     }
 
-    @ToBeImplemented("all dependency reasons are not yet collected")
     def "shows all published dependency reasons"() {
         given:
         mavenRepo.with {
@@ -2139,17 +2220,24 @@ org:foo:[1.0,) FAILED
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        outputContains """org.test:leaf:1.0 (first reason)
+        outputContains """org.test:leaf:1.0
    variant "default" [
       org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
          org.gradle.usage  = java-api
    ]
+   Selection reasons:
+      - Was requested : first reason
+      - Was requested : transitive reason
+
+
+org.test:leaf:1.0
 +--- org.test:a:1.0
 |    \\--- compileClasspath
 \\--- org.test:c:1.0
      \\--- org.test:b:1.0
-          \\--- compileClasspath"""
+          \\--- compileClasspath
+"""
     }
 
     @Unroll

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -365,9 +365,7 @@ dependencies {
         outputContains """
 org:foo:1.0 FAILED
    Selection reasons:
-      - Was requested
       - By constraint : dependency was locked to version '1.0'
-
 
 org:foo:1.0 FAILED
 \\--- lockedConf
@@ -586,7 +584,6 @@ org.test:bar:2.0
       - Was requested
       - Selected by rule : why not?
 
-
 org:bar:1.0 -> org.test:bar:2.0
 \\--- conf
 
@@ -605,7 +602,6 @@ org:foo:2.0
    Selection reasons:
       - Was requested
       - Selected by rule : because I am in control
-
 
 org:foo:1.0 -> 2.0
 \\--- conf
@@ -651,7 +647,6 @@ org:foo:1.0 -> 2.0
    Selection reasons:
       - Was requested
       - Selected by rule : foo superceded by bar
-
 
 org:foo:1.0 -> org:bar:1.0
 \\--- conf
@@ -746,7 +741,6 @@ org:leaf:2.0 -> org:new-leaf:77
       - Was requested
       - Selected by rule : I am not sure I want to explain
 
-
 org:bar:1.0 -> 2.0
 \\--- conf
 
@@ -757,7 +751,6 @@ org:foo:2.0
    Selection reasons:
       - Was requested
       - Selected by rule : I want to
-
 
 org:foo:1.0 -> 2.0
 \\--- conf
@@ -1730,7 +1723,6 @@ org:foo -> $selected
       - Was requested
       - By constraint : $rejected
 
-
 org:foo -> $selected
 \\--- compileClasspath"""
         }
@@ -1785,7 +1777,6 @@ org:foo -> $selected
       - Was requested
       - By constraint : ${rejected}${reason}
 
-
 org:foo -> $selected
 \\--- compileClasspath
 """
@@ -1834,7 +1825,6 @@ org:foo -> $selected
    ]
    Selection reasons:
       - Was requested : ${rejected}${reason}
-
 
 org:foo:${displayVersion} -> $selected
 \\--- compileClasspath
@@ -1891,7 +1881,6 @@ org:foo:${displayVersion} -> $selected
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
 
-
 org:bar:[1.0,) -> 1.0
 \\--- compileClasspath
 
@@ -1903,7 +1892,6 @@ org:foo:1.1
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
-
 
 org:foo:[1.0,) -> 1.1
 \\--- compileClasspath
@@ -1963,7 +1951,6 @@ org:bar:1.0
       - Rejection : 1.2 by rule because version 1.2 is bad
       - Rejection : 1.1 by rule because version 1.1 is bad
 
-
 org:bar:[1.0,) -> 1.0
 \\--- compileClasspath
 
@@ -1975,7 +1962,6 @@ org:foo:1.1
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
-
 
 org:foo:[1.0,) -> 1.1
 \\--- compileClasspath
@@ -2063,7 +2049,6 @@ org.test:leaf:1.0
    ]
    Selection reasons:
       - Was requested : first reason
-
 
 org.test:leaf:1.0
 \\--- org.test:a:1.0
@@ -2161,9 +2146,7 @@ A web-based, searchable dependency report is available by adding the --scan opti
         outputContains """
 org:bar: FAILED
    Selection reasons:
-      - Was requested
       - By constraint : Nope, you won't use this
-
 
 org:bar FAILED
 \\--- compileClasspath
@@ -2229,7 +2212,6 @@ org:foo:[1.0,) FAILED
    Selection reasons:
       - Was requested : first reason
       - Was requested : transitive reason
-
 
 org.test:leaf:1.0
 +--- org.test:a:1.0
@@ -2298,7 +2280,6 @@ org:foo:1.0
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
-
 
 org:foo:[1.0,) -> 1.0
 \\--- compileClasspath

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -54,6 +54,8 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
    ]
+
+project :$expectedProject
 \\--- $configuration"""
 
         where:
@@ -103,8 +105,11 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
       Requested attributes not found in the selected variant:
          org.gradle.blah   = something
    ]
+
+org.test:leaf:1.0
 \\--- org.test:a:1.0
-     \\--- compileClasspath"""
+     \\--- compileClasspath
+"""
     }
 
     def "Asking for variant details of 'FAILED' modules doesn't break the report"() {
@@ -168,6 +173,8 @@ org:leaf:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+
+org:leaf:1.0
 \\--- org:top:1.0
      \\--- conf
 """
@@ -206,6 +213,8 @@ org:leaf:1.0
       Requested attributes not found in the selected variant:
          usage             = dummy
    ]
+
+org:leaf:1.0
 \\--- org:top:1.0
      \\--- conf
 """
@@ -263,6 +272,8 @@ org:testA:1.0
       custom            = dep_value
       org.gradle.status = release (not requested)
    ]
+
+org:testA:1.0
 \\--- conf
 
 org:testB:1.0

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -383,8 +383,6 @@ public class DependencyInsightReportTask extends DefaultTask {
             if (StringUtils.isNotEmpty(dependency.getDescription())) {
                 out.withStyle(Description).text(" (" + dependency.getDescription() + ")");
             }
-            printVariantDetails(out);
-            printExtraDetails(out);
             switch (dependency.getResolutionState()) {
                 case FAILED:
                     out.withStyle(Failure).text(" FAILED");
@@ -395,6 +393,8 @@ public class DependencyInsightReportTask extends DefaultTask {
                     out.withStyle(Failure).text(" (n)");
                     break;
             }
+            printVariantDetails(out);
+            printExtraDetails(out);
         }
 
         private void printExtraDetails(StyledTextOutput out) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -400,7 +400,6 @@ public class DependencyInsightReportTask extends DefaultTask {
         private void printExtraDetails(StyledTextOutput out) {
             List<Section> extraDetails = dependency.getExtraDetails();
             if (!extraDetails.isEmpty()) {
-                out.println();
                 printSections(out, extraDetails, 1);
             }
         }
@@ -413,13 +412,13 @@ public class DependencyInsightReportTask extends DefaultTask {
         }
 
         private void printSection(StyledTextOutput out, Section extraDetail, int depth) {
+            out.println();
             String indent = StringUtils.leftPad("", 3 * depth) + (depth > 1 ? "- " : "");
             String appendix = extraDetail.getChildren().isEmpty() ? "" : ":";
-            String description = extraDetail.getDescription();
+            String description = StringUtils.trim(extraDetail.getDescription());
             String padding = "\n" + StringUtils.leftPad("", indent.length());
             description = description.replaceAll("(?m)(\r?\n)", padding);
             out.withStyle(Description).text(indent + description + appendix);
-            out.println();
         }
 
         private void printVariantDetails(StyledTextOutput out) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -38,6 +38,10 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
         actual = DefaultModuleComponentIdentifier.newId(attempted.getGroup(), attempted.getModule(), attempted.getVersionConstraint().getPreferredVersion());
     }
 
+    public Throwable getFailure() {
+        return dependency.getFailure();
+    }
+
     @Override
     public boolean isResolvable() {
         return false;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.tasks.diagnostics.internal.insight;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -43,7 +41,6 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.Section;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge;
 import org.gradle.util.CollectionUtils;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -51,20 +48,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class DependencyInsightReporter {
-
-    private static final Predicate<ComponentSelectionDescriptorInternal> HAS_CUSTOM_DESCRIPTION = new Predicate<ComponentSelectionDescriptorInternal>() {
-        @Override
-        public boolean apply(@Nullable ComponentSelectionDescriptorInternal input) {
-            return input.hasCustomDescription();
-        }
-    };
-    private static final Function<ComponentSelectionDescriptorInternal, String> GET_DESCRIPTION = new Function<ComponentSelectionDescriptorInternal, String>() {
-        @Nullable
-        @Override
-        public String apply(@Nullable ComponentSelectionDescriptorInternal input) {
-            return input.getDescription();
-        }
-    };
 
     public Collection<RenderableDependency> prepare(Collection<DependencyResult> input, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser) {
         LinkedList<RenderableDependency> out = new LinkedList<RenderableDependency>();
@@ -89,20 +72,14 @@ public class DependencyInsightReporter {
             ResolvedVariantResult selectedVariant = dependency.getSelectedVariant();
             //add description only to the first module
             if (annotated.add(dependency.getActual())) {
-                //add a heading dependency with the annotation if the dependency does not exist in the graph
-                if (!dependency.getRequested().matchesStrictly(dependency.getActual())) {
-                    SelectionReasonsSection selectionReasonsSection = buildSelectionReasonSection(dependency.getReason());
-                    if (selectionReasonsSection.replacesShortDescription) {
-                        reasonDescription = null;
-                    }
-                    List<Section> extraDetails = !selectionReasonsSection.replacesShortDescription ? Collections.<Section>emptyList() : Collections.<Section>singletonList(selectionReasonsSection);
-                    out.add(new DependencyReportHeader(dependency, reasonDescription, selectedVariant, extraDetails));
-                    current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), null, null);
-                    out.add(current);
-                } else {
-                    current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), reasonDescription, selectedVariant);
-                    out.add(current);
+                SelectionReasonsSection selectionReasonsSection = buildSelectionReasonSection(dependency.getReason());
+                if (selectionReasonsSection.replacesShortDescription) {
+                    reasonDescription = null;
                 }
+                List<Section> extraDetails = !selectionReasonsSection.replacesShortDescription ? Collections.<Section>emptyList() : Collections.<Section>singletonList(selectionReasonsSection);
+                out.add(new DependencyReportHeader(dependency, reasonDescription, selectedVariant, extraDetails));
+                current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), null, null);
+                out.add(current);
             } else if (!current.getRequested().equals(dependency.getRequested())) {
                 current = new RequestedVersion(dependency.getRequested(), dependency.getActual(), dependency.isResolvable(), null, null);
                 out.add(current);

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -46,22 +46,31 @@ class DependencyInsightReporterSpec extends Specification {
         def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
-        sorted.size() == 5
+        sorted.size() == 8
 
         sorted[0].name == 'a:x:2.0'
         !sorted[0].description
 
-        sorted[1].name == 'a:x:1.0 -> 2.0'
+        sorted[1].name == 'a:x:2.0'
         !sorted[1].description
 
-        sorted[2].name == 'a:x:1.5 -> 2.0'
+        sorted[2].name == 'a:x:1.0 -> 2.0'
         !sorted[2].description
 
-        sorted[3].name == 'a:z:1.0'
+        sorted[3].name == 'a:x:1.5 -> 2.0'
         !sorted[3].description
 
-        sorted[4].name == 'b:a:5.0'
+        sorted[4].name == 'a:z:1.0'
         !sorted[4].description
+
+        sorted[5].name == 'a:z:1.0'
+        !sorted[5].description
+
+        sorted[6].name == 'b:a:5.0'
+        !sorted[6].description
+
+        sorted[7].name == 'b:a:5.0'
+        !sorted[7].description
     }
 
     def "adds header dependency if the selected version does not exist in the graph"() {
@@ -71,7 +80,7 @@ class DependencyInsightReporterSpec extends Specification {
         def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
-        sorted.size() == 4
+        sorted.size() == 5
 
         sorted[0].name == 'a:x:2.0'
         sorted[0].description == 'forced'
@@ -84,6 +93,9 @@ class DependencyInsightReporterSpec extends Specification {
 
         sorted[3].name == 'b:a:5.0'
         !sorted[3].description
+
+        sorted[4].name == 'b:a:5.0'
+        !sorted[4].description
     }
 
     def "annotates only first dependency in the group"() {
@@ -93,16 +105,22 @@ class DependencyInsightReporterSpec extends Specification {
         def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
 
         then:
-        sorted.size() == 3
+        sorted.size() == 5
 
         sorted[0].name == 'a:x:2.0'
         sorted[0].description == 'conflict resolution'
 
-        sorted[1].name == 'a:x:1.0 -> 2.0'
-        !sorted[1].description
+        sorted[1].name == 'a:x:2.0'
+        sorted[1].description == null
 
-        sorted[2].name == 'b:a:5.0'
-        sorted[2].description == 'forced'
+        sorted[2].name == 'a:x:1.0 -> 2.0'
+        !sorted[2].description
+
+        sorted[3].name == 'b:a:5.0'
+        sorted[3].description == 'forced'
+
+        sorted[4].name == 'b:a:5.0'
+        sorted[4].description == null
     }
 
     private dep(String group, String name, String requested, String selected = requested, ComponentSelectionReason selectionReason = VersionSelectionReasons.requested()) {

--- a/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyInsightReport.out
@@ -2,6 +2,8 @@ commons-codec:commons-codec:1.7 (conflict resolution)
    variant "default+runtime" [
       org.gradle.status = release (not requested)
    ]
+
+commons-codec:commons-codec:1.7
 \--- scm
 
 commons-codec:commons-codec:1.6 -> 1.7

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
@@ -1,8 +1,13 @@
-org.ow2.asm:asm:6.0 (we require a JDK 9 compatible bytecode generator)
+org.ow2.asm:asm:6.0
    variant "compile" [
       org.gradle.status = release (not requested)
       org.gradle.usage  = java-api
    ]
+   Selection reasons:
+      - Was requested : we require a JDK 9 compatible bytecode generator
+
+
+org.ow2.asm:asm:6.0
 \--- compileClasspath
 
 A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguideOutput/dependencyReasonReport.out
@@ -6,7 +6,6 @@ org.ow2.asm:asm:6.0
    Selection reasons:
       - Was requested : we require a JDK 9 compatible bytecode generator
 
-
 org.ow2.asm:asm:6.0
 \--- compileClasspath
 


### PR DESCRIPTION
### Context

This PR fixes the problem that we only keep the first dependency reason
that we find when resolving. If it was a dependency without reason, then
even if a transitive dependency had a custom reason, we wouldn't show it.

Now, we properly collect all reasons during resolution, then show them in
the dependency insight report. It's worth noting that the output of the
report has been changed to always include a header, so that we have the
details for all dependencies which match the predicate.

It's built on top of #5580 
