### PR TITLE
Add an option to report a single dependency path

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -264,7 +264,7 @@ public class JsonProjectDependencyRenderer {
             }
         });
 
-        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter(versionSelectorScheme, versionComparator, versionParser).convertToRenderableItems(selectedDependencies);
+        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter(versionSelectorScheme, versionComparator, versionParser).convertToRenderableItems(selectedDependencies, false);
         return CollectionUtils.collect(sortedDeps, new Transformer<Object, RenderableDependency>() {
             @Override
             public Object transform(RenderableDependency dependency) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -264,7 +264,7 @@ public class JsonProjectDependencyRenderer {
             }
         });
 
-        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter().prepare(selectedDependencies, versionSelectorScheme, versionComparator, versionParser);
+        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter(versionSelectorScheme, versionComparator, versionParser).convertToRenderableItems(selectedDependencies);
         return CollectionUtils.collect(sortedDeps, new Transformer<Object, RenderableDependency>() {
             @Override
             public Object transform(RenderableDependency dependency) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -23,12 +23,8 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.ResolveException;
-import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
@@ -37,25 +33,20 @@ import org.gradle.api.internal.artifacts.configurations.ResolvableDependenciesIn
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.VersionConflictException;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.diagnostics.internal.dsl.DependencyResultSpecNotationConverter;
-import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphRenderer;
-import org.gradle.api.tasks.diagnostics.internal.graph.LegendRenderer;
+import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphsRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.NodeRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.Section;
 import org.gradle.api.tasks.diagnostics.internal.insight.DependencyInsightReporter;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.initialization.StartParameterBuildOptions;
-import org.gradle.internal.UncheckedException;
-import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.graph.GraphRenderer;
-import org.gradle.internal.locking.LockOutOfDateException;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -196,6 +187,40 @@ public class DependencyInsightReportTask extends DefaultTask {
     @TaskAction
     public void report() {
         final Configuration configuration = getConfiguration();
+        assertValidTaskConfiguration(configuration);
+
+        StyledTextOutput output = getTextOutputFactory().create(getClass());
+        ResolutionErrorRenderer errorHandler = new ResolutionErrorRenderer(dependencySpec);
+        Set<DependencyResult> selectedDependencies = selectDependencies(configuration, errorHandler);
+
+        if (selectedDependencies.isEmpty()) {
+            output.println("No dependencies matching given input were found in " + String.valueOf(configuration));
+            return;
+        }
+        errorHandler.renderErrors(output);
+        renderSelectedDependencies(configuration, output, selectedDependencies);
+        renderBuildScanHint(output);
+    }
+
+    private void renderSelectedDependencies(Configuration configuration, StyledTextOutput output, Set<DependencyResult> selectedDependencies) {
+        GraphRenderer renderer = new GraphRenderer(output);
+        DependencyInsightReporter reporter = new DependencyInsightReporter(getVersionSelectorScheme(), getVersionComparator(), getVersionParser());
+        Collection<RenderableDependency> itemsToRender = reporter.convertToRenderableItems(selectedDependencies);
+        RootDependencyRenderer rootRenderer = new RootDependencyRenderer(configuration, getAttributesFactory());
+        ReplaceProjectWithConfigurationNameRenderer dependenciesRenderer = new ReplaceProjectWithConfigurationNameRenderer(configuration);
+        DependencyGraphsRenderer dependencyGraphRenderer = new DependencyGraphsRenderer(output, renderer, rootRenderer, dependenciesRenderer);
+        dependencyGraphRenderer.render(itemsToRender);
+        dependencyGraphRenderer.complete();
+    }
+
+    private void renderBuildScanHint(StyledTextOutput output) {
+        output.println();
+        output.text("A web-based, searchable dependency report is available by adding the ");
+        output.withStyle(UserInput).format("--%s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
+        output.println(" option.");
+    }
+
+    private void assertValidTaskConfiguration(Configuration configuration) {
         if (configuration == null) {
             throw new InvalidUserDataException("Dependency insight report cannot be generated because the input configuration was not specified. "
                 + "\nIt can be specified from the command line, e.g: '" + getPath() + " --configuration someConf --dependency someDep'");
@@ -205,21 +230,11 @@ public class DependencyInsightReportTask extends DefaultTask {
             throw new InvalidUserDataException("Dependency insight report cannot be generated because the dependency to show was not specified."
                 + "\nIt can be specified from the command line, e.g: '" + getPath() + " --dependency someDep'");
         }
+    }
 
-
-        final StyledTextOutput output = getTextOutputFactory().create(getClass());
-        final GraphRenderer renderer = new GraphRenderer(output);
-
+    private Set<DependencyResult> selectDependencies(Configuration configuration, ResolutionErrorRenderer errorHandler) {
         ResolvableDependenciesInternal incoming = (ResolvableDependenciesInternal) configuration.getIncoming();
-        ResolutionResult result = incoming.getResolutionResult(new Action<Throwable>() {
-            @Override
-            public void execute(Throwable throwable) {
-                if (throwable instanceof ResolveException) {
-                    Throwable cause = throwable.getCause();
-                    handleResolutionError(cause, output);
-                }
-            }
-        });
+        ResolutionResult result = incoming.getResolutionResult(errorHandler);
 
         final Set<DependencyResult> selectedDependencies = new LinkedHashSet<DependencyResult>();
         result.allDependencies(new Action<DependencyResult>() {
@@ -230,102 +245,9 @@ public class DependencyInsightReportTask extends DefaultTask {
                 }
             }
         });
-
-        if (selectedDependencies.isEmpty()) {
-            output.println("No dependencies matching given input were found in " + String.valueOf(configuration));
-            return;
-        }
-
-        Collection<RenderableDependency> sortedDeps = new DependencyInsightReporter().prepare(selectedDependencies, getVersionSelectorScheme(), getVersionComparator(), getVersionParser());
-
-        NodeRenderer nodeRenderer = new NodeRenderer() {
-            public void renderNode(StyledTextOutput target, RenderableDependency node, boolean alreadyRendered) {
-                boolean leaf = node.getChildren().isEmpty();
-                target.text(leaf ? configuration.getName() : node.getName());
-                if (alreadyRendered && !leaf) {
-                    target.withStyle(Info).text(" (*)");
-                }
-            }
-        };
-
-        LegendRenderer legendRenderer = new LegendRenderer(output);
-        DependencyGraphRenderer dependencyGraphRenderer = new DependencyGraphRenderer(renderer, nodeRenderer, legendRenderer);
-
-        int i = 1;
-        for (final RenderableDependency dependency : sortedDeps) {
-            renderer.visit(new RenderDependencyAction(dependency, configuration, getAttributesFactory()), true);
-            dependencyGraphRenderer.render(dependency);
-            boolean last = i++ == sortedDeps.size();
-            if (!last) {
-                output.println();
-            }
-        }
-
-        legendRenderer.printLegend();
-
-        output.println();
-        output.text("A web-based, searchable dependency report is available by adding the ");
-        output.withStyle(UserInput).format("--%s", StartParameterBuildOptions.BuildScanOption.LONG_OPTION);
-        output.println(" option.");
+        return selectedDependencies;
     }
 
-    private void handleResolutionError(Throwable cause, StyledTextOutput output) {
-        if (cause instanceof VersionConflictException) {
-            handleConflict((VersionConflictException) cause, output);
-        } else if (cause instanceof LockOutOfDateException) {
-            handleOutOfDateLocks((LockOutOfDateException) cause, output);
-        } else {
-            // Fallback to failing the task in case we don't know anything special
-            // about the error
-            throw UncheckedException.throwAsUncheckedException(cause);
-        }
-    }
-
-    private void handleOutOfDateLocks(LockOutOfDateException cause, StyledTextOutput output) {
-        List<String> errors = cause.getErrors();
-        output.text("The dependency locks are out-of-date:");
-        output.println();
-        for (String error : errors) {
-            output.text("   - " + error);
-            output.println();
-        }
-        output.println();
-    }
-
-    private void handleConflict(VersionConflictException conflict, StyledTextOutput output) {
-        for (List<ModuleVersionIdentifier> moduleVersionIdentifiers : conflict.getConflicts()) {
-            boolean matchesSpec = hasVersionConflictOnRequestedDependency(moduleVersionIdentifiers);
-            if (!matchesSpec) {
-                continue;
-            }
-            output.text("Dependency resolution failed because of conflicts between the following modules:");
-            output.println();
-            for (ModuleVersionIdentifier moduleVersionIdentifier : moduleVersionIdentifiers) {
-                output.text("   - ");
-                output.withStyle(StyledTextOutput.Style.Error).text(moduleVersionIdentifier.toString());
-                output.println();
-            }
-            output.println();
-        }
-    }
-
-    private boolean hasVersionConflictOnRequestedDependency(List<ModuleVersionIdentifier> moduleVersionIdentifiers) {
-        boolean matchesSpec = false;
-        for (final ModuleVersionIdentifier mvi : moduleVersionIdentifiers) {
-            matchesSpec |= dependencySpec.isSatisfiedBy(new DependencyResult() {
-                @Override
-                public ComponentSelector getRequested() {
-                    return DefaultModuleComponentSelector.newSelector(mvi.getGroup(), mvi.getName(), mvi.getVersion());
-                }
-
-                @Override
-                public ResolvedComponentResult getFrom() {
-                    return null;
-                }
-            });
-        }
-        return matchesSpec;
-    }
 
     private static AttributeMatchDetails match(Attribute<?> actualAttribute, Object actualValue, AttributeContainer requestedAttributes) {
         for (Attribute<?> requested : requestedAttributes.keySet()) {
@@ -367,18 +289,17 @@ public class DependencyInsightReportTask extends DefaultTask {
         not_requested
     }
 
-    private static class RenderDependencyAction implements Action<StyledTextOutput> {
-        private final RenderableDependency dependency;
+    private static class RootDependencyRenderer implements NodeRenderer {
         private final Configuration configuration;
         private final ImmutableAttributesFactory attributesFactory;
 
-        public RenderDependencyAction(RenderableDependency dependency, Configuration configuration, ImmutableAttributesFactory attributesFactory) {
-            this.dependency = dependency;
+        public RootDependencyRenderer(Configuration configuration, ImmutableAttributesFactory attributesFactory) {
             this.configuration = configuration;
             this.attributesFactory = attributesFactory;
         }
 
-        public void execute(StyledTextOutput out) {
+        @Override
+        public void renderNode(StyledTextOutput out, RenderableDependency dependency, boolean alreadyRendered) {
             out.withStyle(Identifier).text(dependency.getName());
             if (StringUtils.isNotEmpty(dependency.getDescription())) {
                 out.withStyle(Description).text(" (" + dependency.getDescription() + ")");
@@ -393,11 +314,11 @@ public class DependencyInsightReportTask extends DefaultTask {
                     out.withStyle(Failure).text(" (n)");
                     break;
             }
-            printVariantDetails(out);
-            printExtraDetails(out);
+            printVariantDetails(out, dependency);
+            printExtraDetails(out, dependency);
         }
 
-        private void printExtraDetails(StyledTextOutput out) {
+        private void printExtraDetails(StyledTextOutput out, RenderableDependency dependency) {
             List<Section> extraDetails = dependency.getExtraDetails();
             if (!extraDetails.isEmpty()) {
                 printSections(out, extraDetails, 1);
@@ -421,7 +342,7 @@ public class DependencyInsightReportTask extends DefaultTask {
             out.withStyle(Description).text(indent + description + appendix);
         }
 
-        private void printVariantDetails(StyledTextOutput out) {
+        private void printVariantDetails(StyledTextOutput out, RenderableDependency dependency) {
             ResolvedVariantResult resolvedVariant = dependency.getResolvedVariant();
             if (resolvedVariant != null) {
                 out.println();
@@ -508,4 +429,21 @@ public class DependencyInsightReportTask extends DefaultTask {
         }
 
     }
+
+    private static class ReplaceProjectWithConfigurationNameRenderer implements NodeRenderer {
+        private final Configuration configuration;
+
+        public ReplaceProjectWithConfigurationNameRenderer(Configuration configuration) {
+            this.configuration = configuration;
+        }
+
+        public void renderNode(StyledTextOutput target, RenderableDependency node, boolean alreadyRendered) {
+            boolean leaf = node.getChildren().isEmpty();
+            target.text(leaf ? configuration.getName() : node.getName());
+            if (alreadyRendered && !leaf) {
+                target.withStyle(Info).text(" (*)");
+            }
+        }
+    }
+
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.VersionConflictException;
+import org.gradle.api.specs.Spec;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.locking.LockOutOfDateException;
+import org.gradle.internal.logging.text.StyledTextOutput;
+
+import java.util.List;
+
+class ResolutionErrorRenderer implements Action<Throwable> {
+    private final Spec<DependencyResult> dependencySpec;
+    private final List<Action<StyledTextOutput>> errorActions = Lists.newArrayListWithExpectedSize(1);
+
+    public ResolutionErrorRenderer(Spec<DependencyResult> dependencySpec) {
+        this.dependencySpec = dependencySpec;
+    }
+
+    @Override
+    public void execute(Throwable throwable) {
+        if (throwable instanceof ResolveException) {
+            Throwable cause = throwable.getCause();
+            handleResolutionError(cause);
+        } else {
+            throw UncheckedException.throwAsUncheckedException(throwable);
+        }
+    }
+
+    private void handleResolutionError(Throwable cause) {
+        if (cause instanceof VersionConflictException) {
+            handleConflict((VersionConflictException) cause);
+        } else if (cause instanceof LockOutOfDateException) {
+            handleOutOfDateLocks((LockOutOfDateException) cause);
+        } else {
+            // Fallback to failing the task in case we don't know anything special
+            // about the error
+            throw UncheckedException.throwAsUncheckedException(cause);
+        }
+    }
+
+    private void handleOutOfDateLocks(final LockOutOfDateException cause) {
+        registerError(new Action<StyledTextOutput>() {
+            @Override
+            public void execute(StyledTextOutput output) {
+                List<String> errors = cause.getErrors();
+                output.text("The dependency locks are out-of-date:");
+                output.println();
+                for (String error : errors) {
+                    output.text("   - " + error);
+                    output.println();
+                }
+                output.println();
+            }
+        });
+    }
+
+    private void handleConflict(final VersionConflictException conflict) {
+        registerError(new Action<StyledTextOutput>() {
+            @Override
+            public void execute(StyledTextOutput output) {
+                for (List<ModuleVersionIdentifier> moduleVersionIdentifiers : conflict.getConflicts()) {
+                    boolean matchesSpec = hasVersionConflictOnRequestedDependency(moduleVersionIdentifiers);
+                    if (!matchesSpec) {
+                        continue;
+                    }
+                    output.text("Dependency resolution failed because of conflicts between the following modules:");
+                    output.println();
+                    for (ModuleVersionIdentifier moduleVersionIdentifier : moduleVersionIdentifiers) {
+                        output.text("   - ");
+                        output.withStyle(StyledTextOutput.Style.Error).text(moduleVersionIdentifier.toString());
+                        output.println();
+                    }
+                    output.println();
+                }
+            }
+        });
+
+    }
+
+    public void renderErrors(StyledTextOutput output) {
+        for (Action<StyledTextOutput> errorAction : errorActions) {
+            errorAction.execute(output);
+        }
+    }
+
+    private void registerError(Action<StyledTextOutput> errorAction) {
+        errorActions.add(errorAction);
+    }
+
+    private boolean hasVersionConflictOnRequestedDependency(List<ModuleVersionIdentifier> moduleVersionIdentifiers) {
+        boolean matchesSpec = false;
+        for (final ModuleVersionIdentifier mvi : moduleVersionIdentifiers) {
+            matchesSpec |= dependencySpec.isSatisfiedBy(new DependencyResult() {
+                @Override
+                public ComponentSelector getRequested() {
+                    return DefaultModuleComponentSelector.newSelector(mvi.getGroup(), mvi.getName(), mvi.getVersion());
+                }
+
+                @Override
+                public ResolvedComponentResult getFrom() {
+                    return null;
+                }
+            });
+        }
+        return matchesSpec;
+    }
+
+}

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/DependencyGraphsRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/DependencyGraphsRenderer.java
@@ -38,6 +38,7 @@ public class DependencyGraphsRenderer {
     private final NodeRenderer rootRenderer;
     private final NodeRenderer dependenciesRenderer;
     private final LegendRenderer legendRenderer;
+    private boolean showSinglePath;
 
     public DependencyGraphsRenderer(StyledTextOutput output, GraphRenderer renderer, NodeRenderer rootRenderer, NodeRenderer dependenciesRenderer) {
         this.output = output;
@@ -45,6 +46,14 @@ public class DependencyGraphsRenderer {
         this.rootRenderer = rootRenderer;
         this.dependenciesRenderer = dependenciesRenderer;
         this.legendRenderer = new LegendRenderer(output);
+    }
+
+    public boolean isShowSinglePath() {
+        return showSinglePath;
+    }
+
+    public void setShowSinglePath(boolean showSinglePath) {
+        this.showSinglePath = showSinglePath;
     }
 
     public void render(Collection<RenderableDependency> items) {
@@ -78,12 +87,16 @@ public class DependencyGraphsRenderer {
 
     private void renderChildren(Set<? extends RenderableDependency> children, Set<Object> visited) {
         int i = 0;
-        int count = children.size();
+        int childCould = children.size();
+        int count = showSinglePath ? Math.min(1, childCould) : childCould;
         if (count > 0) {
             renderer.startChildren();
             for (RenderableDependency child : children) {
                 boolean last = ++i == count;
                 doRender(child, last, visited);
+                if (last) {
+                    break;
+                }
             }
             renderer.completeChildren();
         }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/NodeRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/NodeRenderer.java
@@ -20,5 +20,12 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependenc
 import org.gradle.internal.logging.text.StyledTextOutput;
 
 public interface NodeRenderer {
+    NodeRenderer NO_OP = new NodeRenderer() {
+        @Override
+        public void renderNode(StyledTextOutput output, RenderableDependency node, boolean alreadyRendered) {
+
+        }
+    };
+
     void renderNode(StyledTextOutput output, RenderableDependency node, boolean alreadyRendered);
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependency.java
@@ -21,6 +21,11 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * A renderable dependency may be a dependency OR something related
+ * to a dependency, like a header. In practice, for a single actual
+ * dependency, we may render multiple renderable dependencies.
+ */
 public interface RenderableDependency {
     Object getId();
     String getName();

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RequestedVersion.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RequestedVersion.java
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -31,30 +30,16 @@ public class RequestedVersion extends AbstractRenderableDependencyResult impleme
     private final ComponentSelector requested;
     private final ComponentIdentifier actual;
     private final boolean resolvable;
-    private final String description;
     private final Set<RenderableDependency> children = new LinkedHashSet<RenderableDependency>();
-    private final ResolvedVariantResult variantResult;
 
-    public RequestedVersion(ComponentSelector requested, ComponentIdentifier actual, boolean resolvable, String description, ResolvedVariantResult resolvedVariant) {
+    public RequestedVersion(ComponentSelector requested, ComponentIdentifier actual, boolean resolvable) {
         this.requested = requested;
         this.actual = actual;
         this.resolvable = resolvable;
-        this.description = description;
-        this.variantResult = resolvedVariant;
     }
 
     public void addChild(DependencyEdge child) {
         children.addAll(child.getChildren());
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return variantResult;
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -72,7 +72,7 @@ public class DependencyInsightReporter {
         this.versionParser = versionParser;
     }
 
-    public Collection<RenderableDependency> convertToRenderableItems(Collection<DependencyResult> dependencies) {
+    public Collection<RenderableDependency> convertToRenderableItems(Collection<DependencyResult> dependencies, boolean singlePathToDependency) {
         LinkedList<RenderableDependency> out = new LinkedList<RenderableDependency>();
         Collection<DependencyEdge> sortedEdges = toDependencyEdges(dependencies);
 
@@ -89,8 +89,9 @@ public class DependencyInsightReporter {
             } else if (!current.getRequested().equals(dependency.getRequested())) {
                 current = newRequestedVersion(out, dependency);
             }
-
-            current.addChild(dependency);
+            if (!singlePathToDependency || current.getChildren().isEmpty()) {
+                current.addChild(dependency);
+            }
         }
 
         return out;

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskSpec.groovy
@@ -23,7 +23,7 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class DependencyInsightReportTaskSpec extends AbstractProjectBuilderSpec {
-    def task
+    DependencyInsightReportTask task
 
     def setup() {
         task = TestUtil.createTask(DependencyInsightReportTask, project)
@@ -74,5 +74,18 @@ class DependencyInsightReportTaskSpec extends AbstractProjectBuilderSpec {
         then:
         task.dependencySpec != null
         task.configuration.name == 'foo'
+    }
+
+    def "can limit the paths to a dependency"() {
+        when:
+        project.configurations.create("foo")
+        task.setConfiguration 'foo'
+        task.setDependencySpec 'bar'
+        task.setShowSinglePathToDependency true
+
+        then:
+        task.dependencySpec != null
+        task.configuration.name == 'foo'
+        task.showSinglePathToDependency == true
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRendererTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRendererTest.groovy
@@ -16,8 +16,7 @@
 package org.gradle.api.tasks.diagnostics.internal.dependencies
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphRenderer
-import org.gradle.api.tasks.diagnostics.internal.graph.LegendRenderer
+import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphsRenderer
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.SimpleDependency
 import org.gradle.internal.logging.text.TestStyledTextOutput
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -28,7 +27,6 @@ class AsciiDependencyReportRendererTest extends AbstractProjectBuilderSpec {
 
     def setup() {
         renderer.output = textOutput
-        renderer.legendRenderer = Mock(LegendRenderer)
     }
 
     def "informs if no configurations"() {
@@ -50,6 +48,7 @@ class AsciiDependencyReportRendererTest extends AbstractProjectBuilderSpec {
         configuration2.isCanBeResolved() >> true
 
         when:
+        renderer.prepareVisit()
         renderer.startConfiguration(configuration1);
         renderer.completeConfiguration(configuration1);
         renderer.startConfiguration(configuration2);
@@ -64,7 +63,7 @@ class AsciiDependencyReportRendererTest extends AbstractProjectBuilderSpec {
     }
 
     def "renders dependency graph"() {
-        renderer.dependencyGraphRenderer = Mock(DependencyGraphRenderer)
+        renderer.dependencyGraphRenderer = Mock(DependencyGraphsRenderer)
         def root = new SimpleDependency("root")
         root.children.add(new SimpleDependency("dep"))
 
@@ -72,17 +71,7 @@ class AsciiDependencyReportRendererTest extends AbstractProjectBuilderSpec {
         renderer.renderNow(root)
 
         then:
-        1 * renderer.dependencyGraphRenderer.render(root)
-    }
-
-    def "renders legend on complete"() {
-        renderer.dependencyGraphRenderer = Mock(DependencyGraphRenderer)
-
-        when:
-        renderer.complete()
-
-        then:
-        1 * renderer.legendRenderer.printLegend()
+        1 * renderer.dependencyGraphRenderer.render([root])
     }
 
     def "safely completes if no configurations"() {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/DependencyGraphRendererSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/DependencyGraphRendererSpec.groovy
@@ -25,8 +25,7 @@ class DependencyGraphRendererSpec extends Specification {
 
     private textOutput = new TestStyledTextOutput().ignoreStyle()
     private graphRenderer = new GraphRenderer(textOutput)
-    private legendRenderer = new LegendRenderer(textOutput)
-    private renderer = new DependencyGraphRenderer(graphRenderer, new SimpleNodeRenderer(), legendRenderer)
+    private renderer = new DependencyGraphsRenderer(textOutput, graphRenderer, NodeRenderer.NO_OP, new SimpleNodeRenderer())
 
     def "renders graph"() {
         def root = new SimpleDependency("root")
@@ -41,8 +40,8 @@ class DependencyGraphRendererSpec extends Specification {
         dep2.children.addAll(dep21, dep22)
 
         when:
-        renderer.render(root)
-        legendRenderer.printLegend()
+        renderer.render([root])
+        renderer.complete()
 
         then:
         textOutput.value.readLines() == [
@@ -66,8 +65,8 @@ class DependencyGraphRendererSpec extends Specification {
         dep2.children.addAll(dep1, dep22)
 
         when:
-        renderer.render(root)
-        legendRenderer.printLegend()
+        renderer.render([root])
+        renderer.complete()
 
         then:
         textOutput.value.readLines() == [

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import spock.lang.Specification
+import spock.lang.Subject
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier.newId
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.CONFLICT_RESOLUTION
@@ -39,11 +40,14 @@ class DependencyInsightReporterSpec extends Specification {
     def versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
     def versionComparator = new DefaultVersionComparator()
 
+    @Subject
+    def reporter = new DependencyInsightReporter(versionSelectorScheme, versionComparator, versionParser)
+
     def "sorts dependencies"() {
         def dependencies = [dep("a", "x", "1.0", "2.0"), dep("a", "x", "1.5", "2.0"), dep("b", "a", "5.0"), dep("a", "z", "1.0"), dep("a", "x", "2.0")]
 
         when:
-        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
+        def sorted = reporter.convertToRenderableItems(dependencies)
 
         then:
         sorted.size() == 8
@@ -77,7 +81,7 @@ class DependencyInsightReporterSpec extends Specification {
         def dependencies = [dep("a", "x", "1.0", "2.0", forced()), dep("a", "x", "1.5", "2.0", forced()), dep("b", "a", "5.0")]
 
         when:
-        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
+        def sorted = reporter.convertToRenderableItems(dependencies)
 
         then:
         sorted.size() == 5
@@ -102,7 +106,7 @@ class DependencyInsightReporterSpec extends Specification {
         def dependencies = [dep("a", "x", "1.0", "2.0", conflict()), dep("a", "x", "2.0", "2.0", conflict()), dep("b", "a", "5.0", "5.0", forced())]
 
         when:
-        def sorted = new DependencyInsightReporter().prepare(dependencies, versionSelectorScheme, versionComparator, versionParser);
+        def sorted = reporter.convertToRenderableItems(dependencies)
 
         then:
         sorted.size() == 5


### PR DESCRIPTION
### Context

This PR adds an option to the dependency insight report to only show a single dependency path for each dependency. This is useful whenever the dependency graph is large and that there are many paths leading to a dependency, which is happening on some customer reports.

I also refactored the dependency insight report to (hopefully) make it more readable and hope future maintainers will understand better what it does.

This PR is built on top of #5580.