### PR TITLE
Require distribution in less integration tests

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProfilingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProfilingIntegrationTest.groovy
@@ -33,7 +33,7 @@ allprojects {
 }
 '''
         when:
-        executer.requireGradleDistribution().withArgument("--profile")
+        executer.withArgument("--profile")
         succeeds("build", "fooTask", "-x", "barTask")
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -70,9 +70,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 licenseAgree = 'yes'
             }
         """.stripIndent()
-        // Using the embedded executer, we get an NPE from the build scan plugin since it is trying to get the Gradle installation - which is null for the embedded executer.
-        // We force forking by requiring a Gradle distribution.
-        executer.requireGradleDistribution()
 
         when:
         succeeds('customTask', '-Dscan.dump')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/BuildResultLoggerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/BuildResultLoggerIntegrationTest.groovy
@@ -21,11 +21,6 @@ import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 
 class BuildResultLoggerIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
     def setup() {
-        // Force a forking executer
-        // This is necessary since for the embedded executer
-        // the Task statistics are not part of the output
-        // returned by "this.output"
-        executer.requireGradleDistribution()
 
         file("input.txt") << "data"
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildScriptClasspathIntegrationSpec.groovy
@@ -28,8 +28,6 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
     MavenHttpRepository repo
 
     def setup() {
-        executer.requireDaemon()
-        executer.requireIsolatedDaemons()
         repo = new MavenHttpRepository(server, mavenRepo)
 
         repo.module("commons-io", "commons-io", "1.4").publish().allowAll()
@@ -136,6 +134,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     def "url connection caching is not disabled by default"() {
+
         given:
         buildFile << """
             task checkUrlConnectionCaching {
@@ -146,6 +145,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec {
                 }
             }
         """
+        executer.requireDaemon().requireIsolatedDaemons()
 
         expect:
         succeeds("checkUrlConnectionCaching")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
@@ -93,7 +93,7 @@ class CacheProjectIntegrationTest extends AbstractIntegrationTest {
         classFile.assertHasChangedSince(classFileSnapshot)
         classFileSnapshot = classFile.snapshot()
 
-        executer.expectDeprecationWarning().requireGradleDistribution()
+        executer.expectDeprecationWarning()
         testBuild("newTask", "I am new", "--recompile-scripts")
         classFile.assertContentsHaveNotChangedSince(classFileSnapshot)
     }
@@ -124,7 +124,7 @@ class CacheProjectIntegrationTest extends AbstractIntegrationTest {
         assert dependenciesCache.isDirectory() && dependenciesCache.listFiles().length > 0
 
         modifyLargeBuildScript()
-        executer.expectDeprecationWarning().requireGradleDistribution()
+        executer.expectDeprecationWarning()
         testBuild("newTask", "I am new", "--recompile-scripts")
         assert dependenciesCache.isDirectory() && dependenciesCache.listFiles().length > 0
     }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/MixInCoreTypesTransformingClassLoaderIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/MixInCoreTypesTransformingClassLoaderIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.Ignore
 
-@Ignore
 class MixInCoreTypesTransformingClassLoaderIntegrationTest extends AbstractIntegrationSpec {
     def "custom task types have bridge methods for inputs/outputs"() {
         buildFile << """
@@ -47,8 +45,6 @@ class MixInCoreTypesTransformingClassLoaderIntegrationTest extends AbstractInteg
                 }
             }
         """
-
-        executer.requireGradleDistribution()
 
         expect:
         succeeds "customTask"

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
@@ -42,8 +42,6 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "processes annotation for Java class if annotation processor is available on classpath"() {
-        executer.requireGradleDistribution()
-
         when:
         AnnotationProcessorPublisher annotationProcessorPublisher = new AnnotationProcessorPublisher()
         annotationProcessorPublisher.writeSourceFiles()
@@ -69,8 +67,6 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "processes annotation for Java class if annotation processor is available on processor path"() {
-        executer.requireGradleDistribution()
-
         when:
         AnnotationProcessorPublisher annotationProcessorPublisher = new AnnotationProcessorPublisher()
         annotationProcessorPublisher.writeSourceFiles()


### PR DESCRIPTION
No distribution is required in any of the tests changed here.
Requiring a distribution has several drawbacks:

- you need to run intTestImage before testing any change
- the test can't run in the embedded executer, making it slow
- the test is harder to debug, as it's not run in the embedded executer

There are probably more tests that don't really needs this,
but just changing these few should improve turnarounds a bit.
