### PR TITLE
Inject Gradle Runner Into Spock Test

### DIFF
--- a/subprojects/docs/src/docs/userguide/testKit.adoc
+++ b/subprojects/docs/src/docs/userguide/testKit.adoc
@@ -62,6 +62,8 @@ Any test execution framework can be used.
 
 As Gradle build scripts are written in the Groovy programming language, and as many plugins are implemented in Groovy, it is often a productive choice to write Gradle functional tests in Groovy. Furthermore, it is recommended to use the (Groovy based) https://code.google.com/p/spock/[Spock test execution framework] as it offers many compelling features over the use of JUnit.
 
+The TestKit also integrates tightly with Spock. That means that any field or parameter of type api:org.gradle.testkit.runner.GradleRunner[] in Spock tests that is not manually assigned gets automatically an individual instance injected, each with their own automatically generated temporary project directory if you don't specify an explicit project directory using the `@ProjectDirProvider` annotation on the field or parameter.
+
 The following demonstrates the usage of Gradle runner in a Groovy Spock test:
 
 ++++
@@ -71,6 +73,62 @@ The following demonstrates the usage of Gradle runner in a Groovy Spock test:
 ++++
 
 It is a common practice to implement any custom build logic (like plugins and task types) that is more complex in nature as external classes in a standalone project. The main driver behind this approach is bundle the compiled code into a JAR file, publish it to a binary repository and reuse it across various projects.
+
+[[sec:injecting_gradle_runner_into_spock_test]]
+=== Injecting Gradle runner into Spock tests
+
+When using TestKit with Spock, any field or parameter of type api:org.gradle.testkit.runner.GradleRunner[] that is not manually assigned gets automatically an individual instance injected, each with their own automatically generated temporary project directory if you don't specify an explicit project directory using the `@ProjectDirProvider` annotation on the field or parameter. If an automatically generated temporary project directory is used, it gets deleted when the injected instance gets out of scope.
+
+Shared fields are filled in and cleaned up in a specification interceptor. This means that all iterations of all feature methods see the same value with the same underlying data on disk and also all setup and cleanup methods see those values. They are created before the specification starts and are cleaned up after the specification ends.
+
+Non-shared fields are filled in and cleaned up in an iteration interceptor. This means that the fields are filled in at the start of each iteration. Iteration means that for data-driven feature methods with a `where:` block the fields are filled at the start of each individual iteration and at the start means before any setup methods. The filled in objects and their underlying data on disk is available until the end of the iteration, i. e. until after all cleanup methods.
+
+++++
+<sample id="testKitInjectGradleRunnerIntoFieldsWithSpock" dir="testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample" title="Inject GradleRunner into fields with Spock">
+    <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="fields"/>
+</sample>
+++++
+
+Parameters are filled in and cleaned up in a feature method interceptor. This means that each call of the feature method (i. e. each individual iteration) gets individual injected values with individual underlying data on disk and they are cleaned up as soon as the feature method is finished. Those values and their underlying data on disk are not available during setup methods or in cleanup methods.
+
+++++
+<sample id="testKitInjectGradleRunnerIntoParametersWithSpock" dir="testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample" title="Inject GradleRunner into parameters with Spock">
+    <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="parameter"/>
+</sample>
+++++
+
+As of Spock 1.1 special care has to be taken for data-driven features (methods with a `where:` block) due to https://github.com/spockframework/spock/issues/651[issue #651] and https://github.com/spockframework/spock/issues/652[issue #652].
+
+This means for a data-driven feature where a parameter has to be injected
+
+ * all data variables and all to-be-injected parameters have to be defined as method parameters
+ * all method parameters have to be assigned a value in the `where:` block
+ * the order of the method parameters has to be identical to the order of the data variables in the `where:` block
+ * the to-be-injected parameters have to be set to `null` in the `where:` block
+
+++++
+<sample id="testKitInjectGradleRunnerIntoParametersOfDataDrivenFeatureWithSpock" dir="testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample" title="Inject GradleRunner into parameters of data-driven feature with Spock">
+    <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="parameter-in-data-driven-feature"/>
+</sample>
+++++
+
+When injecting `GradleRunner` instances, they by default have a newly created temporary directory per instance as project directory. Alternatively you can specify what should be used as project directory by annotating the respective field or parameter with a `@ProjectDirProvider` annotation.
+
+This annotation needs one argument, which is a closure that has to return what should be used as project directory for the Gradle runner. The valid return types for the given closure are defined by the availability of a `get` method for the type or one of its supertypes or interfaces in the class `ProjectDirProviderCategory`. These currently are `java.io.File`, `java.nio.file.Path` and `org.junit.rules.TemporaryFolder`. The valid types are also mentioned in the error message if you use an invalid type, so simply use `@ProjectDirProvider({ new Object() })` and run the test to get a list of supported return types. The closure must not return `null`, otherwise you get an error.
+
+This annotation makes only sense on unassigned `GradleRunner` fields and parameters. On any other field or parameter this annotation will be ignored.
+
+++++
+<sample id="testKitInjectGradleRunnerWithCustomProjectDirIntoFieldsWithSpock" dir="testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample" title="Inject GradleRunner with custom project dir into fields with Spock">
+    <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="fields-with-custom-project-dir"/>
+</sample>
+++++
+
+++++
+<sample id="testKitInjectGradleRunnerWithCustomProjectDirIntoParametersWithSpock" dir="testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample" title="Inject GradleRunner with custom project dir into parameters with Spock">
+    <sourcefile file="BuildLogicFunctionalTest.groovy" snippet="parameter-with-custom-project-dir"/>
+</sample>
+++++
 
 [[sub:test-kit-classpath-injection]]
 === Getting the plugin-under-test into the test build

--- a/subprojects/docs/src/samples/testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/gradleRunnerInjectionIntoSpockTests/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.sample
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.spock.ProjectDirProvider
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreRest
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class BuildLogicFunctionalTest extends Specification {
+    // START SNIPPET fields
+    @Shared
+    private GradleRunner sharedGradleRunner
+
+    private GradleRunner gradleRunner
+    // END SNIPPET fields
+
+    // START SNIPPET fields-with-custom-project-dir
+    @Shared
+    @ClassRule
+    private TemporaryFolder sharedTestProjectDir = new TemporaryFolder()
+
+    @ProjectDirProvider({ sharedTestProjectDir })
+    private GradleRunner gradleRunnerWithCustomProjectDir
+
+    @Shared
+    @ProjectDirProvider({ Files.createTempDirectory null })
+    private GradleRunner sharedGradleRunnerWithCustomProjectDir
+    // END SNIPPET fields-with-custom-project-dir
+
+    // START SNIPPET parameter
+    def 'GradleRunner is injected as parameter'(GradleRunner gradleRunner) {
+        when:
+        gradleRunner.build()
+
+        then:
+        noExceptionThrown()
+    }
+    // END SNIPPET parameter
+
+    // START SNIPPET parameter-in-data-driven-feature
+    def 'GradleRunner is injected as parameter into data-driven feature'(
+            a, b, GradleRunner gradleRunner) {
+        when:
+        gradleRunner.build()
+
+        then:
+        noExceptionThrown()
+
+        where:
+        a | b
+        1 | 3
+        2 | 4
+
+        and:
+        gradleRunner = null
+    }
+    // END SNIPPET parameter-in-data-driven-feature
+
+    // START SNIPPET parameter-with-custom-project-dir
+    @Rule
+    private TemporaryFolder testProjectDir
+
+    def 'GradleRunner is injected as parameter with custom project dir'(
+            @ProjectDirProvider({ testProjectDir }) GradleRunner gradleRunner) {
+        when:
+        gradleRunner.build()
+
+        then:
+        noExceptionThrown()
+    }
+    // END SNIPPET parameter-with-custom-project-dir
+}

--- a/subprojects/docs/src/samples/testKit/gradleRunner/spockQuickstart/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/spockQuickstart/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy
@@ -19,16 +19,14 @@ package org.gradle.sample
 // START SNIPPET functional-test-spock
 import org.gradle.testkit.runner.GradleRunner
 import static org.gradle.testkit.runner.TaskOutcome.*
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 class BuildLogicFunctionalTest extends Specification {
-    @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+    GradleRunner gradleRunner
     File buildFile
 
     def setup() {
-        buildFile = testProjectDir.newFile('build.gradle')
+        buildFile = new File(gradleRunner.projectDir, 'build.gradle')
     }
 
     def "hello world task prints hello world"() {
@@ -42,8 +40,7 @@ class BuildLogicFunctionalTest extends Specification {
         """
 
         when:
-        def result = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
+        def result = gradleRunner
             .withArguments('helloWorld')
             .build()
 

--- a/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerExtension.groovy
+++ b/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerExtension.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import org.spockframework.runtime.extension.AbstractGlobalExtension
+import org.spockframework.runtime.model.SpecInfo
+
+/**
+ * <h3>General</h3>
+ * This global Spock extension adds three interceptors that automatically fill in all shared and non-shared fields and all
+ * feature method parameters that are of type {@link org.gradle.testkit.runner.GradleRunner} and are still unassigned
+ * (i. e. have value {@code null}) at injection time.
+ *
+ * <h3>Shared Fields</h3>
+ *
+ * {@link spock.lang.Shared @Shared} fields are filled in and cleaned up in a specification interceptor. This means that all
+ * iterations of all feature methods see the same value with the same underlying data on disk and also all setup and
+ * cleanup methods see those values. They are created before the specification starts and are cleaned up after the
+ * specification ends.
+ *
+ * <h3>Non-shared Fields</h3>
+ *
+ * Non-shared fields are filled in and cleaned up in an iteration interceptor. This means that the fields are filled in
+ * at the start of each iteration. Iteration means that for data-driven feature methods with a {@code where:} block the
+ * fields are filled at the start of each individual iteration and at the start means before any setup methods. The
+ * filled in objects and their underlying data on disk is available until the end of the iteration, i. e. until after
+ * all cleanup methods.
+ *
+ * <h3>Parameters</h3>
+ *
+ * Parameters are filled in and cleaned up in a feature method interceptor. This means that each call of the feature
+ * method (i. e. each individual iteration) gets individual injected values with individual underlying data on disk and
+ * they are cleaned up as soon as the feature method is finished. Those values and their underlying data on disk are not
+ * available during setup methods or in cleanup methods.
+ * <p/>
+ * As of Spock 1.0 special care has to be taken for data-driven features (methods with a {@code where:} block) due to
+ * <a href="https://github.com/spockframework/spock/issues/651">issue #651</a> and
+ * <a href="https://github.com/spockframework/spock/issues/652">issue #652</a>.<br/>
+ * This means for a data-driven feature where a parameter has to be injected
+ * <ul>
+ *     <li>all data variables and all to-be-injected parameters have to be defined as method parameters</li>
+ *     <li>all method parameters have to be assigned a value in the {@code where:} block</li>
+ *     <li>
+ *         the order of the method parameters has to be identical to the order of the data variables in the
+ *         {@code where:} block
+ *     </li>
+ *     <li>the to-be-injected parameters have to be set to {@code null} in the {@code where:} block</li>
+ * </ul>
+ * <b>Example:</b>
+ * <pre>
+ * def test(a, b, GradleRunner gradleRunner) {
+ *     expect:
+ *     true
+ *
+ *     where:
+ *     a    | b
+ *     'a1' | 'b1'
+ *     'a2' | 'b2'
+ *
+ *     and:
+ *     gradleRunner = null
+ * }
+ * </pre>
+ *
+ * <h3>{@code GradleRunner} instances</h3>
+ *
+ * When injecting {@code GradleRunner} instances, they by default have a newly created temporary directory per instance
+ * as project directory. Alternatively you can specify what should be used as project directory by annotating the
+ * respective field or parameter with a
+ * {@link org.gradle.testkit.runner.spock.ProjectDirProvider @ProjectDirProvider} annotation.
+ */
+class InjectGradleRunnerExtension extends AbstractGlobalExtension {
+    @Override
+    void visitSpec(SpecInfo spec) {
+        // fill shared fields
+        spec.addInterceptor new InjectGradleRunnerIntoFieldsInterceptor()
+
+        // fill non-shared fields and parameters for all feature iterations
+        spec.allFeatures.each {
+            it.addIterationInterceptor new InjectGradleRunnerIntoFieldsInterceptor(false)
+            it.featureMethod.addInterceptor new InjectGradleRunnerIntoParametersInterceptor()
+        }
+    }
+}

--- a/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerInterceptorBase.groovy
+++ b/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerInterceptorBase.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import org.gradle.testkit.runner.GradleRunner
+import org.spockframework.runtime.extension.IMethodInterceptor
+
+abstract class InjectGradleRunnerInterceptorBase implements IMethodInterceptor {
+    private static supportedProjectDirProviderTypes = ProjectDirProviderCategory.methods
+        .findAll { it.name == 'get' }
+        .findAll { it.parameterTypes.size() == 1 }
+        .collect { it.parameterTypes.first() }
+
+    File determineProjectDir(projectDirProvider, fieldOrParameterName) {
+        if(!projectDirProvider) {
+            throw new IllegalArgumentException("The project dir provider closure for the GradleRunner $fieldOrParameterName returned '$projectDirProvider'")
+        }
+
+        if(!supportedProjectDirProviderTypes.any { it.isAssignableFrom projectDirProvider.getClass() }) {
+            throw new IllegalArgumentException("The project dir provider closure for the GradleRunner $fieldOrParameterName " +
+                "returned an object of the unsupported type '${projectDirProvider.getClass().typeName}'\n" +
+                "\tsupported types:\n\t\t${supportedProjectDirProviderTypes.typeName.sort().join('\n\t\t')}")
+        }
+
+        def projectDir
+        use(ProjectDirProviderCategory) {
+            projectDir = projectDirProvider.get()
+        }
+
+        if(!projectDir) {
+            throw new IllegalArgumentException("The extracted directory from the project dir provider closure result for the GradleRunner $fieldOrParameterName is '$projectDir'")
+        }
+
+        projectDir
+    }
+
+    GradleRunner prepareProjectDir(File projectDir) {
+        // create, configure and return the gradle runner instance
+        GradleRunner
+            .create()
+            .forwardStdOutput(System.out.newWriter())
+            .forwardStdError(System.err.newWriter())
+            .withProjectDir(projectDir)
+    }
+}

--- a/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerIntoFieldsInterceptor.groovy
+++ b/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerIntoFieldsInterceptor.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.spock.ProjectDirProvider
+import org.spockframework.runtime.extension.IMethodInvocation
+import spock.lang.Specification
+
+import static java.nio.file.Files.createTempDirectory
+
+class InjectGradleRunnerIntoFieldsInterceptor extends InjectGradleRunnerInterceptorBase {
+    private shared
+
+    InjectGradleRunnerIntoFieldsInterceptor(shared = true) {
+        this.shared = shared
+    }
+
+    @Override
+    public void intercept(IMethodInvocation invocation) {
+        def instance = (shared ? invocation.sharedInstance : invocation.instance) as Specification
+
+        def fieldsToFill = instance
+            .specificationContext
+            .currentSpec
+            .fields
+            .findAll { it.type == GradleRunner }
+            .findAll { it.shared == shared }
+            .findAll { !it.readValue(instance) }
+
+        if(!fieldsToFill) {
+            invocation.proceed()
+            return
+        }
+
+        List<File> temporaryProjectDirs = []
+        try {
+            fieldsToFill.each {
+                // determine the project dir to use
+                def projectDirClosure = it.getAnnotation(ProjectDirProvider)?.value()
+
+                File projectDir
+
+                if(!projectDirClosure) {
+                    projectDir = createTempDirectory('gradleRunner_').toFile()
+                    temporaryProjectDirs << projectDir
+                } else {
+                    projectDir = determineProjectDir(projectDirClosure.newInstance(instance, instance)(), "field '$it.name'")
+                }
+
+                it.writeValue instance, prepareProjectDir(projectDir)
+            }
+
+            invocation.proceed()
+        } finally {
+            temporaryProjectDirs*.deleteDir()
+        }
+    }
+}

--- a/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerIntoParametersInterceptor.groovy
+++ b/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerIntoParametersInterceptor.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.spock.ProjectDirProvider
+import org.spockframework.runtime.extension.IMethodInvocation
+
+import static java.nio.file.Files.createTempDirectory
+
+class InjectGradleRunnerIntoParametersInterceptor extends InjectGradleRunnerInterceptorBase {
+    @Override
+    public void intercept(IMethodInvocation invocation) {
+        // create a map of all GradleRunner parameters with their parameter index
+        Map<Class<? extends Object>, Integer> parameters = [:]
+        invocation.method.reflection.parameterTypes.eachWithIndex { parameter, i -> parameters << [(parameter): i] }
+        parameters = parameters.findAll { it.key == GradleRunner }
+
+        // enlarge arguments array if necessary
+        def lastGradleRunnerParameterIndex = parameters*.value.max()
+        lastGradleRunnerParameterIndex = lastGradleRunnerParameterIndex == null ? 0 : lastGradleRunnerParameterIndex + 1
+        if(invocation.arguments.length < lastGradleRunnerParameterIndex) {
+            def newArguments = new Object[lastGradleRunnerParameterIndex]
+            System.arraycopy invocation.arguments, 0, newArguments, 0, invocation.arguments.length
+            invocation.arguments = newArguments
+        }
+
+        // find all parameters to fill
+        def parametersToFill = parameters.findAll { !invocation.arguments[it.value] }
+
+        if(!parametersToFill) {
+            invocation.proceed()
+            return
+        }
+
+        def parameterAnnotations = invocation.method.reflection.parameterAnnotations
+
+        List<File> temporaryProjectDirs = []
+        try {
+            parametersToFill.each { parameter, i ->
+                // determine the project dir to use
+                def projectDirClosure = parameterAnnotations[i].find { it instanceof ProjectDirProvider }?.value()
+
+                File projectDir
+
+                if(!projectDirClosure) {
+                    projectDir = createTempDirectory('gradleRunner_').toFile()
+                    temporaryProjectDirs << projectDir
+                } else {
+                    projectDir = determineProjectDir(projectDirClosure.newInstance(invocation.instance, invocation.instance)(), "parameter '${invocation.feature.parameterNames[i]}'")
+                }
+
+                invocation.arguments[i] = prepareProjectDir(projectDir)
+            }
+
+            invocation.proceed()
+        } finally {
+            temporaryProjectDirs*.deleteDir()
+        }
+    }
+}

--- a/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/ProjectDirProviderCategory.groovy
+++ b/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/internal/spock/ProjectDirProviderCategory.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import org.junit.rules.TemporaryFolder
+
+import java.nio.file.Path
+
+class ProjectDirProviderCategory {
+    static get(File file) {
+        file
+    }
+
+    static get(Path path) {
+        path.toFile()
+    }
+
+    static get(TemporaryFolder temporaryFolder) {
+        temporaryFolder.root
+    }
+}

--- a/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/spock/ProjectDirProvider.groovy
+++ b/subprojects/test-kit/src/main/groovy/org/gradle/testkit/runner/spock/ProjectDirProvider.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.spock
+
+import java.lang.annotation.Retention
+import java.lang.annotation.Target
+
+import static java.lang.annotation.ElementType.FIELD
+import static java.lang.annotation.ElementType.PARAMETER
+import static java.lang.annotation.RetentionPolicy.RUNTIME
+
+/**
+ * This annotation can be used to set the project directory of a {@link org.gradle.testkit.runner.GradleRunner} field or
+ * parameter that gets filled automatically.
+ * <p/>
+ * This annotation needs one argument, which is a closure that has to return what should be used as project directory
+ * for the Gradle runner. The valid return types for the given closure are defined by the availability of a {@code get}
+ * method for the type or one of its supertypes or interfaces in the class
+ * {@link org.gradle.testkit.runner.internal.spock.ProjectDirProviderCategory}. These currently are {@link File},
+ * {@link java.nio.file.Path} and {@link org.junit.rules.TemporaryFolder}.
+ * <p/>
+ * The closure must not return {@code null}.
+ * <p/>
+ * This annotation makes only sense on unassigned {@code GradleRunner} fields and parameters. On any other field or
+ * parameter this annotation will be ignored.<br/>
+ * <b>Example:</b>
+ * <pre>
+ * @Rule
+ * private TemporaryFolder testProjectDir
+ *
+ * def test(@ProjectDirProvider({ testProjectDir }) GradleRunner gradleRunner) {
+ *     expect:
+ *     gradleRunner.build()
+ * }
+ * </pre>
+ */
+@Retention(RUNTIME)
+@Target([FIELD, PARAMETER])
+@interface ProjectDirProvider {
+    /**
+     * A closure that has to return what should be used as project directory for the annotated Gradle runner. The valid
+     * return types for the given closure are defined by the availability of a {@code get} method for the type or one of
+     * its supertypes or interfaces in the class {@link org.gradle.testkit.runner.internal.spock.ProjectDirProviderCategory}.
+     * These currently are {@link File}, {@link java.nio.file.Path} and {@link org.junit.rules.TemporaryFolder}.
+     * <p/>
+     * The closure must not return {@code null}.
+     */
+    Class<Closure<?>> value()
+}

--- a/subprojects/test-kit/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/subprojects/test-kit/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,17 @@
+#
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.gradle.testkit.runner.internal.spock.InjectGradleRunnerExtension

--- a/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/spock/GradleRunnerInjectionTest.groovy
+++ b/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/spock/GradleRunnerInjectionTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.spock.ProjectDirProvider
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GradleRunnerInjectionTest extends Specification {
+    @Shared
+    private Path tempDir = Files.createTempDirectory null
+
+    @Shared
+    @ClassRule
+    private TemporaryFolder sharedTestProjectDir = new TemporaryFolder()
+
+    @Rule
+    private TemporaryFolder testProjectDir
+
+    @Shared
+    private GradleRunner sharedGradleRunner
+
+    @Shared
+    @ProjectDirProvider({ tempDir })
+    private GradleRunner sharedGradleRunnerWithCustomProjectDir
+
+    private GradleRunner gradleRunner
+
+    @ProjectDirProvider({ sharedTestProjectDir })
+    private GradleRunner gradleRunnerWithCustomProjectDir
+
+    def 'GradleRunner is injected as shared field'() {
+        expect:
+        sharedGradleRunner
+    }
+
+    def 'GradleRunner is injected as non-shared field'() {
+        expect:
+        gradleRunner
+    }
+
+    def 'GradleRunner is injected as parameter'(GradleRunner gradleRunnerParameter) {
+        expect:
+        gradleRunnerParameter
+    }
+
+    def 'each injected GradleRunner has its own project directory'(GradleRunner gradleRunnerParameter) {
+        expect:
+        gradleRunnerParameter.projectDir != gradleRunner.projectDir
+        gradleRunnerParameter.projectDir != sharedGradleRunner.projectDir
+        gradleRunner.projectDir != sharedGradleRunner.projectDir
+    }
+
+    def 'ProjectDirProvider annotated gradle runner parameter uses the configured directory'(@ProjectDirProvider({ testProjectDir.root }) GradleRunner gradleRunnerParameter) {
+        expect:
+        gradleRunnerParameter.projectDir == testProjectDir.root
+    }
+
+    def 'ProjectDirProvider annotated gradle runner field uses the configured directory'() {
+        expect:
+        gradleRunnerWithCustomProjectDir.projectDir == sharedTestProjectDir.root
+    }
+
+    def 'ProjectDirProvider annotated shared gradle runner field uses the configured directory'() {
+        expect:
+        sharedGradleRunnerWithCustomProjectDir.projectDir == tempDir.toFile()
+    }
+}

--- a/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerInterceptorBaseTest.groovy
+++ b/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/spock/InjectGradleRunnerInterceptorBaseTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.internal.spock
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.nio.file.Path
+
+class InjectGradleRunnerInterceptorBaseTest extends Specification {
+    @Subject
+    def injectGradleRunnerInterceptorBase = Spy(InjectGradleRunnerInterceptorBase)
+
+    def 'null projectDirProvider throws IllegalArgumentException'() {
+        when:
+        injectGradleRunnerInterceptorBase.determineProjectDir(null, '"gradleRunner"')
+
+        then:
+        IllegalArgumentException iae = thrown()
+        iae.message == 'The project dir provider closure for the GradleRunner "gradleRunner" returned \'null\''
+    }
+
+    def 'unsupported projectDirProvider class throws IllegalArgumentException'() {
+        when:
+        injectGradleRunnerInterceptorBase.determineProjectDir(new Object(), '"gradleRunner"')
+
+        then:
+        IllegalArgumentException iae = thrown()
+        iae.message.startsWith '''
+            The project dir provider closure for the GradleRunner "gradleRunner" returned an object of the unsupported type 'java.lang.Object'
+            \tsupported types:
+        '''.stripIndent().trim()
+    }
+
+    def 'null result from projectDirProvider extraction throws IllegalArgumentException'() {
+        when:
+        injectGradleRunnerInterceptorBase.determineProjectDir(Mock(Path), '"gradleRunner"')
+
+        then:
+        IllegalArgumentException iae = thrown()
+        iae.message == 'The extracted directory from the project dir provider closure result for the GradleRunner "gradleRunner" is \'null\''
+    }
+}

--- a/subprojects/test-kit/test-kit.gradle
+++ b/subprojects/test-kit/test-kit.gradle
@@ -9,6 +9,9 @@ dependencies {
     compile project(':toolingApi')
     compile libraries.commons_io.coordinates
     runtime project(':native')
+    compileOnly('org.spockframework:spock-core:1.0-groovy-2.4') {
+        exclude group: 'org.codehaus.groovy', module: 'groovy-all'
+    }
     integTestRuntime project(':toolingApiBuilders')
     integTestRuntime project(':pluginDevelopment')
 }


### PR DESCRIPTION
I invented this for another project where I contributed to and found this quite convenient to use.
So i thought I polish it up a bit and contribute it to Gradle directly for a good integration with Spock.

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/.github/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes