### PR TITLE
Show errors in dependency insight report

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -38,6 +38,10 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
         actual = DefaultModuleComponentIdentifier.newId(attempted.getGroup(), attempted.getModule(), attempted.getVersionConstraint().getPreferredVersion());
     }
 
+    public Throwable getFailure() {
+        return dependency.getFailure();
+    }
+
     @Override
     public boolean isResolvable() {
         return false;


### PR DESCRIPTION
### Context

This PR adds support for rendering failures in the dependency insight
report. Before this, the only message you would get was `FAILED`, which
forces to implement a task to show the actual error, which can be a bit
painful sometimes. Instead, errors are now reported as extra details in
the header.

This is built on top of #5595.
