### PR TITLE
Enable service injection in ComponentMetadataRule

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/action/ConfigurableRules.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/action/ConfigurableRules.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.action;
+
+import java.util.List;
+
+public interface ConfigurableRules<DETAILS> {
+    List<ConfigurableRule<DETAILS>> getConfigurableRules();
+    boolean isCacheable();
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/action/DefaultConfigurableRules.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/action/DefaultConfigurableRules.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.action;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+public class DefaultConfigurableRules<DETAILS> implements ConfigurableRules<DETAILS> {
+
+    public static <T> ConfigurableRules<T> of(ConfigurableRule<T> unique) {
+        return new DefaultConfigurableRules<T>(singletonList(unique));
+    }
+
+    private final List<ConfigurableRule<DETAILS>> configurableRules;
+    private final boolean cacheable;
+
+    public DefaultConfigurableRules(List<ConfigurableRule<DETAILS>> rules) {
+        this.configurableRules = ImmutableList.copyOf(rules);
+
+        cacheable = computeCacheable();
+    }
+
+    private boolean computeCacheable() {
+        boolean isCacheable = false;
+        for (ConfigurableRule<DETAILS> configurableRule : configurableRules) {
+            if (configurableRule.isCacheable()) {
+                isCacheable = true;
+            }
+        }
+        return isCacheable;
+    }
+
+    @Override
+    public List<ConfigurableRule<DETAILS>> getConfigurableRules() {
+        return configurableRules;
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return cacheable;
+    }
+
+    @Override
+    public String toString() {
+        return configurableRules.toString();
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/action/InstantiatingActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/action/InstantiatingActionTest.groovy
@@ -38,19 +38,20 @@ class InstantiatingActionTest extends Specification {
 
         when:
         def action = new InstantiatingAction<Details>(
-            DefaultConfigurableRule.of(RuleWithParams, new Action<ActionConfiguration>() {
-                @Override
-                void execute(ActionConfiguration actionConfiguration) {
-                    actionConfiguration.params(123, "test string")
-                }
-            }, TestUtil.valueSnapshotter()),
+            DefaultConfigurableRules.of(
+                DefaultConfigurableRule.of(RuleWithParams, new Action<ActionConfiguration>() {
+                    @Override
+                    void execute(ActionConfiguration actionConfiguration) {
+                        actionConfiguration.params(123, "test string")
+                    }
+                }, TestUtil.valueSnapshotter())),
             TestUtil.instantiatorFactory().decorate(),
             shouldNotFail
         )
 
         then:
-        action.rule.ruleParams.isolate() == [123, "test string"] as Object[]
-        action.rule.ruleClass == RuleWithParams
+        action.rules.configurableRules[0].ruleParams.isolate() == [123, "test string"] as Object[]
+        action.rules.configurableRules[0].ruleClass == RuleWithParams
 
         when:
         action.execute(details)
@@ -68,14 +69,14 @@ class InstantiatingActionTest extends Specification {
 
         when:
         def action = new InstantiatingAction<Details>(
-            DefaultConfigurableRule.of(RuleWithInjectedParams),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(RuleWithInjectedParams)),
             TestUtil.instantiatorFactory().inject(registry),
             shouldNotFail
         )
 
         then:
-        action.rule.ruleParams.isolate() == [] as Object[]
-        action.rule.ruleClass == RuleWithInjectedParams
+        action.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
+        action.rules.configurableRules[0].ruleClass == RuleWithInjectedParams
 
         when:
         action.execute(details)
@@ -94,19 +95,20 @@ class InstantiatingActionTest extends Specification {
 
         when:
         def action = new InstantiatingAction<Details>(
-            DefaultConfigurableRule.of(RuleWithInjectedAndRegularParams, new Action<ActionConfiguration>() {
-                @Override
-                void execute(ActionConfiguration actionConfiguration) {
-                    actionConfiguration.params(456)
-                }
-            }, TestUtil.valueSnapshotter()),
+            DefaultConfigurableRules.of(
+                DefaultConfigurableRule.of(RuleWithInjectedAndRegularParams, new Action<ActionConfiguration>() {
+                    @Override
+                    void execute(ActionConfiguration actionConfiguration) {
+                        actionConfiguration.params(456)
+                    }
+                }, TestUtil.valueSnapshotter())),
             TestUtil.instantiatorFactory().inject(registry),
             shouldNotFail
         )
 
         then:
-        action.rule.ruleParams.isolate() == [456] as Object[]
-        action.rule.ruleClass == RuleWithInjectedAndRegularParams
+        action.rules.configurableRules[0].ruleParams.isolate() == [456] as Object[]
+        action.rules.configurableRules[0].ruleClass == RuleWithInjectedAndRegularParams
 
         when:
         action.execute(details)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentAttributesRulesIntegrationTest.groovy
@@ -39,6 +39,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
+                @javax.inject.Inject
                 public AttributeRule(Attribute attribute) {
                     targetAttribute = attribute
                 }
@@ -110,6 +111,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
+                @javax.inject.Inject
                 public AttributeRule(Attribute attribute) {
                     targetAttribute = attribute
                 }
@@ -181,6 +183,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
+                @javax.inject.Inject
                 public AttributeRule(Attribute attribute) {
                     targetAttribute = attribute
                 }
@@ -249,6 +252,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
+                @javax.inject.Inject
                 public AttributeRule(Attribute attribute) {
                     targetAttribute = attribute
                 }
@@ -320,6 +324,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
+                @javax.inject.Inject
                 public AttributeRule(Attribute attribute) {
                     targetAttribute = attribute
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+
+class ComponentMetadataRulesCachingIntegrationTest extends AbstractModuleDependencyResolveTest implements ComponentMetadataRulesSupport {
+    String getDefaultStatus() {
+        GradleMetadataResolveRunner.useIvy()?'integration':'release'
+    }
+
+    def setup() {
+        buildFile << """
+dependencies {
+    conf 'org.test:projectA:1.0'
+}
+
+// implement Sync manually to make sure that task is never up-to-date
+task resolve {
+    doLast {
+        delete 'libs'
+        copy {
+            from configurations.conf
+            into 'libs'
+        }
+    }
+}
+"""
+    }
+
+    def "rule is cached across builds"() {
+        repository {
+            'org.test:projectA:1.0'()
+        }
+        buildFile << """
+
+@CacheableRule
+class CachedRule implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println 'Rule executed'
+    }
+}
+
+dependencies {
+    components {
+        all(CachedRule)
+    }
+}
+"""
+
+        when:
+        repositoryInteractions {
+            'org.test:projectA:1.0' {
+                allowAll()
+            }
+        }
+
+        then:
+        succeeds 'resolve'
+        outputContains('Rule executed')
+
+
+        then:
+        succeeds 'resolve'
+        outputDoesNotContain('Rule executed')
+    }
+
+    def 'rule cache properly differentiates inputs'() {
+        repository {
+            'org.test:projectA:1.0'()
+        }
+        buildFile << """
+
+@CacheableRule
+class CachedRuleA implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println 'Rule A executed'
+            context.details.changing = true
+    }
+}
+
+@CacheableRule
+class CachedRuleB implements ComponentMetadataRule {
+    public void execute(ComponentMetadataContext context) {
+            println 'Rule B executed - saw changing ' + context.details.changing
+    }
+}
+
+dependencies {
+    components {
+        if (project.hasProperty('cacheA')) {
+            all(CachedRuleA)
+        }
+        all(CachedRuleB)
+    }
+}
+"""
+        when:
+        repositoryInteractions {
+            'org.test:projectA:1.0' {
+                allowAll()
+            }
+        }
+
+        then:
+        succeeds 'resolve'
+        outputContains('Rule B executed - saw changing false')
+
+
+        then:
+        succeeds 'resolve', '-PcacheA'
+        outputContains('Rule A executed')
+        outputContains('Rule B executed - saw changing true')
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesErrorHandlingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesErrorHandlingIntegrationTest.groovy
@@ -62,7 +62,7 @@ class ComponentMetadataRulesErrorHandlingIntegrationTest extends AbstractHttpDep
         failure.assertHasFileName("Build file '$buildFile.path'")
         failure.assertHasLineNumber(22)
         failure.assertHasCause("There was an error while evaluating a component metadata rule for org.test:projectA:1.0.")
-        failure.assertHasCause("Could not find method foo() for arguments [] on object of type WrongRule.")
+        failure.assertHasCause("No signature of method: WrongRule.foo() is applicable for argument types: () values: []")
     }
 
     def "produces sensible error for invalid component metadata rule" () {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesInjectionIntegrationTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.util.ToBeImplemented
+
+class ComponentMetadataRulesInjectionIntegrationTest extends AbstractHttpDependencyResolutionTest implements ComponentMetadataRulesSupport {
+
+    @ToBeImplemented("Ideally we would have a solution to provide such a service in this case")
+    def 'cannot inject and use RepositoryResourceAccessor for flat dir repo'() {
+        file('lib', 'my-lib-1.0.jar').createFile()
+        buildFile << """
+repositories {
+    flatDir {
+        dirs 'lib'
+    }
+}
+
+configurations {
+    conf
+}
+
+class AssertingRule implements ComponentMetadataRule {
+    RepositoryResourceAccessor accessor
+    
+    @javax.inject.Inject
+    public AssertingRule(RepositoryResourceAccessor accessor) {
+        this.accessor = accessor
+    }
+    public void execute(ComponentMetadataContext context) {
+        println 'AssertingRule executed'
+    }
+}
+
+dependencies {
+    components {
+        all(AssertingRule)
+    }
+    conf 'org:my-lib:1.0'
+}
+
+task resolve {
+    doLast {
+        delete 'libs'
+        copy {
+            from configurations.conf
+            into 'libs'
+        }
+    }
+}
+"""
+        when:
+        fails 'resolve'
+
+        then:
+        failure.assertHasCause('Could not create an instance of type AssertingRule.')
+        failure.assertHasCause('Unable to determine AssertingRule argument #1: missing parameter value of type interface org.gradle.api.artifacts.repositories.RepositoryResourceAccessor')
+
+    }
+
+    def 'can inject and use RepositoryResourceAccessor for maven local repo'() {
+        using m2
+        m2.mavenRepo().module("org", "my-lib", "1.0").publish()
+
+        buildFile << """
+repositories {
+    mavenLocal()
+}
+
+configurations {
+    conf
+}
+
+class AssertingRule implements ComponentMetadataRule {
+    RepositoryResourceAccessor accessor
+    
+    @javax.inject.Inject
+    public AssertingRule(RepositoryResourceAccessor accessor) {
+        this.accessor = accessor
+    }
+    public void execute(ComponentMetadataContext context) {
+        println 'AssertingRule executed'
+        accessor.withResource('org/my-lib/1.0/my-lib-1.0.pom') {
+            assert it.available() != 0
+        }
+    }
+}
+
+dependencies {
+    components {
+        all(AssertingRule)
+    }
+    conf 'org:my-lib:1.0'
+}
+
+task resolve {
+    doLast {
+        delete 'libs'
+        copy {
+            from configurations.conf
+            into 'libs'
+        }
+    }
+}
+"""
+        when:
+        succeeds 'resolve'
+
+        then:
+        outputContains('AssertingRule executed')
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/IvySpecificComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/IvySpecificComponentMetadataRulesIntegrationTest.groovy
@@ -109,22 +109,11 @@ resolve.doLast { assert IvyRule.ruleInvoked }
             }
         }
 
-        buildFile <<
-            """
-import java.util.concurrent.atomic.AtomicBoolean
-
-def ruleInvoked = new AtomicBoolean()
-
+        buildFile << """
 class IvyRule implements ComponentMetadataRule {
-    AtomicBoolean ruleInvoked
-
-    IvyRule(AtomicBoolean ruleInvoked) {
-        this.ruleInvoked = ruleInvoked
-    }
 
     @Override
     void execute(ComponentMetadataContext context) {
-            ruleInvoked.set(true)
             def descriptor = context.getDescriptor(IvyModuleDescriptor)
             descriptor.extraInfo.get('foo')
     }
@@ -132,13 +121,9 @@ class IvyRule implements ComponentMetadataRule {
 
 dependencies {
     components {
-        all(IvyRule, {
-            params(ruleInvoked)
-        })
+        all(IvyRule)
     }
 }
-
-resolve.doLast { assert ruleInvoked }
 """
 
         and:
@@ -153,7 +138,7 @@ resolve.doLast { assert ruleInvoked }
 
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
-        failure.assertHasLineNumber(57)
+        failure.assertHasLineNumber(47)
         failure.assertHasCause("Could not resolve all files for configuration ':conf'.")
         failure.assertHasCause("Could not resolve org.test:projectA:1.0.")
         failure.assertHasCause("Cannot get extra info element named 'foo' by name since elements with this name were found from multiple namespaces (http://my.extra.info/foo, http://some.other.ns).  Use get(String namespace, String name) instead.")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyCustomStatusLatestVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyCustomStatusLatestVersionIntegrationTest.groovy
@@ -80,6 +80,7 @@ class StatusRule implements ComponentMetadataRule {
 
     String releaseVersion
     
+    @javax.inject.Inject
     public StatusRule(String releaseVersion) {
         this.releaseVersion = releaseVersion
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -982,7 +982,7 @@ group:projectB:2.2;release
         outputContains 'Providing metadata for group:projectA:1.2'
     }
 
-    def "can cache the result of processing a rule accross projects"() {
+    def "can cache the result of processing a rule across projects"() {
         settingsFile << """
             include 'b'
         """
@@ -1032,8 +1032,8 @@ group:projectB:2.2;release
 
         then:
         noExceptionThrown()
-        outputContains "Found result for rule DefaultConfigurableRule{rule=class MP, ruleParams=[]} and key group:projectB:2.2"
-        outputContains "Found result for rule DefaultConfigurableRule{rule=class MP, ruleParams=[]} and key group:projectB:1.1"
+        result.assertRawOutputContains "Found result for rule [DefaultConfigurableRule{rule=class MP, ruleParams=[]}] and key group:projectB:2.2"
+        result.assertRawOutputContains "Found result for rule [DefaultConfigurableRule{rule=class MP, ruleParams=[]}] and key group:projectB:1.1"
     }
 
     def "changing the implementation of a rule invalidates the cache"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
@@ -16,12 +16,13 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ComponentMetadata;
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
 public interface ComponentMetadataProcessor {
     ComponentMetadataProcessor NO_OP = new ComponentMetadataProcessor() {
         @Override
-        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
+        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata, CachePolicy cachePolicy) {
             return metadata;
         }
 
@@ -31,7 +32,7 @@ public interface ComponentMetadataProcessor {
         }
     };
 
-    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata);
+    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata, CachePolicy cachePolicy);
 
     /**
      * Processes "shallow" metadata, only for selecting a version. This metadata is typically

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessor.java
@@ -16,13 +16,12 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ComponentMetadata;
-import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
 public interface ComponentMetadataProcessor {
     ComponentMetadataProcessor NO_OP = new ComponentMetadataProcessor() {
         @Override
-        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata, CachePolicy cachePolicy) {
+        public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
             return metadata;
         }
 
@@ -32,7 +31,7 @@ public interface ComponentMetadataProcessor {
         }
     };
 
-    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata, CachePolicy cachePolicy);
+    ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata);
 
     /**
      * Processes "shallow" metadata, only for selecting a version. This metadata is typically

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessorFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+/**
+ * A factory for {@link ComponentMetadataProcessor}.
+ * <p>
+ * In a build, {@link org.gradle.api.artifacts.ComponentMetadataRule component metadata rules} can be added to transform dependencies metadata.
+ * These are registered with the {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler ComponentMetadataHandler} which does not have contextual information,
+ * such as the repository from which the dependency comes from.
+ * <p>
+ * The {@link MetadataResolutionContext} enables a {@link ComponentMetadataProcessor} to execute with the proper context.
+ */
+public interface ComponentMetadataProcessorFactory {
+
+    /**
+     * Creates a contextual {@link ComponentMetadataProcessor}
+     *
+     * @param resolutionContext the provided context
+     * @return a {@code ComponentMetadataProcessor}
+     */
+    ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -93,6 +93,7 @@ import org.gradle.internal.locking.DefaultDependencyLockingHandler;
 import org.gradle.internal.locking.DefaultDependencyLockingProvider;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resource.cached.ExternalResourceFileStore;
 import org.gradle.internal.resource.local.FileResourceRepository;
@@ -246,8 +247,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory);
         }
 
-        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory) {
-            return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory);
+        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {
+            return instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory, componentMetadataRuleExecutor);
         }
 
         DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -260,8 +260,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultArtifactHandler.class, configurationContainer, publishArtifactNotationParser);
         }
 
-        GlobalDependencyResolutionRules createModuleMetadataHandler(ComponentMetadataProcessor componentMetadataProcessor, ComponentModuleMetadataProcessor moduleMetadataProcessor, List<DependencySubstitutionRules> rules) {
-            return new DefaultGlobalDependencyResolutionRules(componentMetadataProcessor, moduleMetadataProcessor, rules);
+        GlobalDependencyResolutionRules createModuleMetadataHandler(ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentModuleMetadataProcessor moduleMetadataProcessor, List<DependencySubstitutionRules> rules) {
+            return new DefaultGlobalDependencyResolutionRules(componentMetadataProcessorFactory, moduleMetadataProcessor, rules);
         }
 
         ConfigurationResolver createDependencyResolver(ArtifactDependencyResolver artifactDependencyResolver,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultGlobalDependencyResolutionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultGlobalDependencyResolutionRules.java
@@ -26,22 +26,24 @@ import org.gradle.util.CollectionUtils;
 import java.util.List;
 
 public class DefaultGlobalDependencyResolutionRules implements GlobalDependencyResolutionRules {
-    private final ComponentMetadataProcessor componentMetadataProcessor;
+    private final ComponentMetadataProcessorFactory componentMetadataProcessorFactory;
     private final ComponentModuleMetadataProcessor moduleMetadataProcessor;
     private final DependencySubstitutionRules globalDependencySubstitutionRule;
 
-    public DefaultGlobalDependencyResolutionRules(ComponentMetadataProcessor componentMetadataProcessor,
+    public DefaultGlobalDependencyResolutionRules(ComponentMetadataProcessorFactory componentMetadataProcessorFactory,
                                                   ComponentModuleMetadataProcessor moduleMetadataProcessor,
                                                   List<DependencySubstitutionRules> ruleProviders) {
-        this.componentMetadataProcessor = componentMetadataProcessor;
+        this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
         this.moduleMetadataProcessor = moduleMetadataProcessor;
         this.globalDependencySubstitutionRule = new CompositeDependencySubstitutionRules(ruleProviders);
     }
 
-    public ComponentMetadataProcessor getComponentMetadataProcessor() {
-        return componentMetadataProcessor;
+    @Override
+    public ComponentMetadataProcessorFactory getComponentMetadataProcessorFactory() {
+        return componentMetadataProcessorFactory;
     }
 
+    @Override
     public ComponentModuleMetadataProcessor getModuleMetadataProcessor() {
         return moduleMetadataProcessor;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -38,6 +38,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.DefaultModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCacheProvider;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCaches;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.SuppliedComponentMetadataSerializer;
@@ -101,6 +103,7 @@ import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.TextResourceLoader;
@@ -389,9 +392,21 @@ class DependencyManagementBuildScopeServices {
     }
 
 
+    ModuleComponentResolveMetadataSerializer createModuleComponentResolveMetadataSerializer(AttributeContainerSerializer attributeContainerSerializer, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+        return new ModuleComponentResolveMetadataSerializer(new ModuleMetadataSerializer(attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory), moduleIdentifierFactory);
+    }
+
     SuppliedComponentMetadataSerializer createSuppliedComponentMetadataSerializer(ImmutableModuleIdentifierFactory moduleIdentifierFactory, AttributeContainerSerializer attributeContainerSerializer) {
         ModuleVersionIdentifierSerializer moduleVersionIdentifierSerializer = new ModuleVersionIdentifierSerializer(moduleIdentifierFactory);
         return new SuppliedComponentMetadataSerializer(moduleVersionIdentifierSerializer, attributeContainerSerializer);
+    }
+
+    ComponentMetadataRuleExecutor createComponentMetadataRuleExecutor(ValueSnapshotter valueSnapshotter,
+                                                                      CacheRepository cacheRepository,
+                                                                      InMemoryCacheDecoratorFactory cacheDecoratorFactory,
+                                                                      BuildCommencedTimeProvider timeProvider,
+                                                                      ModuleComponentResolveMetadataSerializer serializer) {
+        return new ComponentMetadataRuleExecutor(cacheRepository, cacheDecoratorFactory, valueSnapshotter, timeProvider, serializer);
     }
 
     ComponentMetadataSupplierRuleExecutor createComponentMetadataSupplierRuleExecutor(ValueSnapshotter snapshotter,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.FeaturePreviews;
+import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.component.DefaultComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
@@ -294,7 +295,8 @@ class DependencyManagementBuildScopeServices {
                                               VersionComparator versionComparator,
                                               ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                               RepositoryBlacklister repositoryBlacklister,
-                                              VersionParser versionParser) {
+                                              VersionParser versionParser,
+                                              InstantiatorFactory instantiatorFactory) {
         StartParameterResolutionOverride startParameterResolutionOverride = new StartParameterResolutionOverride(startParameter);
         return new ResolveIvyFactory(
             moduleRepositoryCacheProvider,
@@ -304,7 +306,8 @@ class DependencyManagementBuildScopeServices {
             versionComparator,
             moduleIdentifierFactory,
             repositoryBlacklister,
-            versionParser);
+            versionParser,
+            instantiatorFactory);
     }
 
     ArtifactDependencyResolver createArtifactDependencyResolver(ResolveIvyFactory resolveIvyFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/GlobalDependencyResolutionRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/GlobalDependencyResolutionRules.java
@@ -19,10 +19,17 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 
 public interface GlobalDependencyResolutionRules {
 
+    ComponentMetadataProcessorFactory NO_OP_FACTORY = new ComponentMetadataProcessorFactory() {
+        @Override
+        public ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext) {
+            return ComponentMetadataProcessor.NO_OP;
+        }
+    };
+
     GlobalDependencyResolutionRules NO_OP = new GlobalDependencyResolutionRules() {
         @Override
-        public ComponentMetadataProcessor getComponentMetadataProcessor() {
-            return ComponentMetadataProcessor.NO_OP;
+        public ComponentMetadataProcessorFactory getComponentMetadataProcessorFactory() {
+            return NO_OP_FACTORY;
         }
 
         @Override
@@ -36,7 +43,7 @@ public interface GlobalDependencyResolutionRules {
         }
     };
 
-    ComponentMetadataProcessor getComponentMetadataProcessor();
+    ComponentMetadataProcessorFactory getComponentMetadataProcessorFactory();
     ComponentModuleMetadataProcessor getModuleMetadataProcessor();
     DependencySubstitutionRules getDependencySubstitutionRules();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/MetadataResolutionContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/MetadataResolutionContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
+import org.gradle.internal.reflect.Instantiator;
+
+/**
+ * Provides context for metadata resolution, sourced from a repository definition.
+ *
+ * @see ComponentMetadataProcessorFactory
+ */
+public interface MetadataResolutionContext {
+
+    /**
+     * The cache policy of a repository
+     *
+     * @return the cache policy
+     */
+    CachePolicy getCachePolicy();
+
+    /**
+     * Provides an injecting instantiator, giving access to services potentially contextual to a repository.
+     *
+     * @return a injecting instantiator
+     */
+    Instantiator getInjectingInstantiator();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
@@ -23,12 +23,12 @@ import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
-public class DefaultComponentMetadataContext implements ComponentMetadataContext {
+class DefaultComponentMetadataContext implements ComponentMetadataContext {
 
     private final ComponentMetadataDetails details;
     private final ModuleComponentResolveMetadata metadata;
 
-    public DefaultComponentMetadataContext(ComponentMetadataDetails details, ModuleComponentResolveMetadata metadata) {
+    DefaultComponentMetadataContext(ComponentMetadataDetails details, ModuleComponentResolveMetadata metadata) {
         this.details = details;
         this.metadata = metadata;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.ComponentMetadata;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.VariantMetadata;
+import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.MetadataResolutionContext;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.UserProvidedMetadata;
+import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.internal.action.ConfigurableRule;
+import org.gradle.internal.action.DefaultConfigurableRules;
+import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
+import org.gradle.internal.rules.RuleAction;
+import org.gradle.internal.rules.SpecRuleAction;
+import org.gradle.internal.typeconversion.NotationParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class DefaultComponentMetadataProcessor implements ComponentMetadataProcessor {
+
+    private static final Transformer<ModuleComponentResolveMetadata, WrappingComponentMetadataContext> DETAILS_TO_RESULT = new Transformer<ModuleComponentResolveMetadata, WrappingComponentMetadataContext>() {
+            @Override
+            public ModuleComponentResolveMetadata transform(WrappingComponentMetadataContext componentMetadataContext) {
+                return componentMetadataContext.getMutableMetadata().asImmutable();
+            }
+        };
+
+    private final Instantiator instantiator;
+    private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
+    private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+    private final ImmutableAttributesFactory attributesFactory;
+    private final ComponentMetadataRuleExecutor ruleExecutor;
+    private final MetadataResolutionContext metadataResolutionContext;
+    private final Set<SpecRuleAction<? super ComponentMetadataDetails>> rules;
+    private final Set<SpecConfigurableRule> classBasedRules;
+
+    public DefaultComponentMetadataProcessor(Set<SpecRuleAction<? super ComponentMetadataDetails>> rules,
+                                             Set<SpecConfigurableRule> classBasedRules,
+                                             Instantiator instantiator,
+                                             NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
+                                             NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
+                                             ImmutableAttributesFactory attributesFactory,
+                                             ComponentMetadataRuleExecutor ruleExecutor,
+                                             MetadataResolutionContext resolutionContext) {
+        this.rules = rules;
+        this.classBasedRules = classBasedRules;
+        this.instantiator = instantiator;
+        this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
+        this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
+        this.attributesFactory = attributesFactory;
+        this.ruleExecutor = ruleExecutor;
+        this.metadataResolutionContext = resolutionContext;
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
+        ModuleComponentResolveMetadata updatedMetadata;
+        if (rules.isEmpty() && classBasedRules.isEmpty()) {
+            updatedMetadata = metadata;
+        } else if (rules.isEmpty()) {
+            updatedMetadata = processClassRuleWithCaching(metadata, metadataResolutionContext);
+        } else {
+            MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
+            ComponentMetadataDetails details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+            processAllRules(metadata, details, metadata.getModuleVersionId());
+            updatedMetadata = mutableMetadata.asImmutable();
+        }
+
+        if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
+            throw new ModuleVersionResolveException(updatedMetadata.getModuleVersionId(), String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().getDisplayName(), updatedMetadata.getStatusScheme()));
+        }
+        return updatedMetadata;
+    }
+
+    @Override
+    public ComponentMetadata processMetadata(ComponentMetadata metadata) {
+        ComponentMetadata updatedMetadata;
+        if (rules.isEmpty() && classBasedRules.isEmpty()) {
+            updatedMetadata = metadata;
+        } else {
+            ShallowComponentMetadataAdapter details = new ShallowComponentMetadataAdapter(metadata, attributesFactory);
+            processAllRules(null, details, metadata.getId());
+            updatedMetadata = details.asImmutable();
+        }
+        if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
+            throw new ModuleVersionResolveException(updatedMetadata.getId(), String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().toString(), updatedMetadata.getStatusScheme()));
+        }
+        return updatedMetadata;
+    }
+
+    private void processAllRules(ModuleComponentResolveMetadata metadata, ComponentMetadataDetails details, ModuleVersionIdentifier id) {
+        for (SpecRuleAction<? super ComponentMetadataDetails> rule : rules) {
+            processRule(rule, metadata, details);
+        }
+        processClassRule(metadata, details, id, metadataResolutionContext.getInjectingInstantiator());
+    }
+
+    private void processClassRule(final ModuleComponentResolveMetadata metadata, final ComponentMetadataDetails details, ModuleVersionIdentifier id, Instantiator instantiator) {
+        InstantiatingAction<ComponentMetadataContext> action = collectRulesAndCreateAction(id, instantiator);
+
+        DefaultComponentMetadataContext componentMetadataContext = new DefaultComponentMetadataContext(details, metadata);
+        try {
+            action.execute(componentMetadataContext);
+        } catch (InvalidUserCodeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidUserCodeException(String.format("There was an error while evaluating a component metadata rule for %s.", details.getId()), e);
+        }
+    }
+
+    private ModuleComponentResolveMetadata processClassRuleWithCaching(final ModuleComponentResolveMetadata metadata, MetadataResolutionContext metadataResolutionContext) {
+        InstantiatingAction<ComponentMetadataContext> action = collectRulesAndCreateAction(metadata.getModuleVersionId(), metadataResolutionContext.getInjectingInstantiator());
+        try {
+            return ruleExecutor.execute(metadata, action, DETAILS_TO_RESULT,
+                new Transformer<WrappingComponentMetadataContext, ModuleComponentResolveMetadata>() {
+                    @Override
+                    public WrappingComponentMetadataContext transform(ModuleComponentResolveMetadata moduleVersionIdentifier) {
+                        return new WrappingComponentMetadataContext(metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+                    }
+                }, metadataResolutionContext.getCachePolicy());
+        } catch (InvalidUserCodeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidUserCodeException(String.format("There was an error while evaluating a component metadata rule for %s.", metadata.getModuleVersionId()), e);
+        }
+    }
+
+    private InstantiatingAction<ComponentMetadataContext> collectRulesAndCreateAction(ModuleVersionIdentifier id, Instantiator instantiator) {
+        ArrayList<ConfigurableRule<ComponentMetadataContext>> rules = new ArrayList<ConfigurableRule<ComponentMetadataContext>>();
+        for (SpecConfigurableRule classBasedRule : classBasedRules) {
+            if (classBasedRule.getSpec().isSatisfiedBy(id)) {
+                rules.add(classBasedRule.getConfigurableRule());
+            }
+        }
+        return new InstantiatingAction<ComponentMetadataContext>(new DefaultConfigurableRules<ComponentMetadataContext>(rules), instantiator, new ExceptionHandler());
+    }
+
+
+    private void processRule(SpecRuleAction<? super ComponentMetadataDetails> specRuleAction, ModuleComponentResolveMetadata metadata, final ComponentMetadataDetails details) {
+        if (!specRuleAction.getSpec().isSatisfiedBy(details)) {
+            return;
+        }
+
+        final List<Object> inputs = Lists.newArrayList();
+        final RuleAction<? super ComponentMetadataDetails> action = specRuleAction.getAction();
+        for (Class<?> inputType : action.getInputTypes()) {
+            if (inputType == IvyModuleDescriptor.class) {
+                // Ignore the rule if it expects Ivy metadata and this isn't an Ivy module
+                if (!(metadata instanceof IvyModuleResolveMetadata)) {
+                    return;
+                }
+
+                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
+                inputs.add(new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus()));
+                continue;
+            }
+
+            // We've already validated the inputs: should never get here.
+            throw new IllegalStateException();
+        }
+
+        try {
+            synchronized (this) {
+                action.execute(details, inputs);
+            }
+        } catch (InvalidUserCodeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidUserCodeException(String.format("There was an error while evaluating a component metadata rule for %s.", details.getId()), e);
+        }
+    }
+
+    private static class ExceptionHandler implements InstantiatingAction.ExceptionHandler<ComponentMetadataContext> {
+
+        @Override
+        public void handleException(ComponentMetadataContext context, Throwable throwable) {
+            throw new InvalidUserCodeException(String.format("There was an error while evaluating a component metadata rule for %s.", context.getDetails().getId()), throwable);
+        }
+    }
+
+    static class ShallowComponentMetadataAdapter implements ComponentMetadataDetails {
+        private final ModuleVersionIdentifier id;
+        private boolean changing;
+        private List<String> statusScheme;
+        private AttributeContainerInternal attributes;
+
+        public ShallowComponentMetadataAdapter(ComponentMetadata source, ImmutableAttributesFactory attributesFactory) {
+            id = source.getId();
+            changing = source.isChanging();
+            statusScheme = source.getStatusScheme();
+            attributes = attributesFactory.mutable((AttributeContainerInternal) source.getAttributes());
+        }
+
+        @Override
+        public void setChanging(boolean changing) {
+            this.changing = changing;
+        }
+
+        @Override
+        public void setStatus(String status) {
+            this.attributes.attribute(ProjectInternal.STATUS_ATTRIBUTE, status);
+        }
+
+        @Override
+        public void setStatusScheme(List<String> statusScheme) {
+            this.statusScheme = statusScheme;
+        }
+
+        @Override
+        public void withVariant(String name, Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
+        public void allVariants(Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
+        public ModuleVersionIdentifier getId() {
+            return id;
+        }
+
+        @Override
+        public boolean isChanging() {
+            return changing;
+        }
+
+        @Override
+        public String getStatus() {
+            return attributes.getAttribute(ProjectInternal.STATUS_ATTRIBUTE);
+        }
+
+        @Override
+        public List<String> getStatusScheme() {
+            return statusScheme;
+        }
+
+        @Override
+        public ComponentMetadataDetails attributes(Action<? super AttributeContainer> action) {
+            action.execute(attributes);
+            return this;
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return attributes;
+        }
+
+        public ComponentMetadata asImmutable() {
+            return new UserProvidedMetadata(id, statusScheme, attributes.asImmutable());
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/SpecConfigurableRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/SpecConfigurableRule.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.specs.Spec;
+import org.gradle.internal.action.ConfigurableRule;
+
+class SpecConfigurableRule {
+
+    private final ConfigurableRule<ComponentMetadataContext> configurableRule;
+    private final Spec<ModuleVersionIdentifier> spec;
+
+    SpecConfigurableRule(ConfigurableRule<ComponentMetadataContext> configurableRule, Spec<ModuleVersionIdentifier> spec) {
+
+        this.configurableRule = configurableRule;
+        this.spec = spec;
+    }
+
+    public ConfigurableRule<ComponentMetadataContext> getConfigurableRule() {
+        return configurableRule;
+    }
+
+    public Spec<ModuleVersionIdentifier> getSpec() {
+        return spec;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
+import org.gradle.internal.component.external.model.IvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+
+class WrappingComponentMetadataContext implements ComponentMetadataContext {
+
+
+    private final ModuleComponentResolveMetadata metadata;
+    private final Instantiator instantiator;
+    private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
+    private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+
+    private MutableModuleComponentResolveMetadata mutableMetadata;
+    private ComponentMetadataDetails details;
+
+    public WrappingComponentMetadataContext(ModuleComponentResolveMetadata metadata, Instantiator instantiator,
+                                            NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
+                                            NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser) {
+        this.metadata = metadata;
+        this.instantiator = instantiator;
+        this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
+        this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
+    }
+
+    @Override
+    public <T> T getDescriptor(Class<T> descriptorClass) {
+        if (IvyModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
+            if (metadata instanceof IvyModuleResolveMetadata) {
+                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
+                return descriptorClass.cast(new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus()));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ComponentMetadataDetails getDetails() {
+        createMutableMetadataIfNeeded();
+        if (details == null) {
+            details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+
+        }
+        return details;
+    }
+
+    MutableModuleComponentResolveMetadata getMutableMetadata() {
+        createMutableMetadataIfNeeded();
+        return mutableMetadata;
+    }
+
+    private void createMutableMetadataIfNeeded() {
+        if (mutableMetadata == null) {
+            mutableMetadata = metadata.asMutable();
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -230,7 +230,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         private ModuleComponentResolveMetadata getProcessedMetadata(ModuleMetadataCache.CachedMetadata cachedMetadata) {
             ModuleComponentResolveMetadata metadata = cachedMetadata.getProcessedMetadata();
             if (metadata == null) {
-                metadata = metadataProcessor.processMetadata(cachedMetadata.getMetadata());
+                metadata = metadataProcessor.processMetadata(cachedMetadata.getMetadata(), cachePolicy);
                 // Save the processed metadata for next time.
                 cachedMetadata.setProcessedMetadata(metadata);
             }
@@ -385,7 +385,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
                     ModuleComponentResolveMetadata resolvedMetadata = result.getMetaData();
                     ModuleSource moduleSource = resolvedMetadata.getSource();
                     ModuleMetadataCache.CachedMetadata cachedMetadata = moduleMetadataCache.cacheMetaData(delegate, moduleComponentIdentifier, resolvedMetadata);
-                    ModuleComponentResolveMetadata processedMetadata = metadataProcessor.processMetadata(resolvedMetadata);
+                    ModuleComponentResolveMetadata processedMetadata = metadataProcessor.processMetadata(resolvedMetadata, cachePolicy);
                     cachedMetadata.setProcessedMetadata(processedMetadata);
                     moduleSource = new CachingModuleSource(processedMetadata.getContentHash().asBigInteger(), requestMetaData.isChanging() || processedMetadata.isChanging(), moduleSource);
                     result.resolved(processedMetadata.withSource(moduleSource));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -82,9 +82,8 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
     private final ModuleArtifactsCache moduleArtifactsCache;
     private final ModuleArtifactCache moduleArtifactCache;
 
-    private final CachePolicy cachePolicy;
-
     private final ModuleComponentRepository delegate;
+    private final CachePolicy cachePolicy;
     private final BuildCommencedTimeProvider timeProvider;
     private final ComponentMetadataProcessor metadataProcessor;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
@@ -100,8 +99,8 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         this.moduleVersionsCache = caches.moduleVersionsCache;
         this.moduleArtifactsCache = caches.moduleArtifactsCache;
         this.moduleArtifactCache = caches.moduleArtifactCache;
-        this.timeProvider = timeProvider;
         this.cachePolicy = cachePolicy;
+        this.timeProvider = timeProvider;
         this.metadataProcessor = metadataProcessor;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
     }
@@ -230,7 +229,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         private ModuleComponentResolveMetadata getProcessedMetadata(ModuleMetadataCache.CachedMetadata cachedMetadata) {
             ModuleComponentResolveMetadata metadata = cachedMetadata.getProcessedMetadata();
             if (metadata == null) {
-                metadata = metadataProcessor.processMetadata(cachedMetadata.getMetadata(), cachePolicy);
+                metadata = metadataProcessor.processMetadata(cachedMetadata.getMetadata());
                 // Save the processed metadata for next time.
                 cachedMetadata.setProcessedMetadata(metadata);
             }
@@ -385,7 +384,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
                     ModuleComponentResolveMetadata resolvedMetadata = result.getMetaData();
                     ModuleSource moduleSource = resolvedMetadata.getSource();
                     ModuleMetadataCache.CachedMetadata cachedMetadata = moduleMetadataCache.cacheMetaData(delegate, moduleComponentIdentifier, resolvedMetadata);
-                    ModuleComponentResolveMetadata processedMetadata = metadataProcessor.processMetadata(resolvedMetadata, cachePolicy);
+                    ModuleComponentResolveMetadata processedMetadata = metadataProcessor.processMetadata(resolvedMetadata);
                     cachedMetadata.setProcessedMetadata(processedMetadata);
                     moduleSource = new CachingModuleSource(processedMetadata.getContentHash().asBigInteger(), requestMetaData.isChanging() || processedMetadata.isChanging(), moduleSource);
                     result.resolved(processedMetadata.withSource(moduleSource));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
@@ -79,11 +79,11 @@ public class DynamicVersionResolver {
     private final VersionParser versionParser;
     private final Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory;
     private final ImmutableAttributesFactory attributesFactory;
-    private final ComponentMetadataProcessor componentMetadataProcessor;
+    private final ComponentMetadataProcessorFactory componentMetadataProcessor;
     private final ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor;
     private final CachePolicy cachePolicy;
 
-    public DynamicVersionResolver(VersionedComponentChooser versionedComponentChooser, VersionParser versionParser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessor componentMetadataProcessor, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
+    public DynamicVersionResolver(VersionedComponentChooser versionedComponentChooser, VersionParser versionParser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessor, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
         this.versionedComponentChooser = versionedComponentChooser;
         this.versionParser = versionParser;
         this.metaDataFactory = metaDataFactory;
@@ -253,21 +253,21 @@ public class DynamicVersionResolver {
         private final VersionSelector rejectedVersionSelector;
         private final VersionParser versionParser;
         private final ImmutableAttributes consumerAttributes;
-        private final ComponentMetadataProcessor componentMetadataProcessor;
+        private final ComponentMetadataProcessorFactory componentMetadataProcessorFactory;
         private final ImmutableAttributesFactory attributesFactory;
         private final ComponentMetadataSupplierRuleExecutor metadataSupplierRuleExecutor;
         private final CachePolicy cachePolicy;
         private ModuleComponentIdentifier firstRejected = null;
 
 
-        public RepositoryResolveState(VersionedComponentChooser versionedComponentChooser, ModuleDependencyMetadata dependency, ModuleComponentRepository repository, VersionSelector versionSelector, VersionSelector rejectedVersionSelector, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessor componentMetadataProcessor, ComponentMetadataSupplierRuleExecutor metadataSupplierRuleExecutor, CachePolicy cachePolicy) {
+        public RepositoryResolveState(VersionedComponentChooser versionedComponentChooser, ModuleDependencyMetadata dependency, ModuleComponentRepository repository, VersionSelector versionSelector, VersionSelector rejectedVersionSelector, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor metadataSupplierRuleExecutor, CachePolicy cachePolicy) {
             this.versionedComponentChooser = versionedComponentChooser;
             this.dependency = dependency;
             this.versionSelector = versionSelector;
             this.rejectedVersionSelector = rejectedVersionSelector;
             this.repository = repository;
             this.versionParser = versionParser;
-            this.componentMetadataProcessor = componentMetadataProcessor;
+            this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
             this.attributesFactory = attributesFactory;
             this.metadataSupplierRuleExecutor = metadataSupplierRuleExecutor;
             this.cachePolicy = cachePolicy;
@@ -352,7 +352,7 @@ public class DynamicVersionResolver {
             for (String version : versionListingResult.result.getVersions()) {
                 CandidateResult candidateResult = candidateComponents.get(version);
                 if (candidateResult == null) {
-                    candidateResult = new CandidateResult(dependency, version, repository, attemptCollector, versionParser, componentMetadataProcessor, attributesFactory, metadataSupplierRuleExecutor, cachePolicy);
+                    candidateResult = new CandidateResult(dependency, version, repository, attemptCollector, versionParser, componentMetadataProcessorFactory, attributesFactory, metadataSupplierRuleExecutor, cachePolicy);
                     candidateComponents.put(version, candidateResult);
                 }
                 candidates.add(candidateResult);
@@ -382,7 +382,7 @@ public class DynamicVersionResolver {
         private final AttemptCollector attemptCollector;
         private final ModuleDependencyMetadata dependencyMetadata;
         private final Version version;
-        private final ComponentMetadataProcessor componentMetadataProcessor;
+        private final ComponentMetadataProcessorFactory componentMetadataProcessorFactory;
         private final ImmutableAttributesFactory attributesFactory;
         private final ComponentMetadataSupplierRuleExecutor supplierRuleExecutor;
         private boolean searchedLocally;
@@ -390,9 +390,9 @@ public class DynamicVersionResolver {
         private final DefaultBuildableModuleComponentMetaDataResolveResult result = new DefaultBuildableModuleComponentMetaDataResolveResult();
         private final CachePolicy cachePolicy;
 
-        public CandidateResult(ModuleDependencyMetadata dependencyMetadata, String version, ModuleComponentRepository repository, AttemptCollector attemptCollector, VersionParser versionParser, ComponentMetadataProcessor componentMetadataProcessor, ImmutableAttributesFactory attributesFactory, ComponentMetadataSupplierRuleExecutor supplierRuleExecutor, CachePolicy cachePolicy) {
+        public CandidateResult(ModuleDependencyMetadata dependencyMetadata, String version, ModuleComponentRepository repository, AttemptCollector attemptCollector, VersionParser versionParser, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ImmutableAttributesFactory attributesFactory, ComponentMetadataSupplierRuleExecutor supplierRuleExecutor, CachePolicy cachePolicy) {
             this.dependencyMetadata = dependencyMetadata;
-            this.componentMetadataProcessor = componentMetadataProcessor;
+            this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
             this.attributesFactory = attributesFactory;
             this.supplierRuleExecutor = supplierRuleExecutor;
             this.cachePolicy = cachePolicy;
@@ -433,8 +433,8 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public ComponentMetadataProcessor getComponentMetadataProcessor() {
-            return componentMetadataProcessor;
+        public ComponentMetadataProcessorFactory getComponentMetadataProcessorFactory() {
+            return componentMetadataProcessorFactory;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
@@ -42,10 +43,12 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
     private final ComponentMetadataProcessor metadataProcessor;
     private final LocalAccess localAccess = new LocalAccess();
     private final RemoteAccess remoteAccess = new RemoteAccess();
+    private final CachePolicy cachePolicy;
 
-    public LocalModuleComponentRepository(ModuleComponentRepository delegate, ComponentMetadataProcessor metadataProcessor) {
+    public LocalModuleComponentRepository(ModuleComponentRepository delegate, ComponentMetadataProcessor metadataProcessor, CachePolicy cachePolicy) {
         super(delegate);
         this.metadataProcessor = metadataProcessor;
+        this.cachePolicy = cachePolicy;
     }
 
     public ModuleComponentRepositoryAccess getLocalAccess() {
@@ -78,7 +81,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
             }
 
             if (result.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved) {
-                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData()));
+                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData(), cachePolicy));
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
-import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
@@ -43,12 +42,10 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
     private final ComponentMetadataProcessor metadataProcessor;
     private final LocalAccess localAccess = new LocalAccess();
     private final RemoteAccess remoteAccess = new RemoteAccess();
-    private final CachePolicy cachePolicy;
 
-    public LocalModuleComponentRepository(ModuleComponentRepository delegate, ComponentMetadataProcessor metadataProcessor, CachePolicy cachePolicy) {
+    public LocalModuleComponentRepository(ModuleComponentRepository delegate, ComponentMetadataProcessor metadataProcessor) {
         super(delegate);
         this.metadataProcessor = metadataProcessor;
-        this.cachePolicy = cachePolicy;
     }
 
     public ModuleComponentRepositoryAccess getLocalAccess() {
@@ -81,7 +78,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
             }
 
             if (result.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved) {
-                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData(), cachePolicy));
+                result.setMetadata(metadataProcessor.processMetadata(result.getMetaData()));
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentResolveState.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.action.InstantiatingAction;
@@ -30,7 +30,7 @@ public interface ModuleComponentResolveState extends Versioned {
 
     BuildableModuleComponentMetaDataResolveResult resolve();
 
-    ComponentMetadataProcessor getComponentMetadataProcessor();
+    ComponentMetadataProcessorFactory getComponentMetadataProcessorFactory();
 
     ImmutableAttributesFactory getAttributesFactory();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
@@ -47,10 +47,10 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
     private final VersionSelectorScheme versionSelectorScheme;
     private final AttributeContainer consumerAttributes;
 
-    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessor componentMetadataProcessor, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
+    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.versionSelectorScheme = versionSelectorScheme;
-        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
+        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, cachePolicy);
         this.consumerAttributes = consumerAttributes;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -104,7 +104,7 @@ public class ResolveIvyFactory {
             if (baseRepository.isLocal()) {
                 moduleComponentRepository = new CachingModuleComponentRepository(moduleComponentRepository, cacheProvider.getInMemoryCaches(),
                     cachePolicy, timeProvider, metadataProcessor, moduleIdentifierFactory);
-                moduleComponentRepository = new LocalModuleComponentRepository(moduleComponentRepository, metadataProcessor);
+                moduleComponentRepository = new LocalModuleComponentRepository(moduleComponentRepository, metadataProcessor, cachePolicy);
             } else {
                 moduleComponentRepository = startParameterResolutionOverride.overrideModuleVersionRepository(moduleComponentRepository);
                 moduleComponentRepository = new CachingModuleComponentRepository(moduleComponentRepository, cacheProvider.getCaches(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.Transformer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
-import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
@@ -48,7 +48,7 @@ public class UserResolverChain implements ComponentResolvers {
                              AttributeContainer consumerAttributes,
                              AttributesSchema attributesSchema,
                              ImmutableAttributesFactory attributesFactory,
-                             ComponentMetadataProcessor componentMetadataProcessor, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
+                             ComponentMetadataProcessorFactory componentMetadataProcessor, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
         this.componentSelectionRules = componentSelectionRules;
         VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules, attributesSchema);
         ModuleTransformer metaDataFactory = new ModuleTransformer();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache;
+
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.serialize.AbstractSerializer;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+
+import java.io.EOFException;
+
+public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer<ModuleComponentResolveMetadata> {
+
+    private final ModuleMetadataSerializer delegate;
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+
+    public ModuleComponentResolveMetadataSerializer(ModuleMetadataSerializer delegate, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+        this.delegate = delegate;
+        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata read(Decoder decoder) throws EOFException, Exception {
+
+        return delegate.read(decoder, moduleIdentifierFactory).asImmutable();
+    }
+
+    @Override
+    public void write(Encoder encoder, ModuleComponentResolveMetadata value) throws Exception {
+        delegate.write(encoder, value);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -135,7 +135,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
             }
         }
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
-        resolvers.add(ivyFactory.create(resolutionStrategy, repositories, metadataHandler.getComponentMetadataProcessor(), resolveContext.getAttributes(), consumerSchema, attributesFactory, componentMetadataSupplierRuleExecutor));
+        resolvers.add(ivyFactory.create(resolutionStrategy, repositories, metadataHandler.getComponentMetadataProcessorFactory(), resolveContext.getAttributes(), consumerSchema, attributesFactory, componentMetadataSupplierRuleExecutor));
         return new ComponentResolversChain(resolvers, artifactTypeRegistry);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -125,7 +125,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
         }
         List<ResolutionAwareRepository> repositories = CollectionUtils.collect(repositoryHandler, Transformers.cast(ResolutionAwareRepository.class));
         ResolutionStrategyInternal resolutionStrategy = configurationContainer.detachedConfiguration().getResolutionStrategy();
-        ComponentResolvers componentResolvers = ivyFactory.create(resolutionStrategy, repositories, metadataHandler.getComponentMetadataProcessor(), ImmutableAttributes.EMPTY, null, attributesFactory, componentMetadataSupplierRuleExecutor);
+        ComponentResolvers componentResolvers = ivyFactory.create(resolutionStrategy, repositories, metadataHandler.getComponentMetadataProcessorFactory(), ImmutableAttributes.EMPTY, null, attributesFactory, componentMetadataSupplierRuleExecutor);
         ComponentMetaDataResolver componentMetaDataResolver = componentResolvers.getComponentResolver();
         ArtifactResolver artifactResolver = new ErrorHandlingArtifactResolver(componentResolvers.getArtifactResolver());
         return createResult(componentMetaDataResolver, artifactResolver);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRule;
+import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ImplicitInputsCapturingInstantiator;
@@ -132,7 +133,7 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
 
 
     private static <T> InstantiatingAction<T> createRuleAction(final Instantiator instantiator, final ConfigurableRule<T> rule) {
-        return new InstantiatingAction<T>(rule, instantiator, new InstantiatingAction.ExceptionHandler<T>() {
+        return new InstantiatingAction<T>(DefaultConfigurableRules.of(rule), instantiator, new InstantiatingAction.ExceptionHandler<T>() {
             @Override
             public void handleException(T target, Throwable throwable) {
                 throw UncheckedException.throwAsUncheckedException(throwable);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -110,7 +110,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     }
 
     public FlatDirectoryArtifactRepository createFlatDirRepository() {
-        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, ivyMetadataFactory);
+        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, ivyMetadataFactory, instantiatorFactory);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -168,7 +168,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         Instantiator injector = createInjectorForMetadataSuppliers(transport, instantiatorFactory, getUrl(), externalResourcesFileStore);
         InstantiatingAction<ComponentMetadataSupplierDetails> supplierFactory = createComponentMetadataSupplierFactory(injector, isolatableFactory);
         InstantiatingAction<ComponentMetadataListerDetails> listerFactory = createComponentMetadataVersionLister(injector, isolatableFactory);
-        return new IvyResolver(getName(), transport, locallyAvailableResourceFinder, metaDataProvider.dynamicResolve, artifactFileStore, moduleIdentifierFactory, supplierFactory, listerFactory, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE);
+        return new IvyResolver(getName(), transport, locallyAvailableResourceFinder, metaDataProvider.dynamicResolve, artifactFileStore, moduleIdentifierFactory, supplierFactory, listerFactory, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -204,7 +204,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         Instantiator injector = createInjectorForMetadataSuppliers(transport, instantiatorFactory, getUrl(), resourcesFileStore);
         InstantiatingAction<ComponentMetadataSupplierDetails> supplier = createComponentMetadataSupplierFactory(injector, isolatableFactory);
         InstantiatingAction<ComponentMetadataListerDetails> lister = createComponentMetadataVersionLister(injector, isolatableFactory);
-        return new MavenResolver(getName(), rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, metadataSources, MavenMetadataArtifactProvider.INSTANCE, mavenMetadataLoader, supplier, lister);
+        return new MavenResolver(getName(), rootUri, transport, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, metadataSources, MavenMetadataArtifactProvider.INSTANCE, mavenMetadataLoader, supplier, lister, injector);
     }
 
     @Override
@@ -255,6 +255,10 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     protected LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> getLocallyAvailableResourceFinder() {
         return locallyAvailableResourceFinder;
+    }
+
+    protected InstantiatorFactory getInstantiatorFactory() {
+        return instantiatorFactory;
     }
 
     private static class DefaultDescriber implements Transformer<String, MavenArtifactRepository> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.MutableMavenModuleResolveMetadata;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.DefaultResourceAwareResolveResult;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.FileStore;
@@ -73,6 +74,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
 
         RepositoryTransport transport = getTransport(rootUri.getScheme());
         MavenMetadataLoader mavenMetadataLoader = new MavenMetadataLoader(transport.getResourceAccessor(), getResourcesFileStore());
+        Instantiator injector = createInjectorForMetadataSuppliers(transport, getInstantiatorFactory(), getUrl(), getResourcesFileStore());
         MavenResolver resolver = new MavenResolver(
             getName(),
             rootUri,
@@ -84,7 +86,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
             MavenMetadataArtifactProvider.INSTANCE,
             mavenMetadataLoader,
             null,
-            null);
+            null, injector);
         for (URI repoUrl : getArtifactUrls()) {
             resolver.addArtifactLocation(repoUrl);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -56,6 +56,7 @@ import org.gradle.internal.component.model.ModuleDescriptorArtifactMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -106,6 +107,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
 
     private final InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory;
     private final InstantiatingAction<ComponentMetadataListerDetails> providedVersionLister;
+    private final Instantiator injector;
 
     private String id;
     private ExternalResourceArtifactResolver cachedArtifactResolver;
@@ -120,7 +122,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
                                        ImmutableMetadataSources metadataSources,
                                        MetadataArtifactProvider metadataArtifactProvider,
                                        @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory,
-                                       @Nullable InstantiatingAction<ComponentMetadataListerDetails> providedVersionLister) {
+                                       @Nullable InstantiatingAction<ComponentMetadataListerDetails> providedVersionLister, Instantiator injector) {
         this.name = name;
         this.local = local;
         this.cachingResourceAccessor = cachingResourceAccessor;
@@ -132,6 +134,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         this.metadataArtifactProvider = metadataArtifactProvider;
         this.componentMetadataSupplierFactory = componentMetadataSupplierFactory;
         this.providedVersionLister = providedVersionLister;
+        this.injector = injector;
     }
 
     public String getId() {
@@ -166,6 +169,10 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
 
     public boolean isLocal() {
         return local;
+    }
+
+    public Instantiator getComponentMetadataInstantiator() {
+        return injector;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -30,6 +30,7 @@ import org.gradle.internal.component.external.model.MetadataSourcedComponentArti
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
 import org.gradle.internal.resource.local.FileStore;
@@ -54,8 +55,8 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
                        @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory,
                        @Nullable InstantiatingAction<ComponentMetadataListerDetails> componentMetadataVersionListerFactory,
                        ImmutableMetadataSources repositoryContentFilter,
-                       MetadataArtifactProvider metadataArtifactProvider) {
-        super(name, transport.isLocal(), transport.getRepository(), transport.getResourceAccessor(), locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, repositoryContentFilter, metadataArtifactProvider, componentMetadataSupplierFactory, componentMetadataVersionListerFactory);
+                       MetadataArtifactProvider metadataArtifactProvider, Instantiator injector) {
+        super(name, transport.isLocal(), transport.getRepository(), transport.getResourceAccessor(), locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, repositoryContentFilter, metadataArtifactProvider, componentMetadataSupplierFactory, componentMetadataVersionListerFactory, injector);
         this.dynamicResolve = dynamicResolve;
         this.localRepositoryAccess = new IvyLocalRepositoryAccess();
         this.remoteRepositoryAccess = new IvyRemoteRepositoryAccess();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -38,6 +38,7 @@ import org.gradle.internal.component.external.model.MutableMavenModuleResolveMet
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -73,7 +74,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
                          MetadataArtifactProvider metadataArtifactProvider,
                          MavenMetadataLoader mavenMetadataLoader,
                          @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory,
-                         @Nullable InstantiatingAction<ComponentMetadataListerDetails> versionListerFactory) {
+                         @Nullable InstantiatingAction<ComponentMetadataListerDetails> versionListerFactory, Instantiator injector) {
         super(name, transport.isLocal(),
             transport.getRepository(),
             transport.getResourceAccessor(),
@@ -83,7 +84,8 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
             metadataSources,
             metadataArtifactProvider,
             componentMetadataSupplierFactory,
-            versionListerFactory);
+            versionListerFactory,
+            injector);
         this.mavenMetaDataLoader = mavenMetadataLoader;
         this.root = rootUri;
         updatePatterns();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultCompatibilityRuleChain.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.CompatibilityRuleChain;
 import org.gradle.internal.action.DefaultConfigurableRule;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory;
+import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.type.ModelType;
@@ -54,12 +55,14 @@ public class DefaultCompatibilityRuleChain<T> implements CompatibilityRuleChain<
 
     @Override
     public void add(Class<? extends AttributeCompatibilityRule<T>> rule, Action<? super ActionConfiguration> configureAction) {
-        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule, configureAction, isolatableFactory), instantiator, new ExceptionHandler<T>(rule)));
+        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule, configureAction, isolatableFactory)),
+                    instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override
     public void add(final Class<? extends AttributeCompatibilityRule<T>> rule) {
-        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule), instantiator, new ExceptionHandler<T>(rule)));
+        rules.add(new InstantiatingAction<CompatibilityCheckDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<CompatibilityCheckDetails<T>>of(rule)),
+                    instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultDisambiguationRuleChain.java
@@ -26,6 +26,7 @@ import org.gradle.api.attributes.DisambiguationRuleChain;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.internal.action.DefaultConfigurableRule;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory;
+import org.gradle.internal.action.DefaultConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.type.ModelType;
@@ -46,12 +47,14 @@ public class DefaultDisambiguationRuleChain<T> implements DisambiguationRuleChai
 
     @Override
     public void add(final Class<? extends AttributeDisambiguationRule<T>> rule, Action<? super ActionConfiguration> configureAction) {
-        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule, configureAction, isolatableFactory), instantiator, new ExceptionHandler<T>(rule)));
+        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule, configureAction, isolatableFactory)),
+                        instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override
     public void add(final Class<? extends AttributeDisambiguationRule<T>> rule) {
-        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule), instantiator, new ExceptionHandler<T>(rule)));
+        this.rules.add(new InstantiatingAction<MultipleCandidatesDetails<T>>(DefaultConfigurableRules.of(DefaultConfigurableRule.<MultipleCandidatesDetails<T>>of(rule)),
+                        instantiator, new ExceptionHandler<T>(rule)));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resolve.caching;
+
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedModuleVersion;
+import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
+import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
+import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
+import org.gradle.cache.CacheRepository;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.serialize.Serializer;
+import org.gradle.util.BuildCommencedTimeProvider;
+
+import java.io.Serializable;
+
+public class ComponentMetadataRuleExecutor extends CrossBuildCachingRuleExecutor<ModuleComponentResolveMetadata, ComponentMetadataContext, ModuleComponentResolveMetadata> {
+
+    private final static Transformer<Serializable, ModuleComponentResolveMetadata> KEY_TO_SNAPSHOTTABLE = new Transformer<Serializable, ModuleComponentResolveMetadata>() {
+        @Override
+        public Serializable transform(ModuleComponentResolveMetadata moduleMetadata) {
+            return moduleMetadata.getContentHash().asBigInteger();
+        }
+    };
+
+    public ComponentMetadataRuleExecutor(CacheRepository cacheRepository,
+                                         InMemoryCacheDecoratorFactory cacheDecoratorFactory,
+                                         ValueSnapshotter snapshotter,
+                                         BuildCommencedTimeProvider timeProvider,
+                                         Serializer<ModuleComponentResolveMetadata> componentMetadataContextSerializer) {
+        super("md-rule", cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, createValidator(timeProvider), KEY_TO_SNAPSHOTTABLE, componentMetadataContextSerializer);
+    }
+
+    private static EntryValidator<ModuleComponentResolveMetadata> createValidator(final BuildCommencedTimeProvider timeProvider) {
+        return new CrossBuildCachingRuleExecutor.EntryValidator<ModuleComponentResolveMetadata>() {
+            @Override
+            public boolean isValid(CachePolicy policy, final CrossBuildCachingRuleExecutor.CachedEntry<ModuleComponentResolveMetadata> entry) {
+                long age = timeProvider.getCurrentTime() - entry.getTimestamp();
+                final ModuleComponentResolveMetadata result = entry.getResult();
+                boolean mustRefreshModule = policy.mustRefreshModule(new SimpleResolvedModuleVersion(result.getModuleVersionId()), age, result.isChanging());
+                return !mustRefreshModule;
+            }
+        };
+    }
+
+    private static class SimpleResolvedModuleVersion implements ResolvedModuleVersion {
+
+        private final ModuleVersionIdentifier identifier;
+
+        private SimpleResolvedModuleVersion(ModuleVersionIdentifier identifier) {
+            this.identifier = identifier;
+        }
+
+        @Override
+        public ModuleVersionIdentifier getId() {
+            return identifier;
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl
+
+import org.gradle.api.Action
+import org.gradle.api.ActionConfiguration
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.MetadataResolutionContext
+import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
+import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
+import org.gradle.api.internal.changedetection.state.ValueSnapshotter
+import org.gradle.api.internal.notations.DependencyMetadataNotationParser
+import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter
+import org.gradle.cache.CacheRepository
+import org.gradle.internal.action.DefaultConfigurableRule
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.DefaultMutableIvyModuleResolveMetadata
+import org.gradle.internal.component.external.model.DefaultMutableMavenModuleResolveMetadata
+import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.internal.resolve.ModuleVersionResolveException
+import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor
+import org.gradle.internal.serialize.Serializer
+import org.gradle.internal.typeconversion.NotationParserBuilder
+import org.gradle.util.BuildCommencedTimeProvider
+import org.gradle.util.TestUtil
+import org.gradle.util.internal.SimpleMapInterner
+import spock.lang.Specification
+
+class DefaultComponentMetadataProcessorTest extends Specification {
+
+    private static final String GROUP = "group"
+    private static final String MODULE = "module"
+
+    MetadataResolutionContext context = Mock()
+    def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
+    def instantiator = DirectInstantiator.INSTANCE
+    def stringInterner = SimpleMapInterner.notThreadSafe()
+    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    def dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl, stringInterner)
+    def dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl, stringInterner)
+    def moduleIdentifierNotationParser = NotationParserBuilder.toType(ModuleIdentifier).converter(new ModuleIdentifierNotationConverter(new DefaultImmutableModuleIdentifierFactory())).toComposite();
+
+    def 'setup'() {
+        TestComponentMetadataRule.instanceCount = 0
+        TestComponentMetadataRuleWithArgs.instanceCount = 0
+        TestComponentMetadataRuleWithArgs.constructorParams = null
+    }
+
+    def "does nothing when no rules registered"() {
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+        def metadata = ivyMetadata().asImmutable()
+
+        expect:
+        processor.processMetadata(metadata).is(metadata)
+    }
+
+    def "instantiates class rule when processing metadata"() {
+        given:
+        context.injectingInstantiator >> instantiator
+        String notation = "${GROUP}:${MODULE}"
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [ruleForModule(notation)] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+
+
+        when:
+        processor.processMetadata(ivyMetadata().asImmutable())
+
+        then:
+        TestComponentMetadataRule.instanceCount == 1
+    }
+
+    def "instantiates class rule with params when processing metadata"() {
+        given:
+        context.injectingInstantiator >> instantiator
+        String notation = "${GROUP}:${MODULE}"
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [ruleForModuleWithParams(notation, "foo", 42L)] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+
+        when:
+        processor.processMetadata(ivyMetadata().asImmutable())
+
+        then:
+        TestComponentMetadataRuleWithArgs.instanceCount == 1
+        TestComponentMetadataRuleWithArgs.constructorParams == ["foo", 42L] as Object[]
+    }
+
+    def "processing fails when status is not present in status scheme"() {
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+        def metadata = ivyMetadata()
+        metadata.status = "green"
+        metadata.statusScheme = ["alpha", "beta"]
+
+        when:
+        processor.processMetadata(metadata.asImmutable())
+
+        then:
+        ModuleVersionResolveException e = thrown()
+        e.message == /Unexpected status 'green' specified for group:module:version. Expected one of: [alpha, beta]/
+    }
+
+    private SpecConfigurableRule ruleForModule(String notation) {
+        return new SpecConfigurableRule(DefaultConfigurableRule.of(TestComponentMetadataRule), new DefaultComponentMetadataHandler.ModuleVersionIdentifierSpec(moduleIdentifierNotationParser.parseNotation(notation)))
+    }
+
+    private SpecConfigurableRule ruleForModuleWithParams(String notation, Object... params) {
+        return new SpecConfigurableRule(DefaultConfigurableRule.of(TestComponentMetadataRuleWithArgs, {
+            it.params(params)
+        } as Action<ActionConfiguration>, TestUtil.valueSnapshotter()), new DefaultComponentMetadataHandler.ModuleVersionIdentifierSpec(moduleIdentifierNotationParser.parseNotation(notation)))
+    }
+
+    private DefaultMutableIvyModuleResolveMetadata ivyMetadata() {
+        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId("group", "module", "version"))
+        metadata.status = "integration"
+        metadata.statusScheme = ["integration", "release"]
+        return metadata
+    }
+
+    private DefaultMutableMavenModuleResolveMetadata mavenMetadata() {
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId("group", "module", "version"))
+        metadata.status = "integration"
+        metadata.statusScheme = ["integration", "release"]
+        return metadata
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
@@ -75,7 +75,7 @@ class DependencyResolverIdentifierTest extends Specification {
     static class TestResolver extends ExternalResourceResolver {
 
         protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder locallyAvailableResourceFinder, FileStore artifactFileStore, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
-            super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, metadataSources, metadataArtifactProvider, null, null)
+            super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, metadataSources, metadataArtifactProvider, null, null, null)
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor
+import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCachePolicy
@@ -161,8 +162,10 @@ class MetadataProviderTest extends Specification {
     def "can use a metadata rule to provide metadata"() {
         given:
         resolveState.id >> id
-        resolveState.componentMetadataProcessor >> Mock(ComponentMetadataProcessor) {
-            processMetadata(_) >> { args -> args[0] }
+        resolveState.componentMetadataProcessorFactory >> Mock(ComponentMetadataProcessorFactory) {
+            createComponentMetadataProcessor(_) >> Mock(ComponentMetadataProcessor) {
+                processMetadata(_) >> { args -> args[0] }
+            }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
             DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
@@ -186,9 +189,11 @@ class MetadataProviderTest extends Specification {
         }
         given:
         resolveState.id >> id
-        resolveState.componentMetadataProcessor >> Mock(ComponentMetadataProcessor) {
-            processMetadata(_) >> { args ->
-                processedMetadata
+        resolveState.componentMetadataProcessorFactory >> Mock(ComponentMetadataProcessorFactory) {
+            createComponentMetadataProcessor(_) >> Mock(ComponentMetadataProcessor) {
+                processMetadata(_) >> { args ->
+                    processedMetadata
+                }
             }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
@@ -210,8 +215,10 @@ class MetadataProviderTest extends Specification {
     def "can mutate attributes using a metadata supplier"() {
         given:
         resolveState.id >> id
-        resolveState.componentMetadataProcessor >> Mock(ComponentMetadataProcessor) {
-            processMetadata(_) >> { args -> args[0] }
+        resolveState.componentMetadataProcessorFactory >> Mock(ComponentMetadataProcessorFactory) {
+            createComponentMetadataProcessor(_) >> Mock(ComponentMetadataProcessor) {
+                processMetadata(_) >> { args -> args[0] }
+            }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
             DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
@@ -237,7 +244,7 @@ class MetadataProviderTest extends Specification {
     def "validates that user supplied attributes are desugared"() {
         given:
         resolveState.id >> id
-        resolveState.componentMetadataProcessor >> Mock(ComponentMetadataProcessor) {
+        resolveState.componentMetadataProcessorFactory >> Mock(ComponentMetadataProcessor) {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/MetadataProviderTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCa
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
 import org.gradle.cache.CacheRepository
+import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
@@ -164,7 +165,7 @@ class MetadataProviderTest extends Specification {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplier),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )
@@ -191,7 +192,7 @@ class MetadataProviderTest extends Specification {
             }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplier),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )
@@ -213,7 +214,7 @@ class MetadataProviderTest extends Specification {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplier),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplier)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )
@@ -240,7 +241,7 @@ class MetadataProviderTest extends Specification {
             processMetadata(_) >> { args -> args[0] }
         }
         resolveState.componentMetadataSupplier >> new InstantiatingAction<ComponentMetadataSupplierDetails>(
-            DefaultConfigurableRule.of(TestSupplierWithInvalidAttributes),
+            DefaultConfigurableRules.of(DefaultConfigurableRule.of(TestSupplierWithInvalidAttributes)),
             TestUtil.instantiatorFactory().inject(),
             Stub(InstantiatingAction.ExceptionHandler)
         )

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry
@@ -52,6 +53,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
         localMavenRepoLocator, fileResolver, transportFactory, locallyAvailableResourceFinder,
@@ -61,7 +63,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
 
     def testCreateFlatDirResolver() {
         expect:
-        def repo =factory.createFlatDirRepository()
+        def repo = factory.createFlatDirRepository()
         repo instanceof DefaultFlatDirArtifactRepository
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
@@ -25,6 +26,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
+import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
 import org.gradle.util.TestUtil
@@ -40,7 +42,7 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory())
 
-    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, moduleIdentifierFactory, metadataFactory)
+    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, moduleIdentifierFactory, metadataFactory, Mock(InstantiatorFactory))
 
     def "creates a repository with multiple root directories"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.api.internal.model.NamedObjectInstantiator
@@ -56,6 +57,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory, TestUtil.valueSnapshotter())
 
@@ -302,8 +304,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def supplier = repository.createResolver().componentMetadataSupplier
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplier
-        supplier.rule.ruleParams.isolate() == [] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplier
+        supplier.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom metadata rule"() {
@@ -320,8 +322,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def supplier = resolver.getComponentMetadataSupplier()
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplierWithParams
-        supplier.rule.ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplierWithParams
+        supplier.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
     }
 
     def "can set a custom version lister"() {
@@ -337,8 +339,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionLister
-        lister.rule.ruleParams.isolate() == [] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionLister
+        lister.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom version lister"() {
@@ -354,8 +356,8 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionListerWithParams
-        lister.rule.ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionListerWithParams
+        lister.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
     }
 
     static class CustomVersionLister implements ComponentMetadataVersionLister {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModul
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.resource.ExternalResourceRepository
@@ -51,6 +52,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
         resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory, TestUtil.valueSnapshotter())
@@ -179,8 +181,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def supplier = resolver.componentMetadataSupplier
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplier
-        supplier.rule.ruleParams.isolate() == [] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplier
+        supplier.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom metadata rule"() {
@@ -197,8 +199,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def supplier = resolver.getComponentMetadataSupplier()
 
         then:
-        supplier.rule.ruleClass == CustomMetadataSupplierWithParams
-        supplier.rule.ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
+        supplier.rules.configurableRules[0].ruleClass == CustomMetadataSupplierWithParams
+        supplier.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
     }
 
     def "can set a custom version lister"() {
@@ -214,8 +216,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionLister
-        lister.rule.ruleParams.isolate() == [] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionLister
+        lister.rules.configurableRules[0].ruleParams.isolate() == [] as Object[]
     }
 
     def "can inject configuration into a custom version lister"() {
@@ -231,8 +233,8 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         def lister = repository.createResolver().providedVersionLister
 
         then:
-        lister.rule.ruleClass == CustomVersionListerWithParams
-        lister.rule.ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
+        lister.rules.configurableRules[0].ruleClass == CustomVersionListerWithParams
+        lister.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
     }
 
     static class CustomVersionLister implements ComponentMetadataVersionLister {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMeta
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
+import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -42,6 +43,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final IsolatableFactory isolatableFactory = TestUtil.valueSnapshotter()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(resolver,
         transportFactory,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata
 import org.gradle.internal.action.ConfigurableRule
+import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.FileStore
@@ -187,7 +188,7 @@ class IvyResolverTest extends Specification {
             supplier,
             lister,
             metadataSources,
-            metadataArtifactProvider).with {
+            metadataArtifactProvider, Mock(Instantiator)).with {
             if (ivyPattern) {
                 it.addDescriptorLocation(URI.create(""), ivyPattern)
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadata
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata
 import org.gradle.internal.action.ConfigurableRule
@@ -173,8 +174,8 @@ class IvyResolverTest extends Specification {
             }
         }
 
-        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
-        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
         new IvyResolver(
             "repo",

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -33,6 +33,7 @@ import org.gradle.internal.component.external.model.MavenModuleResolveMetadata
 import org.gradle.internal.component.external.model.MetadataSourcedComponentArtifacts
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
 import org.gradle.internal.action.ConfigurableRule
+import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.FileStore
@@ -145,6 +146,6 @@ class MavenResolverTest extends Specification {
         def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
         def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
-        new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), moduleIdentifierFactory, metadataSources, metadataArtifactProvider, Stub(MavenMetadataLoader), supplier, lister)
+        new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), moduleIdentifierFactory, metadataSources, metadataArtifactProvider, Stub(MavenMetadataLoader), supplier, lister, Mock(Instantiator))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadata
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.ComponentVariant
 import org.gradle.internal.component.external.model.FixedComponentArtifacts
@@ -141,8 +142,8 @@ class MavenResolverTest extends Specification {
             }
         }
 
-        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
-        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(Stub(ConfigurableRule), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
+        def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
         new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), moduleIdentifierFactory, metadataSources, metadataArtifactProvider, Stub(MavenMetadataLoader), supplier, lister)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
@@ -37,7 +37,7 @@ public class TestResolver extends ExternalResourceResolver<ModuleComponentResolv
     ExternalResourceArtifactResolver artifactResolver;
 
     protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder, FileStore<ModuleComponentArtifactIdentifier> artifactFileStore, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
-        super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, metadataSources, metadataArtifactProvider, null, null);
+        super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, metadataSources, metadataArtifactProvider, null, null, null);
     }
 
 


### PR DESCRIPTION
This is currently limited to the RepositoryResourceAccessor and is not
available for flat dir repositories.

This is based on top of #5560