### PR TITLE
Let ProjectConnection extend Closeable interface

### DIFF
--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
@@ -28,7 +28,7 @@ import java.io.Closeable;
  *        .connect()) {
  *    
  *    //obtain some information from the build
- *    BuildEnvironment environment = connection.model(BuildEnvironment.class).get()
+ *    BuildEnvironment environment = connection.model(BuildEnvironment.class).get();
  *    
  *    //run some tasks
  *    connection.newBuild()

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
@@ -16,28 +16,26 @@
 package org.gradle.tooling;
 
 import org.gradle.api.Incubating;
+import java.io.Closeable;
 
 /**
  * <p>Represents a long-lived connection to a Gradle project. You obtain an instance of a {@code ProjectConnection} by using {@link org.gradle.tooling.GradleConnector#connect()}.</p>
  *
  * <pre class='autoTested'>
- * ProjectConnection connection = GradleConnector.newConnector()
- *    .forProjectDirectory(new File("someFolder"))
- *    .connect();
  *
- * try {
+ * try (ProjectConnection connection = GradleConnector.newConnector()
+ *        .forProjectDirectory(new File("someFolder"))
+ *        .connect()) {
+ *    
  *    //obtain some information from the build
- *    BuildEnvironment environment = connection.model(BuildEnvironment.class)
- *      .get();
- *
+ *    BuildEnvironment environment = connection.model(BuildEnvironment.class).get()
+ *    
  *    //run some tasks
  *    connection.newBuild()
  *      .forTasks("tasks")
  *      .setStandardOutput(System.out)
  *      .run();
  *
- * } finally {
- *    connection.close();
  * }
  * </pre>
  *
@@ -49,7 +47,7 @@ import org.gradle.api.Incubating;
  *
  * @since 1.0-milestone-3
  */
-public interface ProjectConnection {
+public interface ProjectConnection extends Closeable {
     /**
      * Fetches a snapshot of the model of the given type for this project. This method blocks until the model is available.
      *


### PR DESCRIPTION
ProjectConnection should extend Closeable interface for use of try-with-resources pattern.

Signed-off-by: Stefan <stefanleh@users.noreply.github.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
