### PR TITLE
Remove spurious kotlin-dsl plugin version declaration

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
 }
 
 plugins {
-    `kotlin-dsl` version "0.17.2"
+    `kotlin-dsl`
     id("org.gradle.kotlin.ktlint-convention") version "0.1.8" apply false
 }
 


### PR DESCRIPTION
Not needed anymore as using the same version as the provider (`0.18.0`)  is what we want.