### PR TITLE
Inject Gradle version into installation chapter

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -140,7 +140,8 @@ tasks.withType(CacheableAsciidoctorTask) {
     attributes 'source-highlighter': 'prettify',
                website: 'http://www.gradle.org',
                javaApi: 'https://docs.oracle.com/javase/7/docs/api',
-               antManual: 'https://ant.apache.org/manual'
+               antManual: 'https://ant.apache.org/manual',
+               gradleVersion: version
 
     doLast {
         outputDir.eachFileMatch(~/.*.xml/) { File file ->

--- a/subprojects/docs/src/docs/userguide/installation.adoc
+++ b/subprojects/docs/src/docs/userguide/installation.adoc
@@ -42,7 +42,7 @@ Gradle uses whatever JDK it finds in your path. Alternatively, you can set the `
 link:http://sdkman.io[SDKMAN!] is a tool for managing parallel versions of multiple Software Development Kits on most Unix-based systems.
 
 ----
-❯ sdk install gradle 4.6
+❯ sdk install gradle
 ----
 
 link:http://brew.sh[Homebrew] is "the missing package manager for macOS".
@@ -89,10 +89,11 @@ Need to work with an older version? See the link:https://gradle.org/releases[rel
 
 Unzip the distribution zip file in the directory of your choosing, e.g.:
 
+[subs="attributes"]
 ----
 ❯ mkdir /opt/gradle
-❯ unzip -d /opt/gradle gradle-4.6-bin.zip
-❯ ls /opt/gradle/gradle-4.6
+❯ unzip -d /opt/gradle gradle-{gradleVersion}-bin.zip
+❯ ls /opt/gradle/gradle-{gradleVersion}
 LICENSE  NOTICE  bin  getting-started.html  init.d  lib  media
 ----
 
@@ -100,7 +101,7 @@ LICENSE  NOTICE  bin  getting-started.html  init.d  lib  media
 
 Create a new directory `C:\Gradle` with **File Explorer**.
 
-Open a second **File Explorer** window and go to the directory where the Gradle distribution was downloaded. Double-click the ZIP archive to expose the content. Drag the content folder `gradle-4.6` to your newly created `C:\Gradle` folder.
+Open a second **File Explorer** window and go to the directory where the Gradle distribution was downloaded. Double-click the ZIP archive to expose the content. Drag the content folder `gradle-{gradleVersion}` to your newly created `C:\Gradle` folder.
 
 Alternatively you can unpack the Gradle distribution ZIP into `C:\Gradle` using an archiver tool of your choice.
 
@@ -112,15 +113,16 @@ For running Gradle, firstly add the environment variable `GRADLE_HOME`. This sho
 
 Configure your `PATH` environment variable to include the `bin` directory of the unzipped distribution, e.g.:
 
+[subs="attributes"]
 ----
-❯ export PATH=$PATH:/opt/gradle/gradle-4.6/bin
+❯ export PATH=$PATH:/opt/gradle/gradle-{gradleVersion}/bin
 ----
 
 ===== Microsoft Windows users
 
 In **File Explorer** right-click on the `This PC` (or `Computer`) icon, then click `Properties` -> `Advanced System Settings` -> `Environmental Variables`.
 
-Under `System Variables` select `Path`, then click `Edit`. Add an entry for `C:\Gradle\gradle-4.6\bin`. Click OK to save.
+Under `System Variables` select `Path`, then click `Edit`. Add an entry for `C:\Gradle\gradle-{gradleVersion}\bin`. Click OK to save.
 
 <<sec:installation_next_steps,↓ Proceed to next steps>>
 
@@ -130,11 +132,12 @@ Under `System Variables` select `Path`, then click `Edit`. Add an entry for `C:\
 
 Open a console (or a Windows command prompt) and run `gradle -v` to run gradle and display the version, e.g.:
 
+[subs="attributes"]
 ----
 ❯ gradle -v
 
 ------------------------------------------------------------
-Gradle 4.6
+Gradle {gradleVersion}
 ------------------------------------------------------------
 
 Build time:   2018-02-21 15:28:42 UTC


### PR DESCRIPTION
I have added a `gradleVersion` Asciidoctor attribute to the docs build. The
installation chapter now uses that to display the appropriate Gradle version
in various locations.

In order to get this working for the code blocks, I had to add

    [subs="attributes"]

before each of the code blocks that referenced the `gradleVersion` attribute.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
