### PR TITLE
[WIP] - Correct caching of ModuleComponentResolveMetadata

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataContext.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataContext.java
@@ -18,8 +18,11 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
- * Provides access to compoment metadata from a {@link ComponentMetadataRule}.
+ * Provides access to component metadata from a {@link ComponentMetadataRule}.
  *
  * @since 4.9
  */
@@ -37,7 +40,9 @@ public interface ComponentMetadataContext {
      *
      * @see org.gradle.api.artifacts.ivy.IvyModuleDescriptor
      */
+    @Nullable
     <T> T getDescriptor(Class<T> descriptorClass);
 
+    @Nonnull
     ComponentMetadataDetails getDetails();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeValuesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeValuesIntegrationTest.groovy
@@ -54,9 +54,6 @@ class AttributeValuesIntegrationTest extends AbstractIntegrationSpec {
     def "can use attribute value that can be made isolated - #type"() {
         given:
         buildFile << """
-    class Thing implements Named, Serializable { 
-        String name
-    }
     interface Flavor extends Named { }
     def attr = Attribute.of($type)
     

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -266,7 +266,7 @@ dependencies {
         outputDoesNotContain('Attribute rule executed')
     }
 
-    @Ignore
+//    @Ignore
     @ToBeImplemented
     @RequiredFeatures(
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -62,6 +62,7 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublica
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.LossyAttributeContainerSerializer;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultLocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenFileLocations;
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvider;
@@ -106,6 +107,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
+import org.gradle.internal.resolve.caching.FullAttributeContainerSerializer;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.resource.cached.ByUrlCachedExternalResourceIndex;
@@ -184,7 +186,7 @@ class DependencyManagementBuildScopeServices {
     }
 
     AttributeContainerSerializer createAttributeContainerSerializer(ImmutableAttributesFactory attributesFactory) {
-        return new AttributeContainerSerializer(attributesFactory, NamedObjectInstantiator.INSTANCE);
+        return new LossyAttributeContainerSerializer(attributesFactory, NamedObjectInstantiator.INSTANCE);
     }
 
     ModuleRepositoryCacheProvider createModuleRepositoryCacheProvider(BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory,
@@ -395,8 +397,8 @@ class DependencyManagementBuildScopeServices {
     }
 
 
-    ModuleComponentResolveMetadataSerializer createModuleComponentResolveMetadataSerializer(AttributeContainerSerializer attributeContainerSerializer, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        return new ModuleComponentResolveMetadataSerializer(new ModuleMetadataSerializer(attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory), moduleIdentifierFactory);
+    ModuleComponentResolveMetadataSerializer createModuleComponentResolveMetadataSerializer(ImmutableAttributesFactory attributesFactory, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+        return new ModuleComponentResolveMetadataSerializer(new ModuleMetadataSerializer(new FullAttributeContainerSerializer(attributesFactory), mavenMetadataFactory, ivyMetadataFactory), moduleIdentifierFactory);
     }
 
     SuppliedComponentMetadataSerializer createSuppliedComponentMetadataSerializer(ImmutableModuleIdentifierFactory moduleIdentifierFactory, AttributeContainerSerializer attributeContainerSerializer) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -17,7 +17,12 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.DefaultIvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.DefaultMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.RealisedIvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.RealisedMavenModuleResolveMetadata;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -42,6 +47,18 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
 
     @Override
     public void write(Encoder encoder, ModuleComponentResolveMetadata value) throws Exception {
-        delegate.write(encoder, value);
+        AbstractRealisedModuleComponentResolveMetadata transformed = transformToRealisedForSerialization(value);
+        delegate.write(encoder, transformed);
+
+    }
+
+    private AbstractRealisedModuleComponentResolveMetadata transformToRealisedForSerialization(ModuleComponentResolveMetadata metadata) {
+        if (metadata instanceof DefaultIvyModuleResolveMetadata) {
+            return RealisedIvyModuleResolveMetadata.transform((DefaultIvyModuleResolveMetadata) metadata);
+        } else if (metadata instanceof DefaultMavenModuleResolveMetadata) {
+            return RealisedMavenModuleResolveMetadata.transform((DefaultMavenModuleResolveMetadata) metadata);
+        }
+        throw new IllegalStateException("The type of metadata received is not supported - " + metadata.getClass().getName());
+
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/LossyAttributeContainerSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/LossyAttributeContainerSerializer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
+
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.changedetection.state.CoercingStringValueSnapshot;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.serialize.AbstractSerializer;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+
+import java.io.IOException;
+
+/**
+ * A lossy attribute container serializer. It's lossy because it doesn't preserve the attribute
+ * types: it will serialize the contents as strings, and read them as strings, only for reporting
+ * purposes.
+ */
+public class LossyAttributeContainerSerializer extends AbstractSerializer<AttributeContainer> implements AttributeContainerSerializer {
+    private final ImmutableAttributesFactory attributesFactory;
+    private final NamedObjectInstantiator instantiator;
+    private static final byte STRING_ATTRIBUTE = 1;
+    private static final byte BOOLEAN_ATTRIBUTE = 2;
+
+    public LossyAttributeContainerSerializer(ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator instantiator) {
+        this.attributesFactory = attributesFactory;
+        this.instantiator = instantiator;
+    }
+
+    @Override
+    public ImmutableAttributes read(Decoder decoder) throws IOException {
+        ImmutableAttributes attributes = ImmutableAttributes.EMPTY;
+        int count = decoder.readSmallInt();
+        for (int i = 0; i < count; i++) {
+            String name = decoder.readString();
+            byte type = decoder.readByte();
+            if (type == BOOLEAN_ATTRIBUTE) {
+                attributes = attributesFactory.concat(attributes, Attribute.of(name, Boolean.class), decoder.readBoolean());
+            } else {
+                String value = decoder.readString();
+                attributes = attributesFactory.concat(attributes, Attribute.of(name, String.class), new CoercingStringValueSnapshot(value, instantiator));
+            }
+        }
+        return attributes;
+    }
+
+    @Override
+    public void write(Encoder encoder, AttributeContainer container) throws IOException {
+        encoder.writeSmallInt(container.keySet().size());
+        for (Attribute<?> attribute : container.keySet()) {
+            encoder.writeString(attribute.getName());
+            if (attribute.getType().equals(Boolean.class)) {
+                encoder.writeByte(BOOLEAN_ATTRIBUTE);
+                encoder.writeBoolean((Boolean) container.getAttribute(attribute));
+            } else {
+                assert attribute.getType().equals(String.class);
+                encoder.writeByte(STRING_ATTRIBUTE);
+                encoder.writeString((String) container.getAttribute(attribute));
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -110,11 +110,15 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     }
 
 
-    private static class VariantNameSpec implements Spec<VariantResolveMetadata> {
+    public static class VariantNameSpec implements Spec<VariantResolveMetadata> {
         private final String name;
 
         private VariantNameSpec(String name) {
             this.name = name;
+        }
+
+        public String getName() {
+            return name;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.DefaultVariantMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+abstract class AbstractConfigurationMetadata implements ConfigurationMetadata, VariantResolveMetadata {
+    private final ModuleComponentIdentifier componentId;
+    private final String name;
+    private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
+    private final boolean transitive;
+    private final boolean visible;
+    private final ImmutableList<String> hierarchy;
+    private final ImmutableList<ExcludeMetadata> excludes;
+    private final ImmutableAttributes attributes;
+    private final ImmutableCapabilities capabilities;
+    // Should be final, and set in constructor
+    private ImmutableList<ModuleDependencyMetadata> configDependencies;
+
+    public AbstractConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
+                                         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableList<String> hierarchy,
+                                         ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes,
+                                         ImmutableList<ModuleDependencyMetadata> configDependencies, ImmutableCapabilities capabilities) {
+
+        this.componentId = componentId;
+        this.name = name;
+        this.transitive = transitive;
+        this.visible = visible;
+        this.artifacts = artifacts;
+        this.hierarchy = hierarchy;
+        this.excludes = excludes;
+        this.attributes = attributes;
+        this.configDependencies = configDependencies;
+        this.capabilities = capabilities;
+    }
+
+    @Override
+    public DisplayName asDescribable() {
+        return Describables.of(componentId, "configuration", name);
+    }
+
+    @Override
+    public String toString() {
+        return asDescribable().getDisplayName();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Collection<String> getHierarchy() {
+        return hierarchy;
+    }
+
+    @Override
+    public boolean isTransitive() {
+        return transitive;
+    }
+
+    @Override
+    public boolean isVisible() {
+        return visible;
+    }
+
+    @Override
+    public boolean isCanBeConsumed() {
+        return true;
+    }
+
+    @Override
+    public boolean isCanBeResolved() {
+        return false;
+    }
+
+    protected void setDependencies(List<ModuleDependencyMetadata> dependencies) {
+        assert this.configDependencies == null; // Can only set once: should really be part of the constructor
+        this.configDependencies = ImmutableList.copyOf(dependencies);
+    }
+
+    @Override
+    public List<? extends ModuleComponentArtifactMetadata> getArtifacts() {
+        return artifacts;
+    }
+
+    @Override
+    public Set<? extends VariantResolveMetadata> getVariants() {
+        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+    }
+
+    @Override
+    public ImmutableList<ExcludeMetadata> getExcludes() {
+        return excludes;
+    }
+
+    @Override
+    public ModuleComponentArtifactMetadata artifact(IvyArtifactName artifact) {
+        return new DefaultModuleComponentArtifactMetadata(componentId, artifact);
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public CapabilitiesMetadata getCapabilities() {
+        return capabilities;
+    }
+
+    protected ImmutableList<ModuleDependencyMetadata> getConfigDependencies() {
+        return configDependencies;
+    }
+
+    protected ModuleComponentIdentifier getComponentId() {
+        return componentId;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.ModuleSource;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+abstract class AbstractLazyModuleComponentResolveMetadata extends AbstractModuleComponentResolveMetadata {
+    private final VariantMetadataRules variantMetadataRules;
+
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> graphVariants;
+
+    AbstractLazyModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
+        super(metadata);
+        variantMetadataRules = metadata.getVariantMetadataRules();
+    }
+
+    /**
+     * Creates a copy of the given metadata
+     */
+    AbstractLazyModuleComponentResolveMetadata(AbstractLazyModuleComponentResolveMetadata metadata, @Nullable ModuleSource source) {
+        super(metadata, source);
+        variantMetadataRules = metadata.variantMetadataRules;
+    }
+
+    /**
+     * Clear any cached state, for the case where the inputs are invalidated.
+     * This only happens when constructing a copy
+     */
+    protected void copyCachedState(AbstractLazyModuleComponentResolveMetadata metadata) {
+        super.copyCachedState(metadata);
+        this.graphVariants = metadata.graphVariants;
+    }
+
+    @Override
+    protected final DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy) {
+        return createConfiguration(componentId, name, transitive, visible, hierarchy, variantMetadataRules);
+    }
+
+    /**
+     * Creates a {@link org.gradle.internal.component.model.ConfigurationMetadata} implementation for this component.
+     */
+    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules);
+
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> buildVariantsForGraphTraversal(List<? extends ComponentVariant> variants) {
+        if (variants.isEmpty()) {
+            return maybeDeriveVariants();
+        }
+        ImmutableList.Builder<ConfigurationMetadata> configurations = new ImmutableList.Builder<ConfigurationMetadata>();
+        for (ComponentVariant variant : variants) {
+            configurations.add(new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules));
+        }
+        return Optional.<ImmutableList<? extends ConfigurationMetadata>>of(configurations.build());
+    }
+
+    @Override
+    public synchronized Optional<ImmutableList<? extends ConfigurationMetadata>> getVariantsForGraphTraversal() {
+        if (graphVariants == null) {
+            graphVariants = buildVariantsForGraphTraversal(getVariants());
+        }
+        return graphVariants;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -43,6 +43,10 @@ abstract class AbstractLazyModuleComponentResolveMetadata extends AbstractModule
         variantMetadataRules = metadata.variantMetadataRules;
     }
 
+    protected VariantMetadataRules getVariantMetadataRules() {
+        return variantMetadataRules;
+    }
+
     /**
      * Clear any cached state, for the case where the inputs are invalidated.
      * This only happens when constructing a copy

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -78,7 +78,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         variants = metadata.getVariants();
     }
 
-    public AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants) {
+    public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants) {
         this.componentIdentifier = metadata.getId();
         this.moduleVersionIdentifier = metadata.getModuleVersionId();
         changing = metadata.isChanging();
@@ -88,7 +88,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         configurationDefinitions = metadata.getConfigurationDefinitions();
         attributesFactory = metadata.getAttributesFactory();
         contentHash = metadata.getContentHash();
-        attributes = extractAttributes(metadata);
+        attributes = metadata.getAttributes();
         this.variants = variants;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -475,12 +475,12 @@ abstract class AbstractMutableModuleComponentResolveMetadata implements MutableM
         private final ModuleComponentIdentifier componentId;
         private final String name;
         private final ImmutableAttributes attributes;
-        private final ImmutableList<DependencyImpl> dependencies;
-        private final ImmutableList<DependencyConstraintImpl> dependencyConstraints;
-        private final ImmutableList<FileImpl> files;
+        private final ImmutableList<? extends Dependency> dependencies;
+        private final ImmutableList<? extends DependencyConstraint> dependencyConstraints;
+        private final ImmutableList<? extends File> files;
         private final ImmutableCapabilities capabilities;
 
-        ImmutableVariantImpl(ModuleComponentIdentifier componentId, String name, ImmutableAttributes attributes, ImmutableList<DependencyImpl> dependencies, ImmutableList<DependencyConstraintImpl> dependencyConstraints, ImmutableList<FileImpl> files, ImmutableCapabilities capabilities) {
+        ImmutableVariantImpl(ModuleComponentIdentifier componentId, String name, ImmutableAttributes attributes, ImmutableList<? extends Dependency> dependencies, ImmutableList<? extends DependencyConstraint> dependencyConstraints, ImmutableList<? extends File> files, ImmutableCapabilities capabilities) {
             this.componentId = componentId;
             this.name = name;
             this.attributes = attributes;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class AbstractRealisedModuleComponentResolveMetadata extends AbstractModuleComponentResolveMetadata {
+
+    protected static final String ALL_VARIANTS_NAME = "__ALL||VARIANTS++";
+
+    static ImmutableList<? extends ComponentVariant> enrichVariants(ModuleComponentResolveMetadata mutableMetadata, VariantMetadataRules variantMetadataRules, ImmutableList<? extends ComponentVariant> variants, Set<String> remainingVariants) {
+        List<AbstractMutableModuleComponentResolveMetadata.ImmutableVariantImpl> realisedVariants = Lists.newArrayListWithExpectedSize(variants.size());
+        for (ComponentVariant variant : variants) {
+            remainingVariants.remove(variant.getName());
+
+            ImmutableAttributes attributes = variantMetadataRules.applyVariantAttributeRules(variant, variant.getAttributes());
+            realisedVariants.add(new AbstractMutableModuleComponentResolveMetadata.ImmutableVariantImpl(mutableMetadata.getId(), variant.getName(), attributes,
+                variant.getDependencies(), variant.getDependencyConstraints(), variant.getFiles(),
+                ImmutableCapabilities.of(variant.getCapabilities().getCapabilities())));
+        }
+        return ImmutableList.copyOf(realisedVariants);
+    }
+
+    private final Map<String, ImmutableAttributes> potentialVariantToAttributesMap;
+    private final ImmutableAttributes allVariantsAttributes;
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> graphVariants;
+
+    public AbstractRealisedModuleComponentResolveMetadata(AbstractRealisedModuleComponentResolveMetadata metadata) {
+        super(metadata);
+        this.potentialVariantToAttributesMap = metadata.potentialVariantToAttributesMap;
+        this.allVariantsAttributes = metadata.allVariantsAttributes;
+    }
+
+    public AbstractRealisedModuleComponentResolveMetadata(AbstractRealisedModuleComponentResolveMetadata metadata, ModuleSource source) {
+        super(metadata, source);
+        this.potentialVariantToAttributesMap = metadata.potentialVariantToAttributesMap;
+        this.allVariantsAttributes = metadata.allVariantsAttributes;
+    }
+
+    public AbstractRealisedModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata mutableMetadata, ImmutableList<? extends ComponentVariant> variants, Map<String, ImmutableAttributes> potentialVariantToAttributesMap, ImmutableAttributes allVariantsAttributes) {
+        super(mutableMetadata, variants);
+        this.potentialVariantToAttributesMap = potentialVariantToAttributesMap;
+        this.allVariantsAttributes = allVariantsAttributes;
+    }
+
+    @Override
+    protected final RealisedConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy) {
+        return createConfiguration(componentId, name, transitive, visible, hierarchy, potentialVariantToAttributesMap, allVariantsAttributes);
+    }
+
+    protected abstract RealisedConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, Map<String, ImmutableAttributes> potentialVariantToAttributesMap, ImmutableAttributes allVariantsAttributes);
+
+    @Override
+    public Optional<ImmutableList<? extends ConfigurationMetadata>> getVariantsForGraphTraversal() {
+        if (graphVariants == null) {
+            graphVariants = buildVariantsForGraphTraversal(getVariants());
+        }
+        return graphVariants;
+    }
+
+    protected Map<String, ImmutableAttributes> getPotentialVariantToAttributesMap() {
+        return potentialVariantToAttributesMap;
+    }
+
+    protected ImmutableAttributes getAllVariantsAttributes() {
+        return allVariantsAttributes;
+    }
+
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> buildVariantsForGraphTraversal(List<? extends ComponentVariant> variants) {
+        if (variants.isEmpty()) {
+            return maybeDeriveVariants();
+        }
+        ImmutableList.Builder<ConfigurationMetadata> configurations = new ImmutableList.Builder<ConfigurationMetadata>();
+        for (ComponentVariant variant : variants) {
+            configurations.add(new RealisedVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory()));
+        }
+        return Optional.<ImmutableList<? extends ConfigurationMetadata>>of(configurations.build());
+    }
+
+    protected static class NameOnlyVariantResolveMetadata implements VariantResolveMetadata {
+        private final String name;
+
+        public NameOnlyVariantResolveMetadata(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public DisplayName asDescribable() {
+            throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
+        }
+
+        @Override
+        public AttributeContainerInternal getAttributes() {
+            throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
+        }
+
+        @Override
+        public List<? extends ComponentArtifactMetadata> getArtifacts() {
+            throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
+        }
+
+        @Override
+        public CapabilitiesMetadata getCapabilities() {
+            throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,14 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantResolveMetadata;
@@ -42,22 +39,14 @@ import java.util.Set;
 /**
  * An immutable {@link ConfigurationMetadata} wrapper around a {@link ComponentVariant}.
  */
-class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
+class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadata {
     private final ModuleComponentIdentifier componentId;
     private final ComponentVariant variant;
     private final ImmutableList<GradleDependencyMetadata> dependencies;
-    private final VariantMetadataRules variantMetadataRules;
-    private final ImmutableAttributes componentLevelAttributes;
 
-    private List<GradleDependencyMetadata> calculatedDependencies;
-    private ImmutableAttributesFactory attributesFactory;
-
-    VariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules) {
+    AbstractVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant) {
         this.componentId = componentId;
-        this.variant = new RuleAwareVariant(variant);
-        this.attributesFactory = attributesFactory;
-        this.componentLevelAttributes = componentLevelAttributes;
-        this.variantMetadataRules = variantMetadataRules;
+        this.variant = variant;
         List<GradleDependencyMetadata> dependencies = new ArrayList<GradleDependencyMetadata>(variant.getDependencies().size());
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint(), dependency.getAttributes());
@@ -146,83 +135,11 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
     }
 
     @Override
-    public List<? extends DependencyMetadata> getDependencies() {
-        if (calculatedDependencies == null) {
-            calculatedDependencies = variantMetadataRules.applyDependencyMetadataRules(variant, dependencies);
-        }
-        return calculatedDependencies;
+    public List<? extends ModuleDependencyMetadata> getDependencies() {
+        return dependencies;
     }
 
-    private AttributeContainerInternal mergeComponentAndVariantAttributes(AttributeContainerInternal variantAttributes) {
-        return attributesFactory.concat(componentLevelAttributes, variantAttributes.asImmutable());
-    }
-
-    /**
-     * This class wraps the component variant so that attribute rules are executed once
-     * for all, and passed correctly to the various consumers. In particular, we need to make sure
-     * that the attributes are the same whenever we resolve the graph for dependencies and artifacts.
-     */
-    private class RuleAwareVariant implements ComponentVariant {
-        private final ComponentVariant delegate;
-
-        private ImmutableAttributes computedAttributes;
-        private CapabilitiesMetadata computedCapabilities;
-
-        private RuleAwareVariant(ComponentVariant delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public String getName() {
-            return delegate.getName();
-        }
-
-        @Override
-        public DisplayName asDescribable() {
-            return delegate.asDescribable();
-        }
-
-        /**
-         * Returns the complete set of attributes of this variant, which consists of a view of the union
-         * of the component level attributes and the variant attributes as found in metadata, potentially
-         * modified by rules.
-         *
-         * @return the updated variant attributes
-         */
-        @Override
-        public ImmutableAttributes getAttributes() {
-            if (computedAttributes == null) {
-                computedAttributes = variantMetadataRules.applyVariantAttributeRules(delegate, mergeComponentAndVariantAttributes(delegate.getAttributes()));
-            }
-            return computedAttributes;
-        }
-
-        @Override
-        public List<? extends ComponentArtifactMetadata> getArtifacts() {
-            return delegate.getArtifacts();
-        }
-
-        @Override
-        public ImmutableList<? extends Dependency> getDependencies() {
-            return delegate.getDependencies();
-        }
-
-        @Override
-        public ImmutableList<? extends DependencyConstraint> getDependencyConstraints() {
-            return delegate.getDependencyConstraints();
-        }
-
-        @Override
-        public ImmutableList<? extends File> getFiles() {
-            return delegate.getFiles();
-        }
-
-        @Override
-        public CapabilitiesMetadata getCapabilities() {
-            if (computedCapabilities == null) {
-                computedCapabilities = variantMetadataRules.applyCapabilitiesRules(delegate, delegate.getCapabilities());
-            }
-            return computedCapabilities;
-        }
+    protected ComponentVariant getVariant() {
+        return variant;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -17,41 +17,22 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.model.VariantResolveMetadata;
-import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
-import org.gradle.internal.component.model.IvyArtifactName;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Effectively immutable implementation of ConfigurationMetadata.
  * Used to represent Ivy and Maven modules in the dependency graph.
  */
-public class DefaultConfigurationMetadata implements ConfigurationMetadata, VariantResolveMetadata {
-    private final ModuleComponentIdentifier componentId;
-    private final String name;
-    private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
-    private final boolean transitive;
-    private final boolean visible;
-    private final ImmutableList<String> hierarchy;
-    private final VariantMetadataRules componentMetadataRules;
-    private final ImmutableList<ExcludeMetadata> excludes;
-    private final ImmutableAttributes attributes;
-    private final ImmutableCapabilities capabilities;
+public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata {
 
-    // Should be final, and set in constructor
-    private ImmutableList<ModuleDependencyMetadata> configDependencies;
+    private final VariantMetadataRules componentMetadataRules;
+
     private List<ModuleDependencyMetadata> calculatedDependencies;
 
     // Could be precomputed, but we avoid doing so if attributes are never requested
@@ -72,110 +53,36 @@ public class DefaultConfigurationMetadata implements ConfigurationMetadata, Vari
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes attributes,
                                          ImmutableList<ModuleDependencyMetadata> configDependencies) {
-        this.componentId = componentId;
-        this.name = name;
-        this.transitive = transitive;
-        this.visible = visible;
-        this.artifacts = artifacts;
-        this.hierarchy = hierarchy;
+        super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependencies, ImmutableCapabilities.EMPTY);
         this.componentMetadataRules = componentMetadataRules;
-        this.excludes = excludes;
-        this.attributes = attributes;
-        this.configDependencies = configDependencies;
-        this.capabilities = ImmutableCapabilities.EMPTY;
-    }
-
-    @Override
-    public DisplayName asDescribable() {
-        return Describables.of(componentId, "configuration", name);
-    }
-
-    @Override
-    public String toString() {
-        return asDescribable().getDisplayName();
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public Collection<String> getHierarchy() {
-        return hierarchy;
-    }
-
-    @Override
-    public boolean isTransitive() {
-        return transitive;
-    }
-
-    @Override
-    public boolean isVisible() {
-        return visible;
     }
 
     @Override
     public ImmutableAttributes getAttributes() {
         if (computedAttributes == null) {
-            computedAttributes = componentMetadataRules.applyVariantAttributeRules(this, attributes);
+            computedAttributes = componentMetadataRules.applyVariantAttributeRules(this, super.getAttributes());
         }
         return computedAttributes;
     }
 
     @Override
-    public boolean isCanBeConsumed() {
-        return true;
-    }
-
-    @Override
-    public boolean isCanBeResolved() {
-        return false;
-    }
-
-    @Override
     public List<? extends DependencyMetadata> getDependencies() {
         if (calculatedDependencies == null) {
-            calculatedDependencies = componentMetadataRules.applyDependencyMetadataRules(this, configDependencies);
+            calculatedDependencies = componentMetadataRules.applyDependencyMetadataRules(this, getConfigDependencies());
         }
         return calculatedDependencies;
-    }
-
-    protected void setDependencies(List<ModuleDependencyMetadata> dependencies) {
-        assert this.configDependencies == null; // Can only set once: should really be part of the constructor
-        this.configDependencies = ImmutableList.copyOf(dependencies);
-    }
-
-    @Override
-    public List<? extends ModuleComponentArtifactMetadata> getArtifacts() {
-        return artifacts;
     }
 
     @Override
     public CapabilitiesMetadata getCapabilities() {
         if (computedCapabilities == null) {
-            computedCapabilities = componentMetadataRules.applyCapabilitiesRules(this, capabilities);
+            computedCapabilities = componentMetadataRules.applyCapabilitiesRules(this, super.getCapabilities());
         }
         return computedCapabilities;
     }
 
-    @Override
-    public Set<? extends VariantResolveMetadata> getVariants() {
-        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
-    }
-
-    @Override
-    public ImmutableList<ExcludeMetadata> getExcludes() {
-        return excludes;
-    }
-
-    @Override
-    public ModuleComponentArtifactMetadata artifact(IvyArtifactName artifact) {
-        return new DefaultModuleComponentArtifactMetadata(componentId, artifact);
-    }
-
     protected DefaultConfigurationMetadata withAttributes(ImmutableAttributes attributes) {
-        return new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, attributes, configDependencies);
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadata.java
@@ -33,7 +33,6 @@ import static org.gradle.internal.component.external.model.DefaultMavenModuleRes
 
 public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableModuleComponentResolveMetadata implements MutableMavenModuleResolveMetadata {
 
-    private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
     private final boolean improvedPomSupportEnabled;
 
@@ -47,27 +46,25 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
                                                     boolean improvedPomSupportEnabled) {
         super(attributesFactory, id, componentIdentifier);
         this.dependencies = ImmutableList.copyOf(dependencies);
-        this.attributesFactory = attributesFactory;
         this.objectInstantiator = objectInstantiator;
         this.improvedPomSupportEnabled = improvedPomSupportEnabled;
     }
 
     DefaultMutableMavenModuleResolveMetadata(MavenModuleResolveMetadata metadata,
-                                             ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
+                                             NamedObjectInstantiator objectInstantiator,
                                              boolean improvedPomSupportEnabled) {
         super(metadata);
         this.packaging = metadata.getPackaging();
         this.relocated = metadata.isRelocated();
         this.snapshotTimestamp = metadata.getSnapshotTimestamp();
         this.dependencies = metadata.getDependencies();
-        this.attributesFactory = attributesFactory;
         this.objectInstantiator = objectInstantiator;
         this.improvedPomSupportEnabled = improvedPomSupportEnabled;
     }
 
     @Override
     public MavenModuleResolveMetadata asImmutable() {
-        return new DefaultMavenModuleResolveMetadata(this, attributesFactory, objectInstantiator, improvedPomSupportEnabled);
+        return new DefaultMavenModuleResolveMetadata(this);
     }
 
     @Override
@@ -119,5 +116,13 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     @Override
     public ImmutableList<MavenDependencyDescriptor> getDependencies() {
         return dependencies;
+    }
+
+    boolean isImprovedPomSupportEnabled() {
+        return improvedPomSupportEnabled;
+    }
+
+    NamedObjectInstantiator getObjectInstantiator() {
+        return objectInstantiator;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -24,13 +24,13 @@ import java.util.List;
 public class ImmutableCapabilities implements CapabilitiesMetadata {
     public static final ImmutableCapabilities EMPTY = new ImmutableCapabilities(ImmutableList.<ImmutableCapability>of());
 
-    private final ImmutableList<ImmutableCapability> capabilities;
+    private final ImmutableList<? extends Capability> capabilities;
 
-    public static ImmutableCapabilities of(List<ImmutableCapability> capabilities) {
+    public static ImmutableCapabilities of(List<? extends Capability> capabilities) {
         return new ImmutableCapabilities(ImmutableList.copyOf(capabilities));
     }
 
-    public ImmutableCapabilities(ImmutableList<ImmutableCapability> capabilities) {
+    public ImmutableCapabilities(ImmutableList<? extends Capability> capabilities) {
         this.capabilities = capabilities;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyConfigurationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/IvyConfigurationHelper.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.external.descriptor.Artifact;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.Exclude;
+import org.gradle.internal.component.model.ExcludeMetadata;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+class IvyConfigurationHelper {
+
+    private final ImmutableList<Artifact> artifactDefinitions;
+    private final Map<Artifact, ModuleComponentArtifactMetadata> artifacts;
+    private final ImmutableList<Exclude> excludes;
+    private final ImmutableList<IvyDependencyDescriptor> dependencies;
+    private final ModuleComponentIdentifier componentId;
+
+    public IvyConfigurationHelper(ImmutableList<Artifact> artifactDefinitions, Map<Artifact, ModuleComponentArtifactMetadata> artifacts, ImmutableList<Exclude> excludes, ImmutableList<IvyDependencyDescriptor> dependencies, ModuleComponentIdentifier componentId) {
+
+        this.artifactDefinitions = artifactDefinitions;
+        this.artifacts = artifacts;
+        this.excludes = excludes;
+        this.dependencies = dependencies;
+        this.componentId = componentId;
+    }
+
+    ImmutableList<ModuleComponentArtifactMetadata> filterArtifacts(String name, ImmutableList<String> hierarchy) {
+        Set<ModuleComponentArtifactMetadata> artifacts = new LinkedHashSet<ModuleComponentArtifactMetadata>();
+        collectArtifactsFor(name, artifacts);
+        for (String parent : hierarchy) {
+            collectArtifactsFor(parent, artifacts);
+        }
+        return ImmutableList.copyOf(artifacts);
+    }
+
+    private void collectArtifactsFor(String name, Collection<ModuleComponentArtifactMetadata> dest) {
+        for (Artifact artifact : artifactDefinitions) {
+            if (artifact.getConfigurations().contains(name)) {
+                ModuleComponentArtifactMetadata artifactMetadata = artifacts.get(artifact);
+                if (artifactMetadata == null) {
+                    artifactMetadata = new DefaultModuleComponentArtifactMetadata(componentId, artifact.getArtifactName());
+                    artifacts.put(artifact, artifactMetadata);
+                }
+                dest.add(artifactMetadata);
+            }
+        }
+    }
+
+    ImmutableList<ExcludeMetadata> filterExcludes(ImmutableList<String> hierarchy) {
+        ImmutableList.Builder<ExcludeMetadata> filtered = ImmutableList.builder();
+        for (Exclude exclude : excludes) {
+            for (String config : exclude.getConfigurations()) {
+                if (hierarchy.contains(config)) {
+                    filtered.add(exclude);
+                    break;
+                }
+            }
+        }
+        return filtered.build();
+    }
+
+    ImmutableList<ModuleDependencyMetadata> filterDependencies(ConfigurationMetadata config) {
+        ImmutableList.Builder<ModuleDependencyMetadata> filteredDependencies = ImmutableList.builder();
+        for (IvyDependencyDescriptor dependency : dependencies) {
+            if (include(dependency, config.getName(), config.getHierarchy())) {
+                filteredDependencies.add(contextualize(config, componentId, dependency));
+            }
+        }
+        return filteredDependencies.build();
+    }
+
+    private ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, IvyDependencyDescriptor incoming) {
+        return new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming);
+    }
+
+    private boolean include(IvyDependencyDescriptor dependency, String configName, Collection<String> hierarchy) {
+        Set<String> dependencyConfigurations = dependency.getConfMappings().keySet();
+        for (String moduleConfiguration : dependencyConfigurations) {
+            if (moduleConfiguration.equals("%") || hierarchy.contains(moduleConfiguration)) {
+                return true;
+            }
+            if (moduleConfiguration.equals("*")) {
+                boolean include = true;
+                for (String conf2 : dependencyConfigurations) {
+                    if (conf2.startsWith("!") && conf2.substring(1).equals(configName)) {
+                        include = false;
+                        break;
+                    }
+                }
+                if (include) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+
+import java.util.List;
+
+/**
+ * An immutable {@link ConfigurationMetadata} wrapper around a {@link ComponentVariant}.
+ */
+class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfigurationMetadata {
+    private final VariantMetadataRules variantMetadataRules;
+
+    private List<? extends ModuleDependencyMetadata> calculatedDependencies;
+
+    LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules) {
+        super(componentId, new RuleAwareVariant(variant, attributesFactory, componentLevelAttributes, variantMetadataRules));
+        this.variantMetadataRules = variantMetadataRules;
+    }
+
+    @Override
+    public List<? extends ModuleDependencyMetadata> getDependencies() {
+        if (calculatedDependencies == null) {
+            calculatedDependencies = variantMetadataRules.applyDependencyMetadataRules(getVariant(), super.getDependencies());
+        }
+        return calculatedDependencies;
+    }
+
+    /**
+     * This class wraps the component variant so that attribute rules are executed once
+     * for all, and passed correctly to the various consumers. In particular, we need to make sure
+     * that the attributes are the same whenever we resolve the graph for dependencies and artifacts.
+     */
+    private static class RuleAwareVariant implements ComponentVariant {
+        private final ImmutableAttributesFactory attributesFactory;
+        private final ComponentVariant delegate;
+        private final ImmutableAttributes componentLevelAttributes;
+        private final VariantMetadataRules variantMetadataRules;
+
+        private ImmutableAttributes computedAttributes;
+        private CapabilitiesMetadata computedCapabilities;
+
+        RuleAwareVariant(ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules) {
+            this.attributesFactory = attributesFactory;
+            this.delegate = delegate;
+            this.componentLevelAttributes = componentLevelAttributes;
+            this.variantMetadataRules = variantMetadataRules;
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        public DisplayName asDescribable() {
+            return delegate.asDescribable();
+        }
+
+        /**
+         * Returns the complete set of attributes of this variant, which consists of a view of the union
+         * of the component level attributes and the variant attributes as found in metadata, potentially
+         * modified by rules.
+         *
+         * @return the updated variant attributes
+         */
+        @Override
+        public ImmutableAttributes getAttributes() {
+            if (computedAttributes == null) {
+                computedAttributes = variantMetadataRules.applyVariantAttributeRules(delegate, mergeComponentAndVariantAttributes(delegate.getAttributes()));
+            }
+            return computedAttributes;
+        }
+
+        @Override
+        public List<? extends ComponentArtifactMetadata> getArtifacts() {
+            return delegate.getArtifacts();
+        }
+
+        @Override
+        public ImmutableList<? extends Dependency> getDependencies() {
+            return delegate.getDependencies();
+        }
+
+        @Override
+        public ImmutableList<? extends DependencyConstraint> getDependencyConstraints() {
+            return delegate.getDependencyConstraints();
+        }
+
+        @Override
+        public ImmutableList<? extends File> getFiles() {
+            return delegate.getFiles();
+        }
+
+        @Override
+        public CapabilitiesMetadata getCapabilities() {
+            if (computedCapabilities == null) {
+                computedCapabilities = variantMetadataRules.applyCapabilitiesRules(delegate, delegate.getCapabilities());
+            }
+            return computedCapabilities;
+        }
+
+        private AttributeContainerInternal mergeComponentAndVariantAttributes(AttributeContainerInternal variantAttributes) {
+            return attributesFactory.concat(componentLevelAttributes, variantAttributes.asImmutable());
+        }
+
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+
+import java.util.List;
+
+public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata {
+
+    public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
+                                         ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         ImmutableList<ExcludeMetadata> excludes,
+                                         ImmutableAttributes componentLevelAttributes) {
+        // TODO LJA
+        super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, componentLevelAttributes, null, null);
+    }
+
+    @Override
+    public List<? extends DependencyMetadata> getDependencies() {
+        return getConfigDependencies();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedIvyModuleResolveMetadata.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.external.descriptor.Artifact;
+import org.gradle.internal.component.external.descriptor.Configuration;
+import org.gradle.internal.component.model.Exclude;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.util.CollectionUtils;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComponentResolveMetadata implements IvyModuleResolveMetadata {
+
+    public static RealisedIvyModuleResolveMetadata transform(DefaultIvyModuleResolveMetadata metadata) {
+        VariantMetadataRules variantMetadataRules = metadata.getVariantMetadataRules();
+        HashSet<String> remainingVariants = Sets.newHashSet(variantMetadataRules.getSeenVariants());
+        boolean allVariantsUsed = variantMetadataRules.isSeenAllVariants();
+        ImmutableList<? extends ComponentVariant> variants = enrichVariants(metadata, variantMetadataRules, metadata.getVariants(), remainingVariants);
+        Map<String, ImmutableAttributes> potentialVariantToAttributesMap = Maps.newHashMapWithExpectedSize(remainingVariants.size());
+        for (String variant : remainingVariants) {
+            ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(new NameOnlyVariantResolveMetadata(variant), ImmutableAttributes.EMPTY);
+            potentialVariantToAttributesMap.put(variant, variantAttributes);
+        }
+        ImmutableAttributes allVariantsAttributes;
+        if (allVariantsUsed) {
+            allVariantsAttributes = variantMetadataRules.applyVariantAttributeRules(new NameOnlyVariantResolveMetadata(ALL_VARIANTS_NAME), ImmutableAttributes.EMPTY);
+        } else {
+            allVariantsAttributes = ImmutableAttributes.EMPTY;
+        }
+        return new RealisedIvyModuleResolveMetadata(metadata, variants, potentialVariantToAttributesMap, allVariantsAttributes);
+    }
+
+    private final ImmutableMap<String, Configuration> configurationDefinitions;
+    private final ImmutableList<IvyDependencyDescriptor> dependencies;
+    private final ImmutableList<Artifact> artifactDefinitions;
+    private final ImmutableList<Exclude> excludes;
+    private final ImmutableMap<NamespaceId, String> extraAttributes;
+    private final String branch;
+    private Map<Artifact, ModuleComponentArtifactMetadata> artifacts;
+
+    public RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, List<IvyDependencyDescriptor> dependencies) {
+        super(metadata);
+        this.configurationDefinitions = metadata.getConfigurationDefinitions();
+        this.branch = metadata.getBranch();
+        this.artifactDefinitions = metadata.getArtifactDefinitions();
+        this.dependencies = ImmutableList.copyOf(dependencies);
+        this.excludes = metadata.getExcludes();
+        this.extraAttributes = metadata.getExtraAttributes();
+    }
+
+    public RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, ModuleSource source) {
+        super(metadata, source);
+        this.configurationDefinitions = metadata.configurationDefinitions;
+        this.branch = metadata.branch;
+        this.artifactDefinitions = metadata.artifactDefinitions;
+        this.dependencies = metadata.dependencies;
+        this.excludes = metadata.excludes;
+        this.extraAttributes = metadata.extraAttributes;
+
+        copyCachedState(metadata);
+    }
+
+    public RealisedIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata mutableMetadata, ImmutableList<? extends ComponentVariant> variants, Map<String, ImmutableAttributes> potentialVariantToAttributesMap, ImmutableAttributes allVariantsAttributes) {
+        super(mutableMetadata, variants, potentialVariantToAttributesMap, allVariantsAttributes);
+        this.configurationDefinitions = mutableMetadata.getConfigurationDefinitions();
+        this.branch = mutableMetadata.getBranch();
+        this.artifactDefinitions = mutableMetadata.getArtifactDefinitions();
+        this.dependencies = mutableMetadata.getDependencies();
+        this.excludes = mutableMetadata.getExcludes();
+        this.extraAttributes = mutableMetadata.getExtraAttributes();
+    }
+
+    @Override
+    protected RealisedConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, Map<String, ImmutableAttributes> potentialVariantToAttributesMap, ImmutableAttributes allVariantsAttributes) {
+        if (artifacts == null) {
+            artifacts = new IdentityHashMap<Artifact, ModuleComponentArtifactMetadata>();
+        }
+        IvyConfigurationHelper configurationHelper = new IvyConfigurationHelper(artifactDefinitions, artifacts, excludes, dependencies, componentId);
+        ImmutableList<ModuleComponentArtifactMetadata> artifacts = configurationHelper.filterArtifacts(name, hierarchy);
+        ImmutableList<ExcludeMetadata> excludesForConfiguration = configurationHelper.filterExcludes(hierarchy);
+
+        RealisedConfigurationMetadata configuration = new RealisedConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), excludesForConfiguration, getAttributes().asImmutable());
+        configuration.setDependencies(configurationHelper.filterDependencies(configuration));
+        return configuration;
+    }
+
+    @Override
+    public MutableIvyModuleResolveMetadata asMutable() {
+        throw new UnsupportedOperationException("Implement me!");
+    }
+
+    @Override
+    public IvyModuleResolveMetadata withSource(ModuleSource source) {
+        return new RealisedIvyModuleResolveMetadata(this, source);
+    }
+
+    @Nullable
+    @Override
+    public String getBranch() {
+        return branch;
+    }
+
+    @Override
+    public ImmutableMap<String, Configuration> getConfigurationDefinitions() {
+        return configurationDefinitions;
+    }
+
+    @Override
+    public ImmutableList<Artifact> getArtifactDefinitions() {
+        return artifactDefinitions;
+    }
+
+    @Override
+    public ImmutableList<Exclude> getExcludes() {
+        return excludes;
+    }
+
+    @Override
+    public ImmutableMap<NamespaceId, String> getExtraAttributes() {
+        return extraAttributes;
+    }
+
+    @Override
+    public IvyModuleResolveMetadata withDynamicConstraintVersions() {
+        List<IvyDependencyDescriptor> transformed = CollectionUtils.collect(getDependencies(), new Transformer<IvyDependencyDescriptor, IvyDependencyDescriptor>() {
+            @Override
+            public IvyDependencyDescriptor transform(IvyDependencyDescriptor dependency) {
+                ModuleComponentSelector selector = dependency.getSelector();
+                String dynamicConstraintVersion = dependency.getDynamicConstraintVersion();
+                ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), dynamicConstraintVersion);
+                return dependency.withRequested(newSelector);
+            }
+        });
+        return this.withDependencies(transformed);
+    }
+
+    @Override
+    public ImmutableList<IvyDependencyDescriptor> getDependencies() {
+        return dependencies;
+    }
+
+    private IvyModuleResolveMetadata withDependencies(List<IvyDependencyDescriptor> transformed) {
+        return new RealisedIvyModuleResolveMetadata(this, transformed);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedMutableIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedMutableIvyModuleResolveMetadata.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+public abstract class RealisedMutableIvyModuleResolveMetadata implements MutableIvyModuleResolveMetadata {
+    public RealisedMutableIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata realisedIvyModuleResolveMetadata) {
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+
+public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantBackedConfigurationMetadata {
+
+    private final ImmutableAttributes attributes;
+
+    public RealisedVariantBackedConfigurationMetadata(ModuleComponentIdentifier id, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory) {
+        super(id, variant);
+        attributes = attributesFactory.concat(variant.getAttributes().asImmutable(), componentLevelAttributes);
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return attributes;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
@@ -22,8 +22,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
-import org.gradle.api.internal.changedetection.state.SnapshotSerializer;
-import org.gradle.api.internal.changedetection.state.ValueSnapshot;
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
 import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
 import org.gradle.api.logging.Logger;
@@ -34,6 +32,7 @@ import org.gradle.cache.PersistentCache;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.PersistentIndexedCacheParameters;
 import org.gradle.cache.internal.filelock.LockOptionsBuilder;
+import org.gradle.caching.internal.DefaultBuildCacheHasher;
 import org.gradle.internal.Cast;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.action.ConfigurableRule;
@@ -44,6 +43,7 @@ import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.HashCodeSerializer;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.util.BuildCommencedTimeProvider;
 
@@ -62,7 +62,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
     private final ValueSnapshotter snapshotter;
     private final Transformer<Serializable, KEY> ketToSnapshottable;
     private final PersistentCache cache;
-    private final PersistentIndexedCache<ValueSnapshot, CachedEntry<RESULT>> store;
+    private final PersistentIndexedCache<HashCode, CachedEntry<RESULT>> store;
     private final BuildCommencedTimeProvider timeProvider;
     private final EntryValidator<RESULT> validator;
 
@@ -82,16 +82,14 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
             .cache(name)
             .withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.None))
             .open();
-        PersistentIndexedCacheParameters<ValueSnapshot, CachedEntry<RESULT>> cacheParams = createCacheConfiguration(name, resultSerializer, cacheDecoratorFactory);
+        PersistentIndexedCacheParameters<HashCode, CachedEntry<RESULT>> cacheParams = createCacheConfiguration(name, resultSerializer, cacheDecoratorFactory);
         this.store = this.cache.createCache(cacheParams);
     }
 
-    private PersistentIndexedCacheParameters<ValueSnapshot, CachedEntry<RESULT>> createCacheConfiguration(String name, Serializer<RESULT> resultSerializer, InMemoryCacheDecoratorFactory cacheDecoratorFactory) {
-        Serializer<ValueSnapshot> snapshotSerializer = new SnapshotSerializer();
-
-        PersistentIndexedCacheParameters<ValueSnapshot, CachedEntry<RESULT>> cacheParams = new PersistentIndexedCacheParameters<ValueSnapshot, CachedEntry<RESULT>>(
+    private PersistentIndexedCacheParameters<HashCode, CachedEntry<RESULT>> createCacheConfiguration(String name, Serializer<RESULT> resultSerializer, InMemoryCacheDecoratorFactory cacheDecoratorFactory) {
+        PersistentIndexedCacheParameters<HashCode, CachedEntry<RESULT>> cacheParams = new PersistentIndexedCacheParameters<HashCode, CachedEntry<RESULT>>(
             name,
-            snapshotSerializer,
+            new HashCodeSerializer(),
             createEntrySerializer(resultSerializer)
         );
         cacheParams.cacheDecorator(cacheDecoratorFactory.decorator(2000, true));
@@ -116,14 +114,14 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
     }
 
     private <D extends DETAILS> RESULT tryFromCache(KEY key, InstantiatingAction<DETAILS> action, Transformer<RESULT, D> detailsToResult, Transformer<D, KEY> onCacheMiss, CachePolicy cachePolicy, ConfigurableRules<DETAILS> rules) {
-        final ValueSnapshot snapshot = computeExplicitInputsSnapshot(key, rules);
+        final HashCode keyHash = computeExplicitInputsSnapshot(key, rules);
         DefaultImplicitInputRegistrar registrar = new DefaultImplicitInputRegistrar();
         ImplicitInputsCapturingInstantiator instantiator = findInputCapturingInstantiator(action);
         if (instantiator != null) {
             action = action.withInstantiator(instantiator.capturing(registrar));
         }
         // First step is to find an entry with the explicit inputs in the cache
-        CachedEntry<RESULT> entry = store.get(snapshot);
+        CachedEntry<RESULT> entry = store.get(keyHash);
         if (entry != null) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Found result for rule {} and key {} in cache", rules, key);
@@ -139,7 +137,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
         }
 
         RESULT result = executeRule(key, action, detailsToResult, onCacheMiss);
-        store.put(snapshot, new CachedEntry<RESULT>(timeProvider.getCurrentTime(), registrar.implicits, result));
+        store.put(keyHash, new CachedEntry<RESULT>(timeProvider.getCurrentTime(), registrar.implicits, result));
         return result;
     }
 
@@ -150,7 +148,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
      * @param rules the rules to be snapshotted
      * @return a snapshot of the inputs
      */
-    private ValueSnapshot computeExplicitInputsSnapshot(KEY key, ConfigurableRules<DETAILS> rules) {
+    private HashCode computeExplicitInputsSnapshot(KEY key, ConfigurableRules<DETAILS> rules) {
         List<Object> toBeSnapshotted = Lists.newArrayListWithExpectedSize(2 + 2 * rules.getConfigurableRules().size());
         toBeSnapshotted.add(ketToSnapshottable.transform(key));
         for (ConfigurableRule<DETAILS> rule : rules.getConfigurableRules()) {
@@ -159,7 +157,9 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
             toBeSnapshotted.add(ruleClass);
             toBeSnapshotted.add(ruleParams);
         }
-        return snapshotter.snapshot(toBeSnapshotted);
+        DefaultBuildCacheHasher hasher = new DefaultBuildCacheHasher();
+        snapshotter.snapshot(toBeSnapshotted).appendToHasher(hasher);
+        return hasher.hash();
     }
 
     private ImplicitInputsCapturingInstantiator findInputCapturingInstantiator(InstantiatingAction<DETAILS> action) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/FullAttributeContainerSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/FullAttributeContainerSerializer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.resolve.caching;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * A lossy attribute container serializer. It's lossy because it doesn't preserve the attribute
+ * types: it will serialize the contents as strings, and read them as strings, only for reporting
+ * purposes.
+ */
+public class FullAttributeContainerSerializer implements AttributeContainerSerializer {
+    private final ImmutableAttributesFactory attributesFactory;
+
+    private static final byte STRING_ATTRIBUTE = 1;
+    private static final byte BOOLEAN_ATTRIBUTE = 2;
+    private static final byte SERIALIZED_ATTRIBUTE = 3;
+
+    public FullAttributeContainerSerializer(ImmutableAttributesFactory attributesFactory) {
+        this.attributesFactory = attributesFactory;
+    }
+
+    @Override
+    public ImmutableAttributes read(Decoder decoder) throws IOException {
+        ImmutableAttributes attributes = ImmutableAttributes.EMPTY;
+        int count = decoder.readSmallInt();
+        for (int i = 0; i < count; i++) {
+            String name = decoder.readString();
+            byte type = decoder.readByte();
+            if (type == BOOLEAN_ATTRIBUTE) {
+                attributes = attributesFactory.concat(attributes, Attribute.of(name, Boolean.class), decoder.readBoolean());
+            } else if (type == STRING_ATTRIBUTE){
+                String value = decoder.readString();
+                attributes = attributesFactory.concat(attributes, Attribute.of(name, String.class), value);
+            } else if (type == SERIALIZED_ATTRIBUTE) {
+                Object value;
+                byte[] valueBytes = new byte[decoder.readInt()];
+                decoder.readBytes(valueBytes);
+                ByteArrayInputStream inputStream;
+                try {
+                    inputStream = new ByteArrayInputStream(valueBytes);
+                    ObjectInputStream objectInputStream = new ObjectInputStream(inputStream);
+                    value = objectInputStream.readObject();
+                } catch (ClassNotFoundException e) {
+                    throw new GradleException("Unable to load attribute value", e);
+                }
+                // Ugly cast to make compiler happy - ideally it would notice that value and value.getClass() _must_ satisfy the contract
+                attributes = attributesFactory.concat(attributes, Attribute.of(name, (Class<Object>) value.getClass()), value);
+            }
+        }
+        return attributes;
+    }
+
+    @Override
+    public void write(Encoder encoder, AttributeContainer container) throws IOException {
+        encoder.writeSmallInt(container.keySet().size());
+        for (Attribute<?> attribute : container.keySet()) {
+            encoder.writeString(attribute.getName());
+            if (attribute.getType().equals(Boolean.class)) {
+                encoder.writeByte(BOOLEAN_ATTRIBUTE);
+                encoder.writeBoolean((Boolean) container.getAttribute(attribute));
+            } else if (attribute.getType().equals(String.class)){
+                encoder.writeByte(STRING_ATTRIBUTE);
+                encoder.writeString((String) container.getAttribute(attribute));
+            } else {
+                assert Serializable.class.isAssignableFrom(attribute.getType());
+                Object attributeValue = container.getAttribute(attribute);
+                encoder.writeByte(SERIALIZED_ATTRIBUTE);
+                ByteArrayOutputStream outputStream;
+                try {
+                    outputStream = new ByteArrayOutputStream();
+                    ObjectOutputStream objectStr = new ObjectOutputStream(outputStream);
+                    objectStr.writeObject(attributeValue);
+                    objectStr.flush();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                byte[] bytes = outputStream.toByteArray();
+                encoder.writeInt(bytes.length);
+                encoder.writeBytes(bytes);
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.LossyAttributeContainerSerializer
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.serialize.SerializerSpec
 import spock.lang.Unroll
@@ -27,7 +27,7 @@ import static org.gradle.util.TestUtil.attributes
 import static org.gradle.util.TestUtil.attributesFactory
 
 class ModuleComponentSelectorSerializerTest extends SerializerSpec {
-    private serializer = new ModuleComponentSelectorSerializer(new AttributeContainerSerializer(attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    private serializer = new ModuleComponentSelectorSerializer(new LossyAttributeContainerSerializer(attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     @Unroll
     def "serializes"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.LossyAttributeContainerSerializer
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.file.TestFiles
@@ -148,7 +148,7 @@ class ModuleMetadataSerializerTest extends Specification {
 
     private ModuleMetadataSerializer moduleMetadataSerializer() {
         new ModuleMetadataSerializer(
-            new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE),
+            new LossyAttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE),
             mavenMetadataFactory,
             ivyMetadataFactory
         )

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier.n
 
 class ComponentResultSerializerTest extends SerializerSpec {
 
-    def serializer = new ComponentResultSerializer(new DefaultImmutableModuleIdentifierFactory(), new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    def serializer = new ComponentResultSerializer(new DefaultImmutableModuleIdentifierFactory(), new LossyAttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     def "serializes"() {
         def componentIdentifier = new DefaultModuleComponentIdentifier('group', 'module', 'version')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -42,7 +42,7 @@ import static org.gradle.util.Path.path
 class ComponentSelectorSerializerTest extends SerializerSpec {
     private final VersionParser versionParser = new VersionParser()
     private final DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
-    private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new LossyAttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     private ImmutableVersionConstraint constraint(String version, boolean strict = false) {
         def reject = strict ? versionSelectorScheme.complementForRejection(versionSelectorScheme.parseSelector(version)) : null

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -39,7 +39,7 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 class StreamingResolutionResultBuilderTest extends Specification {
 
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    StreamingResolutionResultBuilder builder = new StreamingResolutionResultBuilder(new DummyBinaryStore(), new DummyStore(), moduleIdentifierFactory, new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    StreamingResolutionResultBuilder builder = new StreamingResolutionResultBuilder(new DummyBinaryStore(), new DummyStore(), moduleIdentifierFactory, new LossyAttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     def "result can be read multiple times"() {
         def rootNode = rootNode(1, "org", "root", "1.0")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadataTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
-abstract class AbstractModuleComponentResolveMetadataTest extends Specification {
+abstract class AbstractLazyModuleComponentResolveMetadataTest extends Specification {
 
     def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
     def configurations = []

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.util.TestUtil
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
-class DefaultIvyModuleResolveMetadataTest extends AbstractModuleComponentResolveMetadataTest {
+class DefaultIvyModuleResolveMetadataTest extends AbstractLazyModuleComponentResolveMetadataTest {
     def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -34,7 +34,7 @@ import spock.lang.Unroll
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
-class DefaultMavenModuleResolveMetadataTest extends AbstractModuleComponentResolveMetadataTest {
+class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentResolveMetadataTest {
 
     private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataSupplierRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataSupplierRuleExecutorTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.cache.CacheDecorator
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.PersistentIndexedCache
+import org.gradle.caching.internal.DefaultBuildCacheHasher
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
@@ -96,6 +97,9 @@ class ComponentMetadataSupplierRuleExecutorTest extends Specification {
     def "expires entry when cache policy tells us to"() {
         def id = DefaultModuleVersionIdentifier.newId('org', 'foo', '1.0')
         def inputsSnapshot = new StringValueSnapshot("1")
+        def hasher = new DefaultBuildCacheHasher()
+        inputsSnapshot.appendToHasher(hasher)
+        def keyHash = hasher.hash()
         def cachedResult = Mock(ComponentMetadata)
         Multimap<String, ImplicitInputRecord<?, ?>> implicits = HashMultimap.create()
         def record = Mock(ImplicitInputRecord)
@@ -116,7 +120,7 @@ class ComponentMetadataSupplierRuleExecutorTest extends Specification {
 
         then:
         1 * valueSnapshotter.snapshot(_) >> inputsSnapshot
-        1 * store.get(inputsSnapshot) >> cachedEntry
+        1 * store.get(keyHash) >> cachedEntry
         if (expired) {
             // should check that the recorded service call returns the same value
             1 * record.getInput() >> '124'
@@ -139,7 +143,7 @@ class ComponentMetadataSupplierRuleExecutorTest extends Specification {
             }
             1 * onCacheMiss.transform(id) >> details
             1 * detailsToResult.transform(details) >> Mock(ComponentMetadata)
-            1 * store.put(inputsSnapshot, _)
+            1 * store.put(keyHash, _)
         }
         if (ruleClass == TestSupplierWithService && reexecute) {
             1 * someService.provide()


### PR DESCRIPTION
This creates a hierarchy below `AbstractModuleComponentResolveMetadata` where one side is lazy and the other eager.

This is work in progress, looking for feedback on the approach.