### PR TITLE
use seperate flag for activating task creation build ops

### DIFF
--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -103,7 +103,7 @@ class BuildScanPluginPerformanceTest extends Specification {
             displayName(WITH_PLUGIN_LABEL)
             invocation {
                 args(*jobArgs)
-                args("-Dscan", "-Dscan.dump", "-Dorg.gradle.internal.tasks.stats")
+                args("-Dscan", "-Dscan.dump", "-Dorg.gradle.internal.tasks.createops")
                 tasksToRun(*tasks)
                 gradleOpts(*opts)
                 expectFailure()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskCreationBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskCreationBuildOperationIntegrationTest.groovy
@@ -196,7 +196,7 @@ class TaskCreationBuildOperationIntegrationTest extends AbstractIntegrationSpec 
 
     private void enable(TestFile file = settingsFile) {
         file << """
-            System.setProperty("org.gradle.internal.tasks.stats", "true")
+            System.setProperty("org.gradle.internal.tasks.createops", "true")
         """
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -69,6 +69,7 @@ import java.util.TreeSet;
 @NonNullApi
 public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements TaskContainerInternal {
     private static final Object[] NO_ARGS = new Object[0];
+    public final static String CREATE_TASKS_CREATE_OPS_PROPERTY = "org.gradle.internal.tasks.createops";
     public final static String EAGERLY_CREATE_LAZY_TASKS_PROPERTY = "org.gradle.internal.tasks.eager";
 
     private static final Set<String> VALID_TASK_ARGUMENTS = ImmutableSet.of(
@@ -97,7 +98,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         // Note: this conditional use of operations is intended to be temporary.
         // The extra operations create extra overhead that we do not want to impose at this time.
-        this.buildOperationExecutor = statistics.isCollecting() ? buildOperationExecutor : NullBuildOperationExecutor.INSTANCE;
+        this.buildOperationExecutor = createOps() ? buildOperationExecutor : NullBuildOperationExecutor.INSTANCE;
     }
 
     public Task create(Map<String, ?> options) {
@@ -200,6 +201,11 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         if (map.get(key) == null) {
             map.put(key, defaultValue);
         }
+    }
+
+    private static boolean createOps() {
+        String createOps = System.getProperty(CREATE_TASKS_CREATE_OPS_PROPERTY);
+        return (createOps != null && createOps.isEmpty()) || Boolean.parseBoolean(createOps);
     }
 
     private <T extends Task> void addTask(T task, boolean replaceExisting) {


### PR DESCRIPTION

### Context
- avoids always printing stats when used for activating task creation capturing in build scan plugin

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
