### PR TITLE
Use daemon when forking from embedded executor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -196,18 +196,7 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
     }
 
     private void findImplementationClasspath(String name, Collection<File> implementationClasspath) {
-        List<String> suffixes = new ArrayList<String>();
-        Matcher matcher = Pattern.compile("gradle-(.+)").matcher(name);
-        matcher.matches();
-        String projectDirName = matcher.group(1);
-        String projectName = toCamelCase(projectDirName);
-        suffixes.add(("/out/production/" + projectName).replace('/', File.separatorChar));
-        suffixes.add(("/" + projectDirName + "/bin").replace('/', File.separatorChar));
-        suffixes.add(("/" + projectDirName + "/src/main/resources").replace('/', File.separatorChar));
-        suffixes.add(("/" + projectDirName + "/build/classes/main").replace('/', File.separatorChar));
-        suffixes.add(("/" + projectDirName + "/build/resources/main").replace('/', File.separatorChar));
-        suffixes.add(("/" + projectDirName + "/build/generated-resources/main").replace('/', File.separatorChar));
-        suffixes.add(("/" + projectDirName + "/build/generated-resources/test").replace('/', File.separatorChar));
+        List<String> suffixes = getClasspathSuffixes(name);
         for (File file : classpath) {
             if (file.isDirectory()) {
                 for (String suffix : suffixes) {
@@ -217,6 +206,38 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
                 }
             }
         }
+    }
+
+    /**
+     * Provides the locations where the classes and resources of a Gradle module can be found
+     * when running in embedded mode from the IDE.
+     *
+     * <ul>
+     * <li>In Eclipse, they are in the bin/ folder.</li>
+     * <li>In IDEA, they are in a folder derived from their module name.</li>
+     * Due to de-duplication with names in the buildSrc project, that module name can start with "gradle-"
+     * </ul>
+     * <li>In both cases we also include the static and generated resources of the project.</li>
+     */
+    private List<String> getClasspathSuffixes(String name) {
+        List<String> suffixes = new ArrayList<String>();
+        Matcher matcher = Pattern.compile("gradle-(.+)").matcher(name);
+        matcher.matches();
+        String projectDirName = matcher.group(1);
+        String projectName = toCamelCase(projectDirName);
+
+        suffixes.add(("/out/production/" + projectName).replace('/', File.separatorChar));
+        suffixes.add(("/out/production/gradle-" + projectName).replace('/', File.separatorChar));
+
+        suffixes.add(("/" + projectDirName + "/bin").replace('/', File.separatorChar));
+
+        suffixes.add(("/" + projectDirName + "/src/main/resources").replace('/', File.separatorChar));
+        suffixes.add(("/" + projectDirName + "/build/classes/java/main").replace('/', File.separatorChar));
+        suffixes.add(("/" + projectDirName + "/build/classes/groovy/main").replace('/', File.separatorChar));
+        suffixes.add(("/" + projectDirName + "/build/resources/main").replace('/', File.separatorChar));
+        suffixes.add(("/" + projectDirName + "/build/generated-resources/main").replace('/', File.separatorChar));
+        suffixes.add(("/" + projectDirName + "/build/generated-resources/test").replace('/', File.separatorChar));
+        return suffixes;
     }
 
     private String toCamelCase(String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
@@ -98,7 +98,7 @@ class DefaultModuleRegistryTest extends Specification {
 
     def "locates module using manifest from runtime ClassLoader when run from build"() {
         given:
-        def classesDir = tmpDir.createDir("some-module/build/classes/main")
+        def classesDir = tmpDir.createDir("some-module/build/classes/java/main")
         def staticResourcesDir = tmpDir.createDir("some-module/src/main/resources")
         def cl = classLoaderFor([classesDir, resourcesDir, staticResourcesDir, runtimeDep])
         def registry = new DefaultModuleRegistry(cl, ClassPath.EMPTY, null)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -809,7 +809,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         FOREGROUND
     }
 
-    private CliDaemonArgument resolveCliDaemonArgument() {
+    protected CliDaemonArgument resolveCliDaemonArgument() {
         for (int i = args.size() - 1; i >= 0; i--) {
             final String arg = args.get(i);
             if (arg.equals("--daemon")) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -40,6 +40,7 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
+import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.DefaultLoggingManagerFactory;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
@@ -85,12 +86,16 @@ import static org.gradle.util.CollectionUtils.collect;
 import static org.gradle.util.CollectionUtils.join;
 
 public abstract class AbstractGradleExecuter implements GradleExecuter {
+
     protected static final ServiceRegistry GLOBAL_SERVICES = ServiceRegistryBuilder.builder()
         .displayName("Global services")
         .parent(newCommandLineProcessLogging())
         .parent(NativeServicesTestFixture.getInstance())
         .provider(new GlobalScopeServices(true))
         .build();
+
+    private static final JvmVersionDetector JVM_VERSION_DETECTOR = GLOBAL_SERVICES.get(JvmVersionDetector.class);
+
     protected final static Set<String> PROPAGATED_SYSTEM_PROPERTIES = Sets.newHashSet();
     private static final List<String> JDK7_PATHS = Arrays.asList("1.7", "jdk7", "-7-", "jdk-7", "7u");
 
@@ -530,6 +535,19 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
         if (isProfile()) {
             buildJvmOpts.add(profiler);
         }
+
+        if (isSharedDaemons()) {
+            if (JVM_VERSION_DETECTOR.getJavaVersion(Jvm.forHome(getJavaHome())).compareTo(JavaVersion.VERSION_1_8) < 0) {
+                buildJvmOpts.add("-XX:MaxPermSize=320m");
+            }
+            buildJvmOpts.add("-Xmx2g");
+        } else {
+            buildJvmOpts.add("-Xmx512m");
+        }
+        if (gradleUserHomeDir != null) {
+            buildJvmOpts.add("-XX:+HeapDumpOnOutOfMemoryError");
+            buildJvmOpts.add("-XX:HeapDumpPath=" + gradleUserHomeDir.getAbsolutePath());
+        }
         return buildJvmOpts;
     }
 
@@ -739,7 +757,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     @Override
     public boolean isUseDaemon() {
         CliDaemonArgument cliDaemonArgument = resolveCliDaemonArgument();
-        if (cliDaemonArgument == NO_DAEMON) {
+        if (cliDaemonArgument == NO_DAEMON ||cliDaemonArgument == FOREGROUND) {
             return false;
         }
         return requireDaemon || cliDaemonArgument == DAEMON;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -31,19 +31,33 @@ import static org.apache.commons.collections.CollectionUtils.containsAny;
 public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     private static final JvmVersionDetector JVM_VERSION_DETECTOR = GLOBAL_SERVICES.get(JvmVersionDetector.class);
 
+    private boolean daemonExplicitlyRequired;
+
     public DaemonGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider) {
         super(distribution, testDirectoryProvider);
-        requireDaemon();
+        super.requireDaemon();
     }
 
     public DaemonGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider, GradleVersion gradleVersion, IntegrationTestBuildContext buildContext) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext);
-        requireDaemon();
+        super.requireDaemon();
+    }
+
+    @Override
+    public GradleExecuter requireDaemon() {
+        daemonExplicitlyRequired = true;
+        return super.requireDaemon();
     }
 
     @Override
     protected void validateDaemonVisibility() {
-        // Ignore. Should really ignore only when daemon has not been explicitly enabled or disabled
+        if (isDaemonExplicitlyRequired()) {
+            super.validateDaemonVisibility();
+        }
+    }
+
+    protected boolean isDaemonExplicitlyRequired() {
+        return daemonExplicitlyRequired || resolveCliDaemonArgument() == CliDaemonArgument.DAEMON;
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -15,9 +15,6 @@
  */
 package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.api.JavaVersion;
-import org.gradle.internal.jvm.Jvm;
-import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.util.GradleVersion;
@@ -29,7 +26,6 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.collections.CollectionUtils.containsAny;
 
 public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
-    private static final JvmVersionDetector JVM_VERSION_DETECTOR = GLOBAL_SERVICES.get(JvmVersionDetector.class);
 
     private boolean daemonExplicitlyRequired;
 
@@ -75,24 +71,6 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
         }
 
         return args;
-    }
-
-    @Override
-    protected List<String> getImplicitBuildJvmArgs() {
-        if (!isUseDaemon() || !isSharedDaemons()) {
-            return super.getImplicitBuildJvmArgs();
-        }
-
-        // Add JVM heap settings only for shared daemons
-        List<String> buildJvmOpts = new ArrayList<String>(super.getImplicitBuildJvmArgs());
-
-        if (JVM_VERSION_DETECTOR.getJavaVersion(Jvm.forHome(getJavaHome())).compareTo(JavaVersion.VERSION_1_8) < 0) {
-            buildJvmOpts.add("-XX:MaxPermSize=320m");
-        }
-
-        buildJvmOpts.add("-XX:+HeapDumpOnOutOfMemoryError");
-        buildJvmOpts.add("-XX:HeapDumpPath=" + buildContext.getGradleUserHomeDir().getAbsolutePath());
-        return buildJvmOpts;
     }
 
     @Override

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileJavaVersionTrackingIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileJavaVersionTrackingIntegrationTest.groovy
@@ -27,11 +27,19 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
 
 @Requires(adhoc = { AvailableJavaHomes.getJdk(VERSION_1_7) && AvailableJavaHomes.getJdk(VERSION_1_8) })
 class GroovyCompileJavaVersionTrackingIntegrationTest extends AbstractIntegrationSpec {
+
+    /**
+     * When running in embedded mode, core tasks are loaded from the runtime classloader.
+     * When running in the daemon, they are loaded from the plugins classloader.
+     * This difference leads to different up-to-date messages, which is why we force
+     * a consistent execution mode.
+     */
     def setup() {
         file("src/main/groovy/org/gradle/Person.groovy") << """
             package org.gradle
             class Person {}
         """
+        executer.requireDaemon().requireIsolatedDaemons()
     }
 
     def "tracks changes to the Groovy compiler JVM Java version"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileJavaVersionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileJavaVersionIntegrationTest.groovy
@@ -28,6 +28,16 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
 @Requires(adhoc = { AvailableJavaHomes.getJdk(VERSION_1_7) && AvailableJavaHomes.getJdk(VERSION_1_8) })
 class JavaCompileJavaVersionIntegrationTest extends AbstractIntegrationSpec {
 
+    /**
+     * When running in embedded mode, core tasks are loaded from the runtime classloader.
+     * When running in the daemon, they are loaded from the plugins classloader.
+     * This difference leads to different up-to-date messages, which is why we force
+     * a consistent execution mode.
+     */
+    def setup() {
+        executer.requireDaemon().requireIsolatedDaemons()
+    }
+
     def "not up-to-date when default Java version changes"() {
         given:
         buildFile << """

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -170,7 +170,7 @@ task sleep {
         poll(60) { assert daemon.standardOutput.contains(DaemonMessages.PROCESS_STARTED) }
 
         when:
-        def infoBuild = executer.withArguments("-i", "-Dorg.gradle.jvmargs=-ea").run()
+        def infoBuild = executer.withArguments("-i").run()
 
         then:
         infoBuild.output.count("debug me!") == 0
@@ -184,7 +184,7 @@ task sleep {
         daemon.standardOutput.count(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS) == 0
 
         when:
-        def debugBuild = executer.withArguments("-d", "-Dorg.gradle.jvmargs=-ea").run()
+        def debugBuild = executer.withArguments("-d").run()
 
         then:
         debugBuild.output.count("debug me!") == 1

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
@@ -78,8 +78,8 @@ class DaemonLifecycleSpec extends DaemonIntegrationSpec {
             executer.withDaemonIdleTimeoutSecs(daemonIdleTimeout)
             executer.withArguments(
                     "-Dorg.gradle.daemon.healthcheckinterval=${periodicCheckInterval * 1000}",
-                    "--debug", // Need debug logging so we can extract the `DefaultDaemonContext`
-                    "-Dorg.gradle.jvmargs=-ea")
+                    "--debug" // Need debug logging so we can extract the `DefaultDaemonContext`
+            )
             if (javaHome) {
                 executer.withJavaHome(javaHome)
             }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -30,6 +30,7 @@ import java.nio.charset.Charset
 class SingleUseDaemonIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
+        executer.withArgument("--no-daemon")
         executer.requireIsolatedDaemons()
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/ForegroundDaemonConfiguration.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/ForegroundDaemonConfiguration.java
@@ -23,7 +23,6 @@ import java.io.File;
 public class ForegroundDaemonConfiguration extends DefaultDaemonServerConfiguration {
     public ForegroundDaemonConfiguration(String daemonUid, File daemonBaseDir, int idleTimeoutMs, int periodicCheckIntervalMs) {
         // Foreground daemon cannot be 'told' what's his startup options as the client sits in the same process so we will infer the jvm opts from the inputArguments()
-        // Simplification, we will make the foreground daemon interested only in managed jvm args
-        super(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, false, new CurrentProcess().getJvmOptions().getManagedJvmArgs());
+        super(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, false, new CurrentProcess().getJvmOptions().getAllImmutableJvmArgs());
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.jvm.Jvm
-
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Assume
@@ -58,7 +57,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         gradle.standardOutput.contains("Execution working dir: " + testDirectory.getAbsolutePath())
 
         and:
-        GradleContextualExecuter.daemon || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        GradleContextualExecuter.isLongLivingProcess() || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     def "sets the working directory to the specified directory during worker execution"() {
@@ -90,7 +89,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         gradle.standardOutput.contains("Execution working dir: " + testDirectory.file("workerDir").getAbsolutePath())
 
         and:
-        GradleContextualExecuter.daemon || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
+        GradleContextualExecuter.isLongLivingProcess() || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
     @Requires(TestPrecondition.JDK_ORACLE)


### PR DESCRIPTION
We missed this when we did the other daemon-by-default changes. Whenever a forking handle was requested from the embedded executor, it would return a no-daemon handle. Fixing this should speed up our quick feedback builds.

While fixing this I found a bunch of bugs in our embedded executor, e.g. not passing environment variables, some modules not being accessible from the classpath etc. This is likely the reason for many of our "requireDistribution" usages, which slow down our development cycle. I'll take a pass over those  later to see which ones are still necessary.

While cleaning up the hierarchy of Gradle executor implementations, I also found that we weren't limiting memory for test daemons at all. This is probably one of the reasons we saw some out of memory errors in some cases. The default that the JVM uses is 1/4th of the machines RAM, which is way too much. 