### PR TITLE
Improve efficiency of registration of lazy task configuration actions

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/ImmutableActionSet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/ImmutableActionSet.java
@@ -94,6 +94,22 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
     }
 
     /**
+     * Creates a new set that includes the actions from this set plus the actions from the given set.
+     */
+    public ImmutableActionSet<T> mergeFrom(ImmutableActionSet<? super T> sibling) {
+        if (sibling == this) {
+            return this;
+        }
+        if (sibling.isEmpty()) {
+            return this;
+        }
+        if (isEmpty()) {
+            return (ImmutableActionSet<T>) sibling;
+        }
+        return of(this, sibling);
+    }
+
+    /**
      * Does this set do anything?
      */
     public abstract boolean isEmpty();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/ImmutableActionSet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/ImmutableActionSet.java
@@ -29,6 +29,7 @@ import org.gradle.api.Action;
  * @param <T> the type of the subject of the action
  */
 public abstract class ImmutableActionSet<T> implements Action<T> {
+    private static final int FEW_VALUES = 5;
     private static final ImmutableActionSet<Object> EMPTY = new EmptySet<Object>();
 
     /**
@@ -54,26 +55,19 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
             unpackAction(action, builder);
         }
         ImmutableSet<Action<? super T>> set = builder.build();
-        if (set.isEmpty()) {
-            return empty();
-        }
-        if (set.size() == 1) {
-            return new SingletonSet<T>(set.iterator().next());
-        }
-        return new CompositeSet<T>(set);
+        return fromActions(set);
     }
 
     private static <T> void unpackAction(Action<? super T> action, ImmutableSet.Builder<Action<? super T>> builder) {
-        if (action instanceof SingletonSet) {
-            SingletonSet<T> singletonSet = (SingletonSet) action;
-            builder.add(singletonSet.singleAction);
-        } else if (action instanceof CompositeSet) {
-            CompositeSet<T> compositeSet = (CompositeSet) action;
-            builder.addAll(compositeSet.multipleActions);
+        if (action instanceof ImmutableActionSet) {
+            ImmutableActionSet<T> immutableSet = (ImmutableActionSet<T>) action;
+            immutableSet.unpackInto(builder);
         } else {
             builder.add(action);
         }
     }
+
+    protected abstract void unpackInto(ImmutableSet.Builder<Action<? super T>> builder);
 
     /**
      * Creates a new set that runs the actions of this set plus the given action.
@@ -84,13 +78,46 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
         }
         if (action instanceof SingletonSet) {
             SingletonSet<T> singletonSet = (SingletonSet) action;
-            return doAdd(singletonSet.singleAction);
+            return addOne(singletonSet.singleAction);
         }
-        if (action instanceof CompositeSet) {
-            CompositeSet<T> compositeSet = (CompositeSet) action;
-            return doAddAll(compositeSet);
+        if (action instanceof SetWithFewActions) {
+            SetWithFewActions<T> compositeSet = (SetWithFewActions<T>) action;
+            return addAll(compositeSet);
         }
-        return doAdd(action);
+        if (action instanceof SetWithManyActions) {
+            SetWithManyActions<T> compositeSet = (SetWithManyActions) action;
+            return addAll(compositeSet);
+        }
+        return addOne(action);
+    }
+
+    private static <T> ImmutableActionSet<T> plus(ImmutableActionSet<T> one, ImmutableActionSet<T> two) {
+        ImmutableSet.Builder<Action<? super T>> builder = ImmutableSet.builder();
+        one.unpackInto(builder);
+        two.unpackInto(builder);
+        ImmutableSet<Action<? super T>> set = builder.build();
+        return fromActions(set);
+    }
+
+    private static <T> ImmutableActionSet<T> plus(ImmutableActionSet<T> one, Action<? super T> two) {
+        ImmutableSet.Builder<Action<? super T>> builder = ImmutableSet.builder();
+        one.unpackInto(builder);
+        builder.add(two);
+        ImmutableSet<Action<? super T>> set = builder.build();
+        return fromActions(set);
+    }
+
+    private static <T> ImmutableActionSet<T> fromActions(ImmutableSet<Action<? super T>> set) {
+        if (set.isEmpty()) {
+            return empty();
+        }
+        if (set.size() == 1) {
+            return new SingletonSet<T>(set.iterator().next());
+        }
+        if (set.size() <= FEW_VALUES) {
+            return new SetWithFewActions<T>(set);
+        }
+        return new SetWithManyActions<T>(set);
     }
 
     /**
@@ -106,7 +133,7 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
         if (isEmpty()) {
             return (ImmutableActionSet<T>) sibling;
         }
-        return of(this, sibling);
+        return add(sibling);
     }
 
     /**
@@ -114,19 +141,30 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
      */
     public abstract boolean isEmpty();
 
-    abstract ImmutableActionSet<T> doAddAll(CompositeSet<T> source);
+    abstract ImmutableActionSet<T> addAll(SetWithFewActions<T> source);
 
-    abstract ImmutableActionSet<T> doAdd(Action<? super T> action);
+    abstract ImmutableActionSet<T> addAll(SetWithManyActions<T> source);
+
+    abstract ImmutableActionSet<T> addOne(Action<? super T> action);
 
     private static class EmptySet<T> extends ImmutableActionSet<T> {
         @Override
-        ImmutableActionSet<T> doAdd(Action<? super T> action) {
+        ImmutableActionSet<T> addOne(Action<? super T> action) {
             return new SingletonSet<T>(action);
         }
 
         @Override
-        ImmutableActionSet<T> doAddAll(CompositeSet<T> source) {
+        ImmutableActionSet<T> addAll(SetWithManyActions<T> source) {
             return source;
+        }
+
+        @Override
+        ImmutableActionSet<T> addAll(SetWithFewActions<T> source) {
+            return source;
+        }
+
+        @Override
+        protected void unpackInto(ImmutableSet.Builder<Action<? super T>> builder) {
         }
 
         @Override
@@ -147,23 +185,37 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
         }
 
         @Override
-        ImmutableActionSet<T> doAdd(Action<? super T> action) {
+        ImmutableActionSet<T> addOne(Action<? super T> action) {
             if (action.equals(singleAction)) {
                 return this;
             }
-            ImmutableSet<Action<? super T>> of = Cast.uncheckedCast(ImmutableSet.of(singleAction, action));
-            return new CompositeSet<T>(of);
+            return new SetWithFewActions<T>(new Action[]{singleAction, action});
         }
 
         @Override
-        ImmutableActionSet<T> doAddAll(CompositeSet<T> source) {
-            if (source.multipleActions.contains(singleAction)) {
+        ImmutableActionSet<T> addAll(SetWithFewActions<T> source) {
+            if (singleAction.equals(source.actions[0])) {
+                // Already at the front. If not at the front, need to recreate
                 return source;
             }
-            ImmutableSet.Builder<Action<? super T>> builder = ImmutableSet.builder();
+            if (source.actions.length < FEW_VALUES && !source.contains(singleAction)) {
+                // Adding a small set with no duplicates
+                Action<? super T>[] newActions = new Action[source.actions.length + 1];
+                newActions[0] = singleAction;
+                System.arraycopy(source.actions, 0, newActions, 1, source.actions.length);
+                return new SetWithFewActions<T>(newActions);
+            }
+            return plus(this, source);
+        }
+
+        @Override
+        ImmutableActionSet<T> addAll(SetWithManyActions<T> source) {
+            return plus(this, source);
+        }
+
+        @Override
+        protected void unpackInto(ImmutableSet.Builder<Action<? super T>> builder) {
             builder.add(singleAction);
-            builder.addAll(source.multipleActions);
-            return new CompositeSet<T>(builder.build());
         }
 
         @Override
@@ -177,33 +229,96 @@ public abstract class ImmutableActionSet<T> implements Action<T> {
         }
     }
 
-    private static class CompositeSet<T> extends ImmutableActionSet<T> {
+    private static class SetWithFewActions<T> extends ImmutableActionSet<T> {
+        private final Action<? super T> actions[];
+
+        SetWithFewActions(ImmutableSet<Action<? super T>> set) {
+            actions = set.toArray(new Action[set.size()]);
+        }
+
+        SetWithFewActions(Action<? super T>[] actions) {
+            this.actions = actions;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        ImmutableActionSet<T> addOne(Action<? super T> action) {
+            if (contains(action)) {
+                // Duplicate, ignore
+                return this;
+            }
+            if (actions.length < FEW_VALUES) {
+                // Adding an action that is not a duplicate
+                Action<? super T>[] newActions = new Action[actions.length + 1];
+                System.arraycopy(actions, 0, newActions, 0, actions.length);
+                newActions[actions.length] = action;
+                return new SetWithFewActions<T>(newActions);
+            }
+
+            return plus(this, action);
+        }
+
+        @Override
+        ImmutableActionSet<T> addAll(SetWithFewActions<T> source) {
+            return plus(this, source);
+        }
+
+        @Override
+        ImmutableActionSet<T> addAll(SetWithManyActions<T> source) {
+            return plus(this, source);
+        }
+
+        @Override
+        protected void unpackInto(ImmutableSet.Builder<Action<? super T>> builder) {
+            builder.add(actions);
+        }
+
+        @Override
+        public void execute(T t) {
+            for (Action<? super T> action : actions) {
+                action.execute(t);
+            }
+        }
+
+        public boolean contains(Action<? super T> action) {
+            for (Action<? super T> current : actions) {
+                if (current.equals(action)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static class SetWithManyActions<T> extends ImmutableActionSet<T> {
         private final ImmutableSet<Action<? super T>> multipleActions;
 
-        CompositeSet(ImmutableSet<Action<? super T>> multipleActions) {
+        SetWithManyActions(ImmutableSet<Action<? super T>> multipleActions) {
             this.multipleActions = multipleActions;
         }
 
         @Override
-        ImmutableActionSet<T> doAdd(Action<? super T> action) {
-            if (multipleActions.contains(action)) {
-                return this;
-            }
-            ImmutableSet.Builder<Action<? super T>> builder = ImmutableSet.builder();
-            builder.addAll(multipleActions);
-            builder.add(action);
-            return new CompositeSet<T>(builder.build());
+        ImmutableActionSet<T> addOne(Action<? super T> action) {
+            return plus(this, action);
         }
 
         @Override
-        ImmutableActionSet<T> doAddAll(CompositeSet<T> source) {
-            if (multipleActions.containsAll(source.multipleActions)) {
-                return this;
-            }
-            ImmutableSet.Builder<Action<? super T>> builder = ImmutableSet.builder();
+        ImmutableActionSet<T> addAll(SetWithManyActions<T> source) {
+            return plus(this, source);
+        }
+
+        @Override
+        ImmutableActionSet<T> addAll(SetWithFewActions<T> source) {
+            return plus(this, source);
+        }
+
+        @Override
+        protected void unpackInto(ImmutableSet.Builder<Action<? super T>> builder) {
             builder.addAll(multipleActions);
-            builder.addAll(source.multipleActions);
-            return new CompositeSet<T>(builder.build());
         }
 
         @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/ImmutableActionSetTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/ImmutableActionSetTest.groovy
@@ -103,39 +103,275 @@ class ImmutableActionSetTest extends Specification {
     def "can create a set from multiple actions"() {
         def action1 = Mock(Action)
         def action2 = Mock(Action)
+        def action3 = Mock(Action)
+        def action4 = Mock(Action)
+        def action5 = Mock(Action)
+        def action6 = Mock(Action)
 
         when:
-        def set1 = ImmutableActionSet.of(action1, action2)
+        def setWith6 = ImmutableActionSet.of(action1, action2, action3, action4, action5, action6)
 
         then:
-        !set1.empty
+        !setWith6.empty
 
         when:
-        set1.execute("value")
+        setWith6.execute("value")
 
         then:
         1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+
+        then:
+        1 * action6.execute("value")
+        0 * _
+
+        when:
+        def setWith5 = ImmutableActionSet.of(action1, action2, action3, action4, action5)
+
+        then:
+        !setWith5.empty
+
+        when:
+        setWith5.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+        0 * _
+
+        when:
+        def setWith4 = ImmutableActionSet.of(action1, action2, action3, action4)
+
+        then:
+        !setWith4.empty
+
+        when:
+        setWith4.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+        0 * _
+
+        when:
+        def setWith3 = ImmutableActionSet.of(action1, action2, action3)
+
+        then:
+        !setWith3.empty
+
+        when:
+        setWith3.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+        0 * _
+
+        when:
+        def setWith2 = ImmutableActionSet.of(action1, action2)
+
+        then:
+        !setWith2.empty
+
+        when:
+        setWith2.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
         1 * action2.execute("value")
         0 * _
 
         when:
-        def set2 = ImmutableActionSet.of(action1)
+        def setWith1 = ImmutableActionSet.of(action1)
 
         then:
-        !set2.empty
+        !setWith1.empty
 
         when:
-        set2.execute("value")
+        setWith1.execute("value")
 
         then:
         1 * action1.execute("value")
         0 * _
 
         when:
-        def set3 = ImmutableActionSet.of()
+        def setWith0 = ImmutableActionSet.of()
 
         then:
-        set3.is(ImmutableActionSet.empty())
+        setWith0.is(ImmutableActionSet.empty())
+    }
+
+    def "can add multiple actions to a set"() {
+        def action1 = Mock(Action)
+        def action2 = Mock(Action)
+        def action3 = Mock(Action)
+        def action4 = Mock(Action)
+        def action5 = Mock(Action)
+        def action6 = Mock(Action)
+        def action7 = Mock(Action)
+
+        when:
+        def set = ImmutableActionSet.empty().add(action1)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+        0 * _
+
+        when:
+        set = set.add(action2)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+        0 * _
+
+        when:
+        set = set.add(action3)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+        0 * _
+
+        when:
+        set = set.add(action4)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+        0 * _
+
+        when:
+        set = set.add(action5)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+        0 * _
+
+        when:
+        set = set.add(action6)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+
+        then:
+        1 * action6.execute("value")
+        0 * _
+
+        when:
+        set = set.add(action7)
+        set.execute("value")
+
+        then:
+        !set.empty
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+
+        then:
+        1 * action6.execute("value")
+
+        then:
+        1 * action7.execute("value")
+        0 * _
     }
 
     def "execution stops on first failure"() {
@@ -184,9 +420,116 @@ class ImmutableActionSetTest extends Specification {
         set.add(action2).is(set)
         set.add(ImmutableActionSet.of(action1)).is(set)
         set.add(ImmutableActionSet.of(action2)).is(set)
-        set.add(ImmutableActionSet.of(action1, action2)).is(set)
-        set.add(ImmutableActionSet.of(action2, action1)).is(set)
         ImmutableActionSet.of(action1).add(set).is(set)
+    }
+
+    def "can add duplicate actions to set"() {
+        def action1 = Mock(Action)
+        def action2 = Mock(Action)
+        def action3 = Mock(Action)
+        def action4 = Mock(Action)
+        def action5 = Mock(Action)
+        def action6 = Mock(Action)
+
+        when:
+        def set = ImmutableActionSet.of(action1, action2)
+        set = set.add(action1)
+        set = set.add(action2)
+        set = set.add(ImmutableActionSet.of(action2, action1))
+        set.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+        0 * _
+
+        when:
+        set = set.add(ImmutableActionSet.of(action1, action2, action3))
+        set = set.add(action1)
+        set = set.add(action3)
+        set = set.add(ImmutableActionSet.of(action3, action2, action1))
+        set.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+        0 * _
+
+        when:
+        set = set.add(ImmutableActionSet.of(action1, action2, action3, action4))
+        set = set.add(action1)
+        set = set.add(action4)
+        set = set.add(ImmutableActionSet.of(action4, action2, action1))
+        set.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+        0 * _
+
+        when:
+        set = set.add(ImmutableActionSet.of(action1, action2, action3, action4, action5))
+        set = set.add(action1)
+        set = set.add(action5)
+        set = set.add(ImmutableActionSet.of(action5, action2, action1))
+        set.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+        0 * _
+
+        when:
+        set = set.add(ImmutableActionSet.of(action1, action2, action3, action4, action5, action6))
+        set = set.add(action1)
+        set = set.add(action6)
+        set = set.add(ImmutableActionSet.of(action6, action2, action1))
+        set.execute("value")
+
+        then:
+        1 * action1.execute("value")
+
+        then:
+        1 * action2.execute("value")
+
+        then:
+        1 * action3.execute("value")
+
+        then:
+        1 * action4.execute("value")
+
+        then:
+        1 * action5.execute("value")
+
+        then:
+        1 * action6.execute("value")
+        0 * _
     }
 
     def "can add self to composite set"() {
@@ -220,7 +563,6 @@ class ImmutableActionSetTest extends Specification {
     }
 
     def "can merge empty set into empty set"() {
-        def action = Mock(Action)
         def empty = ImmutableActionSet.empty()
 
         expect:

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -17,7 +17,6 @@
 package org.gradle.composite.internal;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -37,6 +36,7 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.Pair;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
@@ -50,7 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.List;
 import java.util.Set;
 
 public class DefaultIncludedBuild extends AbstractBuildState implements IncludedBuildState, ConfigurableIncludedBuild, Stoppable {
@@ -62,7 +61,7 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
     private final boolean isImplicit;
     private final BuildState owner;
     private final WorkerLeaseRegistry.WorkerLease parentLease;
-    private final List<Action<? super DependencySubstitutions>> dependencySubstitutionActions = Lists.newArrayList();
+    private ImmutableActionSet<DependencySubstitutions> dependencySubstitutionActions = ImmutableActionSet.empty();
 
     private boolean resolvedDependencySubstitutions;
 
@@ -150,11 +149,11 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
         if (resolvedDependencySubstitutions) {
             throw new IllegalStateException("Cannot configure included build after dependency substitutions are resolved.");
         }
-        dependencySubstitutionActions.add(action);
+        dependencySubstitutionActions = dependencySubstitutionActions.add(action);
     }
 
     @Override
-    public List<Action<? super DependencySubstitutions>> getRegisteredDependencySubstitutions() {
+    public Action<DependencySubstitutions> getRegisteredDependencySubstitutions() {
         resolvedDependencySubstitutions = true;
         return dependencySubstitutionActions;
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/IncludedBuildDependencySubstitutionsBuilder.java
@@ -16,8 +16,6 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutions;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
@@ -51,9 +49,7 @@ public class IncludedBuildDependencySubstitutionsBuilder {
 
     private DependencySubstitutionsInternal resolveDependencySubstitutions(IncludedBuildState build) {
         DependencySubstitutionsInternal dependencySubstitutions = DefaultDependencySubstitutions.forIncludedBuild(build, moduleIdentifierFactory);
-        for (Action<? super DependencySubstitutions> action : build.getRegisteredDependencySubstitutions()) {
-            action.execute(dependencySubstitutions);
-        }
+        build.getRegisteredDependencySubstitutions().execute(dependencySubstitutions);
         return dependencySubstitutions;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -94,16 +94,25 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
     public void addCollection(DomainObjectCollection<? extends T> collection) {
         if (!getStore().containsCollection(collection)) {
             getStore().addComposited(collection);
-            collection.all(backingSet.getEventRegister().getAddAction());
-            collection.whenObjectRemoved(backingSet.getEventRegister().getRemoveAction());
+            collection.all(new Action<T>() {
+                @Override
+                public void execute(T t) {
+                    backingSet.getEventRegister().fireObjectAdded(t);
+                }
+            });
+            collection.whenObjectRemoved(new Action<T>() {
+                @Override
+                public void execute(T t) {
+                    backingSet.getEventRegister().fireObjectRemoved(t);
+                }
+            });
         }
     }
 
     public void removeCollection(DomainObjectCollection<? extends T> collection) {
         getStore().removeComposited(collection);
-        Action<? super T> action = this.backingSet.getEventRegister().getRemoveAction();
         for (T item : collection) {
-            action.execute(item);
+            backingSet.getEventRegister().fireObjectRemoved(item);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -224,7 +224,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
     private boolean doAdd(T toAdd) {
         if (getStore().add(toAdd)) {
             didAdd(toAdd);
-            eventRegister.getAddAction().execute(toAdd);
+            eventRegister.fireObjectAdded(toAdd);
             return true;
         } else {
             return false;
@@ -263,7 +263,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         Object[] c = toArray();
         getStore().clear();
         for (Object o : c) {
-            eventRegister.getRemoveAction().execute((T) o);
+            eventRegister.fireObjectRemoved((T) o);
         }
     }
 
@@ -288,7 +288,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         if (getStore().remove(o)) {
             @SuppressWarnings("unchecked") T cast = (T) o;
             didRemove(cast);
-            eventRegister.getRemoveAction().execute(cast);
+            eventRegister.fireObjectRemoved(cast);
             return true;
         } else {
             return false;
@@ -373,7 +373,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
             assertMutable();
             iterator.remove();
             didRemove(currentElement);
-            getEventRegister().getRemoveAction().execute(currentElement);
+            getEventRegister().fireObjectRemoved(currentElement);
             currentElement = null;
         }
 
@@ -393,12 +393,12 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         }
 
         @Override
-        public Action<S> getAddAction() {
+        public void fireObjectAdded(S element) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public Action<S> getRemoveAction() {
+        public void fireObjectRemoved(S element) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -98,14 +98,16 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         this(filter.getType(), collection.filteredStore(filter), collection.filteredEvents(filter), collection.filteredIndex(filter), instantiator, namer);
     }
 
-    /**
-     * Subclasses that can guarantee that the backing store enforces name uniqueness should override this to simply call super.add(T) (avoiding an unnecessary lookup)
-     */
     @Override
     public boolean add(final T o) {
+        return add(o, getEventRegister().getAddActions());
+    }
+
+    @Override
+    protected <I extends T> boolean add(final I o, Action<? super I> notification) {
         final String name = namer.determineName(o);
         if (index.get(name) == null) {
-            boolean added = super.add(o);
+            boolean added = super.add(o, notification);
             if (added) {
                 whenKnown.execute(new ObjectBackedElementInfo<T>(name, o));
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
@@ -47,7 +47,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
         assertCanAdd(element);
         getStore().add(index, element);
         didAdd(element);
-        getEventRegister().getAddAction().execute(element);
+        getEventRegister().fireObjectAdded(element);
     }
 
     public boolean addAll(int index, Collection<? extends T> c) {
@@ -58,7 +58,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
             if (!hasWithName(getNamer().determineName(t))) {
                 getStore().add(current, t);
                 didAdd(t);
-                getEventRegister().getAddAction().execute(t);
+                getEventRegister().fireObjectAdded(t);
                 changed = true;
                 current++;
             }
@@ -82,9 +82,9 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
         if (oldElement != null) {
             didRemove(oldElement);
         }
-        getEventRegister().getRemoveAction().execute(oldElement);
+        getEventRegister().fireObjectRemoved(oldElement);
         didAdd(element);
-        getEventRegister().getAddAction().execute(element);
+        getEventRegister().fireObjectAdded(element);
         return oldElement;
     }
 
@@ -94,7 +94,7 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
         if (element != null) {
             didRemove(element);
         }
-        getEventRegister().getRemoveAction().execute(element);
+        getEventRegister().fireObjectRemoved(element);
         return element;
     }
 
@@ -182,14 +182,14 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
             assertCanAdd(t);
             iterator.add(t);
             didAdd(t);
-            getEventRegister().getAddAction().execute(t);
+            getEventRegister().fireObjectAdded(t);
         }
 
         public void remove() {
             assertMutable();
             iterator.remove();
             didRemove(lastElement);
-            getEventRegister().getRemoveAction().execute(lastElement);
+            getEventRegister().fireObjectRemoved(lastElement);
             lastElement = null;
         }
 
@@ -198,9 +198,9 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
             assertCanAdd(t);
             iterator.set(t);
             didRemove(lastElement);
-            getEventRegister().getRemoveAction().execute(lastElement);
+            getEventRegister().fireObjectRemoved(lastElement);
             didAdd(t);
-            getEventRegister().getAddAction().execute(t);
+            getEventRegister().fireObjectAdded(t);
             lastElement = null;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.internal.Actions;
 import org.gradle.internal.ImmutableActionSet;
 
 import javax.annotation.Nullable;
@@ -44,7 +43,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     private ImmutableAttributesFactory attributesFactory;
     private DefaultExcludeRuleContainer excludeRuleContainer = new DefaultExcludeRuleContainer();
     private Set<DependencyArtifact> artifacts = new HashSet<DependencyArtifact>();
-    private Action<? super ModuleDependency> onMutate = Actions.doNothing();
+    private ImmutableActionSet<ModuleDependency> onMutate = ImmutableActionSet.empty();
     private AttributeContainerInternal attributes;
 
     @Nullable
@@ -198,7 +197,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
 
     @SuppressWarnings("unchecked")
     public void addMutationValidator(Action<? super ModuleDependency> action) {
-        this.onMutate = ImmutableActionSet.of(onMutate, action);
+        this.onMutate = onMutate.add(action);
     }
 
     protected void validateMutation() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/BroadcastingCollectionEventRegister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/BroadcastingCollectionEventRegister.java
@@ -16,14 +16,14 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
-import org.gradle.internal.MutableActionSet;
+import org.gradle.internal.ImmutableActionSet;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public class BroadcastingCollectionEventRegister<T> implements CollectionEventRegister<T> {
-    private final MutableActionSet<T> addActions = new MutableActionSet<T>();
-    private final MutableActionSet<T> removeActions = new MutableActionSet<T>();
+    private ImmutableActionSet<T> addActions = ImmutableActionSet.empty();
+    private ImmutableActionSet<T> removeActions = ImmutableActionSet.empty();
     private final Class<? extends T> baseType;
     private boolean baseTypeSubscribed;
     private Set<Class<?>> subscribedTypes;
@@ -50,28 +50,30 @@ public class BroadcastingCollectionEventRegister<T> implements CollectionEventRe
         return false;
     }
 
-    public Action<T> getAddAction() {
-        return addActions;
+    @Override
+    public void fireObjectAdded(T element) {
+        addActions.execute(element);
     }
 
-    public Action<T> getRemoveAction() {
-        return removeActions;
+    @Override
+    public void fireObjectRemoved(T element) {
+        removeActions.execute(element);
     }
 
     @Override
     public void registerEagerAddAction(Class<? extends T> type, Action<? super T> addAction) {
         subscribe(type);
-        addActions.add(addAction);
+        addActions = addActions.add(addAction);
     }
 
     @Override
     public void registerLazyAddAction(Action<? super T> addAction) {
-        addActions.add(addAction);
+        addActions = addActions.add(addAction);
     }
 
     @Override
     public void registerRemoveAction(Class<? extends T> type, Action<? super T> removeAction) {
-        removeActions.add(removeAction);
+        removeActions = removeActions.add(removeAction);
     }
 
     private void subscribe(Class<? extends T> type) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/BroadcastingCollectionEventRegister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/BroadcastingCollectionEventRegister.java
@@ -51,6 +51,11 @@ public class BroadcastingCollectionEventRegister<T> implements CollectionEventRe
     }
 
     @Override
+    public ImmutableActionSet<T> getAddActions() {
+        return addActions;
+    }
+
+    @Override
     public void fireObjectAdded(T element) {
         addActions.execute(element);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/BroadcastingCollectionEventRegister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/BroadcastingCollectionEventRegister.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
 import org.gradle.internal.ImmutableActionSet;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -48,6 +49,21 @@ public class BroadcastingCollectionEventRegister<T> implements CollectionEventRe
             }
         }
         return false;
+    }
+
+    /**
+     * Used by the Nebula plugin.
+     * @deprecated Will be removed in Gradle 5.0, with no replacement
+     */
+    @Deprecated
+    public Action<T> getAddAction() {
+        DeprecationLogger.nagUserOfDeprecated("Internal method BroadcastingCollectionEventRegister.getAddAction()");
+        return new Action<T>() {
+            @Override
+            public void execute(T t) {
+                fireObjectAdded(t);
+            }
+        };
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/CollectionEventRegister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/CollectionEventRegister.java
@@ -16,11 +16,17 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.internal.ImmutableActionSet;
 
 import javax.annotation.Nullable;
 
 public interface CollectionEventRegister<T> {
     boolean isSubscribed(@Nullable Class<?> type);
+
+    /**
+     * Returns a snapshot of the <em>current</em> set of actions to run when an element is added.
+     */
+    ImmutableActionSet<T> getAddActions();
 
     void fireObjectAdded(T element);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/CollectionEventRegister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/CollectionEventRegister.java
@@ -22,9 +22,9 @@ import javax.annotation.Nullable;
 public interface CollectionEventRegister<T> {
     boolean isSubscribed(@Nullable Class<?> type);
 
-    Action<T> getAddAction();
+    void fireObjectAdded(T element);
 
-    Action<T> getRemoveAction();
+    void fireObjectRemoved(T element);
 
     void registerEagerAddAction(Class<? extends T> type, Action<? super T> addAction);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
@@ -43,7 +43,7 @@ import static org.gradle.api.reflect.TypeOf.typeOf;
 import static org.gradle.internal.Cast.uncheckedCast;
 
 public class DefaultConvention implements Convention, ExtensionContainerInternal {
-
+    private static final TypeOf<ExtraPropertiesExtension> EXTRA_PROPERTIES_EXTENSION_TYPE = typeOf(ExtraPropertiesExtension.class);
     private final DefaultConvention.ExtensionsDynamicObject extensionsDynamicObject = new ExtensionsDynamicObject();
     private final ExtensionsStorage extensionsStorage = new ExtensionsStorage();
     private final ExtraPropertiesExtension extraProperties = new DefaultExtraPropertiesExtension();
@@ -66,7 +66,7 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
 
     public DefaultConvention(Instantiator instantiator) {
         this.instantiator = instantiator;
-        add(ExtraPropertiesExtension.class, ExtraPropertiesExtension.EXTENSION_NAME, extraProperties);
+        add(EXTRA_PROPERTIES_EXTENSION_TYPE, ExtraPropertiesExtension.EXTENSION_NAME, extraProperties);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -134,22 +134,6 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
         }
 
         @Override
-        public void configure(final Action<? super I> action) {
-            configureEach(new Action<Task>() {
-                private boolean alreadyExecuted = false;
-
-                @Override
-                public void execute(Task task) {
-                    // Task specific configuration action should only be executed once
-                    if (task.getName().equals(identity.name) && !removed && !alreadyExecuted) {
-                        alreadyExecuted = true;
-                        action.execute(identity.type.cast(task));
-                    }
-                }
-            });
-        }
-
-        @Override
         public String toString() {
             return String.format("provider(task %s, %s)", identity.name, identity.type);
         }
@@ -163,6 +147,11 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
         public ExistingTaskProvider(I task, TaskIdentity<I> identity) {
             super(identity);
             this.task = task;
+        }
+
+        @Override
+        public void configure(Action<? super I> action) {
+            action.execute(task);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -24,7 +24,6 @@ import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.Pair;
 
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -33,7 +32,7 @@ import java.util.Set;
 public interface IncludedBuildState extends NestedBuildState {
     String getName();
     ConfigurableIncludedBuild getModel();
-    List<Action<? super DependencySubstitutions>> getRegisteredDependencySubstitutions();
+    Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions();
     Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();
 
     /**

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/BroadcastingCollectionEventRegisterSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/BroadcastingCollectionEventRegisterSpec.groovy
@@ -30,8 +30,8 @@ class BroadcastingCollectionEventRegisterSpec extends Specification {
 
     def "actions do nothing when none registered"() {
         expect:
-        r.addAction.execute("a")
-        r.removeAction.execute("a")
+        r.fireObjectAdded("a")
+        r.fireObjectRemoved("a")
     }
 
     def "nothing subscribed when no actions registered"() {
@@ -50,7 +50,7 @@ class BroadcastingCollectionEventRegisterSpec extends Specification {
         r.registerEagerAddAction(String, action2)
 
         when:
-        r.addAction.execute("a")
+        r.fireObjectAdded("a")
 
         then:
         1 * action1.execute("a")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -583,6 +583,7 @@ class DefaultTaskContainerTest extends Specification {
         def action3 = Mock(Action)
         def action4 = Mock(Action)
         def action5 = Mock(Action)
+        def action6 = Mock(Action)
         def task = task("task")
 
         given:
@@ -590,9 +591,10 @@ class DefaultTaskContainerTest extends Specification {
         def provider = container.register("task", DefaultTask, action2)
         container.configureEach(action3)
         provider.configure(action4)
+        container.configureEach(action5)
 
         when:
-        container.all(action5)
+        container.all(action6)
 
         then:
         1 * taskFactory.create(_ as TaskIdentity) >> task
@@ -611,11 +613,15 @@ class DefaultTaskContainerTest extends Specification {
 
         then:
         1 * action5.execute(task)
+
+        then:
+        1 * action6.execute(task)
         0 * action1._
         0 * action2._
         0 * action3._
         0 * action4._
         0 * action5._
+        0 * action6._
 
         when:
         provider.get()

--- a/subprojects/workers/src/main/java/org/gradle/workers/package-info.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * Workers allow running pieces of work in the background, either
- * in-process in isolated classloaders or out-of-process in reausable
+ * in-process in isolated classloaders or out-of-process in reusable
  * daemons.
  *
  * @since 3.5


### PR DESCRIPTION
### Context

This PR improves the efficiency of registering a task configuration action, e.g when using `tasks.register(name, type, action)` or `tasks.named(name).configure(action)`.

This change moves the task-specific configuration actions to live with the provider that tracks the other state for the task, so that each registered task also has an associated set of actions to run on realization. The actions are discarded after realization. This avoids collecting many essentially no-op actions in the container-wide set of actions, and this keeps each set much smaller and so faster to mutate and execute.

Relative ordering is maintained by merging container level actions into the set of task-specific actions just prior to something interesting happening to the task (adding another task-specific configuration action, realizing the task). There are some offsetting improvements in `ImmutableActionSet` to make this faster, but there are more improvements that could be made here.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
