### PR TITLE
Speed up FileHierarchySet#contains

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
@@ -200,12 +200,24 @@ public class DefaultFileHierarchySet {
             return lastSeparator;
         }
 
+
+        /**
+         * This uses an optimized version of {@link String#regionMatches(int, String, int, int)}
+         * which does not check for negative indices or integer overflow.
+         */
         boolean isChildOfOrThis(String filePath, int offset) {
-            if (!filePath.regionMatches(offset, prefix, 0, prefix.length())) {
+            int pathLength = filePath.length();
+            int prefixLength = prefix.length();
+            int endOfThisSegment = prefixLength + offset;
+            if (pathLength < endOfThisSegment) {
                 return false;
             }
-            int endThisSegment = offset + prefix.length();
-            return endThisSegment == filePath.length() || filePath.charAt(endThisSegment) == File.separatorChar;
+            for (int i = prefixLength - 1, j = endOfThisSegment - 1; i >= 0; i--, j--) {
+                if (prefix.charAt(i) != filePath.charAt(j)) {
+                    return false;
+                }
+            }
+            return endOfThisSegment == pathLength || filePath.charAt(endOfThisSegment) == File.separatorChar;
         }
 
         boolean contains(String filePath, int offset) {


### PR DESCRIPTION
String.regionMatches is rather expensive,
because it checks for negative indices and
integer overflow, both of which are not expected
to happen in the context of the file hierarchy
set.