### PR TITLE
Emit build operation for executing taskgraph whenReady hooks

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
@@ -173,19 +173,19 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
         }
 
         with(operations.only(NotifyTaskGraphWhenReadyBuildOperationType, { it.details.buildPath == ':buildSrc' })) {
-            displayName == 'Notify taskgraph whenReady listeners (:buildSrc)'
+            displayName == 'Notify task graph whenReady listeners (:buildSrc)'
             children*.displayName == ["Apply script buildSrcWhenReady.gradle to project ':buildSrc'"]
             parentId == operations.first("Run tasks (:buildSrc)").id
         }
 
         with(operations.only(NotifyTaskGraphWhenReadyBuildOperationType, { it.details.buildPath == ':included-build' })) {
-            displayName == 'Notify taskgraph whenReady listeners (:included-build)'
+            displayName == 'Notify task graph whenReady listeners (:included-build)'
             children*.displayName == ["Apply script includedWhenReady.gradle to project ':included-build'"]
             parentId == operations.first("Run tasks (:included-build)").id
         }
 
         with(operations.only(NotifyTaskGraphWhenReadyBuildOperationType, { it.details.buildPath == ':' })) {
-            displayName == 'Notify taskgraph whenReady listeners'
+            displayName == 'Notify task graph whenReady listeners'
             children*.displayName == ["Apply script whenReady.gradle to project ':foo'"]
             parentId == operations.first("Run tasks").id
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -116,7 +116,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         applyBuildScriptProgress[0].details.category == 'org.gradle.api.Project'
         applyBuildScriptProgress[0].details.message == 'from build.gradle'
 
-        def notifyTaskGraphProgress = operations.only("Notify taskgraph whenReady listeners").progress
+        def notifyTaskGraphProgress = operations.only("Notify task graph whenReady listeners").progress
         notifyTaskGraphProgress.size() == 1
         notifyTaskGraphProgress[0].details.logLevel == 'WARN'
         notifyTaskGraphProgress[0].details.category == 'org.gradle.api.Project'

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -116,11 +116,11 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         applyBuildScriptProgress[0].details.category == 'org.gradle.api.Project'
         applyBuildScriptProgress[0].details.message == 'from build.gradle'
 
-        def runTasksProgress = operations.only("Run tasks").progress
-        runTasksProgress.size() == 1
-        runTasksProgress[0].details.logLevel == 'WARN'
-        runTasksProgress[0].details.category == 'org.gradle.api.Project'
-        runTasksProgress[0].details.message == 'warning from taskgraph'
+        def notifyTaskGraphProgress = operations.only("Notify taskgraph whenReady listeners").progress
+        notifyTaskGraphProgress.size() == 1
+        notifyTaskGraphProgress[0].details.logLevel == 'WARN'
+        notifyTaskGraphProgress[0].details.category == 'org.gradle.api.Project'
+        notifyTaskGraphProgress[0].details.message == 'warning from taskgraph'
 
         def jarTaskDoLastOperation = operations.only("Execute doLast {} action for :jar")
         operations.parentsOf(jarTaskDoLastOperation).find {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.configuration.ApplyScriptPluginBuildOperationType
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
 import org.gradle.configuration.project.NotifyProjectAfterEvaluatedBuildOperationType
 import org.gradle.configuration.project.NotifyProjectBeforeEvaluatedBuildOperationType
+import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.EvaluateSettingsBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
@@ -88,6 +89,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
 
         notifications.started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
         notifications.finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
+        notifications.started(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ':'])
         notifications.started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
         notifications.finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
     }
@@ -175,6 +177,11 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.started(NotifyProjectsEvaluatedBuildOperationType.Details, [buildPath: ":a"])
         notifications.started(NotifyProjectsEvaluatedBuildOperationType.Details, [buildPath: ":"])
 
+        notifications.started(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":buildSrc"])
+        notifications.started(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a:buildSrc"])
+        notifications.started(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a"])
+        notifications.started(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":"])
+
         // evaluate hierarchies
         notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
         notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(LoadBuildBuildOperationType.Details, [buildPath: ":"]).id
@@ -215,6 +222,11 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.op(NotifyProjectAfterEvaluatedBuildOperationType.Details, [buildPath: ":a", projectPath: ":"]).parentId == notifications.op(ConfigureProjectBuildOperationType.Details, [buildPath: ":a", projectPath: ":"]).id
         notifications.op(NotifyProjectAfterEvaluatedBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"]).parentId == notifications.op(ConfigureProjectBuildOperationType.Details, [buildPath: ":buildSrc", projectPath: ":"]).id
         notifications.op(NotifyProjectAfterEvaluatedBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"]).parentId == notifications.op(ConfigureProjectBuildOperationType.Details, [buildPath: ":a:buildSrc", projectPath: ":"]).id
+
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a"]).parentId == notifications.op(RunBuildBuildOperationType.Details).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':']).id
+        notifications.op(NotifyTaskGraphWhenReadyBuildOperationType.Details, [buildPath: ":a:buildSrc"]).parentId == notifications.op(BuildBuildSrcBuildOperationType.Details, [buildPath: ':a']).id
     }
 
     def "emits for GradleBuild tasks"() {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -297,9 +297,9 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
     private static class NotifyTaskGraphWhenReady implements RunnableBuildOperation {
 
-        private DefaultTaskExecutionGraph taskExecutionGraph;
-        private ListenerBroadcast<TaskExecutionGraphListener> graphListeners;
-        private GradleInternal gradleInternal;
+        private final DefaultTaskExecutionGraph taskExecutionGraph;
+        private final ListenerBroadcast<TaskExecutionGraphListener> graphListeners;
+        private final GradleInternal gradleInternal;
 
         private NotifyTaskGraphWhenReady(DefaultTaskExecutionGraph taskExecutionGraph, ListenerBroadcast<TaskExecutionGraphListener> graphListeners, GradleInternal gradleInternal) {
             this.taskExecutionGraph = taskExecutionGraph;

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -42,9 +42,12 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
+import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.internal.time.Time;
@@ -71,6 +74,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     private final ResourceLockCoordinationService coordinationService;
     // This currently needs to be lazy, as it uses state that is not available when the graph is created
     private final Factory<? extends TaskExecuter> taskExecuter;
+    private final GradleInternal gradleInternal;
     private final ListenerBroadcast<TaskExecutionGraphListener> graphListeners;
     private final ListenerBroadcast<TaskExecutionListener> taskListeners;
     private final DefaultTaskExecutionPlan taskExecutionPlan;
@@ -86,9 +90,11 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         this.taskExecuter = taskExecuter;
         this.buildOperationExecutor = buildOperationExecutor;
         this.coordinationService = coordinationService;
+        this.gradleInternal = gradleInternal;
         graphListeners = listenerManager.createAnonymousBroadcaster(TaskExecutionGraphListener.class);
         taskListeners = listenerManager.createAnonymousBroadcaster(TaskExecutionListener.class);
         taskExecutionPlan = new DefaultTaskExecutionPlan(workerLeaseService, gradleInternal, includedBuildTaskGraph);
+
     }
 
     @Override
@@ -128,8 +134,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     public void execute(Collection<? super Throwable> taskFailures) {
         Timer clock = Time.startTimer();
         ensurePopulated();
-
-        graphListeners.getSource().graphPopulated(this);
+        buildOperationExecutor.run(new NotifyTaskGraphWhenReady(this, graphListeners, gradleInternal));
         try {
             taskPlanExecutor.process(taskExecutionPlan, new ExecuteTaskAction(taskExecuter.create(), buildOperationExecutor.getCurrentOperation()), taskFailures);
             LOGGER.debug("Timing: Executing the DAG took " + clock.getElapsed());
@@ -288,5 +293,32 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     @Override
     public TaskExecutionListener getTaskExecutionListenerSource() {
         return taskListeners.getSource();
+    }
+
+    private static class NotifyTaskGraphWhenReady implements RunnableBuildOperation {
+
+        private DefaultTaskExecutionGraph taskExecutionGraph;
+        private ListenerBroadcast<TaskExecutionGraphListener> graphListeners;
+        private GradleInternal gradleInternal;
+
+        private NotifyTaskGraphWhenReady(DefaultTaskExecutionGraph taskExecutionGraph, ListenerBroadcast<TaskExecutionGraphListener> graphListeners, GradleInternal gradleInternal) {
+            this.taskExecutionGraph = taskExecutionGraph;
+            this.graphListeners = graphListeners;
+            this.gradleInternal = gradleInternal;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            graphListeners.getSource().graphPopulated(taskExecutionGraph);
+            context.setResult(NotifyTaskGraphWhenReadyBuildOperationType.RESULT);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor.displayName(gradleInternal.contextualize("Notify taskgraph whenReady listeners"))
+                .details(new NotifyTaskGraphWhenReadyBuildOperationType.DetailsImpl(
+                    gradleInternal.getIdentityPath()
+                ));
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -315,7 +315,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
         @Override
         public BuildOperationDescriptor.Builder description() {
-            return BuildOperationDescriptor.displayName(gradleInternal.contextualize("Notify taskgraph whenReady listeners"))
+            return BuildOperationDescriptor.displayName(gradleInternal.contextualize("Notify task graph whenReady listeners"))
                 .details(new NotifyTaskGraphWhenReadyBuildOperationType.DetailsImpl(
                     gradleInternal.getIdentityPath()
                 ));

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/NotifyTaskGraphWhenReadyBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/NotifyTaskGraphWhenReadyBuildOperationType.java
@@ -31,9 +31,11 @@ public class NotifyTaskGraphWhenReadyBuildOperationType implements BuildOperatio
     public interface Details {
 
         String getBuildPath();
+
     }
 
     public interface Result {
+
     }
 
     static class DetailsImpl implements NotifyTaskGraphWhenReadyBuildOperationType.Details {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/NotifyTaskGraphWhenReadyBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/NotifyTaskGraphWhenReadyBuildOperationType.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.taskgraph;
+
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.util.Path;
+
+/**
+ * Execution of a build's taskgraph.whenReady hooks
+ *
+ * @since 4.9
+ */
+public class NotifyTaskGraphWhenReadyBuildOperationType implements BuildOperationType<NotifyTaskGraphWhenReadyBuildOperationType.Details, NotifyTaskGraphWhenReadyBuildOperationType.Result> {
+
+    @UsedByScanPlugin
+    public interface Details {
+
+        String getBuildPath();
+    }
+
+    public interface Result {
+    }
+
+    static class DetailsImpl implements NotifyTaskGraphWhenReadyBuildOperationType.Details {
+
+        private final Path buildPath;
+
+        DetailsImpl(Path buildPath) {
+            this.buildPath = buildPath;
+        }
+
+        public String getBuildPath() {
+            return buildPath.getPath();
+        }
+
+    }
+
+    final static NotifyTaskGraphWhenReadyBuildOperationType.Result RESULT = new NotifyTaskGraphWhenReadyBuildOperationType.Result() {
+    };
+
+    private NotifyTaskGraphWhenReadyBuildOperationType() {
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -369,6 +369,13 @@ class DefaultTaskExecutionGraphSpec extends Specification {
 
         then:
         1 * taskPlanExecutor.process(_, _, _)
+
+        and:
+        with(buildOperationExecutor.operations[0]){
+            name == 'Notify taskgraph whenReady listeners'
+            displayName == 'Notify taskgraph whenReady listeners'
+            details.buildPath == ':'
+        }
     }
 
     def "stops execution on first failure when no failure handler provided"() {


### PR DESCRIPTION
### Context
This will assist build scans to separate out work done during these hooks.

### Contributor Checklist
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
