### PR TITLE
Normalize `ModuleIdentifier`

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildDependencySubstitutions.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildDependencySubstitutions.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.internal.Pair;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
@@ -47,11 +46,9 @@ import java.util.SortedSet;
 public class CompositeBuildDependencySubstitutions implements Action<DependencySubstitution> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeBuildDependencySubstitutions.class);
 
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final Multimap<ModuleIdentifier, ProjectComponentIdentifier> replacementMap = ArrayListMultimap.create();
 
-    public CompositeBuildDependencySubstitutions(Collection<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> replacements, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    public CompositeBuildDependencySubstitutions(Collection<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> replacements) {
         for (Pair<ModuleVersionIdentifier, ProjectComponentIdentifier> replacement : replacements) {
             replacementMap.put(replacement.getLeft().getModule(), replacement.getRight());
         }
@@ -74,7 +71,7 @@ public class CompositeBuildDependencySubstitutions implements Action<DependencyS
     }
 
     private ProjectComponentIdentifier getReplacementFor(ModuleComponentSelector selector) {
-        ModuleIdentifier candidateId = moduleIdentifierFactory.module(selector.getGroup(), selector.getModule());
+        ModuleIdentifier candidateId = selector.getModuleIdentifier();
         Collection<ProjectComponentIdentifier> providingProjects = replacementMap.get(candidateId);
         if (providingProjects.isEmpty()) {
             LOGGER.debug("Found no composite build substitute for module '" + candidateId + "'.");

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -51,8 +51,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
             return new DefaultIncludedBuildRegistry(includedBuildFactory, projectRegistry, dependencySubstitutionsBuilder, gradleLauncherFactory, listenerManager, rootServices);
         }
 
-        public CompositeBuildContext createCompositeBuildContext(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-            return new DefaultBuildableCompositeBuildContext(moduleIdentifierFactory);
+        public CompositeBuildContext createCompositeBuildContext() {
+            return new DefaultBuildableCompositeBuildContext();
         }
 
         public LocalComponentProvider createLocalComponentProvider(ProjectStateRegistry projectRegistry) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildableCompositeBuildContext.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildableCompositeBuildContext.java
@@ -22,7 +22,6 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Pair;
@@ -34,10 +33,8 @@ public class DefaultBuildableCompositeBuildContext implements CompositeBuildCont
     // TODO: Synchronization
     private final Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules = Sets.newHashSet();
     private final List<Action<DependencySubstitution>> substitutionRules = Lists.newArrayList();
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
-    public DefaultBuildableCompositeBuildContext(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    public DefaultBuildableCompositeBuildContext() {
     }
 
     @Override
@@ -55,7 +52,7 @@ public class DefaultBuildableCompositeBuildContext implements CompositeBuildCont
         List<Action<DependencySubstitution>> allActions = Lists.newArrayList();
         if (!availableModules.isEmpty()) {
             // Automatically substitute all available modules
-            allActions.add(new CompositeBuildDependencySubstitutions(availableModules, moduleIdentifierFactory));
+            allActions.add(new CompositeBuildDependencySubstitutions(availableModules));
         }
         allActions.addAll(substitutionRules);
         return Actions.composite(allActions);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -95,4 +95,15 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      */
     @Incubating
     SELF attributes(Action<? super AttributeContainer> configureAction);
+
+    /**
+     * The module identifier of the component. Returns the same information
+     * as {@link #getGroup()} and {@link #getName()}.
+     *
+     * @return the module identifier
+     *
+     * @since 4.9
+     */
+    @Incubating
+    ModuleIdentifier getModule();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
@@ -67,4 +67,15 @@ public interface ModuleVersionSelector {
      */
     @Incubating
     boolean matchesStrictly(ModuleVersionIdentifier identifier);
+
+    /**
+     * The module identifier of the component. Returns the same information
+     * as {@link #getGroup()} and {@link #getName()}.
+     *
+     * @return the module identifier
+     *
+     * @since 4.9
+     */
+    @Incubating
+    ModuleIdentifier getModule();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -49,5 +50,15 @@ public interface ModuleComponentIdentifier extends ComponentIdentifier {
      * @since 1.10
      */
     String getVersion();
+
+    /**
+     * The module identifier of the component. Returns the same information
+     * as {@link #getGroup()} and {@link #getModule()}.
+     *
+     * @return the module identifier
+     *
+     * @since 4.9
+     */
+    ModuleIdentifier getModuleIdentifier();
 }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -58,4 +59,14 @@ public interface ModuleComponentSelector extends ComponentSelector {
      */
     @Incubating
     VersionConstraint getVersionConstraint();
+
+    /**
+     * The module identifier of the component. Returns the same information
+     * as {@link #getGroup()} and {@link #getModule()}.
+     *
+     * @return the module identifier
+     *
+     * @since 4.9
+     */
+    ModuleIdentifier getModuleIdentifier();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/JvmLibraryArtifactResolveTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/JvmLibraryArtifactResolveTestFixture.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.test.fixtures.file.TestFile
@@ -27,7 +28,7 @@ import org.gradle.test.fixtures.file.TestFile
 class JvmLibraryArtifactResolveTestFixture {
     private final TestFile buildFile
     private final String config
-    private ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId("some.group", "some-artifact", "1.0")
+    private ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("some.group", "some-artifact"), "1.0")
     private artifactTypes = []
     private expectedSources = []
     private expectedJavadoc = []
@@ -39,12 +40,12 @@ class JvmLibraryArtifactResolveTestFixture {
     }
 
     JvmLibraryArtifactResolveTestFixture withComponentVersion(String group, String module, String version) {
-        this.id = DefaultModuleComponentIdentifier.newId(group, module, version)
+        this.id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, module), version)
         this
     }
 
     JvmLibraryArtifactResolveTestFixture withSnapshotTimestamp(String timestamp) {
-        this.id = new MavenUniqueSnapshotComponentIdentifier(id.group, id.module, id.version, timestamp)
+        this.id = new MavenUniqueSnapshotComponentIdentifier(DefaultModuleIdentifier.newId(id.group, id.module), id.version, timestamp)
         this
     }
 
@@ -168,7 +169,8 @@ task $taskName {
         buildFile << """
 task verify {
     doLast {
-        def componentId = new org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier("${id.group}", "${id.module}", "${id.version}")
+        def mid = org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId("${id.group}", "${id.module}")
+        def componentId = new org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier(mid, "${id.version}")
 
         def result = dependencies.createArtifactResolutionQuery()
             .forComponents(componentId)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MetadataArtifactResolveTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MetadataArtifactResolveTestFixture.groovy
@@ -20,13 +20,14 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ComponentArtifactsResult
 import org.gradle.api.artifacts.result.ComponentResult
 import org.gradle.api.artifacts.result.UnresolvedComponentResult
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.test.fixtures.file.TestFile
 
 class MetadataArtifactResolveTestFixture {
     private final TestFile buildFile
     final String config
-    final ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId('some.group', 'some-artifact', '1.0')
+    final ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('some.group', 'some-artifact'), '1.0')
     private String requestedComponent
     private String requestedArtifact
     private Class<? extends ComponentResult> expectedComponentResult

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
@@ -43,6 +43,7 @@ class ArtifactResolutionQueryIntegrationTest extends AbstractHttpDependencyResol
         settingsFile << 'include "query", "resolve"'
         buildFile << """ 
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier as DMI
 
 allprojects {
     apply plugin: 'java'
@@ -60,7 +61,7 @@ project('query') {
         doLast {
             '${server.uri}/sync'.toURL().text
             dependencies.createArtifactResolutionQuery()
-                        .forComponents(new DefaultModuleComponentIdentifier('group','artifact','1.0'))
+                        .forComponents(new DefaultModuleComponentIdentifier(DMI.newId('group','artifact'),'1.0'))
                         .withArtifacts(JvmLibrary)
                         .execute()
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultComponentSelectorConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultComponentSelectorConverter.java
@@ -29,13 +29,11 @@ import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.util.GUtil;
 
 public class DefaultComponentSelectorConverter implements ComponentSelectorConverter {
-    private static final ModuleVersionSelector UNKNOWN_MODULE_VERSION_SELECTOR = DefaultModuleVersionSelector.newSelector("", "unknown", "");
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private static final ModuleVersionSelector UNKNOWN_MODULE_VERSION_SELECTOR = DefaultModuleVersionSelector.newSelector(DefaultModuleIdentifier.newId("", "unknown"), "");
     private final ComponentIdentifierFactory componentIdentifierFactory;
     private final LocalComponentRegistry localComponentRegistry;
 
-    public DefaultComponentSelectorConverter(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    public DefaultComponentSelectorConverter(ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
         this.componentIdentifierFactory = componentIdentifierFactory;
         this.localComponentRegistry = localComponentRegistry;
     }
@@ -44,10 +42,10 @@ public class DefaultComponentSelectorConverter implements ComponentSelectorConve
     public ModuleIdentifier getModule(ComponentSelector componentSelector) {
         if (componentSelector instanceof ModuleComponentSelector) {
             ModuleComponentSelector module = (ModuleComponentSelector) componentSelector;
-            return moduleIdentifierFactory.module(module.getGroup(), module.getModule());
+            return module.getModuleIdentifier();
         }
         ModuleVersionSelector moduleVersionSelector = getSelector(componentSelector);
-        return moduleIdentifierFactory.module(moduleVersionSelector.getGroup(), moduleVersionSelector.getName());
+        return moduleVersionSelector.getModule();
     }
 
     @Override
@@ -61,13 +59,13 @@ public class DefaultComponentSelectorConverter implements ComponentSelectorConve
             LocalComponentMetadata projectComponent = localComponentRegistry.getComponent(projectId);
             if (projectComponent != null) {
                 ModuleVersionIdentifier moduleVersionId = projectComponent.getModuleVersionId();
-                return DefaultModuleVersionSelector.newSelector(moduleVersionId.getGroup(), moduleVersionId.getName(), moduleVersionId.getVersion());
+                return DefaultModuleVersionSelector.newSelector(moduleVersionId.getModule(), moduleVersionId.getVersion());
             }
         }
         if (selector instanceof LibraryComponentSelector) {
             LibraryComponentSelector libraryComponentSelector = (LibraryComponentSelector) selector;
             String libraryName = GUtil.elvis(libraryComponentSelector.getLibraryName(), "");
-            return DefaultModuleVersionSelector.newSelector(libraryComponentSelector.getProjectPath(), libraryName, "undefined");
+            return DefaultModuleVersionSelector.newSelector(DefaultModuleIdentifier.newId(libraryComponentSelector.getProjectPath(), libraryName), "undefined");
         }
         return UNKNOWN_MODULE_VERSION_SELECTOR;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultImmutableModuleIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultImmutableModuleIdentifierFactory.java
@@ -61,7 +61,7 @@ public class DefaultImmutableModuleIdentifierFactory implements ImmutableModuleI
         }
         ModuleVersionIdentifier identifier = byVersion.get(version);
         if (identifier == null) {
-            identifier = new DefaultModuleVersionIdentifier(mi, version);
+            identifier =  DefaultModuleVersionIdentifier.newId(mi, version);
             byVersion.put(version, identifier);
         }
         return identifier;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleIdentifier.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.ModuleIdentifier;
 
 public class DefaultModuleIdentifier implements ModuleIdentifier {
@@ -23,8 +24,6 @@ public class DefaultModuleIdentifier implements ModuleIdentifier {
     private final String name;
 
     private DefaultModuleIdentifier(String group, String name) {
-        assert group != null : "group cannot be null";
-        assert name != null : "name cannot be null";
         this.group = group;
         this.name = name;
     }
@@ -54,25 +53,20 @@ public class DefaultModuleIdentifier implements ModuleIdentifier {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null || obj.getClass() != getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DefaultModuleIdentifier other = (DefaultModuleIdentifier) obj;
-        if (!name.equals(other.name)) {
-            return false;
-        }
-        if (!group.equals(other.group)) {
-            return false;
-        }
-        return true;
+        DefaultModuleIdentifier that = (DefaultModuleIdentifier) o;
+        return Objects.equal(group, that.group) &&
+            Objects.equal(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return 31 * name.hashCode() ^ group.hashCode();
+        return Objects.hashCode(group, name);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
@@ -25,7 +25,7 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
     private final String version;
     private final int hashCode;
 
-    public DefaultModuleVersionIdentifier(String group, String name, String version) {
+    private DefaultModuleVersionIdentifier(String group, String name, String version) {
         assert group != null : "group cannot be null";
         assert name != null : "name cannot be null";
         assert version != null : "version cannot be null";
@@ -34,7 +34,7 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
         this.hashCode = 31 * id.hashCode() ^ version.hashCode();
     }
 
-    public DefaultModuleVersionIdentifier(ModuleIdentifier id, String version) {
+    private DefaultModuleVersionIdentifier(ModuleIdentifier id, String version) {
         assert version != null : "version cannot be null";
         this.id = id;
         this.version = version;
@@ -91,6 +91,10 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
 
     public static ModuleVersionIdentifier newId(Module module) {
         return new DefaultModuleVersionIdentifier(module.getGroup(), module.getName(), module.getVersion());
+    }
+
+    public static ModuleVersionIdentifier newId(ModuleIdentifier id, String version) {
+        return new DefaultModuleVersionIdentifier(id, version);
     }
 
     public static ModuleVersionIdentifier newId(String group, String name, String version) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
@@ -24,38 +25,26 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConst
 
 public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
-    private String group;
-    private String name;
-    private VersionConstraint moduleVersionConstraint;
+    private final ModuleIdentifier module;
+    private final VersionConstraint moduleVersionConstraint;
 
-    private DefaultModuleVersionSelector(String group, String name, VersionConstraint versionConstraint) {
-        this.group = group;
-        this.name = name;
+    private DefaultModuleVersionSelector(ModuleIdentifier module, VersionConstraint versionConstraint) {
+        this.module = module;
         this.moduleVersionConstraint = versionConstraint;
     }
-    
+
     // DO NOT USE THIS CONSTRUCTOR DIRECTLY
     // It's only there for backwards compatibility with the Nebula plugin
     public DefaultModuleVersionSelector(String group, String name, String version) {
-        this(group, name, new DefaultMutableVersionConstraint(version));
+        this(DefaultModuleIdentifier.newId(group, name), new DefaultMutableVersionConstraint(version));
     }
 
     public String getGroup() {
-        return group;
-    }
-
-    public DefaultModuleVersionSelector setGroup(String group) {
-        this.group = group;
-        return this;
+        return module.getGroup();
     }
 
     public String getName() {
-        return name;
-    }
-
-    public DefaultModuleVersionSelector setName(String name) {
-        this.name = name;
-        return this;
+        return module.getName();
     }
 
     public String getVersion() {
@@ -72,8 +61,13 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
     }
 
     @Override
+    public ModuleIdentifier getModule() {
+        return module;
+    }
+
+    @Override
     public String toString() {
-        return String.format("%s:%s:%s", group, name, moduleVersionConstraint.getPreferredVersion());
+        return String.format("%s:%s", module, moduleVersionConstraint.getPreferredVersion());
     }
 
     @Override
@@ -87,10 +81,7 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
         DefaultModuleVersionSelector that = (DefaultModuleVersionSelector) o;
 
-        if (group != null ? !group.equals(that.group) : that.group != null) {
-            return false;
-        }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
+        if (module != null ? !module.equals(that.module) : that.module != null) {
             return false;
         }
         if (moduleVersionConstraint != null ? !moduleVersionConstraint.equals(that.moduleVersionConstraint) : that.moduleVersionConstraint != null) {
@@ -102,21 +93,20 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
     @Override
     public int hashCode() {
-        int result = group != null ? group.hashCode() : 0;
-        result = 31 * result + (name != null ? name.hashCode() : 0);
+        int result = module != null ? module.hashCode() : 0;
         result = 31 * result + moduleVersionConstraint.hashCode();
         return result;
     }
 
-    public static ModuleVersionSelector newSelector(String group, String name, String preferredVersion) {
-        return new DefaultModuleVersionSelector(group, name, new DefaultMutableVersionConstraint(preferredVersion));
+    public static ModuleVersionSelector newSelector(ModuleIdentifier module, String preferredVersion) {
+        return new DefaultModuleVersionSelector(module, new DefaultMutableVersionConstraint(preferredVersion));
     }
 
-    public static ModuleVersionSelector newSelector(String group, String name, VersionConstraint version) {
-        return new DefaultModuleVersionSelector(group, name, version);
+    public static ModuleVersionSelector newSelector(ModuleIdentifier module, VersionConstraint version) {
+        return new DefaultModuleVersionSelector(module, version);
     }
 
     public static ModuleVersionSelector newSelector(ModuleComponentSelector selector) {
-        return new DefaultModuleVersionSelector(selector.getGroup(), selector.getModule(), selector.getVersionConstraint());
+        return new DefaultModuleVersionSelector(selector.getModuleIdentifier(), selector.getVersionConstraint());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -349,7 +349,7 @@ class DependencyManagementBuildScopeServices {
     }
 
     ComponentSelectorConverter createModuleVersionSelectorFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
-        return new DefaultComponentSelectorConverter(moduleIdentifierFactory, componentIdentifierFactory, localComponentRegistry);
+        return new DefaultComponentSelectorConverter(componentIdentifierFactory, localComponentRegistry);
     }
 
     VersionParser createVersionParser() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -44,7 +44,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         String name = decoder.readString();
         VersionConstraint versionConstraint = readVersionConstraint(decoder);
         ImmutableAttributes attributes = readAttributes(decoder);
-        return newSelector(group, name, versionConstraint, attributes);
+        return newSelector(DefaultModuleIdentifier.newId(group, name), versionConstraint, attributes);
     }
 
     public VersionConstraint readVersionConstraint(Decoder decoder) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.component;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
@@ -39,7 +40,7 @@ public class DefaultComponentIdentifierFactory implements ComponentIdentifierFac
             return currentBuild.getIdentifierForProject(Path.path(projectPath));
         }
 
-        return new DefaultModuleComponentIdentifier(module.getGroup(), module.getName(), module.getVersion());
+        return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(module.getGroup(), module.getName()), module.getVersion());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -19,25 +19,25 @@ import com.google.common.base.Strings;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ModuleVersionSelectorStrictSpec;
 
 public abstract class AbstractExternalModuleDependency extends AbstractModuleDependency implements ExternalModuleDependency {
-    private String group;
-    private String name;
+    private final ModuleIdentifier moduleIdentifier;
     private boolean changing;
     private boolean force;
     private final MutableVersionConstraint versionConstraint;
 
-    public AbstractExternalModuleDependency(String group, String name, String version, String configuration) {
+    public AbstractExternalModuleDependency(ModuleIdentifier module, String version, String configuration) {
         super(configuration);
-        if (name == null) {
-            throw new InvalidUserDataException("Name must not be null!");
+        if (module == null) {
+            throw new InvalidUserDataException("Module must not be null!");
         }
-        this.group = group;
-        this.name = name;
+        this.moduleIdentifier = module;
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
     }
 
@@ -59,11 +59,11 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     }
 
     public String getGroup() {
-        return group;
+        return moduleIdentifier.getGroup();
     }
 
     public String getName() {
-        return name;
+        return moduleIdentifier.getName();
     }
 
     public String getVersion() {
@@ -99,5 +99,17 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     public void version(Action<? super MutableVersionConstraint> configureAction) {
         validateMutation();
         configureAction.execute(versionConstraint);
+    }
+
+    @Override
+    public ModuleIdentifier getModule() {
+        return moduleIdentifier;
+    }
+
+    static ModuleIdentifier assertModuleId(String group, String name) {
+        if (name == null) {
+            throw new InvalidUserDataException("Name must not be null!");
+        }
+        return DefaultModuleIdentifier.newId(group, name);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
@@ -32,7 +32,7 @@ public class DefaultClientModule extends AbstractExternalModuleDependency implem
     }
 
     public DefaultClientModule(String group, String name, String version, String configuration) {
-        super(group, name, version, configuration);
+        super(assertModuleId(group, name), version, configuration);
     }
 
     public String getId() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -19,10 +19,12 @@ package org.gradle.api.internal.artifacts.dependencies;
 import com.google.common.base.Objects;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ModuleVersionSelectorStrictSpec;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -36,8 +38,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
 
     private final static Logger LOG = Logging.getLogger(DefaultDependencyConstraint.class);
 
-    private final String group;
-    private final String name;
+    private final ModuleIdentifier moduleIdentifier;
     private final MutableVersionConstraint versionConstraint;
 
     private String reason;
@@ -45,26 +46,24 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     private AttributeContainerInternal attributes;
 
     public DefaultDependencyConstraint(String group, String name, String version) {
-        this.group = group;
-        this.name = name;
+        this.moduleIdentifier = DefaultModuleIdentifier.newId(group, name);
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
     }
 
-    private DefaultDependencyConstraint(String group, String name, MutableVersionConstraint versionConstraint) {
-        this.group = group;
-        this.name = name;
+    private DefaultDependencyConstraint(ModuleIdentifier module, MutableVersionConstraint versionConstraint) {
+        this.moduleIdentifier = module;
         this.versionConstraint = versionConstraint;
     }
 
     @Nullable
     @Override
     public String getGroup() {
-        return group;
+        return moduleIdentifier.getGroup();
     }
 
     @Override
     public String getName() {
-        return name;
+        return moduleIdentifier.getName();
     }
 
     @Nullable
@@ -108,15 +107,14 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
             return false;
         }
         DefaultDependencyConstraint that = (DefaultDependencyConstraint) o;
-        return Objects.equal(group, that.group) &&
-            Objects.equal(name, that.name) &&
+        return Objects.equal(moduleIdentifier, that.moduleIdentifier) &&
             Objects.equal(versionConstraint, that.versionConstraint) &&
             Objects.equal(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(group, name, versionConstraint, attributes);
+        return Objects.hashCode(moduleIdentifier, versionConstraint, attributes);
     }
 
     @Override
@@ -135,6 +133,11 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     }
 
     @Override
+    public ModuleIdentifier getModule() {
+        return moduleIdentifier;
+    }
+
+    @Override
     public String getReason() {
         return reason;
     }
@@ -145,7 +148,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     }
 
     public DependencyConstraint copy() {
-        DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(group, name, versionConstraint);
+        DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(moduleIdentifier, versionConstraint);
         constraint.reason = reason;
         constraint.attributes = attributes;
         constraint.attributesFactory = attributesFactory;
@@ -155,7 +158,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     @Override
     public String toString() {
         return "constraint " +
-            group + ':' + name + ":" + versionConstraint +
+            moduleIdentifier + ":" + versionConstraint +
             ", attributes=" + attributes;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultExternalModuleDependency.java
@@ -26,7 +26,7 @@ public class DefaultExternalModuleDependency extends AbstractExternalModuleDepen
     }
 
     public DefaultExternalModuleDependency(String group, String name, String version, String configuration) {
-        super(group, name, version, configuration);
+        super(assertModuleId(group, name), version, configuration);
     }
 
     public DefaultExternalModuleDependency copy() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsers.java
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
@@ -63,7 +64,7 @@ public class ComponentSelectorParsers {
         }
 
         protected ModuleComponentSelector parseMap(@MapKey("group") String group, @MapKey("name") String name, @MapKey("version") String version) {
-            return newSelector(group, name, DefaultImmutableVersionConstraint.of(version));
+            return newSelector(DefaultModuleIdentifier.newId(group, name), DefaultImmutableVersionConstraint.of(version));
         }
     }
 
@@ -87,7 +88,7 @@ public class ComponentSelectorParsers {
                         "Invalid format: '" + notation + "'. Group, name and version cannot be empty. Correct example: "
                                 + "'org.gradle:gradle-core:1.0'");
             }
-            result.converted(newSelector(parsed.getGroup(), parsed.getName(), DefaultImmutableVersionConstraint.of(parsed.getVersion())));
+            result.converted(newSelector(DefaultModuleIdentifier.newId(parsed.getGroup(), parsed.getName()), DefaultImmutableVersionConstraint.of(parsed.getVersion())));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.dsl;
 import org.gradle.api.IllegalDependencyNotation;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.MapKey;
@@ -59,7 +60,7 @@ public class ModuleVersionSelectorParsers {
         }
 
         protected ModuleVersionSelector parseMap(@MapKey("group") String group, @MapKey("name") String name, @MapKey("version") String version) {
-            return newSelector(group, name, new DefaultImmutableVersionConstraint(version));
+            return newSelector(DefaultModuleIdentifier.newId(group, name), new DefaultImmutableVersionConstraint(version));
         }
     }
 
@@ -84,7 +85,7 @@ public class ModuleVersionSelectorParsers {
                         "Invalid format: '" + notation + "'. Group, name and version cannot be empty. Correct example: "
                                 + "'org.gradle:gradle-core:1.0'");
             }
-            result.converted(newSelector(parsed.getGroup(), parsed.getName(), new DefaultImmutableVersionConstraint(parsed.getVersion())));
+            result.converted(newSelector(DefaultModuleIdentifier.newId(parsed.getGroup(), parsed.getName()), new DefaultImmutableVersionConstraint(parsed.getVersion())));
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
 import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
@@ -78,14 +79,14 @@ public class DefaultDependencyResolveDetails implements DependencyResolveDetails
         if (delegate.getTarget() instanceof ModuleComponentSelector) {
             ModuleComponentSelector target = (ModuleComponentSelector) delegate.getTarget();
             if (!version.equals(target.getVersionConstraint())) {
-                delegate.useTarget(DefaultModuleComponentSelector.newSelector(target.getGroup(), target.getModule(), version, target.getAttributes()), selectionReason);
+                delegate.useTarget(DefaultModuleComponentSelector.newSelector(target.getModuleIdentifier(), version, target.getAttributes()), selectionReason);
             } else {
                 // Still 'updated' with reason when version remains the same.
                 delegate.useTarget(delegate.getTarget(), selectionReason);
             }
         } else {
             // If the current target is a project component, it must be unmodified from the requested
-            ModuleComponentSelector newTarget = DefaultModuleComponentSelector.newSelector(requested.getGroup(), requested.getName(), version);
+            ModuleComponentSelector newTarget = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(requested.getGroup(), requested.getName()), version);
             delegate.useTarget(newTarget, selectionReason);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -240,7 +240,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         public void execute(DependencySubstitution dependencySubstitution) {
             if (dependencySubstitution.getRequested() instanceof ModuleComponentSelector) {
                 ModuleComponentSelector requested = (ModuleComponentSelector) dependencySubstitution.getRequested();
-                if (moduleId.getGroup().equals(requested.getGroup()) && moduleId.getName().equals(requested.getModule())) {
+                if (moduleId.equals(requested.getModuleIdentifier())) {
                     ((DependencySubstitutionInternal) dependencySubstitution).useTarget(substitute, selectionReason);
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
@@ -55,7 +55,7 @@ class ModuleSelectorStringNotationConverter extends TypedNotationConverter<Strin
         if (!GUtil.isTrue(version)) {
             throw new UnsupportedNotationException(notation);
         }
-        return DefaultModuleComponentSelector.newSelector(group, name, DefaultImmutableVersionConstraint.of(version));
+        return DefaultModuleComponentSelector.newSelector(moduleIdentifierFactory.module(group, name), DefaultImmutableVersionConstraint.of(version));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -137,7 +137,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
     }
 
     private ModuleIdentifier getCacheKey(ModuleComponentSelector requested) {
-        return moduleIdentifierFactory.module(requested.getGroup(), requested.getModule());
+        return requested.getModuleIdentifier();
     }
 
     private class LocateInCacheRepositoryAccess implements ModuleComponentRepositoryAccess {
@@ -165,7 +165,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
                 Set<String> versionList = cachedModuleVersionList.getModuleVersions();
                 Set<ModuleVersionIdentifier> versions = CollectionUtils.collect(versionList, new Transformer<ModuleVersionIdentifier, String>() {
                     public ModuleVersionIdentifier transform(String original) {
-                        return new DefaultModuleVersionIdentifier(moduleId, original);
+                        return DefaultModuleVersionIdentifier.newId(moduleId, original);
                     }
                 });
                 if (cachePolicy.mustRefreshVersionList(moduleId, versions, cachedModuleVersionList.getAgeMillis())) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -400,7 +400,7 @@ public class DynamicVersionResolver {
             this.repository = repository;
             this.attemptCollector = attemptCollector;
             ModuleComponentSelector requested = dependencyMetadata.getSelector();
-            this.identifier = DefaultModuleComponentIdentifier.newId(requested.getGroup(), requested.getModule(), version);
+            this.identifier = DefaultModuleComponentIdentifier.newId(requested.getModuleIdentifier(), version);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -24,7 +25,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
@@ -43,12 +44,10 @@ import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 
 public class RepositoryChainDependencyToComponentIdResolver implements DependencyToComponentIdResolver {
     private final DynamicVersionResolver dynamicRevisionResolver;
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final VersionSelectorScheme versionSelectorScheme;
     private final AttributeContainer consumerAttributes;
 
-    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, VersionSelectorScheme versionSelectorScheme, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
         this.versionSelectorScheme = versionSelectorScheme;
         this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, cachePolicy);
         this.consumerAttributes = consumerAttributes;
@@ -73,8 +72,9 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
                 dynamicRevisionResolver.resolve(toModuleDependencyMetadata(dependency), preferredSelector, rejectSelector, consumerAttributes, result);
             } else {
                 String version = resolvedVersionConstraint.getPreferredVersion();
-                ModuleComponentIdentifier id = new DefaultModuleComponentIdentifier(module.getGroup(), module.getModule(), version);
-                ModuleVersionIdentifier mvId = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getModule(), version);
+                ModuleIdentifier moduleId = module.getModuleIdentifier();
+                ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(moduleId, version);
+                ModuleVersionIdentifier mvId = DefaultModuleVersionIdentifier.newId(moduleId, version);
                 if (rejectSelector != null && rejectSelector.accept(version)) {
                     result.rejected(id, mvId);
                 } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -96,7 +96,7 @@ public class ResolveIvyFactory {
         CachePolicy cachePolicy = resolutionStrategy.getCachePolicy();
         startParameterResolutionOverride.applyToCachePolicy(cachePolicy);
 
-        UserResolverChain moduleResolver = new UserResolverChain(versionSelectorScheme, versionComparator, resolutionStrategy.getComponentSelection(), moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
+        UserResolverChain moduleResolver = new UserResolverChain(versionSelectorScheme, versionComparator, resolutionStrategy.getComponentSelection(), versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
         ParentModuleLookupResolver parentModuleResolver = new ParentModuleLookupResolver(versionSelectorScheme, versionComparator, moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
 
         for (ResolutionAwareRepository repository : repositories) {
@@ -142,7 +142,7 @@ public class ResolveIvyFactory {
         private final UserResolverChain delegate;
 
         public ParentModuleLookupResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, VersionParser versionParser, AttributeContainer consumerAttributes, AttributesSchema attributesSchema, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
-            this.delegate = new UserResolverChain(versionSelectorScheme, versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, cachePolicy);
+            this.delegate = new UserResolverChain(versionSelectorScheme, versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), versionParser, consumerAttributes, attributesSchema, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, cachePolicy);
         }
 
         public void add(ModuleComponentRepository moduleComponentRepository) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -21,7 +21,6 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -43,7 +42,6 @@ public class UserResolverChain implements ComponentResolvers {
     public UserResolverChain(VersionSelectorScheme versionSelectorScheme,
                              VersionComparator versionComparator,
                              ComponentSelectionRulesInternal componentSelectionRules,
-                             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                              VersionParser versionParser,
                              AttributeContainer consumerAttributes,
                              AttributesSchema attributesSchema,
@@ -52,7 +50,7 @@ public class UserResolverChain implements ComponentResolvers {
         this.componentSelectionRules = componentSelectionRules;
         VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules, attributesSchema);
         ModuleTransformer metaDataFactory = new ModuleTransformer();
-        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, moduleIdentifierFactory, versionSelectorScheme, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
+        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, versionSelectorScheme, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
         componentResolver = new RepositoryChainComponentMetaDataResolver(componentChooser, metaDataFactory);
         artifactResolver = new RepositoryChainArtifactResolver();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
@@ -111,8 +112,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
             //Is there any other parent properties?
 
             ModuleComponentSelector parentId = DefaultModuleComponentSelector.newSelector(
-                pomReader.getParentGroupId(),
-                pomReader.getParentArtifactId(),
+                DefaultModuleIdentifier.newId(pomReader.getParentGroupId(), pomReader.getParentArtifactId()),
                 new DefaultImmutableVersionConstraint(pomReader.getParentVersion()));
             PomReader parentPomReader = parsePomForSelector(parserSettings, parentId, pomReader.getAllPomProperties());
             pomReader.setPomParent(parentPomReader);
@@ -138,7 +138,8 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
                         + " is relocated to " + relocation
                         + ". Please update your dependencies.");
                 LOGGER.debug("Relocated module will be considered as a dependency");
-                ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(relocation.getGroup(), relocation.getName(), new DefaultMutableVersionConstraint(relocation.getVersion()));
+                ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
+                    DefaultModuleIdentifier.newId(relocation.getGroup(), relocation.getName()), new DefaultMutableVersionConstraint(relocation.getVersion()));
                 mdBuilder.addDependencyForRelocation(selector);
             }
         } else {
@@ -188,8 +189,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         for (PomDependencyMgt currentDependencyMgt : currentDependencyMgts) {
             if (isDependencyImportScoped(currentDependencyMgt)) {
                 ModuleComponentSelector importedId = DefaultModuleComponentSelector.newSelector(
-                    currentDependencyMgt.getGroupId(),
-                    currentDependencyMgt.getArtifactId(),
+                    DefaultModuleIdentifier.newId(currentDependencyMgt.getGroupId(), currentDependencyMgt.getArtifactId()),
                     new DefaultMutableVersionConstraint(currentDependencyMgt.getVersion()));
                 PomReader importedPom = parsePomForSelector(parseContext, importedId, Maps.<String, String>newHashMap());
                 for (Map.Entry<MavenDependencyKey, PomDependencyMgt> entry : importedPom.getDependencyMgt().entrySet()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
@@ -29,6 +29,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
 import org.apache.ivy.core.module.id.ArtifactId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
@@ -107,7 +108,7 @@ public class IvyModuleDescriptorConverter {
 
     private void addDependency(List<IvyDependencyDescriptor> result, DependencyDescriptor dependencyDescriptor) {
         ModuleRevisionId revisionId = dependencyDescriptor.getDependencyRevisionId();
-        ModuleComponentSelector requested = DefaultModuleComponentSelector.newSelector(revisionId.getOrganisation(), revisionId.getName(), new DefaultImmutableVersionConstraint(revisionId.getRevision()));
+        ModuleComponentSelector requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(revisionId.getOrganisation(), revisionId.getName()), new DefaultImmutableVersionConstraint(revisionId.getRevision()));
 
         ListMultimap<String, String> configMappings = ArrayListMultimap.create();
         for (Map.Entry<String, List<String>> entry : readConfigMappings(dependencyDescriptor).entrySet()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleResolveMetaDataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleResolveMetaDataBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.internal.component.external.descriptor.Artifact;
@@ -71,7 +72,7 @@ class IvyModuleResolveMetaDataBuilder {
 
     public MutableIvyModuleResolveMetadata build() {
         ModuleRevisionId moduleRevisionId = ivyDescriptor.getModuleRevisionId();
-        ModuleComponentIdentifier cid = DefaultModuleComponentIdentifier.newId(moduleRevisionId.getOrganisation(), moduleRevisionId.getName(), moduleRevisionId.getRevision());
+        ModuleComponentIdentifier cid = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(moduleRevisionId.getOrganisation(), moduleRevisionId.getName()), moduleRevisionId.getRevision());
         List<Configuration> configurations = converter.extractConfigurations(ivyDescriptor);
         List<IvyDependencyDescriptor> dependencies = converter.extractDependencies(ivyDescriptor);
         List<Exclude> excludes = converter.extractExcludes(ivyDescriptor);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
@@ -46,6 +46,7 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.IvyUtil;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
@@ -798,7 +799,7 @@ public class IvyXmlModuleDescriptorParser extends AbstractModuleDescriptorParser
         }
 
         protected ModuleDescriptor parseOtherIvyFile(String parentOrganisation, String parentModule, String parentRevision) throws IOException, ParseException, SAXException {
-            ModuleComponentIdentifier importedId = DefaultModuleComponentIdentifier.newId(parentOrganisation, parentModule, parentRevision);
+            ModuleComponentIdentifier importedId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(parentOrganisation, parentModule), parentRevision);
             LocallyAvailableExternalResource externalResource = parseContext.getMetaDataArtifact(importedId, ArtifactType.IVY_DESCRIPTOR);
 
             return parseModuleDescriptor(externalResource, externalResource.getFile().toURI().toURL());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleComponentSelectorSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
@@ -503,7 +504,7 @@ public class ModuleMetadataSerializer {
         }
 
         private ModuleComponentIdentifier readId() throws IOException {
-            return DefaultModuleComponentIdentifier.newId(readString(), readString(), readString());
+            return DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(readString(), readString()), readString());
         }
 
         private Map<NamespaceId, String> readExtraInfo() throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -46,7 +47,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
 
     public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
-            nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
+            DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
         return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
             Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, false, true, dependencyConstraint.getReason());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.VersionConstraintInternal;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadataWrapper;
@@ -41,8 +42,7 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
         boolean transitive = externalModuleDependency.isTransitive();
 
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
-            nullToEmpty(dependency.getGroup()),
-            nullToEmpty(dependency.getName()),
+            DefaultModuleIdentifier.newId(nullToEmpty(dependency.getGroup()), nullToEmpty(dependency.getName())),
             ((VersionConstraintInternal)externalModuleDependency.getVersionConstraint()).asImmutable(),
             dependency.getAttributes());
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
@@ -62,7 +62,7 @@ public class DefaultProjectDependencyPublicationResolver implements ProjectDepen
         if (publications.isEmpty()) {
             // Project has no publications: simply use the project name in place of the dependency name
             if (coordsType.isAssignableFrom(ModuleVersionIdentifier.class)) {
-                return coordsType.cast(new DefaultModuleVersionIdentifier(dependency.getGroup(), dependencyProject.getName(), dependency.getVersion()));
+                return coordsType.cast(DefaultModuleVersionIdentifier.newId(dependency.getGroup(), dependencyProject.getName(), dependency.getVersion()));
             }
             throw new UnsupportedOperationException(String.format("Could not find any publications of type %s in %s.", coordsType.getSimpleName(), dependencyProject.getDisplayName()));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicy.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.cache.ArtifactResolutionControl;
 import org.gradle.api.internal.artifacts.cache.DependencyResolutionControl;
 import org.gradle.api.internal.artifacts.cache.ModuleResolutionControl;
@@ -44,11 +44,9 @@ public class DefaultCachePolicy implements CachePolicy {
     final List<Action<? super DependencyResolutionControl>> dependencyCacheRules;
     final List<Action<? super ModuleResolutionControl>> moduleCacheRules;
     final List<Action<? super ArtifactResolutionControl>> artifactCacheRules;
-    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
 
-    public DefaultCachePolicy(ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        this.moduleIdentifierFactory = moduleIdentifierFactory;
+    public DefaultCachePolicy() {
         this.dependencyCacheRules = new ArrayList<Action<? super DependencyResolutionControl>>();
         this.moduleCacheRules = new ArrayList<Action<? super ModuleResolutionControl>>();
         this.artifactCacheRules = new ArrayList<Action<? super ArtifactResolutionControl>>();
@@ -59,7 +57,6 @@ public class DefaultCachePolicy implements CachePolicy {
     }
 
     DefaultCachePolicy(DefaultCachePolicy policy) {
-        this.moduleIdentifierFactory = policy.moduleIdentifierFactory;
         this.dependencyCacheRules = new ArrayList<Action<? super DependencyResolutionControl>>(policy.dependencyCacheRules);
         this.moduleCacheRules = new ArrayList<Action<? super ModuleResolutionControl>>(policy.moduleCacheRules);
         this.artifactCacheRules = new ArrayList<Action<? super ArtifactResolutionControl>>(policy.artifactCacheRules);
@@ -205,7 +202,7 @@ public class DefaultCachePolicy implements CachePolicy {
     }
 
     private boolean mustRefreshModule(ModuleComponentIdentifier component, ResolvedModuleVersion version, long ageMillis, boolean changingModule) {
-        return mustRefreshModule(moduleIdentifierFactory.moduleWithVersion(component.getGroup(), component.getModule(), component.getVersion()), version, ageMillis, changingModule);
+        return mustRefreshModule(DefaultModuleVersionIdentifier.newId(component.getModuleIdentifier(), component.getVersion()), version, ageMillis, changingModule);
     }
 
     private boolean mustRefreshModule(ModuleVersionIdentifier moduleVersionId, ResolvedModuleVersion version, long ageMillis, boolean changingModule) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -71,7 +71,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private static final String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies";
 
     public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ComponentIdentifierFactory componentIdentifierFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider) {
-        this(new DefaultCachePolicy(moduleIdentifierFactory), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider);
+        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleIdentifierFactory), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider);
     }
 
     DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions, DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
@@ -42,7 +42,7 @@ public class ModuleForcingResolveRule implements Action<DependencySubstitutionIn
         if (!forcedModules.isEmpty()) {
             this.forcedModules = new HashMap<ModuleIdentifier, String>();
             for (ModuleVersionSelector module : forcedModules) {
-                this.forcedModules.put(moduleIdentifierFactory.module(module.getGroup(), module.getName()), module.getVersion());
+                this.forcedModules.put(module.getModule(), module.getVersion());
             }
         } else {
             this.forcedModules = null;
@@ -56,10 +56,10 @@ public class ModuleForcingResolveRule implements Action<DependencySubstitutionIn
         }
         if (details.getRequested() instanceof ModuleComponentSelector) {
             ModuleComponentSelector selector = (ModuleComponentSelector) details.getRequested();
-            ModuleIdentifier key = moduleIdentifierFactory.module(selector.getGroup(), selector.getModule());
+            ModuleIdentifier key = selector.getModuleIdentifier();
             if (forcedModules.containsKey(key)) {
                 DefaultImmutableVersionConstraint versionConstraint = new DefaultImmutableVersionConstraint(forcedModules.get(key));
-                details.useTarget(newSelector(key.getGroup(), key.getName(), versionConstraint, selector.getAttributes()), VersionSelectionReasons.FORCED);
+                details.useTarget(newSelector(key, versionConstraint, selector.getAttributes()), VersionSelectionReasons.FORCED);
 
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
@@ -58,7 +58,7 @@ abstract class AttributeDesugaring {
             AttributeContainer moduleAttributes = module.getAttributes();
             if (!moduleAttributes.isEmpty()) {
                 ImmutableAttributes attributes = ((AttributeContainerInternal) moduleAttributes).asImmutable();
-                return DefaultModuleComponentSelector.newSelector(module.getGroup(), module.getModule(), module.getVersionConstraint(), desugar(attributes, attributesFactory));
+                return DefaultModuleComponentSelector.newSelector(module.getModuleIdentifier(), module.getVersionConstraint(), desugar(attributes, attributesFactory));
             }
         }
         return selector;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
@@ -57,9 +58,9 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
             Path projectPath = Path.path(decoder.readString());
             return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, projectPath, identityPath.getName());
         } else if (Implementation.MODULE.getId() == id) {
-            return new DefaultModuleComponentIdentifier(decoder.readString(), decoder.readString(), decoder.readString());
+            return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString());
         } else if (Implementation.SNAPSHOT.getId() == id) {
-            return new MavenUniqueSnapshotComponentIdentifier(decoder.readString(), decoder.readString(), decoder.readString(), decoder.readString());
+            return new MavenUniqueSnapshotComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString(), decoder.readString());
         } else if (Implementation.LIBRARY.getId() == id) {
             return new DefaultLibraryBinaryIdentifier(decoder.readString(), decoder.readString(), decoder.readString());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -67,7 +68,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             Path projectPath = Path.path(decoder.readString());
             return new DefaultProjectComponentSelector(buildIdentifier, identityPath, projectPath, projectPath.getName(), readAttributes(decoder));
         } else if (Implementation.MODULE.getId() == id) {
-            return DefaultModuleComponentSelector.newSelector(decoder.readString(), decoder.readString(), readVersionConstraint(decoder), readAttributes(decoder));
+            return DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), readVersionConstraint(decoder), readAttributes(decoder));
         } else if (Implementation.LIBRARY.getId() == id) {
             return new DefaultLibraryComponentSelector(decoder.readString(), decoder.readNullableString(), decoder.readNullableString());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ComponentResult;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.component.Component;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
@@ -103,7 +104,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
     }
 
     public ArtifactResolutionQuery forModule(@Nonnull String group, @Nonnull String name, @Nonnull String version) {
-        componentIds.add(DefaultModuleComponentIdentifier.newId(group, name, version));
+        componentIds.add(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, name), version));
         return this;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -53,7 +53,7 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
-        return moduleIdentifierFactory.moduleWithVersion(from.getGroup(), from.getModule(), from.getVersion());
+        return moduleIdentifierFactory.moduleWithVersion(from.getModuleIdentifier(), from.getVersion());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -111,7 +111,7 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     }
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
-        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getGroup(), details.getName(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes());
+        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes());
         return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isPending(), details.getReason());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyImpl.java
@@ -18,39 +18,44 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Cast;
 
 public abstract class AbstractDependencyImpl<T extends DependencyMetadata> implements DependencyMetadata<T> {
-    private final String group;
-    private final String name;
+    private final ModuleIdentifier moduleIdentifier;
     private MutableVersionConstraint versionConstraint;
     private String reason;
     private AttributeContainer attributes = ImmutableAttributes.EMPTY;
 
     public AbstractDependencyImpl(String group, String name, String version) {
-        this.group = group;
-        this.name = name;
+        this.moduleIdentifier = DefaultModuleIdentifier.newId(group, name);
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
     }
 
     @Override
     public String getGroup() {
-        return this.group;
+        return moduleIdentifier.getGroup();
     }
 
     @Override
     public String getName() {
-        return this.name;
+        return moduleIdentifier.getName();
     }
 
     @Override
     public VersionConstraint getVersionConstraint() {
         return this.versionConstraint;
+    }
+
+    @Override
+    public ModuleIdentifier getModule() {
+        return moduleIdentifier;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -81,6 +82,11 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
     }
 
     @Override
+    public ModuleIdentifier getModule() {
+        return getOriginalMetadata().getSelector().getModuleIdentifier();
+    }
+
+    @Override
     public String getReason() {
         return getOriginalMetadata().getReason();
     }
@@ -100,7 +106,7 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
         ModuleComponentSelector selector = getOriginalMetadata().getSelector();
         AttributeContainerInternal attributes = attributesFactory.mutable((AttributeContainerInternal) selector.getAttributes());
         configureAction.execute(attributes);
-        ModuleComponentSelector target = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), attributes.asImmutable());
+        ModuleComponentSelector target = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), selector.getVersionConstraint(), attributes.asImmutable());
         ModuleDependencyMetadata metadata = (ModuleDependencyMetadata) getOriginalMetadata().withTarget(target);
         updateMetadata(metadata);
         return Cast.uncheckedCast(this);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -191,7 +191,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
     }
 
     private void doListModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
-        ModuleIdentifier module = moduleIdentifierFactory.module(dependency.getSelector().getGroup(), dependency.getSelector().getModule());
+        ModuleIdentifier module = dependency.getSelector().getModuleIdentifier();
 
         tryListingViaRule(module, result);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -270,8 +270,8 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     private MavenUniqueSnapshotComponentIdentifier composeSnapshotIdentifier(ModuleComponentIdentifier moduleComponentIdentifier, MavenUniqueSnapshotModuleSource uniqueSnapshotVersion) {
-        return new MavenUniqueSnapshotComponentIdentifier(moduleComponentIdentifier.getGroup(),
-            moduleComponentIdentifier.getModule(),
+        return new MavenUniqueSnapshotComponentIdentifier(
+            moduleComponentIdentifier.getModuleIdentifier(),
             moduleComponentIdentifier.getVersion(),
             uniqueSnapshotVersion.getTimestamp());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifier.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 
@@ -25,14 +26,14 @@ public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleCompone
     private final String timestamp;
     private final int hashCode;
 
-    public MavenUniqueSnapshotComponentIdentifier(String group, String module, String version, String timestamp) {
-        super(group, module, version);
+    public MavenUniqueSnapshotComponentIdentifier(ModuleIdentifier module, String version, String timestamp) {
+        super(module, version);
         this.timestamp = timestamp;
         this.hashCode = super.hashCode() + timestamp.hashCode();
     }
 
     public MavenUniqueSnapshotComponentIdentifier(ModuleComponentIdentifier baseIdentifier, String timestamp) {
-        super(baseIdentifier.getGroup(), baseIdentifier.getModule(), baseIdentifier.getVersion());
+        super(baseIdentifier.getModuleIdentifier(), baseIdentifier.getVersion());
         this.timestamp = timestamp;
         this.hashCode = super.hashCode() + timestamp.hashCode();
     }
@@ -61,7 +62,7 @@ public class MavenUniqueSnapshotComponentIdentifier extends DefaultModuleCompone
     }
 
     public ModuleComponentIdentifier getSnapshotComponent() {
-        return DefaultModuleComponentIdentifier.newId(getGroup(), getModule(), getSnapshotVersion());
+        return DefaultModuleComponentIdentifier.newId(getModuleIdentifier(), getSnapshotVersion());
     }
 
     public String getTimestampedVersion() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultArtifactPublisher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultArtifactPublisher.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ArtifactPublisher;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
@@ -77,7 +78,7 @@ public class DefaultArtifactPublisher implements ArtifactPublisher {
     }
 
     private DefaultIvyModulePublishMetadata toPublishMetaData(Module module, Set<? extends ConfigurationInternal> configurations, boolean validateArtifacts) {
-        ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(module.getGroup(), module.getName(), module.getVersion());
+        ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(module.getGroup(), module.getName()), module.getVersion());
         DefaultIvyModulePublishMetadata publishMetaData = new DefaultIvyModulePublishMetadata(id, module.getStatus());
         addConfigurations(publishMetaData, configurations, validateArtifacts);
         return publishMetaData;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
@@ -102,7 +102,7 @@ public class DefaultIvyModulePublishMetadata implements IvyModulePublishMetadata
                 new DefaultImmutableVersionConstraint(
                     VERSION_TRANSFORMER.transform(versionConstraint.getPreferredVersion()),
                     CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER));
-            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), transformedConstraint, selector.getAttributes());
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), transformedConstraint, selector.getAttributes());
             return dependency.withTarget(newSelector);
         }
         return dependency;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -98,7 +98,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleTarget = (ModuleComponentSelector) target;
-            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(moduleTarget.getGroup(), moduleTarget.getModule(), moduleTarget.getVersionConstraint(), moduleTarget.getAttributes());
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(moduleTarget.getModuleIdentifier(), moduleTarget.getVersionConstraint(), moduleTarget.getAttributes());
             if (newSelector.equals(getSelector())) {
                 return this;
             }
@@ -117,7 +117,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion, selector.getAttributes());
+        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes());
         return withRequested(newSelector);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadata.java
@@ -210,7 +210,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractModuleComponentReso
             public IvyDependencyDescriptor transform(IvyDependencyDescriptor dependency) {
                 ModuleComponentSelector selector = dependency.getSelector();
                     String dynamicConstraintVersion = dependency.getDynamicConstraintVersion();
-                    ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), dynamicConstraintVersion);
+                    ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), dynamicConstraintVersion);
                     return dependency.withRequested(newSelector);
             }
         });

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifier.java
@@ -16,29 +16,31 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.DisplayName;
 
 public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifier, DisplayName {
-    private final String group;
-    private final String module;
+    private final ModuleIdentifier moduleIdentifier;
     private final String version;
     private final int hashCode;
 
-    public DefaultModuleComponentIdentifier(String group, String module, String version) {
-        assert group != null : "group cannot be null";
+    public DefaultModuleComponentIdentifier(ModuleIdentifier module, String version) {
         assert module != null : "module cannot be null";
+        assert module.getGroup() != null : "group cannot be null";
+        assert module.getName() != null : "name cannot be null";
         assert version != null : "version cannot be null";
-        this.group = group;
-        this.module = module;
+        this.moduleIdentifier = module;
         this.version = version;
         // Do NOT change the order of members used in hash code here, it's been empirically
         // tested to reduce the number of collisions on a large dependency graph (performance test)
-        this.hashCode = Objects.hashCode(version, module, group);
+        this.hashCode = Objects.hashCode(version, module);
     }
 
     public String getDisplayName() {
+        String group = moduleIdentifier.getGroup();
+        String module = moduleIdentifier.getName();
         StringBuilder builder = new StringBuilder(group.length() + module.length() + version.length() + 2);
         builder.append(group);
         builder.append(":");
@@ -54,15 +56,20 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
     }
 
     public String getGroup() {
-        return group;
+        return moduleIdentifier.getGroup();
     }
 
     public String getModule() {
-        return module;
+        return moduleIdentifier.getName();
     }
 
     public String getVersion() {
         return version;
+    }
+
+    @Override
+    public ModuleIdentifier getModuleIdentifier() {
+        return moduleIdentifier;
     }
 
     @Override
@@ -76,10 +83,7 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
 
         DefaultModuleComponentIdentifier that = (DefaultModuleComponentIdentifier) o;
 
-        if (!group.equals(that.group)) {
-            return false;
-        }
-        if (!module.equals(that.module)) {
+        if (!moduleIdentifier.equals(that.moduleIdentifier)) {
             return false;
         }
         if (!version.equals(that.version)) {
@@ -99,12 +103,12 @@ public class DefaultModuleComponentIdentifier implements ModuleComponentIdentifi
         return getDisplayName();
     }
 
-    public static ModuleComponentIdentifier newId(String group, String name, String version) {
-        return new DefaultModuleComponentIdentifier(group, name, version);
+    public static ModuleComponentIdentifier newId(ModuleIdentifier module, String version) {
+        return new DefaultModuleComponentIdentifier(module, version);
     }
 
     public static ModuleComponentIdentifier newId(ModuleVersionIdentifier moduleVersionIdentifier) {
-        return new DefaultModuleComponentIdentifier(moduleVersionIdentifier.getGroup(), moduleVersionIdentifier.getName(), moduleVersionIdentifier.getVersion());
+        return new DefaultModuleComponentIdentifier(moduleVersionIdentifier.getModule(), moduleVersionIdentifier.getVersion());
     }
 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -57,7 +57,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion, selector.getAttributes()), excludes, pending, reason);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes()), excludes, pending, reason);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -45,7 +45,7 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     @Override
     public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
         ModuleComponentSelector selector = getSelector();
-        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getGroup(), selector.getModule(), requestedVersion, selector.getAttributes());
+        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes());
         return new ModuleDependencyMetadataWrapper(delegate.withTarget(newSelector));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantBackedConfigurationMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -60,13 +61,13 @@ class VariantBackedConfigurationMetadata implements ConfigurationMetadata {
         this.variantMetadataRules = variantMetadataRules;
         List<GradleDependencyMetadata> dependencies = new ArrayList<GradleDependencyMetadata>(variant.getDependencies().size());
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
-            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint(), dependency.getAttributes());
+            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
             dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason()));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
             dependencies.add(new GradleDependencyMetadata(
-                DefaultModuleComponentSelector.newSelector(dependencyConstraint.getGroup(), dependencyConstraint.getModule(), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes()),
+                DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
                 dependencyConstraint.getReason()

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
@@ -82,7 +83,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                 for (ModuleComponentIdentifier lockedDependency : dependencyLockingState.getLockedDependencies()) {
                     String lockedVersion = lockedDependency.getVersion();
                     VersionConstraint versionConstraint = new DefaultMutableVersionConstraint(lockedVersion, strict);
-                    ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(lockedDependency.getGroup(), lockedDependency.getModule(), versionConstraint);
+                    ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(lockedDependency.getGroup(), lockedDependency.getModule()), versionConstraint);
                     result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
                         Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, getLockReason(strict, lockedVersion)));
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingNotationConverter.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.locking;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 
 class DependencyLockingNotationConverter {
@@ -26,7 +27,7 @@ class DependencyLockingNotationConverter {
         if (parts.length != 3) {
             throw new IllegalArgumentException("The module notation does not respect the lock file format of 'group:name:version' - received '" + notation + "'");
         }
-        return DefaultModuleComponentIdentifier.newId(parts[0], parts[1], parts[2]);
+        return DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(parts[0], parts[1]), parts[2]);
     }
 
     String convertToLockNotation(ModuleComponentIdentifier id) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
@@ -62,19 +63,19 @@ public class ModuleVersionResolveException extends DefaultMultiCauseException {
     }
 
     public ModuleVersionResolveException(ModuleVersionIdentifier id, String message) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getName(), DefaultImmutableVersionConstraint.of(id.getVersion())), message);
+        this(DefaultModuleComponentSelector.newSelector(id.getModule(), DefaultImmutableVersionConstraint.of(id.getVersion())), message);
     }
 
     public ModuleVersionResolveException(ModuleComponentIdentifier id, String messageFormat) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getModule(), DefaultImmutableVersionConstraint.of(id.getVersion())), messageFormat);
+        this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), messageFormat);
     }
 
     public ModuleVersionResolveException(ModuleComponentIdentifier id, Throwable cause) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getModule(), DefaultImmutableVersionConstraint.of(id.getVersion())), Arrays.asList(cause));
+        this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), Arrays.asList(cause));
     }
 
     public ModuleVersionResolveException(ModuleComponentIdentifier id, Iterable<? extends Throwable> causes) {
-        this(DefaultModuleComponentSelector.newSelector(id.getGroup(), id.getModule(), DefaultImmutableVersionConstraint.of(id.getVersion())), causes);
+        this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), causes);
     }
 
     public ModuleVersionResolveException(ModuleVersionSelector selector, Throwable cause) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultModuleVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultModuleVersionSelectorTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts
 
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
@@ -25,17 +26,19 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.new
 
 class DefaultModuleVersionSelectorTest extends Specification {
 
+    private final static ModuleIdentifier UTIL = DefaultModuleIdentifier.newId("org", "util")
+
     static VersionConstraint v(String version) {
         new DefaultMutableVersionConstraint(version)
     }
 
     def "equality"() {
-        def selector = newSelector("org", "util", v("1.0"))
+        def selector = newSelector(UTIL, v("1.0"))
 
-        def same = newSelector("org", "util", v("1.0"))
-        def diffGroup = newSelector("foo", "util", v("1.0"))
-        def diffName = newSelector("org", "foo", v("1.0"))
-        def diffVersion = newSelector("org", "util", v("2.0"))
+        def same = newSelector(UTIL, v("1.0"))
+        def diffGroup = newSelector(DefaultModuleIdentifier.newId("foo", "util"), v("1.0"))
+        def diffName = newSelector(DefaultModuleIdentifier.newId("org", "foo"), v("1.0"))
+        def diffVersion = newSelector(UTIL, v("2.0"))
 
         expect:
         selector == same
@@ -45,8 +48,8 @@ class DefaultModuleVersionSelectorTest extends Specification {
     }
 
     def "knows if matches the id"() {
-        def selector = newSelector("org", "util", v("1.0"))
-        def matching = newId("org", "util", "1.0")
+        def selector = newSelector(UTIL, v("1.0"))
+        def matching = newId(UTIL, "1.0")
 
         def differentGroup = newId("xorg", "util", "1.0")
         def differentName = newId("org", "xutil", "1.0")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.java
@@ -126,7 +126,7 @@ public class DefaultResolvedDependencyTest {
             allowing(resolvedDependency).getModule();
             will(returnValue(version));
             allowing(version).getId();
-            will(returnValue(new DefaultModuleVersionIdentifier("group", name, "1.2")));
+            will(returnValue(DefaultModuleVersionIdentifier.newId("group", name, "1.2")));
         }});
         return new DefaultResolvedArtifact(resolvedDependency.getModule().getId(), artifactStub, context.mock(ComponentArtifactIdentifier.class), context.mock(TaskDependency.class), artifactSource);
     }
@@ -227,7 +227,7 @@ public class DefaultResolvedDependencyTest {
     }
 
     public static ResolvedConfigurationIdentifier newId(String group, String name, String version, String config) {
-        return new ResolvedConfigurationIdentifier(new DefaultModuleVersionIdentifier(group, name, version), config);
+        return new ResolvedConfigurationIdentifier(DefaultModuleVersionIdentifier.newId(group, name, version), config);
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts
 
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer
 import org.gradle.api.internal.model.NamedObjectInstantiator
@@ -27,15 +28,17 @@ import static org.gradle.util.TestUtil.attributes
 import static org.gradle.util.TestUtil.attributesFactory
 
 class ModuleComponentSelectorSerializerTest extends SerializerSpec {
+    private final static ModuleIdentifier UTIL = DefaultModuleIdentifier.newId("org", "util")
+
     private serializer = new ModuleComponentSelectorSerializer(new AttributeContainerSerializer(attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     @Unroll
     def "serializes"() {
         when:
-        def result = serialize(newSelector("org", "foo", new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar')), serializer)
+        def result = serialize(newSelector(UTIL, new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar')), serializer)
 
         then:
-        result == newSelector("org", "foo", new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar'))
+        result == newSelector(UTIL, new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar'))
 
         where:
         version | rejects

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.component
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModule
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.ProjectBackedModule
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -58,7 +59,7 @@ class DefaultComponentIdentifierFactoryTest extends Specification {
         def componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module)
 
         then:
-        componentIdentifier == new DefaultModuleComponentIdentifier('some-group', 'some-name', '1.0')
+        componentIdentifier == new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('some-group', 'some-name'), '1.0')
     }
 
     def "can create component identifier for project dependency in same build"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.build.BuildState
@@ -32,7 +33,7 @@ import spock.lang.Specification
 import static org.gradle.api.internal.artifacts.dsl.ComponentSelectorParsers.multiParser
 import static org.gradle.api.internal.artifacts.dsl.ComponentSelectorParsers.parser
 
-public class ComponentSelectorParsersTest extends Specification {
+class ComponentSelectorParsersTest extends Specification {
 
     def "understands group:name:version notation"() {
         when:
@@ -60,7 +61,8 @@ public class ComponentSelectorParsersTest extends Specification {
     }
 
     def "allows exact type on input"() {
-        def id = DefaultModuleComponentSelector.newSelector("org.foo", "bar", new DefaultMutableVersionConstraint("2.0"))
+        def module = DefaultModuleIdentifier.newId("org.foo", "bar")
+        def id = DefaultModuleComponentSelector.newSelector(module, new DefaultMutableVersionConstraint("2.0"))
 
         when:
         def v = multiParser().parseNotation(id) as List
@@ -76,7 +78,8 @@ public class ComponentSelectorParsersTest extends Specification {
     }
 
     def "allows list of objects on input"() {
-        def id = DefaultModuleComponentSelector.newSelector("org.foo", "bar", new DefaultMutableVersionConstraint("2.0"))
+        def module = DefaultModuleIdentifier.newId("org.foo", "bar")
+        def id = DefaultModuleComponentSelector.newSelector(module, new DefaultMutableVersionConstraint("2.0"))
 
         when:
         def v = multiParser().parseNotation([id, ["hey:man:1.0"], [group:'i', name:'like', version:'maps']]) as List

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -486,14 +486,16 @@ class DefaultComponentMetadataHandlerTest extends Specification {
     }
 
     private DefaultMutableIvyModuleResolveMetadata ivyMetadata() {
-        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId("group", "module", "version"))
+        def module = DefaultModuleIdentifier.newId("group", "module")
+        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata
     }
 
     private DefaultMutableMavenModuleResolveMetadata mavenMetadata() {
-        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId("group", "module", "version"))
+        def module = DefaultModuleIdentifier.newId("group", "module")
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.ActionConfiguration
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.MetadataResolutionContext
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -126,14 +127,16 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     private DefaultMutableIvyModuleResolveMetadata ivyMetadata() {
-        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId("group", "module", "version"))
+        def module = DefaultModuleIdentifier.newId("group", "module")
+        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata
     }
 
     private DefaultMutableMavenModuleResolveMetadata mavenMetadata() {
-        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId("group", "module", "version"))
+        def module = DefaultModuleIdentifier.newId("group", "module")
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsersTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dsl;
 
 
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import spock.lang.Specification
@@ -26,7 +27,7 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.new
 import static org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers.multiParser
 import static org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers.parser
 
-public class ModuleVersionSelectorParsersTest extends Specification {
+class ModuleVersionSelectorParsersTest extends Specification {
 
     def "understands group:name:version notation"() {
         when:
@@ -52,7 +53,8 @@ public class ModuleVersionSelectorParsersTest extends Specification {
     }
 
     def "allows exact type on input"() {
-        def id = newSelector("org.foo", "bar", new DefaultMutableVersionConstraint("2.0"))
+        def module = DefaultModuleIdentifier.newId("org.foo", "bar")
+        def id = newSelector(module, new DefaultMutableVersionConstraint("2.0"))
 
         when:
         def v = multiParser().parseNotation(id) as List
@@ -67,7 +69,8 @@ public class ModuleVersionSelectorParsersTest extends Specification {
     }
 
     def "allows list of objects on input"() {
-        def id = newSelector("org.foo", "bar", new DefaultMutableVersionConstraint("2.0"))
+        def module = DefaultModuleIdentifier.newId("org.foo", "bar")
+        def id = newSelector(module, new DefaultMutableVersionConstraint("2.0"))
 
         when:
         def v = multiParser().parseNotation([id, ["hey:man:1.0"], [group:'i', name:'like', version:'maps']]) as List

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultUnresolvedDependencySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultUnresolvedDependencySpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
@@ -24,7 +25,8 @@ class DefaultUnresolvedDependencySpec extends Specification {
 
     def "provides module details"() {
         when:
-        def dep = new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector('org.foo', "foo", new DefaultMutableVersionConstraint('1.0', ['2.0'])), new RuntimeException("boo!"))
+        def module = DefaultModuleIdentifier.newId("org.foo", "foo")
+        def dep = new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector(module, new DefaultMutableVersionConstraint('1.0', ['2.0'])), new RuntimeException("boo!"))
 
         then:
         dep.selector.group == 'org.foo'

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultResolverResults
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
@@ -179,7 +180,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         1 * resolutionStrategy.dependencyLockingProvider >> lockingProvider
         1 * lockingProvider.loadLockState('lockedConf') >> lockingState
         1 * lockingState.mustValidateLockState() >> true
-        3 * lockingState.lockedDependencies >> [DefaultModuleComponentIdentifier.newId('org', 'foo', '1.0')]
+        3 * lockingState.lockedDependencies >> [DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org', 'foo'), '1.0')]
     }
 
     def "delegates to backing service to resolve build dependencies when there are one or more dependencies"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionCause
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
@@ -235,10 +236,12 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
     }
 
     private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {
-        return DefaultModuleComponentSelector.newSelector(group, module, new DefaultImmutableVersionConstraint(version))
+        def mid = DefaultModuleIdentifier.newId(group, module)
+        return DefaultModuleComponentSelector.newSelector(mid, new DefaultImmutableVersionConstraint(version))
     }
 
     private static ModuleVersionSelector newVersionSelector(String group, String name, String version) {
-        return DefaultModuleVersionSelector.newSelector(group, name, new DefaultImmutableVersionConstraint(version))
+        def mid = DefaultModuleIdentifier.newId(group, name)
+        return DefaultModuleVersionSelector.newSelector(mid, new DefaultImmutableVersionConstraint(version))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.DependencyResolveDetailsInternal
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal
@@ -67,7 +68,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.ruleAction.execute(moduleDetails)
 
         then:
-        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", new DefaultMutableVersionConstraint("1.5"))
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.utils", "api"), new DefaultMutableVersionConstraint("1.5"))
         1 * action.execute(moduleDetails)
         0 * _
 
@@ -88,7 +89,8 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         def componentSelectorConverter = Mock(ComponentSelectorConverter)
         substitutions.allWithDependencyResolveDetails(action, componentSelectorConverter)
 
-        def moduleOldRequested = DefaultModuleVersionSelector.newSelector("org.utils", "api", new DefaultMutableVersionConstraint("1.5"))
+        def mid = DefaultModuleIdentifier.newId("org.utils", "api")
+        def moduleOldRequested = DefaultModuleVersionSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.5"))
         def moduleTarget = DefaultModuleComponentSelector.newSelector(moduleOldRequested)
         def moduleDetails = Mock(DependencySubstitutionInternal)
 
@@ -104,7 +106,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         })
         0 * _
 
-        def projectOldRequested = DefaultModuleVersionSelector.newSelector("org.utils", "api", new DefaultMutableVersionConstraint("1.5"))
+        def projectOldRequested = DefaultModuleVersionSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.5"))
         def projectTarget = TestComponentIdentifiers.newSelector(":api")
         def projectDetails = Mock(DependencySubstitutionInternal)
 
@@ -123,6 +125,8 @@ class DefaultDependencySubstitutionsSpec extends Specification {
 
     @Unroll
     def "substitute module() matches only given module: #matchingModule"() {
+        def mid = DefaultModuleIdentifier.newId("org.utils", "api")
+
         given:
         def matchingSubstitute = Mock(ComponentSelector)
         def nonMatchingSubstitute = Mock(ComponentSelector)
@@ -137,7 +141,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.ruleAction.execute(moduleDetails)
 
         then:
-        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", new DefaultMutableVersionConstraint("1.5"))
+        _ * moduleDetails.requested >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.5"))
         1 * moduleDetails.useTarget(matchingSubstitute, SELECTED_BY_RULE)
         0 * _
 
@@ -193,7 +197,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.ruleAction.execute(projectDetails)
 
         then:
-        _ * projectDetails.requested >> DefaultModuleComponentSelector.newSelector("org.utils", "api", new DefaultMutableVersionConstraint("1.5"))
+        _ * projectDetails.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.utils", "api"), new DefaultMutableVersionConstraint("1.5"))
         0 * _
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverterTest.groovy
@@ -43,8 +43,8 @@ class ModuleSelectorStringNotationConverterTest extends Specification {
 
     def "parses module component identifier notation"() {
         expect:
-        parser.parseNotation("org.gradle:gradle-core:1.+") == DefaultModuleComponentSelector.newSelector("org.gradle", "gradle-core", new DefaultMutableVersionConstraint("1.+"))
-        parser.parseNotation(" foo:bar:[1.3, 2.0)") == DefaultModuleComponentSelector.newSelector("foo", "bar", new DefaultMutableVersionConstraint("[1.3, 2.0)"))
+        parser.parseNotation("org.gradle:gradle-core:1.+") == DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "gradle-core"), new DefaultMutableVersionConstraint("1.+"))
+        parser.parseNotation(" foo:bar:[1.3, 2.0)") == DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("foo", "bar"), new DefaultMutableVersionConstraint("[1.3, 2.0)"))
     }
 
     def "reports invalid notation"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentSelectionRulesProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentSelectionRulesProcessorTest.groovy
@@ -42,7 +42,7 @@ class ComponentSelectionRulesProcessorTest extends Specification {
     ComponentSelectionInternal componentSelection
 
     def setup() {
-        def componentIdentifier = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         componentSelection = new DefaultComponentSelection(componentIdentifier)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
@@ -25,18 +25,17 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCachePolicy
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
 import org.gradle.cache.CacheRepository
+import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.IvyModuleResolveMetadata
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.DependencyMetadata
-import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor
 import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult
 import org.gradle.internal.serialize.Serializer
@@ -56,7 +55,7 @@ class DefaultMetadataProviderTest extends Specification {
     def metaData = Stub(ModuleComponentResolveMetadata)
     def resolveState = Mock(ModuleComponentResolveState)
     def metadataProvider = new DefaultMetadataProvider(resolveState)
-    def cachePolicy = new DefaultCachePolicy(new DefaultImmutableModuleIdentifierFactory())
+    def cachePolicy = new DefaultCachePolicy()
     def ruleExecutor = new ComponentMetadataSupplierRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
 
     def setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
@@ -49,7 +49,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
     def componentSelectionRules = Mock(ComponentSelectionRulesInternal)
     def attributesSchema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), TestUtil.valueSnapshotter())
     def consumerAttributes = ImmutableAttributes.EMPTY
-    def cachePolicy = new DefaultCachePolicy(new DefaultImmutableModuleIdentifierFactory())
+    def cachePolicy = new DefaultCachePolicy()
 
     def chooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules, attributesSchema)
 
@@ -379,8 +379,9 @@ class DefaultVersionedComponentChooserTest extends Specification {
     }
 
     ModuleComponentResolveState component(String v, String status = null, Map<String, ?> attributes = [:]) {
+        def mid = DefaultModuleIdentifier.newId('group', 'name')
         def c = Stub(ModuleComponentResolveState) {
-            getId() >> DefaultModuleComponentIdentifier.newId('group', 'name', v)
+            getId() >> DefaultModuleComponentIdentifier.newId(mid, v)
             getVersion() >> version(v)
             if (status == null && attributes.isEmpty()) {
                 resolve() >> { throw new RuntimeException("No metadata available") }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.component.ArtifactType
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -49,7 +50,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         given:
         def dependency = Mock(ModuleDependencyMetadata)
         def result = Mock(BuildableModuleVersionListingResolveResult)
-        dependency.getSelector() >> DefaultModuleComponentSelector.newSelector('a', 'b', DefaultImmutableVersionConstraint.of('1.0'))
+        dependency.getSelector() >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('a', 'b'), DefaultImmutableVersionConstraint.of('1.0'))
 
         when: 'repo is not blacklisted'
         repositoryBlacklister.isBlacklisted(REPOSITORY_ID) >> false
@@ -77,7 +78,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
     def "can resolve component meta data"() {
         given:
-        def moduleComponentIdentifier = new DefaultModuleComponentIdentifier('a', 'b', '1.0')
+        def moduleComponentIdentifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('a', 'b'), '1.0')
         def requestMetaData = Mock(ComponentOverrideMetadata)
         def result = Mock(BuildableModuleComponentMetaDataResolveResult)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
@@ -20,6 +20,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.IvyUtil
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -31,7 +32,7 @@ import spock.lang.Specification
 
 class ResolverProviderComponentMetaDataResolverTest extends Specification {
     final metaData = metaData("1.2")
-    final moduleComponentId = DefaultModuleComponentIdentifier.newId("group", "project", "1.0")
+    final moduleComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "project"), "1.0")
     final componentRequestMetaData = Mock(ComponentOverrideMetadata)
 
     final Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> transformer = Mock(Transformer)
@@ -46,7 +47,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
 
     ModuleVersionIdentifier moduleVersionIdentifier(ModuleDescriptor moduleDescriptor) {
         def moduleRevId = moduleDescriptor.moduleRevisionId
-        new DefaultModuleVersionIdentifier(moduleRevId.organisation, moduleRevId.name, moduleRevId.revision)
+        DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(moduleRevId.organisation, moduleRevId.name), moduleRevId.revision)
     }
 
     def addRepo1() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -21,6 +21,7 @@ import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
@@ -80,11 +81,11 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
     }
 
     protected static ModuleComponentIdentifier componentId(String group, String name, String version) {
-        DefaultModuleComponentIdentifier.newId(group, name, version)
+        DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, name), version)
     }
 
     protected static ModuleComponentSelector moduleId(String group, String name, String version) {
-        DefaultModuleComponentSelector.newSelector(group, name, new DefaultMutableVersionConstraint(version))
+        DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, name), new DefaultMutableVersionConstraint(version))
     }
 
     protected ArtifactRevisionId artifactId(ModuleRevisionId moduleId, String name, String type, String ext) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.LinkedHashMultimap
 import com.google.common.collect.SetMultimap
 import org.apache.ivy.plugins.matcher.PatternMatcher
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
@@ -403,7 +404,7 @@ class IvyXmlModuleDescriptorParserTest extends Specification {
 
         metadata.dependencies.size() == 1
         def dependency = metadata.dependencies.first()
-        dependency.selector == newSelector("deporg", "depname", new DefaultMutableVersionConstraint("deprev"))
+        dependency.selector == newSelector(DefaultModuleIdentifier.newId("deporg", "depname"), new DefaultMutableVersionConstraint("deprev"))
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2766")
@@ -703,7 +704,7 @@ class IvyXmlModuleDescriptorParserTest extends Specification {
     }
 
     static componentId(String group, String module, String version) {
-        DefaultModuleComponentIdentifier.newId(group, module, version)
+        DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, module), version)
     }
 
     void assertArtifact(String name, String extension, String type, String classifier) {
@@ -717,7 +718,7 @@ class IvyXmlModuleDescriptorParserTest extends Specification {
     def verifyFullDependencies(Collection<IvyDependencyDescriptor> dependencies) {
         // no conf def => equivalent to *->*
         def dd = getDependency(dependencies, "mymodule2")
-        assert dd.selector == newSelector("myorg", "mymodule2", new DefaultMutableVersionConstraint("2.0"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("myorg", "mymodule2"), new DefaultMutableVersionConstraint("2.0"))
         assert dd.confMappings == map("*": ["*"])
         assert !dd.changing
         assert dd.transitive
@@ -730,70 +731,70 @@ class IvyXmlModuleDescriptorParserTest extends Specification {
 
         // conf="myconf1" => equivalent to myconf1->myconf1
         dd = getDependency(dependencies, "yourmodule1")
-        assert dd.selector == newSelector("yourorg", "yourmodule1", new DefaultMutableVersionConstraint("1.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule1"), new DefaultMutableVersionConstraint("1.1"))
         assert dd.dynamicConstraintVersion == "1+"
         assert dd.confMappings == map(myconf1: ["myconf1"])
         assert dd.dependencyArtifacts.empty
 
         // conf="myconf1->yourconf1"
         dd = getDependency(dependencies, "yourmodule2")
-        assert dd.selector == newSelector("yourorg", "yourmodule2", new DefaultMutableVersionConstraint("2+"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule2"), new DefaultMutableVersionConstraint("2+"))
         assert dd.confMappings == map(myconf1: ["yourconf1"])
         assert dd.dependencyArtifacts.empty
 
         // conf="myconf1->yourconf1, yourconf2"
         dd = getDependency(dependencies, "yourmodule3")
-        assert dd.selector == newSelector("yourorg", "yourmodule3", new DefaultMutableVersionConstraint("3.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule3"), new DefaultMutableVersionConstraint("3.1"))
         assert dd.confMappings == map(myconf1: ["yourconf1", "yourconf2"])
         assert dd.dependencyArtifacts.empty
 
         // conf="myconf1, myconf2->yourconf1, yourconf2"
         dd = getDependency(dependencies, "yourmodule4")
-        assert dd.selector == newSelector("yourorg", "yourmodule4", new DefaultMutableVersionConstraint("4.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule4"), new DefaultMutableVersionConstraint("4.1"))
         assert dd.confMappings == map(myconf1:["yourconf1", "yourconf2"], myconf2:["yourconf1", "yourconf2"])
         assert dd.dependencyArtifacts.empty
 
         // conf="myconf1->yourconf1 | myconf2->yourconf1, yourconf2"
         dd = getDependency(dependencies, "yourmodule5")
-        assert dd.selector == newSelector("yourorg", "yourmodule5", new DefaultMutableVersionConstraint("5.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule5"), new DefaultMutableVersionConstraint("5.1"))
         assert dd.confMappings == map(myconf1:["yourconf1"], myconf2:["yourconf1", "yourconf2"])
         assert dd.dependencyArtifacts.empty
 
         // conf="*->@"
         dd = getDependency(dependencies, "yourmodule11")
-        assert dd.selector == newSelector("yourorg", "yourmodule11", new DefaultMutableVersionConstraint("11.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule11"), new DefaultMutableVersionConstraint("11.1"))
         assert dd.confMappings == map("*":["@"])
         assert dd.dependencyArtifacts.empty
 
         // Conf mappings as nested elements
         dd = getDependency(dependencies, "yourmodule6")
-        assert dd.selector == newSelector("yourorg", "yourmodule6", new DefaultMutableVersionConstraint("latest.integration"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule6"), new DefaultMutableVersionConstraint("latest.integration"))
         assert dd.confMappings == map(myconf1:["yourconf1"], myconf2:["yourconf1", "yourconf2"])
         assert dd.dependencyArtifacts.empty
 
         // Conf mappings as deeply nested elements
         dd = getDependency(dependencies, "yourmodule7")
-        assert dd.selector == newSelector("yourorg", "yourmodule7", new DefaultMutableVersionConstraint("7.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule7"), new DefaultMutableVersionConstraint("7.1"))
         assert dd.confMappings == map(myconf1:["yourconf1"], myconf2:["yourconf1", "yourconf2"])
         assert dd.dependencyArtifacts.empty
 
         // Dependency artifacts
         dd = getDependency(dependencies, "yourmodule8")
-        assert dd.selector == newSelector("yourorg", "yourmodule8", new DefaultMutableVersionConstraint("8.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule8"), new DefaultMutableVersionConstraint("8.1"))
         assert dd.dependencyArtifacts.size() == 2
         assertDependencyArtifact(dd, "yourartifact8-1", ["myconf1", "myconf2", "myconf3", "myconf4", "myoldconf"])
         assertDependencyArtifact(dd, "yourartifact8-2", ["myconf1", "myconf2", "myconf3", "myconf4", "myoldconf"])
 
         // Dependency artifacts with confs
         dd = getDependency(dependencies, "yourmodule9")
-        assert dd.selector == newSelector("yourorg", "yourmodule9", new DefaultMutableVersionConstraint("9.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule9"), new DefaultMutableVersionConstraint("9.1"))
         assert dd.dependencyArtifacts.size() == 2
         assertDependencyArtifact(dd, "yourartifact9-1", ["myconf1", "myconf2"])
         assertDependencyArtifact(dd, "yourartifact9-2", ["myconf2", "myconf3"])
 
         // Dependency excludes
         dd = getDependency(dependencies, "yourmodule10")
-        assert dd.selector == newSelector("yourorg", "yourmodule10", new DefaultMutableVersionConstraint("10.1"))
+        assert dd.selector == newSelector(DefaultModuleIdentifier.newId("yourorg", "yourmodule10"), new DefaultMutableVersionConstraint("10.1"))
         assert dd.dependencyArtifacts.empty
         assert dd.allExcludes.size() == 1
         assert dd.allExcludes[0].artifact.name == "toexclude"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache
 
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser
@@ -137,7 +138,7 @@ class ModuleMetadataSerializerTest extends Specification {
     }
 
     MutableModuleComponentResolveMetadata parseGradle(File gradleFile) {
-        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId('test', 'test-module', '1.0'))
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('test', 'test-module'), '1.0'))
         gradleMetadataParser.parse(resource(gradleFile), metadata)
         metadata
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -38,7 +38,7 @@ class ModuleMetadataStoreTest extends Specification {
     ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock(ImmutableModuleIdentifierFactory) {
         module(_,_) >> { args -> DefaultModuleIdentifier.newId(*args)}
     }
-    ModuleComponentIdentifier moduleComponentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "testArtifact", "1.0")
+    ModuleComponentIdentifier moduleComponentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "testArtifact"), "1.0")
     ModuleMetadataSerializer serializer = Mock()
     ModuleMetadataStore store = new ModuleMetadataStore(pathKeyFileStore, serializer, moduleIdentifierFactory, SimpleMapInterner.notThreadSafe())
     private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilderTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter
 
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.PublishArtifactSet
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder
@@ -30,7 +31,7 @@ class DefaultLocalComponentMetadataBuilderTest extends Specification {
     def configurationMetadataBuilder = Mock(LocalConfigurationMetadataBuilder)
     def converter = new DefaultLocalComponentMetadataBuilder(configurationMetadataBuilder)
 
-    def componentId = DefaultModuleComponentIdentifier.newId("org", "name", "rev");
+    def componentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org", "name"), "rev");
 
     def "adds artifacts from each configuration"() {
         def emptySet = new HashSet<String>()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.Module
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
@@ -40,6 +41,8 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
         getAll() >> ([] as Set)
     }
 
+    def mid = DefaultModuleIdentifier.newId('foo', 'bar')
+
     def builder = new DefaultRootComponentMetadataBuilder(
         metaDataProvider,
         componentIdentifierFactory,
@@ -50,7 +53,7 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
 
     def "caches root component metadata"() {
         componentIdentifierFactory.createComponentIdentifier(_) >> {
-            new DefaultModuleComponentIdentifier('foo', 'bar', '1.0')
+            new DefaultModuleComponentIdentifier(mid, '1.0')
         }
         def root = builder.toRootComponentMetaData()
 
@@ -63,13 +66,13 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
 
     def "doesn't cache root component metadata when module identifier changes"() {
         1 * componentIdentifierFactory.createComponentIdentifier(_) >> {
-            new DefaultModuleComponentIdentifier('foo', 'bar', '1.0')
+            new DefaultModuleComponentIdentifier(mid, '1.0')
         }
         def root = builder.toRootComponentMetaData()
 
         when:
         componentIdentifierFactory.createComponentIdentifier(_) >> {
-            new DefaultModuleComponentIdentifier('foo', 'baz', '1.0')
+            new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('foo', 'baz'), '1.0')
         }
 
         def otherRoot = builder.toRootComponentMetaData()
@@ -81,7 +84,7 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
     @Unroll
     def "caching of component metadata when #mutationType change"() {
         componentIdentifierFactory.createComponentIdentifier(_) >> {
-            new DefaultModuleComponentIdentifier('foo', 'bar', '1.0')
+            new DefaultModuleComponentIdentifier(mid, '1.0')
         }
         def root = builder.toRootComponentMetaData()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCachePolicySpec.groovy
@@ -18,13 +18,12 @@ package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedModuleVersion
+import org.gradle.api.internal.artifacts.DefaultArtifactIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.cache.ArtifactResolutionControl
 import org.gradle.api.internal.artifacts.cache.DependencyResolutionControl
 import org.gradle.api.internal.artifacts.cache.ModuleResolutionControl
-import org.gradle.api.internal.artifacts.DefaultArtifactIdentifier
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.configurations.MutationValidator
 import org.gradle.internal.Actions
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -35,7 +34,7 @@ import java.util.concurrent.TimeUnit
 import static java.util.Collections.emptySet
 import static org.gradle.api.internal.artifacts.configurations.MutationValidator.MutationType.STRATEGY
 
-public class DefaultCachePolicySpec extends Specification {
+class DefaultCachePolicySpec extends Specification {
     private static final int SECOND = 1000;
     private static final int MINUTE = SECOND * 60;
     private static final int HOUR = MINUTE * 60;
@@ -43,7 +42,7 @@ public class DefaultCachePolicySpec extends Specification {
     private static final int WEEK = DAY * 7;
     private static final int FOREVER = Integer.MAX_VALUE
 
-    DefaultCachePolicy cachePolicy = new DefaultCachePolicy(new DefaultImmutableModuleIdentifierFactory())
+    DefaultCachePolicy cachePolicy = new DefaultCachePolicy()
 
     def "will cache default"() {
         expect:
@@ -56,7 +55,7 @@ public class DefaultCachePolicySpec extends Specification {
 
     def 'never expires missing module for dynamic versions'() {
         when:
-        def moduleIdentifier = new DefaultModuleIdentifier('org', 'foo')
+        def moduleIdentifier = DefaultModuleIdentifier.newId('org', 'foo')
         def versions = emptySet()
 
         then:
@@ -331,17 +330,17 @@ public class DefaultCachePolicySpec extends Specification {
     }
 
     private def moduleComponent(String group, String name, String version) {
-        new DefaultModuleComponentIdentifier(group, name, version)
+        new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), version)
     }
 
     private def moduleIdentifier(String group, String name, String version) {
-        new DefaultModuleVersionIdentifier(group, name, version)
+        DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(group, name), version)
     }
 
     private def moduleVersion(String group, String name, String version) {
         return new ResolvedModuleVersion() {
             ModuleVersionIdentifier getId() {
-                return new DefaultModuleVersionIdentifier(group, name, version);
+                return DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(group, name), version);
             }
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultComponentSelectionRulesTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy
 import org.gradle.api.Action
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.artifacts.ComponentSelection
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.ComponentSelectionInternal
 import org.gradle.api.internal.artifacts.DefaultComponentSelection
@@ -38,6 +39,8 @@ import static org.gradle.api.internal.artifacts.configurations.MutationValidator
 class DefaultComponentSelectionRulesTest extends Specification {
     static final GROUP = "group"
     static final MODULE = "module"
+    static final ModuleIdentifier MID = DefaultModuleIdentifier.newId(GROUP, MODULE)
+
     RuleActionAdapter adapter = Mock(RuleActionAdapter)
     DefaultComponentSelectionRules rules = new DefaultComponentSelectionRules(new DefaultImmutableModuleIdentifierFactory(), adapter)
     ComponentSelectionInternal componentSelection
@@ -45,7 +48,7 @@ class DefaultComponentSelectionRulesTest extends Specification {
     def ruleSource = new Object()
 
     def setup() {
-        def componentIdentifier = DefaultModuleComponentIdentifier.newId(GROUP, MODULE, "version")
+        def componentIdentifier = DefaultModuleComponentIdentifier.newId(MID, "version")
         componentSelection = new DefaultComponentSelection(componentIdentifier)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -96,6 +96,7 @@ class DefaultResolutionStrategySpec extends Specification {
     }
 
     def "provides dependency resolve rule that forces modules"() {
+        def mid = DefaultModuleIdentifier.newId('org', 'foo')
         given:
         strategy.force 'org:bar:1.0', 'org:foo:2.0'
         def details = Mock(DependencySubstitutionInternal)
@@ -106,9 +107,9 @@ class DefaultResolutionStrategySpec extends Specification {
         then:
         _ * dependencySubstitutions.ruleAction >> Actions.doNothing()
         _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
-        _ * details.getRequested() >> DefaultModuleComponentSelector.newSelector("org", "foo", new DefaultMutableVersionConstraint("1.0"))
-        _ * details.getOldRequested() >> newSelector("org", "foo", new DefaultMutableVersionConstraint("1.0"))
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector("org", "foo", new DefaultMutableVersionConstraint("2.0")), VersionSelectionReasons.FORCED)
+        _ * details.getRequested() >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
+        _ * details.getOldRequested() >> newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
+        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("2.0")), VersionSelectionReasons.FORCED)
         0 * details._
     }
 
@@ -124,6 +125,7 @@ class DefaultResolutionStrategySpec extends Specification {
     }
 
     def "provides dependency resolve rule with forced modules first and then user specified rules"() {
+        def mid = DefaultModuleIdentifier.newId('org', 'foo')
         given:
         strategy.force 'org:bar:1.0', 'org:foo:2.0'
         def details = Mock(DependencySubstitutionInternal)
@@ -134,9 +136,9 @@ class DefaultResolutionStrategySpec extends Specification {
 
         then: //forced modules:
         dependencySubstitutions.ruleAction >> substitutionAction
-        _ * details.requested >> DefaultModuleComponentSelector.newSelector("org", "foo", new DefaultMutableVersionConstraint("1.0"))
-        _ * details.oldRequested >> newSelector("org", "foo", new DefaultMutableVersionConstraint("1.0"))
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector("org", "foo", new DefaultMutableVersionConstraint("2.0")), VersionSelectionReasons.FORCED)
+        _ * details.requested >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
+        _ * details.oldRequested >> newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
+        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("2.0")), VersionSelectionReasons.FORCED)
         _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
 
         then: //user rules follow:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -736,7 +736,7 @@ class DependencyGraphBuilderTest extends Specification {
         def result = resolve()
 
         then:
-        result.unresolvedDependencies == [newSelector('group', 'c', new DefaultMutableVersionConstraint('1.0'))] as Set
+        result.unresolvedDependencies == [newSelector(DefaultModuleIdentifier.newId('group', 'c'), new DefaultMutableVersionConstraint('1.0'))] as Set
 
         when:
         result.rethrowFailure()
@@ -763,7 +763,7 @@ class DependencyGraphBuilderTest extends Specification {
         def result = resolve()
 
         then:
-        result.unresolvedDependencies == [newSelector('group', 'unknown', new DefaultMutableVersionConstraint('1.0'))] as Set
+        result.unresolvedDependencies == [newSelector(DefaultModuleIdentifier.newId('group', 'unknown'), new DefaultMutableVersionConstraint('1.0'))] as Set
 
         when:
         result.rethrowFailure()
@@ -789,7 +789,7 @@ class DependencyGraphBuilderTest extends Specification {
         def result = resolve()
 
         then:
-        result.unresolvedDependencies == [newSelector('group', 'c', new DefaultMutableVersionConstraint('1.0'))] as Set
+        result.unresolvedDependencies == [newSelector(DefaultModuleIdentifier.newId('group', 'c'), new DefaultMutableVersionConstraint('1.0'))] as Set
 
         when:
         result.rethrowFailure()
@@ -816,7 +816,7 @@ class DependencyGraphBuilderTest extends Specification {
         def result = resolve()
 
         then:
-        result.unresolvedDependencies == [newSelector('group', 'c', new DefaultMutableVersionConstraint('1.0'))] as Set
+        result.unresolvedDependencies == [newSelector(DefaultModuleIdentifier.newId('group', 'c'), new DefaultMutableVersionConstraint('1.0'))] as Set
 
         when:
         result.rethrowFailure()
@@ -843,7 +843,7 @@ class DependencyGraphBuilderTest extends Specification {
         def result = resolve()
 
         then:
-        result.unresolvedDependencies == [newSelector('group', 'c', new DefaultMutableVersionConstraint('1.0'))] as Set
+        result.unresolvedDependencies == [newSelector(DefaultModuleIdentifier.newId('group', 'c'), new DefaultMutableVersionConstraint('1.0'))] as Set
 
         when:
         result.rethrowFailure()
@@ -869,7 +869,7 @@ class DependencyGraphBuilderTest extends Specification {
         def result = resolve()
 
         then:
-        result.unresolvedDependencies == [newSelector('group', 'c', new DefaultMutableVersionConstraint('1.0'))] as Set
+        result.unresolvedDependencies == [newSelector(DefaultModuleIdentifier.newId('group', 'c'), new DefaultMutableVersionConstraint('1.0'))] as Set
 
         when:
         result.rethrowFailure()
@@ -1065,7 +1065,7 @@ class DependencyGraphBuilderTest extends Specification {
         def dependencyMetaData = dependsOn(args, from, to.moduleVersionId)
         selectorResolvesTo(dependencyMetaData, to.id, to.moduleVersionId)
         1 * metaDataResolver.resolve(to.id, _, _) >> { ComponentIdentifier id, ComponentOverrideMetadata requestMetaData, BuildableComponentResolveResult result ->
-            result.failed(new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken"))
+            result.failed(new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken"))
         }
     }
 
@@ -1080,16 +1080,16 @@ class DependencyGraphBuilderTest extends Specification {
     def brokenSelector(Map<String, ?> args = [:], def from, String to) {
         def dependencyMetaData = dependsOn(args, from, newId("group", to, "1.0"))
         1 * idResolver.resolve(dependencyMetaData, _, _) >> { DependencyMetadata dep, ResolvedVersionConstraint versionConstraint, BuildableComponentIdResolveResult result ->
-            result.failed(new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken"))
+            result.failed(new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken"))
         }
     }
 
     def dependsOn(Map<String, ?> args = [:], ComponentResolveMetadata from, ModuleVersionIdentifier to) {
-        ModuleVersionIdentifier dependencyId = args.revision ? newId(to.group, to.name, args.revision) : to
+        ModuleVersionIdentifier dependencyId = args.revision ? newId(DefaultModuleIdentifier.newId(to.group, to.name), args.revision) : to
         boolean transitive = args.transitive == null || args.transitive
         boolean force = args.force
         boolean optional = args.optional ?: false
-        ComponentSelector componentSelector = newSelector(dependencyId.group, dependencyId.name, new DefaultMutableVersionConstraint(dependencyId.version))
+        ComponentSelector componentSelector = newSelector(DefaultModuleIdentifier.newId(dependencyId.group, dependencyId.name), new DefaultMutableVersionConstraint(dependencyId.version))
         List<ExcludeMetadata> excludeRules = []
         if (args.exclude) {
             ComponentResolveMetadata excluded = args.exclude

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -225,14 +225,14 @@ class SelectorStateResolverTest extends Specification {
             def reject = versionConstraint.rejectedSelector
 
             if (!prefer.isDynamic()) {
-                def id = DefaultModuleComponentIdentifier.newId(moduleId.group, moduleId.name, prefer.selector)
+                def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(moduleId.group, moduleId.name), prefer.selector)
                 resolvedOrRejected(id, reject, result)
                 return
             }
 
             def resolved = findDynamicVersion(prefer, reject)
             if (resolved) {
-                def id = DefaultModuleComponentIdentifier.newId(moduleId.group, moduleId.name, resolved as String)
+                def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(moduleId.group, moduleId.name), resolved as String)
                 resolvedOrRejected(id, reject, result)
                 return
             }
@@ -268,7 +268,7 @@ class SelectorStateResolverTest extends Specification {
         }
 
         private ModuleVersionNotFoundException missing(VersionSelector prefer) {
-            def moduleComponentSelector = DefaultModuleComponentSelector.newSelector(moduleId.group, moduleId.name, prefer.selector)
+            def moduleComponentSelector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(moduleId.group, moduleId.name), prefer.selector)
             return new ModuleVersionNotFoundException(moduleComponentSelector, [])
         }
     }
@@ -282,7 +282,7 @@ class SelectorStateResolverTest extends Specification {
 
         @Override
         ModuleVersionIdentifier getId() {
-            return new DefaultModuleVersionIdentifier("org", "foo", version)
+            return DefaultModuleVersionIdentifier.newId("org", "foo", version)
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.result.ComponentSelectionReason
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.resolve.ModuleVersionResolveException
@@ -88,11 +89,11 @@ class CachingDependencyResultFactoryTest extends Specification {
     }
 
     def selector(String group='a', String module='a', String version='1') {
-        DefaultModuleComponentSelector.newSelector(group, module, new DefaultMutableVersionConstraint(version))
+        DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version))
     }
 
     def moduleVersionSelector(String group='a', String module='a', String version='1') {
-        newSelector(group, module, new DefaultMutableVersionConstraint(version))
+        newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version))
     }
 
     private static ComponentSelectionReason selectedByRule() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier
@@ -39,7 +40,7 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
 
     def "serializes ModuleComponentIdentifier"() {
         given:
-        ModuleComponentIdentifier identifier = new DefaultModuleComponentIdentifier('group-one', 'name-one', 'version-one')
+        ModuleComponentIdentifier identifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group-one', 'name-one'), 'version-one')
 
         when:
         ModuleComponentIdentifier result = serialize(identifier, serializer)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.serialize.SerializerSpec
@@ -30,7 +31,7 @@ class ComponentResultSerializerTest extends SerializerSpec {
     def serializer = new ComponentResultSerializer(new DefaultImmutableModuleIdentifierFactory(), new AttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
     def "serializes"() {
-        def componentIdentifier = new DefaultModuleComponentIdentifier('group', 'module', 'version')
+        def componentIdentifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', 'module'), 'version')
         def attributes = TestUtil.attributesFactory().mutable()
         attributes.attribute(Attribute.of('type', String), 'custom')
         attributes.attribute(Attribute.of('format', String), 'jar')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
@@ -144,7 +145,7 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
 
     def "serializes ModuleComponentSelector"() {
         given:
-        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector('group-one', 'name-one', constraint('version-one'))
+        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('group-one', 'name-one'), constraint('version-one'))
 
         when:
         ModuleComponentSelector result = serialize(selection, serializer)
@@ -190,7 +191,7 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
 
     def "serializes strict constraint"() {
         given:
-        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector('group-one', 'name-one', constraint('version-one', true))
+        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('group-one', 'name-one'), constraint('version-one', true))
 
         when:
         ModuleComponentSelector result = serialize(selection, serializer)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult
@@ -245,7 +246,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
     }
 
     private DummyModuleVersionSelection comp(String module, ComponentSelectionReason reason = VersionSelectionReasons.requested()) {
-        def moduleVersion = new DummyModuleVersionSelection(resultId: id(module), moduleVersion: newId("x", module, "1"), selectionReason: reason, componentId: new DefaultModuleComponentIdentifier("x", module, "1"))
+        def moduleVersion = new DummyModuleVersionSelection(resultId: id(module), moduleVersion: newId(DefaultModuleIdentifier.newId("x", module), "1"), selectionReason: reason, componentId: new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("x", module), "1"))
         moduleVersion
     }
 
@@ -254,8 +255,8 @@ class DefaultResolutionResultBuilderSpec extends Specification {
     }
 
     private DependencyResult dep(String requested, Exception failure = null, String selected = requested) {
-        def selector = DefaultModuleComponentSelector.newSelector("x", requested, DefaultImmutableVersionConstraint.of("1"))
-        def moduleVersionSelector = newSelector("x", requested, new DefaultMutableVersionConstraint("1"))
+        def selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("x", requested), DefaultImmutableVersionConstraint.of("1"))
+        def moduleVersionSelector = newSelector(DefaultModuleIdentifier.newId("x", requested), new DefaultMutableVersionConstraint("1"))
         failure = failure == null ? null : new ModuleVersionResolveException(moduleVersionSelector, failure)
         new DummyInternalDependencyResult(requested: selector, selected: id(selected), failure: failure)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
@@ -33,7 +34,7 @@ class DependencyResultSerializerTest extends Specification {
     def serializer = new DependencyResultSerializer()
 
     def "serializes successful dependency result"() {
-        def requested = DefaultModuleComponentSelector.newSelector("org", "foo", new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
+        def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org", "foo"), new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
         def successful = Mock(DependencyGraphEdge) {
             getSelector() >> Stub(DependencyGraphSelector) {
                 getResultId() >> 4L
@@ -58,8 +59,9 @@ class DependencyResultSerializerTest extends Specification {
     }
 
     def "serializes failed dependency result"() {
-        def requested = DefaultModuleComponentSelector.newSelector("x", "y", new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
-        def failure = new ModuleVersionResolveException(newSelector("x", "y", new DefaultMutableVersionConstraint("1.2")), new RuntimeException("Boo!"))
+        def mid = DefaultModuleIdentifier.newId("x", "y")
+        def requested = DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
+        def failure = new ModuleVersionResolveException(newSelector(mid, new DefaultMutableVersionConstraint("1.2")), new RuntimeException("Boo!"))
 
         def failed = Mock(DependencyGraphEdge) {
             getSelector() >> Stub(DependencyGraphSelector) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
@@ -52,7 +53,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
 
         then:
         with(result) {
-            root.id == DefaultModuleComponentIdentifier.newId("org", "root", "1.0")
+            root.id == DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org", "root"), "1.0")
             root.selectionReason == root()
         }
         printGraph(result.root) == """org:root:1.0
@@ -218,8 +219,8 @@ class StreamingResolutionResultBuilderTest extends Specification {
     private DependencyGraphNode node(Long resultId, String org, String name, String ver, ComponentSelectionReason reason = requested()) {
         def component = Stub(DependencyGraphComponent)
         _ * component.resultId >> resultId
-        _ * component.moduleVersion >> DefaultModuleVersionIdentifier.newId(org, name, ver)
-        _ * component.componentId >> DefaultModuleComponentIdentifier.newId(org, name, ver)
+        _ * component.moduleVersion >> DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
+        _ * component.componentId >> DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
         _ * component.selectionReason >> reason
 
         def node = Stub(DependencyGraphNode)
@@ -230,8 +231,8 @@ class StreamingResolutionResultBuilderTest extends Specification {
     private RootGraphNode rootNode(Long resultId, String org, String name, String ver) {
         def component = Stub(DependencyGraphComponent)
         _ * component.resultId >> resultId
-        _ * component.moduleVersion >> DefaultModuleVersionIdentifier.newId(org, name, ver)
-        _ * component.componentId >> DefaultModuleComponentIdentifier.newId(org, name, ver)
+        _ * component.moduleVersion >> DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
+        _ * component.componentId >> DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(org, name), ver)
         _ * component.selectionReason >> root()
 
         def node = Stub(RootGraphNode)
@@ -242,7 +243,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
     private DependencyGraphSelector selector(Long resultId, String org, String name, String ver) {
         def selector = Stub(DependencyGraphSelector)
         selector.resultId >> resultId
-        selector.requested >> DefaultModuleComponentSelector.newSelector(org, name, new DefaultMutableVersionConstraint(ver))
+        selector.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
         return selector
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/metadata/ComponentArtifactIdentifierSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/metadata/ComponentArtifactIdentifierSerializerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.metadata
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
@@ -26,7 +27,7 @@ class ComponentArtifactIdentifierSerializerTest extends SerializerSpec {
 
     def "converts ModuleComponentArtifactMetadata"() {
         given:
-        ModuleComponentArtifactIdentifier identifier = new DefaultModuleComponentArtifactIdentifier(DefaultModuleComponentIdentifier.newId("group", "module", "version"), "art-name", "type", "ext", "classifier")
+        ModuleComponentArtifactIdentifier identifier = new DefaultModuleComponentArtifactIdentifier(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version"), "art-name", "type", "ext", "classifier")
 
         when:
         ModuleComponentArtifactIdentifier result = serialize(identifier, serializer)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/metadata/ComponentArtifactMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/metadata/ComponentArtifactMetadataSerializerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.metadata
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
@@ -27,7 +28,7 @@ class ComponentArtifactMetadataSerializerTest extends SerializerSpec {
 
     def "converts ModuleComponentArtifactMetadata"() {
         given:
-        ModuleComponentArtifactMetadata identifier = new DefaultModuleComponentArtifactMetadata(DefaultModuleComponentIdentifier.newId("group", "module", "version"), new DefaultIvyArtifactName("art-name", "type", "ext", "classifier"))
+        ModuleComponentArtifactMetadata identifier = new DefaultModuleComponentArtifactMetadata(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version"), new DefaultIvyArtifactName("art-name", "type", "ext", "classifier"))
 
         when:
         ModuleComponentArtifactMetadata result = serialize(identifier, serializer)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.result.ArtifactResolutionResult
 import org.gradle.api.artifacts.result.UnresolvedComponentResult
 import org.gradle.api.component.Artifact
 import org.gradle.api.component.Component
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers
@@ -92,7 +93,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
         def query = createArtifactResolutionQuery(givenComponentTypeRegistry)
 
         when:
-        ModuleComponentIdentifier componentIdentifier = new DefaultModuleComponentIdentifier('mygroup', 'mymodule', '1.0')
+        ModuleComponentIdentifier componentIdentifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('mygroup', 'mymodule'), '1.0')
         ArtifactResolutionResult result = query
             .forComponents(componentIdentifier)
             .withArtifacts(selectedComponentType, selectedArtifactType)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 import org.gradle.api.Action
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder
@@ -45,7 +46,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     private dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl.class, SimpleMapInterner.notThreadSafe())
     private dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl.class, SimpleMapInterner.notThreadSafe())
 
-    def versionIdentifier = new DefaultModuleVersionIdentifier("org.test", "producer", "1.0")
+    def versionIdentifier = DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "producer"), "1.0")
     def componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     def testAttribute = Attribute.of("someAttribute", String)
     def attributes = TestUtil.attributesFactory().of(testAttribute, "someValue")
@@ -151,9 +152,9 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
 
     void resolve(MutableModuleComponentResolveMetadata component) {
         def immutable = component.asImmutable()
-        def componentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "consumer", "1.0")
+        def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
-        def componentSelector = newSelector(consumerIdentifier.group, consumerIdentifier.name, new DefaultMutableVersionConstraint(consumerIdentifier.version))
+        def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
         def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
 
         def configuration = consumer.selectConfigurations(attributes, immutable, schema)[0]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.internal.component.external.model.GradleDependencyMetadata
 import org.gradle.internal.component.model.DependencyMetadata
@@ -192,7 +193,7 @@ class DependenciesMetadataAdapterTest extends Specification {
     private fillDependencyList(int size) {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
-            ModuleComponentSelector requested = newSelector("org.gradle.test", "module$size", "1.0")
+            ModuleComponentSelector requested = newSelector(DefaultModuleIdentifier.newId("org.gradle.test", "module$size"), "1.0")
             dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null) ]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -18,17 +18,19 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.ComponentMetadataListerDetails
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultIvyDescriptorMetadataSource
 import org.gradle.api.internal.artifacts.repositories.metadata.ImmutableMetadataSources
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataArtifactProvider
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
+import org.gradle.internal.action.ConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata
-import org.gradle.internal.action.ConfigurableRule
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDataResolveResult
 import org.gradle.internal.resource.local.FileResourceRepository
@@ -44,6 +46,10 @@ import static org.gradle.internal.resolve.result.BuildableModuleComponentMetaDat
 
 class IvyResolverTest extends Specification {
     def externalResourceAccessor = Mock(CacheAwareExternalResourceAccessor)
+
+    static ModuleIdentifier mid(String group, String name) {
+        DefaultModuleIdentifier.newId(group, name)
+    }
 
     def "has useful string representation"() {
         expect:
@@ -81,19 +87,19 @@ class IvyResolverTest extends Specification {
         0 * _
 
         where:
-        moduleId                   | layoutPattern
-        newId("", "", "")          | IvyArtifactRepository.GRADLE_IVY_PATTERN
-        newId("", "", "")          | "[module]"
-        newId("group", "", "1")    | IvyArtifactRepository.GRADLE_IVY_PATTERN
-        newId("group", "", "1")    | "[module]"
-        newId("", "name", "1")     | IvyArtifactRepository.GRADLE_IVY_PATTERN
-        newId("", "name", "1")     | "[organisation]/[module]"
-        newId("group", "name", "") | IvyArtifactRepository.GRADLE_IVY_PATTERN
-        newId("group", "name", "") | "[module]-[revision]"
-        newId("", "name", "")      | "([branch])[organisation]/[module]-[revision]"
-        newId("", "name", "")      | "([organisation])/[module]-[revision]"
-        newId("", "name", "")      | "([branch])[organization]/[module]-[revision]"
-        newId("", "name", "")      | "([organization])/[module]-[revision]"
+        moduleId                        | layoutPattern
+        newId(mid("", ""), "")          | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId(mid("", ""), "")          | "[module]"
+        newId(mid("group", ""), "1")    | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId(mid("group", ""), "1")    | "[module]"
+        newId(mid("", "name"), "1")     | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId(mid("", "name"), "1")     | "[organisation]/[module]"
+        newId(mid("group", "name"), "") | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId(mid("group", "name"), "") | "[module]-[revision]"
+        newId(mid("", "name"), "")      | "([branch])[organisation]/[module]-[revision]"
+        newId(mid("", "name"), "")      | "([organisation])/[module]-[revision]"
+        newId(mid("", "name"), "")      | "([branch])[organization]/[module]-[revision]"
+        newId(mid("", "name"), "")      | "([organization])/[module]-[revision]"
     }
 
     @Unroll
@@ -110,18 +116,18 @@ class IvyResolverTest extends Specification {
         0 * _
 
         where:
-        moduleId                    | layoutPattern
-        newId("group", "name", "1") | IvyArtifactRepository.GRADLE_IVY_PATTERN
-        newId("group", "name", "1") | "[module]"
-        newId("", "name", "1")      | "[module]"
-        newId("", "name", "1")      | "[module]-[revision]"
-        newId("group", "name", "")  | "[module]"
-        newId("group", "name", "")  | "[organisation]/[module]"
-        newId("", "name", "1")      | "([organisation]/)[module]-[revision]"
-        newId("group", "name", "")  | "[organisation]/[module]-([revision])"
-        newId("group", "name", "")  | "[organization]/[module]"
-        newId("", "name", "1")      | "([organization]/)[module]-[revision]"
-        newId("group", "name", "")  | "[organization]/[module]-([revision])"
+        moduleId                         | layoutPattern
+        newId(mid("group", "name"), "1") | IvyArtifactRepository.GRADLE_IVY_PATTERN
+        newId(mid("group", "name"), "1") | "[module]"
+        newId(mid("", "name"), "1")      | "[module]"
+        newId(mid("", "name"), "1")      | "[module]-[revision]"
+        newId(mid("group", "name"), "")  | "[module]"
+        newId(mid("group", "name"), "")  | "[organisation]/[module]"
+        newId(mid("", "name"), "1")      | "([organisation]/)[module]-[revision]"
+        newId(mid("group", "name"), "")  | "[organisation]/[module]-([revision])"
+        newId(mid("group", "name"), "")  | "[organization]/[module]"
+        newId(mid("", "name"), "1")      | "([organization]/)[module]-[revision]"
+        newId(mid("group", "name"), "")  | "[organization]/[module]-([revision])"
     }
 
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResourcePatternTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResourcePatternTest.groovy
@@ -84,7 +84,7 @@ class IvyResourcePatternTest extends Specification {
 
     def "computes module version path"() {
         def ivyPattern = new IvyResourcePattern(pattern)
-        def moduleId = DefaultModuleComponentIdentifier.newId(group, module, version)
+        def moduleId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, module), version)
 
         expect:
         ivyPattern.toModuleVersionPath(moduleId).path == expectedPath
@@ -98,7 +98,7 @@ class IvyResourcePatternTest extends Specification {
 
     def "cannot compute module version path if pattern doesn't end with /[artifact]"() {
         def ivyPattern = new IvyResourcePattern(pattern)
-        def moduleId = DefaultModuleComponentIdentifier.newId(group, module, version)
+        def moduleId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, module), version)
 
         when:
         ivyPattern.toModuleVersionPath(moduleId).path
@@ -115,7 +115,7 @@ class IvyResourcePatternTest extends Specification {
     }
 
     private static ModuleComponentArtifactMetadata artifact(String group, String name, String version) {
-        final componentIdentifier = DefaultModuleComponentIdentifier.newId(group, name, version)
+        final componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, name), version)
         return new DefaultModuleComponentArtifactMetadata(new DefaultModuleComponentArtifactIdentifier(componentIdentifier, "ivy", "ivy", "xml"))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePatternTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/M2ResourcePatternTest.groovy
@@ -54,7 +54,7 @@ class M2ResourcePatternTest extends Specification {
 
     def "substitutes snapshot artifact attributes into pattern"() {
         def pattern = new M2ResourcePattern("prefix/" + MavenPattern.M2_PATTERN)
-        def snapshotId = new MavenUniqueSnapshotComponentIdentifier("group", "projectA", "1.2-SNAPSHOT", "2014-timestamp-3333")
+        def snapshotId = new MavenUniqueSnapshotComponentIdentifier(DefaultModuleIdentifier.newId("group", "projectA"), "1.2-SNAPSHOT", "2014-timestamp-3333")
 
         def artifact1 = new DefaultModuleComponentArtifactMetadata(new DefaultModuleComponentArtifactIdentifier(snapshotId, "projectA", "pom", "pom"))
 
@@ -79,7 +79,7 @@ class M2ResourcePatternTest extends Specification {
     def "substitutes attributes into pattern to determine version list pattern"() {
         def pattern = new M2ResourcePattern("prefix/[organisation]/[module]/[revision]/[type]s/[revision]/[artifact].[ext]")
         def ivyName = new DefaultIvyArtifactName("projectA", "pom", "pom")
-        def moduleId = new DefaultModuleIdentifier(group, module)
+        def moduleId = DefaultModuleIdentifier.newId(group, module)
 
         expect:
         pattern.toVersionListPattern(moduleId, ivyName).path == expectedPath
@@ -92,8 +92,8 @@ class M2ResourcePatternTest extends Specification {
 
     def "can build module path"() {
         def pattern = new M2ResourcePattern("prefix/" + MavenPattern.M2_PATTERN)
-        def module1 = new DefaultModuleIdentifier("group", "projectA")
-        def module2 = new DefaultModuleIdentifier("org.group", "projectA")
+        def module1 = DefaultModuleIdentifier.newId("group", "projectA")
+        def module2 = DefaultModuleIdentifier.newId("org.group", "projectA")
 
         expect:
         pattern.toModulePath(module1).path == 'prefix/group/projectA'
@@ -102,8 +102,8 @@ class M2ResourcePatternTest extends Specification {
 
     def "can build module version path"() {
         def pattern = new M2ResourcePattern("prefix/" + MavenPattern.M2_PATTERN)
-        def component1 = newId("group", "projectA", "1.2")
-        def component2 = newId("org.group", "projectA", "1.2")
+        def component1 = newId(DefaultModuleIdentifier.newId("group", "projectA"), "1.2")
+        def component2 = newId(DefaultModuleIdentifier.newId("org.group", "projectA"), "1.2")
 
         expect:
         pattern.toModuleVersionPath(component1).path == 'prefix/group/projectA/1.2'
@@ -114,14 +114,14 @@ class M2ResourcePatternTest extends Specification {
         def pattern = new M2ResourcePattern("/non/m2/pattern")
 
         when:
-        pattern.toModulePath(new DefaultModuleIdentifier("group", "module"))
+        pattern.toModulePath(DefaultModuleIdentifier.newId("group", "module"))
 
         then:
         thrown(UnsupportedOperationException)
     }
 
     private static ModuleComponentArtifactMetadata artifact(String group, String name, String version) {
-        final moduleVersionId = newId(group, name, version)
+        final moduleVersionId = newId(DefaultModuleIdentifier.newId(group, name), version)
         return new DefaultModuleComponentArtifactMetadata(new DefaultModuleComponentArtifactIdentifier(moduleVersionId, "ivy", "ivy", "xml"))
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotComponentIdentifierTest.groovy
@@ -16,14 +16,17 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver
 
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import spock.lang.Specification
 
 import static org.gradle.util.Matchers.strictlyEquals
 
 class MavenUniqueSnapshotComponentIdentifierTest extends Specification {
+    private ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId("group", "module")
 
     def "delegates module version to owner"() {
-        def id = new MavenUniqueSnapshotComponentIdentifier("group", "module", version, "timestamp")
+        def id = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, version, "timestamp")
 
         expect:
         id.group == "group"
@@ -38,7 +41,7 @@ class MavenUniqueSnapshotComponentIdentifierTest extends Specification {
     }
 
     def "can request timestamp or symbolic version"() {
-        def id = new MavenUniqueSnapshotComponentIdentifier("group", "module", version, "timestamp")
+        def id = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, version, "timestamp")
 
         expect:
         id.timestampedVersion == "1.0-timestamp"
@@ -51,7 +54,7 @@ class MavenUniqueSnapshotComponentIdentifierTest extends Specification {
     }
 
     def "has useful display name"() {
-        def id = new MavenUniqueSnapshotComponentIdentifier("group", "module", version, "timestamp")
+        def id = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, version, "timestamp")
 
         expect:
         id.displayName == "group:module:1.0-SNAPSHOT:timestamp"
@@ -64,10 +67,10 @@ class MavenUniqueSnapshotComponentIdentifierTest extends Specification {
 
     def "can compare with other instance"() {
         when:
-        def id1 = new MavenUniqueSnapshotComponentIdentifier("group", "module", "1.0-SNAPSHOT", "timestamp")
-        def same = new MavenUniqueSnapshotComponentIdentifier("group", "module", "1.0-SNAPSHOT", "timestamp")
-        def differentVersion = new MavenUniqueSnapshotComponentIdentifier("group", "module", "1.1-SNAPSHOT", "timestamp")
-        def differentTimestamp = new MavenUniqueSnapshotComponentIdentifier("group", "module", "1.0-SNAPSHOT", "other")
+        def id1 = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, "1.0-SNAPSHOT", "timestamp")
+        def same = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, "1.0-SNAPSHOT", "timestamp")
+        def differentVersion = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, "1.1-SNAPSHOT", "timestamp")
+        def differentTimestamp = new MavenUniqueSnapshotComponentIdentifier(moduleIdentifier, "1.0-SNAPSHOT", "other")
 
         then:
         assert strictlyEquals(id1, same)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotExternalResourceArtifactResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotExternalResourceArtifactResolverTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.DefaultIvyArtifactName
@@ -31,7 +32,7 @@ class MavenUniqueSnapshotExternalResourceArtifactResolverTest extends Specificat
 
     def "creates timestamped artifact"() {
         when:
-        def originalComponentId = DefaultModuleComponentIdentifier.newId("group", "name", "1.0-SNAPSHOT")
+        def originalComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "name"), "1.0-SNAPSHOT")
         def originalIvyName = Mock(IvyArtifactName)
         def originalArtifact = new DefaultModuleComponentArtifactMetadata(originalComponentId, originalIvyName)
         def artifact = resolver.timestamp(originalArtifact)
@@ -48,7 +49,7 @@ class MavenUniqueSnapshotExternalResourceArtifactResolverTest extends Specificat
 
     def "delegates with timestamped artifact"() {
         given:
-        def originalComponentId = DefaultModuleComponentIdentifier.newId("group", "name", "1.0-SNAPSHOT")
+        def originalComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "name"), "1.0-SNAPSHOT")
         def originalIvyName = new DefaultIvyArtifactName("name", "type", "extension")
         def originalArtifact = new DefaultModuleComponentArtifactMetadata(originalComponentId, originalIvyName)
         def artifact = resolver.timestamp(originalArtifact)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.result
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.Factory
@@ -78,7 +79,7 @@ class DefaultResolutionResultTest extends Specification {
         def root = newModule('a', 'a', '1')
         def dep1 = newDependency('b', 'b', '1')
         root.addDependency(dep1)
-        dep1.selected.addDependency(new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector('a', 'a', new DefaultMutableVersionConstraint('1')), root, dep1.selected))
+        dep1.selected.addDependency(new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('a', 'a'), new DefaultMutableVersionConstraint('1')), root, dep1.selected))
 
         when:
         def deps = new DefaultResolutionResult({root} as Factory).allDependencies

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyMapNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyMapNotationConverterTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.typeconversion.NotationParserBuilder
 import spock.lang.Specification
 
-public class DependencyMapNotationConverterTest extends Specification {
+class DependencyMapNotationConverterTest extends Specification {
 
     def parser = NotationParserBuilder.toType(ExternalModuleDependency).converter(new DependencyMapNotationConverter<DefaultExternalModuleDependency>(DirectInstantiator.INSTANCE, DefaultExternalModuleDependency.class)).toComposite()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.typeconversion.NotationParserBuilder
 import org.gradle.util.internal.SimpleMapInterner
 import spock.lang.Specification
 
-public class DependencyStringNotationConverterTest extends Specification {
+class DependencyStringNotationConverterTest extends Specification {
     def parser = new DependencyStringNotationConverter(DirectInstantiator.INSTANCE, DefaultExternalModuleDependency.class, SimpleMapInterner.notThreadSafe());
 
     def "with artifact"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.ivypublish
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -35,7 +36,7 @@ import java.text.SimpleDateFormat
 class DefaultIvyModuleDescriptorWriterTest extends Specification {
 
     private @Rule TestNameTestDirectoryProvider temporaryFolder;
-    ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId("org.test", "projectA", "1.0")
+    ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "projectA"), "1.0")
     ComponentSelectorConverter componentSelectorConverter = Mock(ComponentSelectorConverter)
     def ivyXmlModuleDescriptorWriter = new DefaultIvyModuleDescriptorWriter(componentSelectorConverter)
 
@@ -49,8 +50,8 @@ class DefaultIvyModuleDescriptorWriterTest extends Specification {
         addDependencyDescriptor(conf, "Dep2")
         metadata.addArtifact(new DefaultIvyModuleArtifactPublishMetadata(id, new DefaultIvyArtifactName("testartifact", "jar", "jar"), ["archives", "runtime"] as Set))
 
-        1 * componentSelectorConverter.getSelector(_) >> DefaultModuleVersionSelector.newSelector("org.test", "Dep1", "1.0")
-        1 * componentSelectorConverter.getSelector(_) >> DefaultModuleVersionSelector.newSelector("org.test", "Dep2", "1.0")
+        1 * componentSelectorConverter.getSelector(_) >> DefaultModuleVersionSelector.newSelector(DefaultModuleIdentifier.newId("org.test", "Dep1"), "1.0")
+        1 * componentSelectorConverter.getSelector(_) >> DefaultModuleVersionSelector.newSelector(DefaultModuleIdentifier.newId("org.test", "Dep2"), "1.0")
         File ivyFile = temporaryFolder.file("test/ivy/ivy.xml")
         ivyXmlModuleDescriptorWriter.write(metadata, ivyFile);
 
@@ -74,7 +75,7 @@ class DefaultIvyModuleDescriptorWriterTest extends Specification {
 
     def addDependencyDescriptor(BuildableLocalConfigurationMetadata metadata, String organisation = "org.test", String moduleName, String revision = "1.0") {
         def dep = new LocalComponentDependencyMetadata(metadata.getComponentId(),
-            DefaultModuleComponentSelector.newSelector(organisation, moduleName, new DefaultMutableVersionConstraint(revision)),
+            DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(organisation, moduleName), new DefaultMutableVersionConstraint(revision)),
             "runtime", null, ImmutableAttributes.EMPTY, "default", [] as List, [], false, false, true, false, null)
         metadata.addDependency(dep)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Action
 import org.gradle.api.artifacts.DependenciesMetadata
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
@@ -77,14 +78,14 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
             dependencies = [] //not supported in Ivy metadata
         } else {
             dependencies = deps.collect { name ->
-                new IvyDependencyDescriptor(newSelector("org.test", name, "1.0"), ImmutableListMultimap.of("default", "default"))
+                new IvyDependencyDescriptor(newSelector(DefaultModuleIdentifier.newId("org.test", name), "1.0"), ImmutableListMultimap.of("default", "default"))
             }
         }
         ivyMetadataFactory.create(componentIdentifier, dependencies)
     }
     private mavenComponentMetadata(String[] deps) {
         def dependencies = deps.collect { name ->
-            new MavenDependencyDescriptor(MavenScope.Compile, addAllDependenciesAsConstraints(), newSelector("org.test", name, "1.0"), null, [])
+            new MavenDependencyDescriptor(MavenScope.Compile, addAllDependenciesAsConstraints(), newSelector(DefaultModuleIdentifier.newId("org.test", name), "1.0"), null, [])
         }
         mavenMetadataFactory.create(componentIdentifier, dependencies)
     }
@@ -233,7 +234,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def dependencies = selectTargetConfigurationMetadata(metadataImplementation).dependencies
 
         then:
-        dependencies.collect { it.selector } == [newSelector("org.test", "added", "1.0") ]
+        dependencies.collect { it.selector } == [newSelector(DefaultModuleIdentifier.newId("org.test", "added"), "1.0") ]
 
         where:
         metadataType | metadataImplementation
@@ -269,9 +270,9 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     }
 
     def selectTargetConfigurationMetadata(ModuleComponentResolveMetadata immutable) {
-        def componentIdentifier = DefaultModuleComponentIdentifier.newId("org.test", "consumer", "1.0")
+        def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
-        def componentSelector = newSelector(consumerIdentifier.group, consumerIdentifier.name, new DefaultMutableVersionConstraint(consumerIdentifier.version))
+        def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
         def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
 
         consumer.selectConfigurations(attributes, immutable, schema)[0]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadataTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model
 
 import com.google.common.collect.ImmutableListMultimap
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.model.ModuleSource
@@ -27,7 +28,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 
 abstract class AbstractModuleComponentResolveMetadataTest extends Specification {
 
-    def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+    def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
     def configurations = []
     def dependencies = []
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableListMultimap
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -35,7 +36,7 @@ import static org.gradle.internal.component.external.model.AbstractMutableModule
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specification {
-    def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+    def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
     def configurations = []
     def dependencies = []
 
@@ -52,7 +53,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
     }
 
     def "can replace identifiers"() {
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def metadata = getMetadata()
 
         given:
@@ -157,7 +158,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
     }
 
     def "can attach variants with files"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def metadata = createMetadata(id)
 
         given:
@@ -227,7 +228,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
     }
 
     def "can attach variants with dependencies"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def metadata = createMetadata(id)
 
         given:
@@ -274,7 +275,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
     }
 
     def "variants are attached as consumable configurations used for variant aware selection"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def metadata = createMetadata(id)
 
         def attributes1 = attributes(usage: "compile")
@@ -340,7 +341,7 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
     def dependency(String org, String module, String version, List<String> confs = []) {
         def builder = ImmutableListMultimap.builder()
         confs.each { builder.put(it, it) }
-        def dependency = new IvyDependencyDescriptor(newSelector(org, module, v(version)), builder.build())
+        def dependency = new IvyDependencyDescriptor(newSelector(DefaultModuleIdentifier.newId(org, module), v(version)), builder.build())
         dependencies.add(dependency)
         return dependency
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -153,7 +153,7 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractModuleComponentResolve
     }
 
     def dependency(String org, String module, String version, String fromConf, String toConf) {
-        dependencies.add(new IvyDependencyDescriptor(newSelector(org, module, new DefaultMutableVersionConstraint(version)), ImmutableListMultimap.of(fromConf, toConf)))
+        dependencies.add(new IvyDependencyDescriptor(newSelector(DefaultModuleIdentifier.newId(org, module), new DefaultMutableVersionConstraint(version)), ImmutableListMultimap.of(fromConf, toConf)))
     }
 
     def exclude(String name, List<String> confs = []) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.project.ProjectInternal
@@ -174,7 +175,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractModuleComponentResol
     }
 
     def dependency(String org, String module, String version, String scope) {
-        def selector = newSelector(org, module, new DefaultMutableVersionConstraint(version))
+        def selector = newSelector(DefaultModuleIdentifier.newId(org, module), new DefaultMutableVersionConstraint(version))
         dependencies.add(new MavenDependencyDescriptor(MavenScope.valueOf(scope), false, selector, null, []))
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifierTest.groovy
@@ -16,12 +16,13 @@
 
 package org.gradle.internal.component.external.model
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.util.Matchers
 import spock.lang.Specification
 
 class DefaultModuleComponentArtifactIdentifierTest extends Specification {
     def "has useful string representation"() {
-        def componentId = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def componentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
 
         expect:
         def noClassifier = new DefaultModuleComponentArtifactIdentifier(componentId, "name", "type", "ext")
@@ -42,7 +43,7 @@ class DefaultModuleComponentArtifactIdentifierTest extends Specification {
     }
 
     def "calculates a file name from attributes"() {
-        def componentId = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def componentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
 
         expect:
         def noClassifier = new DefaultModuleComponentArtifactIdentifier(componentId, "name", "type", "ext")
@@ -59,8 +60,8 @@ class DefaultModuleComponentArtifactIdentifierTest extends Specification {
     }
 
     def "is equal when all attributes and module version are the same"() {
-        def componentId = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def otherComponentId = DefaultModuleComponentIdentifier.newId("group", "module", "2")
+        def componentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def otherComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "2")
 
         def withClassifier = new DefaultModuleComponentArtifactIdentifier(componentId,  "name", "type", "ext", 'classifier')
         def same = new DefaultModuleComponentArtifactIdentifier(componentId, "name", "type", "ext", 'classifier')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentIdentifierTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -25,7 +26,7 @@ import static org.gradle.util.Matchers.strictlyEquals
 class DefaultModuleComponentIdentifierTest extends Specification {
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        ModuleComponentIdentifier defaultModuleComponentIdentifier = new DefaultModuleComponentIdentifier('some-group', 'some-name', '1.0')
+        ModuleComponentIdentifier defaultModuleComponentIdentifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('some-group', 'some-name'), '1.0')
 
         then:
         defaultModuleComponentIdentifier.group == 'some-group'
@@ -38,7 +39,7 @@ class DefaultModuleComponentIdentifierTest extends Specification {
     @Unroll
     def "is instantiated with null constructor parameter values (#group, #name, #version)"() {
         when:
-        new DefaultModuleComponentIdentifier(group, name, version)
+        new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), version)
 
         then:
         thrown(AssertionError)
@@ -53,8 +54,8 @@ class DefaultModuleComponentIdentifierTest extends Specification {
     @Unroll
     def "can compare with other instance (#group, #name, #version)"() {
         expect:
-        ModuleComponentIdentifier defaultModuleComponentIdentifier1 = new DefaultModuleComponentIdentifier('some-group', 'some-name', '1.0')
-        ModuleComponentIdentifier defaultModuleComponentIdentifier2 = new DefaultModuleComponentIdentifier(group, name, version)
+        ModuleComponentIdentifier defaultModuleComponentIdentifier1 = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('some-group', 'some-name'), '1.0')
+        ModuleComponentIdentifier defaultModuleComponentIdentifier2 = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), version)
         strictlyEquals(defaultModuleComponentIdentifier1, defaultModuleComponentIdentifier2) == equality
         (defaultModuleComponentIdentifier1.hashCode() == defaultModuleComponentIdentifier2.hashCode()) == hashCode
         (defaultModuleComponentIdentifier1.toString() == defaultModuleComponentIdentifier2.toString()) == stringRepresentation
@@ -69,7 +70,7 @@ class DefaultModuleComponentIdentifierTest extends Specification {
 
     def "can create new ID"() {
         when:
-        ModuleComponentIdentifier defaultModuleComponentIdentifier = DefaultModuleComponentIdentifier.newId('some-group', 'some-name', '1.0')
+        ModuleComponentIdentifier defaultModuleComponentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('some-group', 'some-name'), '1.0')
 
         then:
         defaultModuleComponentIdentifier.group == 'some-group'

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -45,7 +45,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
     }
 
     def "initialises values from descriptor state and defaults"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         configuration("runtime", [])
         configuration("default", ["runtime"])
         def a1 = artifact("runtime.jar", "runtime")
@@ -109,11 +109,11 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
     }
 
     def "can override values from descriptor"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "1.2")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
         def contentHash = new HashValue("123")
-        def excludes = [new DefaultExclude(new DefaultModuleIdentifier("group", "name"))]
+        def excludes = [new DefaultExclude(DefaultModuleIdentifier.newId("group", "name"))]
 
         when:
         def metadata = ivyMetadataFactory.create(id, [], [], [], excludes)
@@ -166,8 +166,8 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
     }
 
     def "making changes to copy does not affect original"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "1.2")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
 
         when:
@@ -198,8 +198,8 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
     }
 
     def "making changes to original does not affect copy"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "1.2")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.internal.component.external.descriptor.Configuration
@@ -42,7 +43,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     }
 
     def "defines configurations for maven scopes and several usage buckets"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def metadata = mavenMetadataFactory.create(id)
 
         expect:
@@ -58,7 +59,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     }
 
     def "default metadata"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def metadata = mavenMetadataFactory.create(id)
 
         expect:
@@ -75,7 +76,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     }
 
     def "initialises values from descriptor state and defaults"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
 
         def vid = Mock(ModuleVersionIdentifier)
         def metadata = mavenMetadataFactory.create(id)
@@ -124,8 +125,8 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     }
 
     def "can override values from descriptor"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "1.2")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
         def contentHash = new HashValue("123")
 
@@ -182,8 +183,8 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     }
 
     def "making changes to copy does not affect original"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "1.2")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
         def metadata = mavenMetadataFactory.create(id)
 
@@ -231,8 +232,8 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     }
 
     def "making changes to original does not affect copy"() {
-        def id = DefaultModuleComponentIdentifier.newId("group", "module", "version")
-        def newId = DefaultModuleComponentIdentifier.newId("group", "module", "1.2")
+        def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
+        def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
         def metadata = mavenMetadataFactory.create(id)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model
 import org.gradle.api.Action
 import org.gradle.api.artifacts.DependenciesMetadata
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.util.TestUtil
@@ -43,8 +44,8 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
     def "maven optional dependencies are accessible as dependency constraints"() {
         given:
         def mavenMetadata = mavenMetadataFactory.create(componentIdentifier, [
-            new MavenDependencyDescriptor(MavenScope.Compile, false, newSelector("org", "notOptional", "1.0"), null, []),
-            new MavenDependencyDescriptor(MavenScope.Compile, true, newSelector("org", "optional", "1.0"), null, [])
+            new MavenDependencyDescriptor(MavenScope.Compile, false, newSelector(DefaultModuleIdentifier.newId("org", "notOptional"), "1.0"), null, []),
+            new MavenDependencyDescriptor(MavenScope.Compile, true, newSelector(DefaultModuleIdentifier.newId("org", "optional"), "1.0"), null, [])
         ])
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ExternalDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ExternalDependencyDescriptorTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
@@ -30,7 +31,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 abstract class ExternalDependencyDescriptorTest extends Specification {
     def attributesSchema = Stub(AttributesSchemaInternal)
 
-    def requested = newSelector("org", "module", v("1.2+"))
+    def requested = newSelector(DefaultModuleIdentifier.newId("org", "module"), v("1.2+"))
     def id = DefaultModuleVersionIdentifier.newId("org", "module", "1.2+")
 
     static VersionConstraint v(String version) {
@@ -45,7 +46,7 @@ abstract class ExternalDependencyDescriptorTest extends Specification {
         given:
 
         when:
-        def target = newSelector("org", "module", v("1.3+"))
+        def target = newSelector(DefaultModuleIdentifier.newId("org", "module"), v("1.3+"))
         def copy = metadata.withRequested(target)
 
         then:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLibraryComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLibraryComponentSelectorTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.internal.component.local.model
 
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier
 import org.gradle.api.artifacts.component.LibraryComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -110,7 +111,7 @@ class DefaultLibraryComponentSelectorTest extends Specification {
     def "does not match id for unexpected component selector type"() {
         when:
         LibraryComponentSelector defaultBuildComponentSelector = new DefaultLibraryComponentSelector(':myPath', 'myLib')
-        boolean matches = defaultBuildComponentSelector.matchesStrictly(new DefaultModuleComponentIdentifier('group', 'name', '1.0'))
+        boolean matches = defaultBuildComponentSelector.matchesStrictly(new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', 'name'), '1.0'))
 
         then:
         assert !matches

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.internal.component.local.model
 
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -68,7 +69,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
     def "does not match id for unexpected component selector type"() {
         when:
         ProjectComponentSelector defaultBuildComponentSelector = newSelector(':myPath')
-        boolean matches = defaultBuildComponentSelector.matchesStrictly(new DefaultModuleComponentIdentifier('group', 'name', '1.0'))
+        boolean matches = defaultBuildComponentSelector.matchesStrictly(new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', 'name'), '1.0'))
 
         then:
         assert !matches

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.component.local.model
 
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -27,10 +29,11 @@ import org.gradle.internal.locking.DefaultDependencyLockingState
 class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
     def dependencyLockingHandler = Mock(DependencyLockingProvider)
     def metadata = new RootLocalComponentMetadata(id, componentIdentifier, "status", Mock(AttributesSchemaInternal), dependencyLockingHandler)
+    private ModuleIdentifier mid = DefaultModuleIdentifier.newId('org', 'foo')
 
     def 'locking constraints are attached to a configuration and not its children'() {
         given:
-        def constraint = DefaultModuleComponentIdentifier.newId('org', 'foo', '1.1')
+        def constraint = DefaultModuleComponentIdentifier.newId(mid, '1.1')
         dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(false, [constraint] as Set)
         dependencyLockingHandler.loadLockState("child") >> DefaultDependencyLockingState.EMPTY_LOCK_CONSTRAINT
         addConfiguration('conf').enableLocking()
@@ -47,7 +50,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
 
     def 'locking constraints are not transitive'() {
         given:
-        def constraint = DefaultModuleComponentIdentifier.newId('org', 'foo', '1.1')
+        def constraint = DefaultModuleComponentIdentifier.newId(mid, '1.1')
         dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(false, [constraint] as Set)
         addConfiguration('conf').enableLocking()
 
@@ -63,7 +66,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
 
     def 'provides useful reason for locking constraints'() {
         given:
-        def constraint = DefaultModuleComponentIdentifier.newId('org', 'foo', '1.1')
+        def constraint = DefaultModuleComponentIdentifier.newId(mid, '1.1')
         dependencyLockingHandler.loadLockState("conf") >> new DefaultDependencyLockingState(partial, [constraint] as Set)
         addConfiguration('conf').enableLocking()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.locking
 
 import org.gradle.StartParameter
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.test.fixtures.file.TestFile
@@ -73,7 +74,7 @@ org:foo:1.0
 
         then:
         result.mustValidateLockState()
-        result.getLockedDependencies() == [newId('org', 'bar', '1.3'), newId('org', 'foo', '1.0')] as Set
+        result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('org', 'bar'), '1.3'), newId(DefaultModuleIdentifier.newId('org', 'foo'), '1.0')] as Set
     }
 
     def 'can load lockfile as prefer constraints in update mode'() {
@@ -90,7 +91,7 @@ org:foo:1.0
 
         then:
         !result.mustValidateLockState()
-        result.getLockedDependencies() == [newId('org', 'bar', '1.3')] as Set
+        result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('org', 'bar'), '1.3')] as Set
     }
 
     def 'can filter lock entries using module update patterns'() {
@@ -124,7 +125,7 @@ com:foo:1.0
 
         then:
         !result.mustValidateLockState()
-        result.getLockedDependencies() == [newId('com', 'foo', '1.0')] as Set
+        result.getLockedDependencies() == [newId(DefaultModuleIdentifier.newId('com', 'foo'), '1.0')] as Set
     }
 
     def 'fails with invalid content in lock file'() {
@@ -141,7 +142,7 @@ com:foo:1.0
     }
 
     private ModuleComponentIdentifier module(String org, String name, String version) {
-        return new DefaultModuleComponentIdentifier(org, name, version)
+        return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(org, name), version)
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.locking
 
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent
@@ -39,6 +41,8 @@ class DependencyLockingArtifactVisitorTest extends Specification {
     RootGraphNode rootNode = Mock()
     RootConfigurationMetadata metadata = Mock()
     DependencyLockingState lockState = Mock()
+    ModuleIdentifier mid = DefaultModuleIdentifier.newId("org", "foo")
+
     @Subject
     def visitor = new DependencyLockingArtifactVisitor(configuration, dependencyLockingProvider)
 
@@ -77,7 +81,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
         then:
         2 * node.owner >> component
-        1 * component.componentId >> newId('org', 'foo', '1.0')
+        1 * component.componentId >> newId(mid, '1.0')
     }
 
     def 'ignores node having a ModuleComponentIdentifier but an empty version'() {
@@ -122,7 +126,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
     def 'finishes without error when visited match expected'() {
         given:
-        def id = newId('org', 'foo', '1.1')
+        def id = newId(mid, '1.1')
         startWithState([id])
         addVisitedNode(id)
 
@@ -136,7 +140,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
     def 'throws when extra modules visited'() {
         given:
         startWithState([])
-        addVisitedNode(newId('org', 'foo', '1.0'))
+        addVisitedNode(newId(mid, '1.0'))
 
         when:
         visitor.complete()
@@ -148,7 +152,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
     def 'throws when module not visited'() {
         given:
-        startWithState([newId('org', 'foo', '1.1')])
+        startWithState([newId(mid, '1.1')])
 
         when:
         visitor.complete()
@@ -160,7 +164,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
     def 'invokes locking provider on complete with visited modules'() {
         given:
-        def identifier = newId('org', 'foo', '1.1')
+        def identifier = newId(mid, '1.1')
         startWithoutLockState()
         addVisitedNode(identifier)
 
@@ -174,7 +178,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
     def 'invokes locking provider on complete with visited modules and indicates changing modules seen'() {
         given:
-        def identifier = newId('org', 'foo', '1.1')
+        def identifier = newId(mid, '1.1')
         startWithoutLockState()
         addVisitedChangingNode(identifier)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingNotationConverterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.locking
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -55,7 +56,7 @@ class DependencyLockingNotationConverterTest extends Specification {
     def 'converts a ModuleComponentIdentifier to a lock notation'() {
         given:
         def converter = new DependencyLockingNotationConverter()
-        def module = new DefaultModuleComponentIdentifier('org', 'foo', '1.1')
+        def module = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('org', 'foo'), '1.1')
 
         when:
         def converted = converter.convertToLockNotation(module)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockEntryFilterFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.locking
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -54,7 +55,7 @@ class LockEntryFilterFactoryTest extends Specification {
 
     private static ModuleComponentIdentifier id(String notation) {
         String[] parts = notation.split(':')
-        DefaultModuleComponentIdentifier.newId(parts[0], parts[1], parts[2])
+        DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(parts[0], parts[1]), parts[2])
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionNotFoundExceptionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionNotFoundExceptionTest.groovy
@@ -15,7 +15,9 @@
  */
 package org.gradle.internal.resolve
 
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.AttributeMatcher
@@ -27,6 +29,10 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class ModuleVersionNotFoundExceptionTest extends Specification {
+    static ModuleIdentifier mid(String group, String name) {
+        DefaultModuleIdentifier.newId(group, name)
+    }
+
     def "formats message to include id when no locations"() {
         def exception = new ModuleVersionNotFoundException(newId("org", "a", "1.2"), [])
 
@@ -45,7 +51,7 @@ Searched in the following locations:
     }
 
     def "formats message for selector and locations when no versions attempted"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], [], [])
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], [], [])
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any matches for org:a:1.+ as no versions of org:a are available.
@@ -55,7 +61,7 @@ Searched in the following locations:
     }
 
     def "formats message for selector and locations when versions attempted and non rejected"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["1.1", "1.2"], [])
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["1.1", "1.2"], [])
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -68,7 +74,7 @@ Searched in the following locations:
     }
 
     def "formats message for selector and locations when versions attempted and some rejected"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], [reject("1.1"), reject("1.2")])
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], [reject("1.1"), reject("1.2")])
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -84,7 +90,7 @@ Searched in the following locations:
     }
 
     def "formats message for selector and locations when versions attempted and all rejected"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], [], [reject("1.1"), reject("1.2")])
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], [], [reject("1.1"), reject("1.2")])
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -97,7 +103,7 @@ Searched in the following locations:
     }
 
     def "limits list of candidates"() {
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], (1..20).collect { it.toString() }, (1..10).collect { reject(it.toString()) })
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], (1..20).collect { it.toString() }, (1..10).collect { reject(it.toString()) })
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -121,9 +127,9 @@ Searched in the following locations:
     }
 
     def "can add incoming paths to exception"() {
-        def a = DefaultModuleComponentIdentifier.newId("org", "a", "1.2")
-        def b = DefaultModuleComponentIdentifier.newId("org", "b", "5")
-        def c = DefaultModuleComponentIdentifier.newId("org", "c", "1.0")
+        def a = DefaultModuleComponentIdentifier.newId(mid("org", "a"), "1.2")
+        def b = DefaultModuleComponentIdentifier.newId(mid("org", "b"), "5")
+        def c = DefaultModuleComponentIdentifier.newId(mid("org", "c"), "1.0")
 
         def exception = new ModuleVersionNotFoundException(newId("a", "b", "c"), ["http://somewhere"])
         def onePath = exception.withIncomingPaths([[a, b, c]])
@@ -141,7 +147,7 @@ Required by:
                 rejectedByAttributes('1.1', [color: ['red', 'blue', false]]),
                 rejectedByAttributes('1.0', [color: ['red', 'green', false]]),
         ]
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -161,7 +167,7 @@ Searched in the following locations:
                 rejectedByAttributes('1.1', [color: ['red', 'red', true], shape: ['square', 'circle', false]]),
                 rejectedByAttributes('1.0', [color: ['red', 'green', false], shape: ['square', 'circle', false]]),
         ]
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -186,7 +192,7 @@ Searched in the following locations:
                 rejectedByAttributes('1.1', [color: ['red', 'red', true], shape: ['square', 'circle', false]]),
                 rejectedByAttributes('1.0', [color: ['red', 'green', false], shape: ['square', 'circle', false]]),
         ]
-        def exception = new ModuleVersionNotFoundException(newSelector("org", "a", new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
+        def exception = new ModuleVersionNotFoundException(newSelector(mid("org", "a"), new DefaultMutableVersionConstraint("1.+")), ["http://somewhere", "file:/somewhere"], ["0.9", "0.10"], versions)
 
         expect:
         exception.message == toPlatformLineSeparators("""Could not find any version that matches org:a:1.+.
@@ -208,11 +214,11 @@ Searched in the following locations:
 
 
     static RejectedVersion reject(String version) {
-        new RejectedVersion(DefaultModuleComponentIdentifier.newId("org", "foo", version)) {}
+        new RejectedVersion(DefaultModuleComponentIdentifier.newId(mid("org", "foo"), version)) {}
     }
 
     static RejectedByAttributesVersion rejectedByAttributes(String version, Map<String, List<String>> attributes) {
-        return new RejectedByAttributesVersion(DefaultModuleComponentIdentifier.newId("org", "foo", version), toDescriptions(attributes))
+        return new RejectedByAttributesVersion(DefaultModuleComponentIdentifier.newId(mid("org", "foo"), version), toDescriptions(attributes))
     }
 
     static List<AttributeMatcher.MatchingDescription> toDescriptions(Map<String, List<String>> attributes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionResolveExceptionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionResolveExceptionTest.groovy
@@ -15,7 +15,9 @@
  */
 package org.gradle.internal.resolve
 
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
 
@@ -28,20 +30,24 @@ class ModuleVersionResolveExceptionTest extends Specification {
         new DefaultMutableVersionConstraint(version)
     }
 
+    private static ModuleIdentifier mid(String group, String name) {
+        DefaultModuleIdentifier.newId(group, name)
+    }
+
     def "provides default message that includes selector"() {
-        def exception1 = new ModuleVersionResolveException(newSelector("org", "a", v("1.2")), new RuntimeException())
+        def exception1 = new ModuleVersionResolveException(newSelector(mid("org", "a"), v("1.2")), new RuntimeException())
 
         expect:
         exception1.message == 'Could not resolve org:a:1.2.'
     }
 
     def "can add incoming paths to exception"() {
-        def a = newId("org", "a", "1.2")
-        def b = newId("org", "b", "5")
-        def c = newId("org", "c", "1.0")
+        def a = newId(mid("org", "a"), "1.2")
+        def b = newId(mid("org", "b"), "5")
+        def c = newId(mid("org", "c"), "1.0")
 
         def cause = new RuntimeException()
-        def exception = new ModuleVersionResolveException(newSelector("a", "b", v("c")), cause)
+        def exception = new ModuleVersionResolveException(newSelector(mid("a", "b"), v("c")), cause)
         def onePath = exception.withIncomingPaths([[a, b, c]])
         def twoPaths = exception.withIncomingPaths([[a, b, c], [a, c]])
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.resolve.result
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
@@ -73,7 +74,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "cannot get id when resolve failed"() {
-        def failure = new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
 
         when:
         result.failed(failure)
@@ -85,7 +86,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "cannot get meta-data when resolve failed"() {
-        def failure = new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
 
         when:
         result.failed(failure)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.resolve.result
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.resolve.ModuleVersionResolveException
@@ -44,7 +45,7 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
 
         when:
         descriptor.failed(failure)
@@ -113,7 +114,7 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
 
     def "cannot get meta-data when failed"() {
         given:
-        def failure = new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
         descriptor.failed(failure)
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleVersionListingResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleVersionListingResolveResultTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.resolve.result
 
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import spock.lang.Specification
@@ -43,7 +44,7 @@ class DefaultBuildableModuleVersionListingResolveResultTest extends Specificatio
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(newSelector("a", "b", new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
 
         when:
         descriptor.failed(failure)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.internal.Describables
@@ -34,17 +35,17 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.new
 class ResolutionResultDataBuilder {
 
     static DefaultResolvedDependencyResult newDependency(String group='a', String module='a', String version='1', String selectedVersion='1') {
-        new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(group, module, new DefaultMutableVersionConstraint(version)), newModule(group, module, selectedVersion), newModule())
+        new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version)), newModule(group, module, selectedVersion), newModule())
     }
 
     static DefaultUnresolvedDependencyResult newUnresolvedDependency(String group='x', String module='x', String version='1', String selectedVersion='1') {
-        def requested = DefaultModuleComponentSelector.newSelector(group, module, new DefaultMutableVersionConstraint(version))
-        new DefaultUnresolvedDependencyResult(requested, VersionSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(group, module, new DefaultMutableVersionConstraint(version)), "broken"))
+        def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version))
+        new DefaultUnresolvedDependencyResult(requested, VersionSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version)), "broken"))
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1',
                                                         ComponentSelectionReason selectionReason = VersionSelectionReasons.requested(), ResolvedVariantResult variant = newVariant()) {
-        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(group, module, version), variant)
+        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), variant)
     }
 
     static DefaultResolvedDependencyResult newDependency(ComponentSelector componentSelector, String group='a', String module='a', String selectedVersion='1') {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
@@ -178,7 +178,8 @@ abstract class AbstractProjectDependencyConflictResolutionIntegrationSpec extend
 
     static String checkHelper(String buildId, String projectPath) { """
         def moduleId(String group, String name, String version) {
-            return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(group, name, version)
+            def mid = org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId(group, name)
+            return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(mid, version)
         }
 
         def projectId(String projectName) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
@@ -199,7 +198,7 @@ public class JsonProjectDependencyRenderer {
     private ModuleIdentifier getModuleIdentifier(RenderableDependency renderableDependency) {
         if (renderableDependency.getId() instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier id = (ModuleComponentIdentifier) renderableDependency.getId();
-            return DefaultModuleIdentifier.newId(id.getGroup(), id.getModule());
+            return id.getModuleIdentifier();
         }
         return null;
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
@@ -116,7 +116,7 @@ class ResolutionErrorRenderer implements Action<Throwable> {
             matchesSpec |= dependencySpec.isSatisfiedBy(new DependencyResult() {
                 @Override
                 public ComponentSelector getRequested() {
-                    return DefaultModuleComponentSelector.newSelector(mvi.getGroup(), mvi.getName(), mvi.getVersion());
+                    return DefaultModuleComponentSelector.newSelector(mvi.getModule(), mvi.getVersion());
                 }
 
                 @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
@@ -55,8 +55,7 @@ public abstract class AbstractRenderableDependencyResult extends AbstractRendera
      * @return Indicates whether version differs
      */
     private boolean isSameGroupAndModuleButDifferentVersion(ModuleComponentSelector requested, ModuleComponentIdentifier selected) {
-        return requested.getGroup().equals(selected.getGroup())
-            && requested.getModule().equals(selected.getModule())
+        return requested.getModuleIdentifier().equals(selected.getModuleIdentifier())
             && !requested.getVersionConstraint().getPreferredVersion().equals(selected.getVersion());
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -35,7 +35,7 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
         this.dependency = dependency;
         // TODO:Prezi Is this cast safe? Can't this be a LibraryComponentSelector, say?
         ModuleComponentSelector attempted = (ModuleComponentSelector)dependency.getAttempted();
-        actual = DefaultModuleComponentIdentifier.newId(attempted.getGroup(), attempted.getModule(), attempted.getVersionConstraint().getPreferredVersion());
+        actual = DefaultModuleComponentIdentifier.newId(attempted.getModuleIdentifier(), attempted.getVersionConstraint().getPreferredVersion());
     }
 
     public Throwable getFailure() {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/reporting/dependencies/internal/StrictDependencyResultSpecTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/reporting/dependencies/internal/StrictDependencyResultSpecTest.groovy
@@ -30,7 +30,7 @@ class StrictDependencyResultSpecTest extends Specification {
         new StrictDependencyResultSpec(moduleIdentifier).isSatisfiedBy(newDependency("org.foo", "foo-core", "1.0"))
 
         where:
-        moduleIdentifier << [new DefaultModuleIdentifier('org.foo', 'foo-core')]
+        moduleIdentifier << [id('org.foo', 'foo-core')]
     }
 
     def "knows mismatching dependencies"() {
@@ -38,8 +38,8 @@ class StrictDependencyResultSpecTest extends Specification {
         !new StrictDependencyResultSpec(moduleIdentifier).isSatisfiedBy(newDependency("org.foo", "foo-core", "1.0"))
 
         where:
-        moduleIdentifier << [new DefaultModuleIdentifier('org.foobar', 'foo-core'),
-                             new DefaultModuleIdentifier('org.foo', 'foo-coreImpl')]
+        moduleIdentifier << [id('org.foobar', 'foo-core'),
+                             id('org.foo', 'foo-coreImpl')]
     }
 
     def "matches unresolved dependencies"() {
@@ -47,7 +47,7 @@ class StrictDependencyResultSpecTest extends Specification {
         new StrictDependencyResultSpec(moduleIdentifier).isSatisfiedBy(newUnresolvedDependency("org.foo", "foo-core", "5.0"))
 
         where:
-        moduleIdentifier << [new DefaultModuleIdentifier('org.foo', 'foo-core')]
+        moduleIdentifier << [id('org.foo', 'foo-core')]
     }
 
     def "does not match unresolved dependencies"() {
@@ -55,7 +55,11 @@ class StrictDependencyResultSpecTest extends Specification {
         !new StrictDependencyResultSpec(moduleIdentifier).isSatisfiedBy(newUnresolvedDependency("org.foo", "foo-core", "5.0"))
 
         where:
-        moduleIdentifier << [new DefaultModuleIdentifier('org.foobar', 'foo-core'),
-                             new DefaultModuleIdentifier('org.foo', 'foo-coreImpl')]
+        moduleIdentifier << [id('org.foobar', 'foo-core'),
+                             id('org.foo', 'foo-coreImpl')]
+    }
+
+    private DefaultModuleIdentifier id(String group, String name) {
+        DefaultModuleIdentifier.newId(group, name)
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics.internal.graph.nodes
 
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -30,15 +31,15 @@ class AbstractRenderableDependencyResultSpec extends Specification {
 
     def "renders name for ModuleComponentSelector"() {
         given:
-        def requested = DefaultModuleComponentSelector.newSelector('org.mockito', 'mockito-core', new DefaultMutableVersionConstraint('1.0'),)
+        def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), new DefaultMutableVersionConstraint('1.0'),)
 
         expect:
-        dep(requested, DefaultModuleComponentIdentifier.newId('org.mockito', 'mockito-core', '1.0')).name == 'org.mockito:mockito-core:1.0'
-        dep(requested, DefaultModuleComponentIdentifier.newId('org.mockito', 'mockito-core', '2.0')).name == 'org.mockito:mockito-core:1.0 -> 2.0'
-        dep(requested, DefaultModuleComponentIdentifier.newId('org.mockito', 'mockito', '1.0')).name == 'org.mockito:mockito-core:1.0 -> org.mockito:mockito:1.0'
-        dep(requested, DefaultModuleComponentIdentifier.newId('com.mockito', 'mockito', '2.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito:mockito:2.0'
-        dep(requested, DefaultModuleComponentIdentifier.newId('com.mockito.other', 'mockito-core', '3.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito.other:mockito-core:3.0'
-        dep(requested, DefaultModuleComponentIdentifier.newId('com.mockito.other', 'mockito-core', '1.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito.other:mockito-core:1.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), '1.0')).name == 'org.mockito:mockito-core:1.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), '2.0')).name == 'org.mockito:mockito-core:1.0 -> 2.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org.mockito', 'mockito'), '1.0')).name == 'org.mockito:mockito-core:1.0 -> org.mockito:mockito:1.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('com.mockito', 'mockito'), '2.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito:mockito:2.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('com.mockito.other', 'mockito-core'), '3.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito.other:mockito-core:3.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('com.mockito.other', 'mockito-core'), '1.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito.other:mockito-core:1.0'
         dep(requested, newProjectId(':a')).name == 'org.mockito:mockito-core:1.0 -> project :a'
     }
 
@@ -49,7 +50,7 @@ class AbstractRenderableDependencyResultSpec extends Specification {
         expect:
         dep(requested, newProjectId(':a')).name == 'project :a'
         dep(requested, newProjectId(':b')).name == 'project :a -> project :b'
-        dep(requested, DefaultModuleComponentIdentifier.newId('org.somegroup', 'module', '1.0')).name == 'project :a -> org.somegroup:module:1.0'
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org.somegroup', 'module'), '1.0')).name == 'project :a -> org.somegroup:module:1.0'
     }
 
     private AbstractRenderableDependencyResult dep(ComponentSelector requested, ComponentIdentifier selected) {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependencyResultTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependencyResultTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics.internal.graph.nodes
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
 
@@ -28,7 +29,7 @@ class RenderableDependencyResultTest extends Specification {
 
     def "renders name"() {
         given:
-        def requested = newSelector('org.mockito', 'mockito-core', new DefaultMutableVersionConstraint('1.0'))
+        def requested = newSelector(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), new DefaultMutableVersionConstraint('1.0'))
         def same = newModule('org.mockito', 'mockito-core', '1.0')
         def differentVersion = newModule('org.mockito', 'mockito-core', '2.0')
         def differentName = newModule('org.mockito', 'mockito', '1.0')

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResultTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResultTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics.internal.graph.nodes
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
 
@@ -30,11 +31,11 @@ class RenderableUnresolvedDependencyResultTest extends Specification {
 
     def "renders name"() {
         given:
-        def requested = newSelector('org.mockito', 'mockito-core', v('1.0'))
-        def same = newSelector('org.mockito', 'mockito-core', v('1.0'))
-        def differentVersion = newSelector('org.mockito', 'mockito-core', v('2.0'))
-        def differentName = newSelector('org.mockito', 'mockito', v('1.0'))
-        def differentGroup = newSelector('com.mockito', 'mockito', v('2.0'))
+        def requested = newSelector(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), v('1.0'))
+        def same = newSelector(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), v('1.0'))
+        def differentVersion = newSelector(DefaultModuleIdentifier.newId('org.mockito', 'mockito-core'), v('2.0'))
+        def differentName = newSelector(DefaultModuleIdentifier.newId('org.mockito', 'mockito'), v('1.0'))
+        def differentGroup = newSelector(DefaultModuleIdentifier.newId('com.mockito', 'mockito'), v('2.0'))
 
         expect:
         dep(requested, same).name == 'org.mockito:mockito-core:1.0'

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SimpleDependency.java
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/SimpleDependency.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -39,7 +40,7 @@ public class SimpleDependency extends AbstractRenderableDependency {
         this.name = name;
         this.resolvable = resolvable;
         this.description = description;
-        this.id = newId(name, name, "1.0");
+        this.id = newId(DefaultModuleIdentifier.newId(name, name), "1.0");
     }
 
     public ModuleComponentIdentifier getId() {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.diagnostics.internal.insight
 
 import org.gradle.api.artifacts.result.ComponentSelectionReason
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
@@ -190,10 +191,10 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private DefaultResolvedDependencyResult dep(String group, String name, String requested, String selected = requested, ComponentSelectionReason selectionReason = VersionSelectionReasons.requested()) {
-        def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(group, name, selected), defaultVariant())
-        new DefaultResolvedDependencyResult(newSelector(group, name, new DefaultMutableVersionConstraint(requested)),
+        def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant())
+        new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId(group, name), new DefaultMutableVersionConstraint(requested)),
                 selectedModule,
-                new DefaultResolvedComponentResult(newId("a", "root", "1"), VersionSelectionReasons.requested(), new DefaultModuleComponentIdentifier(group, name, selected), defaultVariant()))
+                new DefaultResolvedComponentResult(newId("a", "root", "1"), VersionSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant()))
     }
 
     private DefaultResolvedVariantResult defaultVariant() {
@@ -201,11 +202,11 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private DefaultResolvedDependencyResult path(String path) {
-        DefaultResolvedComponentResult from = new DefaultResolvedComponentResult(newId("group", "root", "1"), VersionSelectionReasons.requested(), new DefaultModuleComponentIdentifier("group", "root", "1"), defaultVariant())
+        DefaultResolvedComponentResult from = new DefaultResolvedComponentResult(newId("group", "root", "1"), VersionSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("group", "root"), "1"), defaultVariant())
         List<DefaultResolvedDependencyResult> pathElements = (path.split(' -> ') as List).reverse().collect {
             def (name, version) = it.split(':')
-            def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), VersionSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId('group', name, version), defaultVariant())
-            def result = new DefaultResolvedDependencyResult(newSelector("group", name, version), componentResult, from)
+            def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), VersionSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('group', name), version), defaultVariant())
+            def result = new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId("group", name), version), componentResult, from)
             from = componentResult
             result
         }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorterSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.diagnostics.internal.insight
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
@@ -53,15 +54,15 @@ class DependencyResultSorterSpec extends Specification {
         where:
         d1                                                                                                                                                          | d2
         null                                                                                                                                                        | null
-        null         | newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0")) | null
-        newDependency(null, DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0")) | newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0")) | newDependency(null, DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        null         | newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0")) | null
+        newDependency(null, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0")) | newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0")) | newDependency(null, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
     }
 
     def "sorts by comparing ProjectComponentSelector on left and ModuleComponentSelector on right"() {
-        def d1 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        def d1 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -71,8 +72,8 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by comparing ModuleComponentSelector on left and ProjectComponentSelector on right"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        def d2 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        def d2 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -82,16 +83,16 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by requested ModuleComponentSelector by version"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.aha", "aha", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.aha", "aha"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
 
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("0.8")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d3 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d4 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.5")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "core"), v("0.8")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "core"), "2.0"))
+        def d3 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "core"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "core"), "2.0"))
+        def d4 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "core"), v("1.5")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "core"), "2.0"))
 
-        def d5 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "xxxx", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
+        def d5 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "xxxx"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "xxxx"), "1.0"))
 
-        def d6 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "zzzz", v("1.5")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        def d7 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "zzzz", v("2.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        def d6 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), v("1.5")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        def d7 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), v("2.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d5, d3, d6, d1, d2, d7, d4], versionSelectorScheme, versionComparator, versionParser)
@@ -101,11 +102,12 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "for a given module prefers dependency where selected exactly matches requested"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("2.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("2.2")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.2"))
-        def d3 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d4 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.5")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d5 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("3.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.2"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("2.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("2.2")), DefaultModuleComponentIdentifier.newId(core, "2.2"))
+        def d3 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d4 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.5")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d5 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("3.0")), DefaultModuleComponentIdentifier.newId(core, "2.2"))
 
         when:
         def sorted = DependencyResultSorter.sort([d3, d1, d5, d2, d4], versionSelectorScheme, versionComparator, versionParser)
@@ -115,14 +117,15 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "semantically compares versions for ModuleComponentSelector"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("0.8")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0-alpha")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d3 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d4 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.2")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d5 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.11")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d6 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.11.2")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d7 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.11.11")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d8 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("2")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("0.8")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0-alpha")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d3 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d4 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.2")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d5 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.11")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d6 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.11.2")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d7 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.11.11")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d8 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("2")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d4, d7, d1, d6, d8, d5, d3, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -132,15 +135,16 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "orders a mix of dynamic and static versions for ModuleComponentSelector"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("2.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("not-a-dynamic-selector")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d3 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("0.8")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d4 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d5 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("(,2.0]")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d6 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.2+")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d7 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("[1.2,)")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d8 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("latest.integration")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d9 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("latest.zzz")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("2.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("not-a-dynamic-selector")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d3 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("0.8")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d4 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d5 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("(,2.0]")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d6 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.2+")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d7 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("[1.2,)")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d8 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("latest.integration")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
+        def d9 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("latest.zzz")), DefaultModuleComponentIdentifier.newId(core, "2.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d4, d7, d1, d6, d8, d5, d3, d9, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -150,14 +154,15 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by from when requested ModuleComponentSelector version is the same"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"), DefaultModuleComponentIdentifier.newId("org.a", "a", "1.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"), DefaultModuleComponentIdentifier.newId("org.b", "a", "1.0"))
-        def d3 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"), DefaultModuleComponentIdentifier.newId("org.b", "b", "0.8"))
-        def d4 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"), DefaultModuleComponentIdentifier.newId("org.b", "b", "1.12"))
-        def d5 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"), DefaultModuleComponentIdentifier.newId("org.b", "b", "2.0"))
-        def d6 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"), DefaultModuleComponentIdentifier.newId("org.b", "c", "0.9"))
-        def d7 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "other", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "other", "1.0"), DefaultModuleComponentIdentifier.newId("org.b", "a", "0.9"))
-        def d8 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "other", v("1.0")), DefaultModuleComponentIdentifier.newId("org.gradle", "other", "1.0"), DefaultModuleComponentIdentifier.newId("org.b", "a", "0.9.1"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.a", "a"), "1.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "a"), "1.0"))
+        def d3 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "b"), "0.8"))
+        def d4 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "b"), "1.12"))
+        def d5 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "b"), "2.0"))
+        def d6 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), DefaultModuleComponentIdentifier.newId(core, "2.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "c"), "0.9"))
+        def d7 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "other"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "other"), "1.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "a"), "0.9"))
+        def d8 = newDependency(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org.gradle", "other"), v("1.0")), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "other"), "1.0"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.b", "a"), "0.9.1"))
 
         when:
         def sorted = DependencyResultSorter.sort([d7, d8, d1, d3, d5, d2, d4, d6], versionSelectorScheme, versionComparator, versionParser)
@@ -168,16 +173,17 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by requested ProjectComponentSelector by project path"() {
-        def d1 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(TestComponentIdentifiers.newSelector(":hisProject"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
 
-        def d2 = newDependency(TestComponentIdentifiers.newSelector(":myPath"), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d3 = newDependency(TestComponentIdentifiers.newSelector(":newPath"), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
-        def d4 = newDependency(TestComponentIdentifiers.newSelector(":path2:path6"), DefaultModuleComponentIdentifier.newId("org.gradle", "core", "2.0"))
+        def d2 = newDependency(TestComponentIdentifiers.newSelector(":myPath"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "core"), "2.0"))
+        def d3 = newDependency(TestComponentIdentifiers.newSelector(":newPath"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "core"), "2.0"))
+        def d4 = newDependency(TestComponentIdentifiers.newSelector(":path2:path6"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "core"), "2.0"))
 
-        def d5 = newDependency(TestComponentIdentifiers.newSelector(":path3:path2"), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
+        def d5 = newDependency(TestComponentIdentifiers.newSelector(":path3:path2"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "xxxx"), "1.0"))
 
-        def d6 = newDependency(TestComponentIdentifiers.newSelector(":project2"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        def d7 = newDependency(TestComponentIdentifiers.newSelector(":project5"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
+        def d6 = newDependency(TestComponentIdentifiers.newSelector(":project2"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        def d7 = newDependency(TestComponentIdentifiers.newSelector(":project5"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d5, d3, d6, d1, d2, d7, d4], versionSelectorScheme, versionComparator, versionParser)
@@ -187,8 +193,9 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by from for just ProjectComponentIdentifiers"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project6"), newProjectId(":project2"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project6"), newProjectId(":project2"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
 
         when:
         def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -198,8 +205,9 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by from for just ModuleComponentIdentifiers"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project5"), DefaultModuleComponentIdentifier.newId("org.gradle", "zzzz", "3.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project5"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "zzzz"), "3.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "xxxx"), "1.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -209,8 +217,9 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by from for left ProjectComponentIdentifier and right ModuleComponentIdentifier"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "xxxx"), "1.0"))
 
         when:
         def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -220,8 +229,9 @@ class DependencyResultSorterSpec extends Specification {
     }
 
     def "sorts by from for left ModuleComponentIdentifier and right ProjectComponentIdentifier"() {
-        def d1 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId("org.gradle", "xxxx", "1.0"))
-        def d2 = newDependency(DefaultModuleComponentSelector.newSelector("org.gradle", "core", v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
+        def core = DefaultModuleIdentifier.newId("org.gradle", "core")
+        def d1 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project6"), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.gradle", "xxxx"), "1.0"))
+        def d2 = newDependency(DefaultModuleComponentSelector.newSelector(core, v("1.0")), newProjectId(":project5"), newProjectId(":project1"))
 
         when:
         def sorted = DependencyResultSorter.sort([d1, d2], versionSelectorScheme, versionComparator, versionParser)
@@ -230,7 +240,7 @@ class DependencyResultSorterSpec extends Specification {
         sorted == [d2, d1]
     }
 
-    private newDependency(ComponentSelector requested, ComponentIdentifier selected, ComponentIdentifier from = DefaultModuleComponentIdentifier.newId("org", "a", "1.0")) {
+    private newDependency(ComponentSelector requested, ComponentIdentifier selected, ComponentIdentifier from = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org", "a"), "1.0")) {
         return Stub(DependencyEdge) {
             toString() >> "$requested -> $selected"
             getRequested() >> requested

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -103,7 +103,7 @@ public class EclipseDependenciesCreator {
             File sourceFile = sources.isEmpty() ? null : sources.iterator().next().getFile();
             File javaDocFile = javaDoc.isEmpty() ? null : javaDoc.iterator().next().getFile();
             ModuleComponentIdentifier componentIdentifier = (ModuleComponentIdentifier) artifact.getId().getComponentIdentifier();
-            DefaultModuleVersionIdentifier moduleVersionIdentifier = new DefaultModuleVersionIdentifier(componentIdentifier.getGroup(), componentIdentifier.getModule(), componentIdentifier.getVersion());
+            ModuleVersionIdentifier moduleVersionIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier.getModuleIdentifier(), componentIdentifier.getVersion());
             modules.add(createLibraryEntry(artifact.getFile(), sourceFile, javaDocFile, classpath, moduleVersionIdentifier, pathToSourceSets));
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -170,7 +170,7 @@ public class IdeaDependenciesProvider {
         public void visitModuleDependency(ResolvedArtifactResult artifact, Set<ResolvedArtifactResult> sources, Set<ResolvedArtifactResult> javaDoc) {
             ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) artifact.getId().getComponentIdentifier();
             SingleEntryModuleLibrary library = new SingleEntryModuleLibrary(toPath(ideaModule, artifact.getFile()), scope);
-            library.setModuleVersion(new DefaultModuleVersionIdentifier(moduleId.getGroup(), moduleId.getModule(), moduleId.getVersion()));
+            library.setModuleVersion(DefaultModuleVersionIdentifier.newId(moduleId.getModuleIdentifier(), moduleId.getVersion()));
             Set<Path> sourcePaths = Sets.newLinkedHashSet();
             for (ResolvedArtifactResult sourceArtifact : sources) {
                 sourcePaths.add(toPath(ideaModule, sourceArtifact.getFile()));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultIdeDependencyResolver.java
@@ -55,7 +55,7 @@ public class DefaultIdeDependencyResolver {
         for (ResolvedArtifactResult artifact : artifacts) {
             ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) artifact.getId().getComponentIdentifier();
             IdeExtendedRepoFileDependency ideRepoFileDependency = new IdeExtendedRepoFileDependency();
-            ideRepoFileDependency.setId(new DefaultModuleVersionIdentifier(moduleId.getGroup(), moduleId.getModule(), moduleId.getVersion()));
+            ideRepoFileDependency.setId(DefaultModuleVersionIdentifier.newId(moduleId.getModuleIdentifier(), moduleId.getVersion()));
             externalDependencies.add(ideRepoFileDependency);
         }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -412,7 +412,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     public ModuleVersionIdentifier getCoordinates() {
-        return new DefaultModuleVersionIdentifier(getOrganisation(), getModule(), getRevision());
+        return DefaultModuleVersionIdentifier.newId(getOrganisation(), getModule(), getRevision());
     }
 
     @Nullable

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy.internal.publisher;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
 import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 import org.gradle.api.publish.ivy.IvyArtifact;
@@ -30,7 +31,7 @@ public class DependencyResolverIvyPublisher implements IvyPublisher {
     public void publish(IvyNormalizedPublication publication, PublicationAwareRepository repository) {
         ModuleVersionPublisher publisher = repository.createPublisher();
         IvyPublicationIdentity projectIdentity = publication.getProjectIdentity();
-        ModuleComponentIdentifier moduleVersionIdentifier = DefaultModuleComponentIdentifier.newId(projectIdentity.getOrganisation(), projectIdentity.getModule(), projectIdentity.getRevision());
+        ModuleComponentIdentifier moduleVersionIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(projectIdentity.getOrganisation(), projectIdentity.getModule()), projectIdentity.getRevision());
 
         // Use the legacy metadata type so that we can leverage `ModuleVersionPublisher.publish()`
         DefaultIvyModulePublishMetadata publishMetaData = new DefaultIvyModulePublishMetadata(moduleVersionIdentifier, "");

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
@@ -74,7 +74,7 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
 
     @Override
     public ModuleVersionIdentifier getCoordinates() {
-        return new DefaultModuleVersionIdentifier(group.get(), baseName.get() + "_" + GUtil.toWords(name, '_'), version.get());
+        return DefaultModuleVersionIdentifier.newId(group.get(), baseName.get() + "_" + GUtil.toWords(name, '_'), version.get());
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -470,7 +470,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     public ModuleVersionIdentifier getCoordinates() {
-        return new DefaultModuleVersionIdentifier(getGroupId(), getArtifactId(), getVersion());
+        return DefaultModuleVersionIdentifier.newId(getGroupId(), getArtifactId(), getVersion());
     }
 
     @Nullable

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.internal.attributes.EmptySchema;
@@ -99,8 +100,8 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
         metadata.addDependencies(value, defaultProject, configuration);
     }
 
-    private static DefaultModuleVersionIdentifier localModuleVersionIdentifierFor(LibraryBinaryIdentifier componentId) {
-        return new DefaultModuleVersionIdentifier(componentId.getProjectPath(), componentId.getLibraryName(), VERSION);
+    private static ModuleVersionIdentifier localModuleVersionIdentifierFor(LibraryBinaryIdentifier componentId) {
+        return DefaultModuleVersionIdentifier.newId(componentId.getProjectPath(), componentId.getLibraryName(), VERSION);
     }
 
     private DefaultLibraryLocalComponentMetadata(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier) {
@@ -147,7 +148,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
     }
 
     private ModuleComponentSelector moduleComponentSelectorFrom(ModuleDependencySpec module) {
-        return DefaultModuleComponentSelector.newSelector(module.getGroup(), module.getName(), effectiveVersionFor(module.getVersion()));
+        return DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(module.getGroup(), module.getName()), effectiveVersionFor(module.getVersion()));
     }
 
     /**

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayDistributionPluginRenameArtifactFilesTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/plugins/PlayDistributionPluginRenameArtifactFilesTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.FileCopyDetails
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 import spock.lang.Specification
@@ -153,7 +154,7 @@ class PlayDistributionPluginRenameArtifactFilesTest extends Specification {
 
 
     private ModuleComponentIdentifier moduleId(String group) {
-        return new DefaultModuleComponentIdentifier(group, "module", "1.0")
+        return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, "module"), "1.0")
     }
 
     private ResolvedArtifactResult resolvedArtifact(File artifactFile, ComponentIdentifier componentId) {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -18,9 +18,11 @@ package org.gradle.plugin.management.internal.autoapply;
 
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
 import org.gradle.plugin.management.internal.DefaultPluginRequest;
 import org.gradle.plugin.management.internal.DefaultPluginRequests;
@@ -35,6 +37,7 @@ import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOpti
  * A hardcoded {@link AutoAppliedPluginRegistry} that only knows about the build-scan plugin for now.
  */
 public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegistry {
+    private final static ModuleIdentifier AUTO_APPLIED_ID = DefaultModuleIdentifier.newId(AutoAppliedBuildScanPlugin.GROUP, AutoAppliedBuildScanPlugin.NAME);
     private final BuildDefinition buildDefinition;
 
     public DefaultAutoAppliedPluginRegistry(BuildDefinition buildDefinition) {
@@ -60,7 +63,7 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
     }
 
     private DefaultPluginRequest createScanPluginRequest() {
-        ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(AutoAppliedBuildScanPlugin.GROUP, AutoAppliedBuildScanPlugin.NAME, AutoAppliedBuildScanPlugin.VERSION);
+        ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(AUTO_APPLIED_ID, AutoAppliedBuildScanPlugin.VERSION);
         return new DefaultPluginRequest(AutoAppliedBuildScanPlugin.ID, AutoAppliedBuildScanPlugin.VERSION, true, null, getScriptDisplayName(), artifact);
     }
 


### PR DESCRIPTION
### Context

This commit reworks the `ComponentModuleIdentifier`/`ComponentModuleSelector`/`ModuleVersionSelector`
classes to use `ModuleIdentifier` under the hood, instead of storing denormalized strings. This has
the advantage that we can reduce the use of the module identifier factory, which is called very
often during dependency resolution. Sharing instances reduces the need for conversions, and makes
comparisons faster.

The PR is huge because a lot of tests had to be updated to take normalization into account. I tried to make use of the factory methods as much as possible, which shows there's still room for improvement. However, it also highlights a number of inconsistencies in the way "nullability" was handled. Unfortunately, I couldn't streamline everything (like, making sure you never pass `null`) because some places in the code *do* expect `null` with a different semantics. It would be nice to change, but it's quite hard for backwards compatibility.