### PR TITLE
Restore compatibility with artifactory/bintray plugins

### DIFF
--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginLegacyPluginPublishingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginLegacyPluginPublishingIntegrationTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.devel.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class JavaGradlePluginLegacyPluginPublishingIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            apply plugin: 'java-gradle-plugin'
+            group = 'com.example'
+            version = '1.0'
+        """
+        settingsFile << """
+            rootProject.name = 'plugins'
+        """
+    }
+
+    def "can resolve plugin publications in an afterEvaluate hook"() {
+        given:
+        plugin('foo', 'com.example.foo')
+        publishToIvy()
+        publishToMaven()
+        buildFile << """
+            afterEvaluate {
+                assert publishing.publications.size() == 4
+            }
+        """
+        executer.expectDeprecationWarning()
+
+        expect:
+        succeeds 'help'
+    }
+    def publishToMaven() {
+        buildFile << """
+            apply plugin: 'maven-publish'
+            publishing {
+                repositories {
+                    maven {
+                        url '${mavenRepo.uri}'
+                    }
+                }
+            }
+        """
+    }
+
+    def publishToIvy() {
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            publishing {
+                repositories {
+                    ivy {
+                        url '${ivyRepo.uri}'
+                    }
+                }
+            }
+        """
+    }
+
+    def plugin(String name, String pluginId) {
+        String implementationClass = name.capitalize();
+
+        file("src/main/java/com/xxx/${implementationClass}.java") << """
+package com.xxx;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+public class ${implementationClass} implements Plugin<Project> {
+    public void apply(Project project) { }
+}
+"""
+        buildFile << """
+            gradlePlugin {
+                plugins {
+                    ${name} {
+                        id = '${pluginId}'
+                        implementationClass = '${implementationClass}'
+                    }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorSpec;
@@ -33,27 +34,43 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
+import javax.inject.Inject;
+
 import static org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver.PLUGIN_MARKER_SUFFIX;
 
 class IvyPluginPublishingPlugin implements Plugin<Project> {
+    private final FeaturePreviews featurePreviews;
+
+    @Inject
+    IvyPluginPublishingPlugin(FeaturePreviews featurePreviews) {
+        this.featurePreviews = featurePreviews;
+    }
 
     @Override
     public void apply(Project project) {
-        project.afterEvaluate(new Action<Project>() {
+        if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_PUBLISHING)) {
+            project.afterEvaluate(new Action<Project>() {
+                @Override
+                public void execute(final Project project) {
+                    configurePublishing(project);
+                }
+            });
+        } else {
+            configurePublishing(project);
+        }
+    }
+
+    private void configurePublishing(final Project project) {
+        project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
             @Override
-            public void execute(final Project project) {
+            public void execute(PublishingExtension publishing) {
                 final GradlePluginDevelopmentExtension pluginDevelopment = project.getExtensions().getByType(GradlePluginDevelopmentExtension.class);
                 if (!pluginDevelopment.isAutomatedPublishing()) {
                     return;
                 }
-                project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
-                    @Override
-                    public void execute(PublishingExtension publishing) {
-                        SoftwareComponent mainComponent = project.getComponents().getByName("java");
-                        IvyPublication mainPublication = addMainPublication(publishing, mainComponent);
-                        addMarkerPublications(mainPublication, publishing, pluginDevelopment);
-                    }
-                });
+                SoftwareComponent mainComponent = project.getComponents().getByName("java");
+                IvyPublication mainPublication = addMainPublication(publishing, mainComponent);
+                addMarkerPublications(mainPublication, publishing, pluginDevelopment);
             }
         });
     }


### PR DESCRIPTION
The artifactory and bintray plugins resolve all publications in
an afterEvaluate hook. This is not a good idea, but what we have
to work with at the moment. We now only use afterEvaluate {} when
the stable publishing feature is enabled and otherwise rely on the
deferred configurable behavior instead.