### PR TITLE
Allow dependencies on a project with auxiliary publications

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
@@ -76,10 +76,18 @@ public class DefaultProjectDependencyPublicationResolver implements ProjectDepen
             }
         }
         Set<ProjectPublication> topLevel = new LinkedHashSet<ProjectPublication>();
+        Set<ProjectPublication> topLevelWithComponent = new LinkedHashSet<ProjectPublication>();
         for (ProjectPublication publication : publications) {
             if (!publication.isAlias() && (publication.getComponent() == null || !ignored.contains(publication.getComponent()))) {
                 topLevel.add(publication);
+                if (publication.getComponent() != null) {
+                    topLevelWithComponent.add(publication);
+                }
             }
+        }
+
+        if (topLevelWithComponent.size() == 1) {
+            return topLevelWithComponent.iterator().next().getCoordinates(coordsType);
         }
 
         // See if all entry points have the same identifier

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
@@ -178,6 +178,26 @@ Found the following publications in <project>:
   - Publication 'pub3' with coordinates other-group:other-name2:other-version""")
     }
 
+    def "When target project has multiple publications with different coordinates, but only one has a component, that one is resolved"() {
+        given:
+        def component1 = Stub(SoftwareComponentInternal)
+
+        when:
+        def publication = pub('mock', "pub-group", "pub-name", "pub-version")
+        publication.component >> component1
+        def publication2 = pub('pub2', "other-group", "other-name1", "other-version")
+        def publication3 = pub('pub3', "other-group", "other-name2", "other-version")
+
+        dependentProjectHasPublications(publication, publication2, publication3)
+
+        then:
+        with (resolve()) {
+            group == "pub-group"
+            name == "pub-name"
+            version == "pub-version"
+        }
+    }
+
     def "resolve fails when target project has no publications with coordinate of requested type and no default available"() {
         when:
         dependentProjectHasPublications()

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -73,7 +73,7 @@ project(":project3") {
         resolveArtifacts(project1) { expectFiles 'changed-module-changed.jar', 'project1-1.0.jar', 'project2-2.0.jar' }
     }
 
-    def "reports failure when project dependency references a project with multiple publications"() {
+    def "reports failure when project dependency references a project with multiple conflicting publications"() {
         createBuildScripts("""
 project(":project3") {
     publishing {
@@ -103,6 +103,25 @@ Found the following publications in project ':project3':
   - Ivy publication 'ivy' with coordinates org.gradle.test:project3:3.0
   - Ivy publication 'extraComponent' with coordinates extra.org:extra-module:extra
   - Ivy publication 'extra' with coordinates extra.org:extra-module-2:extra"""
+    }
+
+    def "referenced project can have additional non-component publications"() {
+        createBuildScripts("""
+project(":project3") {
+    publishing {
+        publications {
+            extra(IvyPublication) {
+                organisation "extra.org"
+                module "extra-module-2"
+                revision "extra"
+            }
+        }
+    }
+}
+""")
+
+        expect:
+        succeeds "publish"
     }
 
     def "referenced project can have multiple additional publications that contain a child of some other publication"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -68,7 +68,7 @@ project(":project3") {
         }
     }
 
-    def "reports failure when project dependency references a project with multiple publications"() {
+    def "reports failure when project dependency references a project with multiple conflicting publications"() {
         createBuildScripts("""
 project(":project3") {
     publishing {
@@ -98,6 +98,25 @@ Found the following publications in project ':project3':
   - Maven publication 'maven' with coordinates org.gradle.test:project3:3.0
   - Maven publication 'extraComp' with coordinates extra.group:extra-comp:extra
   - Maven publication 'extra' with coordinates extra.group:extra:extra"""
+    }
+
+    def "referenced project can have additional non-component publications"() {
+        createBuildScripts("""
+project(":project3") {
+    publishing {
+        publications {
+            extra(MavenPublication) {
+                groupId "extra.group"
+                artifactId "extra"
+                version "extra"
+            }
+        }
+    }
+}
+""")
+
+        expect:
+        succeeds "publish"
     }
 
     def "referenced project can have multiple additional publications that contain a child of some other publication"() {


### PR DESCRIPTION
Users commonly publish their test fixtures alongside the main
component. Until now, depending on such a project would result
in an error during publishing, saying the Gradle can't decide
which of the publication coordinates to depend on.

Ideally we would model test fixtures as a first-class component
or provide an extensible API for users to define their own components
and their relationship. But to unblock this very common use case
quickly we decided to use a simple heuristic for now:

If a project only has one publication with a component, that publication
is the one we use when generating dependency declarations. The other
non-component publications are assumed to be auxiliary.