### PR TITLE
Remove testSampleDirName from Sample rule

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/NativeIdeSamplesIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/NativeIdeSamplesIntegrationTest.groovy
@@ -17,23 +17,19 @@ package org.gradle.ide.visualstudio
 
 import org.gradle.ide.visualstudio.fixtures.AbstractVisualStudioIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
+import org.junit.rules.TestRule
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class NativeIdeSamplesIntegrationTest extends AbstractVisualStudioIntegrationSpec {
-    @Rule public final Sample visualStudio = sample(temporaryFolder, 'visual-studio')
+    public final Sample visualStudio = new Sample(testDirectoryProvider, "native-binaries/visual-studio")
 
-    private static Sample sample(TestDirectoryProvider testDirectoryProvider, String name) {
-        return new Sample(testDirectoryProvider, "native-binaries/${name}", name)
-    }
+    @Rule
+    public final TestRule rules = visualStudio.runInSampleDirectory(executer)
 
     def "visual studio"() {
-        given:
-        sample visualStudio
-
         when:
         run "visualStudio"
 
@@ -55,7 +51,6 @@ class NativeIdeSamplesIntegrationTest extends AbstractVisualStudioIntegrationSpe
         useMsbuildTool()
 
         given:
-        sample visualStudio
         run "visualStudio"
 
         when:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/Sample.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/Sample.java
@@ -16,11 +16,13 @@
 
 package org.gradle.integtests.fixtures;
 
+import org.gradle.integtests.fixtures.executer.GradleExecuter;
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
-import org.junit.rules.MethodRule;
-import org.junit.runners.model.FrameworkMethod;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,10 +34,9 @@ import javax.annotation.Nullable;
  * {@link org.gradle.integtests.fixtures.UsesSample} annotation on the test method to determine which sample the
  * test requires. If not found, uses the default sample provided in the constructor.
  */
-public class Sample implements MethodRule {
+public class Sample implements TestRule {
     private final Logger logger = LoggerFactory.getLogger(Sample.class);
     private final String defaultSampleName;
-    private final String testSampleDirName;
 
     private String sampleName;
     private TestFile sampleDir;
@@ -46,17 +47,13 @@ public class Sample implements MethodRule {
     }
 
     public Sample(TestDirectoryProvider testDirectoryProvider, String defaultSampleName) {
-        this(testDirectoryProvider, defaultSampleName, null);
-    }
-
-    public Sample(TestDirectoryProvider testDirectoryProvider, String defaultSampleName, String testSampleDirName) {
         this.testDirectoryProvider = testDirectoryProvider;
         this.defaultSampleName = defaultSampleName;
-        this.testSampleDirName = testSampleDirName;
     }
 
-    public Statement apply(final Statement base, FrameworkMethod method, Object target) {
-        sampleName = getSampleName(method);
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        sampleName = getSampleName(description);
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -73,8 +70,8 @@ public class Sample implements MethodRule {
         };
     }
 
-    private String getSampleName(FrameworkMethod method) {
-        UsesSample annotation = method.getAnnotation(UsesSample.class);
+    private String getSampleName(Description description) {
+        UsesSample annotation = description.getAnnotation(UsesSample.class);
         return annotation != null
             ? annotation.value()
             : defaultSampleName;
@@ -89,9 +86,6 @@ public class Sample implements MethodRule {
 
     @Nullable
     private TestFile computeSampleDir() {
-        if (testSampleDirName != null) {
-            return testFile(testSampleDirName);
-        }
         if (sampleName != null) {
             return testFile(sampleName);
         }
@@ -100,5 +94,20 @@ public class Sample implements MethodRule {
 
     private TestFile testFile(String testSampleDirName) {
         return testDirectoryProvider.getTestDirectory().file(testSampleDirName);
+    }
+
+    public TestRule runInSampleDirectory(final GradleExecuter executer) {
+        return RuleChain.outerRule(this).around(new TestRule() {
+            @Override
+            public Statement apply(final Statement base, Description description) {
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        executer.inDirectory(getDir());
+                        base.evaluate();
+                    }
+                };
+            }
+        });
     }
 }

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -16,42 +16,35 @@
 package org.gradle.nativeplatform
 
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
-import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
+import org.junit.rules.TestRule
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPATIBLE
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     @Rule final TestNameTestDirectoryProvider testDirProvider = new TestNameTestDirectoryProvider()
-    @Rule public final Sample cppLib = sample(testDirProvider, 'cpp-lib')
-    @Rule public final Sample cppExe = sample(testDirProvider, 'cpp-exe')
-    @Rule public final Sample multiProject = sample(testDirProvider, 'multi-project')
-    @Rule public final Sample flavors = sample(testDirProvider, 'flavors')
-    @Rule public final Sample variants = sample(testDirProvider, 'variants')
-    @Rule public final Sample toolChains = sample(testDirProvider, 'tool-chains')
-    @Rule public final Sample prebuilt = sample(testDirProvider, 'prebuilt')
-    @Rule public final Sample targetPlatforms = sample(testDirProvider, 'target-platforms')
-    @Rule public final Sample sourcesetVariant = sample(testDirectoryProvider, "sourceset-variant")
-    @Rule public final Sample customCheck = sample(testDirectoryProvider, "custom-check")
+    final Sample sample = new Sample(testDirProvider)
 
-    private static Sample sample(TestDirectoryProvider testDirectoryProvider, String name) {
-        return new Sample(testDirectoryProvider, "native-binaries/${name}", name)
+    @Rule
+    public final TestRule rules = sample.runInSampleDirectory(executer)
+
+    private void inSampleDir() {
+        inDirectory(sample.dir)
     }
 
+    @UsesSample('native-binaries/cpp-exe')
     def "exe"() {
         given:
         // Need to PATH to be set to find the 'strip' executable
         toolChain.initialiseEnvironment()
-
-        and:
-        sample cppExe
 
         when:
         run "installMain"
@@ -60,17 +53,15 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         executedAndNotSkipped ":compileMainExecutableMainCpp", ":linkMainExecutable", ":stripMainExecutable", ":mainExecutable"
 
         and:
-        executable(cppExe.dir.file("build/exe/main/main")).exec().out == "Hello, World!\n"
-        installation(cppExe.dir.file("build/install/main")).exec().out == "Hello, World!\n"
+        executable(sample.dir.file("build/exe/main/main")).exec().out == "Hello, World!\n"
+        installation(sample.dir.file("build/install/main")).exec().out == "Hello, World!\n"
 
         cleanup:
         toolChain.resetEnvironment()
     }
 
+    @UsesSample('native-binaries/cpp-lib')
     def "lib"() {
-        given:
-        sample cppLib
-
         when:
         run "mainSharedLibrary"
 
@@ -78,23 +69,21 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         executedAndNotSkipped ":compileMainSharedLibraryMainCpp", ":linkMainSharedLibrary", ":mainSharedLibrary"
 
         and:
-        sharedLibrary(cppLib.dir.file("build/libs/main/shared/main")).assertExists()
+        sharedLibrary(sample.dir.file("build/libs/main/shared/main")).assertExists()
 
         when:
-        sample cppLib
+        inSampleDir()
         run "mainStaticLibrary"
 
         then:
         executedAndNotSkipped ":compileMainStaticLibraryMainCpp", ":createMainStaticLibrary", ":mainStaticLibrary"
 
         and:
-        staticLibrary(cppLib.dir.file("build/libs/main/static/main")).assertExists()
+        staticLibrary(sample.dir.file("build/libs/main/static/main")).assertExists()
     }
 
+    @UsesSample("native-binaries/flavors")
     def flavors() {
-        given:
-        sample flavors
-
         when:
         run "installMainEnglishExecutable"
 
@@ -103,14 +92,14 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         executedAndNotSkipped ":compileMainEnglishExecutableMainCpp", ":linkMainEnglishExecutable", ":mainEnglishExecutable"
 
         and:
-        executable(flavors.dir.file("build/exe/main/english/main")).assertExists()
-        sharedLibrary(flavors.dir.file("build/libs/hello/shared/english/hello")).assertExists()
+        executable(sample.dir.file("build/exe/main/english/main")).assertExists()
+        sharedLibrary(sample.dir.file("build/libs/hello/shared/english/hello")).assertExists()
 
         and:
-        installation(flavors.dir.file("build/install/main/english")).exec().out == "Hello world!\n"
+        installation(sample.dir.file("build/install/main/english")).exec().out == "Hello world!\n"
 
         when:
-        sample flavors
+        inSampleDir()
         run "installMainFrenchExecutable"
 
         then:
@@ -118,27 +107,25 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         executedAndNotSkipped ":compileMainFrenchExecutableMainCpp", ":linkMainFrenchExecutable", ":mainFrenchExecutable"
 
         and:
-        executable(flavors.dir.file("build/exe/main/french/main")).assertExists()
-        sharedLibrary(flavors.dir.file("build/libs/hello/shared/french/hello")).assertExists()
+        executable(sample.dir.file("build/exe/main/french/main")).assertExists()
+        sharedLibrary(sample.dir.file("build/libs/hello/shared/french/hello")).assertExists()
 
         and:
-        installation(flavors.dir.file("build/install/main/french")).exec().out == "Bonjour monde!\n"
+        installation(sample.dir.file("build/install/main/french")).exec().out == "Bonjour monde!\n"
     }
 
+    @UsesSample("native-binaries/variants")
     def variants() {
-        given:
-        sample variants
-
         when:
         run "assemble"
 
         then:
-        final debugX86 = executable(variants.dir.file("build/exe/main/x86/debug/main"))
-        final releaseX86 = executable(variants.dir.file("build/exe/main/x86/release/main"))
-        final debugX64 = executable(variants.dir.file("build/exe/main/x64/debug/main"))
-        final releaseX64 = executable(variants.dir.file("build/exe/main/x64/release/main"))
-        final debugIA64 = executable(variants.dir.file("build/exe/main/itanium/debug/main"))
-        final releaseIA64 = executable(variants.dir.file("build/exe/main/itanium/release/main"))
+        final debugX86 = executable(sample.dir.file("build/exe/main/x86/debug/main"))
+        final releaseX86 = executable(sample.dir.file("build/exe/main/x86/release/main"))
+        final debugX64 = executable(sample.dir.file("build/exe/main/x64/debug/main"))
+        final releaseX64 = executable(sample.dir.file("build/exe/main/x64/release/main"))
+        final debugIA64 = executable(sample.dir.file("build/exe/main/itanium/debug/main"))
+        final releaseIA64 = executable(sample.dir.file("build/exe/main/itanium/release/main"))
 
         debugX86.arch.name == "x86"
         debugX86.assertDebugFileExists()
@@ -162,21 +149,17 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         releaseIA64.assertDoesNotExist()
     }
 
+    @UsesSample("native-binaries/tool-chains")
     def "tool chains"() {
-        given:
-        sample toolChains
-
         when:
         run "installMainExecutable"
 
         then:
-        executable(toolChains.dir.file("build/exe/main/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
+        executable(sample.dir.file("build/exe/main/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
     }
 
+    @UsesSample("native-binaries/multi-project")
     def multiProject() {
-        given:
-        sample multiProject
-
         when:
         run "installMainExecutable"
 
@@ -184,18 +167,16 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         ":exe:mainExecutable" in executedTasks
 
         and:
-        sharedLibrary(multiProject.dir.file("lib/build/libs/main/shared/main")).assertExists()
-        executable(multiProject.dir.file("exe/build/exe/main/main")).assertExists()
-        installation(multiProject.dir.file("exe/build/install/main")).exec().out == "Hello, World!\n"
+        sharedLibrary(sample.dir.file("lib/build/libs/main/shared/main")).assertExists()
+        executable(sample.dir.file("exe/build/exe/main/main")).assertExists()
+        installation(sample.dir.file("exe/build/install/main")).exec().out == "Hello, World!\n"
     }
 
+    @UsesSample("native-binaries/target-platforms")
     @RequiresInstalledToolChain(GCC_COMPATIBLE)
     def "target platforms"() {
         given:
-        sample targetPlatforms
-
-        and:
-        targetPlatforms.dir.file("build.gradle") << """
+        sample.dir.file("build.gradle") << """
 model {
     toolChains {
         all{
@@ -217,39 +198,39 @@ model {
         run "installMainArmExecutable", "installMainSparcExecutable"
 
         then:
-        executable(targetPlatforms.dir.file("build/exe/main/arm/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
-        executable(targetPlatforms.dir.file("build/exe/main/arm/main")).arch.isI386()
+        executable(sample.dir.file("build/exe/main/arm/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
+        executable(sample.dir.file("build/exe/main/arm/main")).arch.isI386()
 
-        executable(targetPlatforms.dir.file("build/exe/main/sparc/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
+        executable(sample.dir.file("build/exe/main/sparc/main")).exec().out == "Hello from ${toolChain.typeDisplayName}!\n"
     }
 
+    @UsesSample("native-binaries/prebuilt")
     def prebuilt() {
         given:
-        inDirectory(prebuilt.dir.file("3rd-party-lib/util"))
+        inDirectory(sample.dir.file("3rd-party-lib/util"))
         run "assemble"
 
         and:
-        sample prebuilt
+        inSampleDir()
 
         when:
         succeeds "assemble"
 
         then:
 
-        executable(prebuilt.dir.file("build/exe/main/debug/main")).exec().out ==
+        executable(sample.dir.file("build/exe/main/debug/main")).exec().out ==
 """Built with Boost version: 1_55
 Util build type: DEBUG
 """
-        executable(prebuilt.dir.file("build/exe/main/release/main")).exec().out ==
+        executable(sample.dir.file("build/exe/main/release/main")).exec().out ==
 """Built with Boost version: 1_55
 Util build type: RELEASE
 """
     }
 
+    @UsesSample("native-binaries/sourceset-variant")
     def sourcesetvariant() {
         given:
-        sample sourcesetVariant
-
         final String platformName
         if (OperatingSystem.current().isMacOsX()) {
             platformName = "MacOSX"
@@ -268,14 +249,12 @@ Util build type: RELEASE
         executedAndNotSkipped(":compileMainExecutableMainExecutablePlatform$platformName", ":installMainExecutable")
 
         and:
-        executable(sourcesetVariant.dir.file("build/exe/main/main")).assertExists()
-        installation(sourcesetVariant.dir.file("build/install/main")).exec().out.contains("Attributes of '$platformName' platform")
+        executable(sample.dir.file("build/exe/main/main")).assertExists()
+        installation(sample.dir.file("build/install/main")).exec().out.contains("Attributes of '$platformName' platform")
     }
 
+    @UsesSample("native-binaries/custom-check")
     def customcheck() {
-        given:
-        sample customCheck
-
         when:
         run 'check'
 
@@ -283,7 +262,7 @@ Util build type: RELEASE
         executedAndNotSkipped(':myCustomCheck')
 
         and:
-        sample customCheck
+        inSampleDir()
 
         when:
         run ':checkHelloSharedLibrary'

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.Sample
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
-import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
@@ -30,11 +29,7 @@ import static org.junit.Assume.assumeTrue
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class CUnitSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
-    @Rule public final Sample cunit = sample(temporaryFolder, 'cunit')
-
-    private static Sample sample(TestDirectoryProvider testDirectoryProvider, String name) {
-        return new Sample(testDirectoryProvider, "native-binaries/${name}", name)
-    }
+    @Rule public final Sample cunit = new Sample(temporaryFolder, 'native-binaries/cunit')
 
     def "cunit components"() {
         given:

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestSamplesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestSamplesIntegrationTest.groovy
@@ -16,23 +16,20 @@
 
 
 package org.gradle.nativeplatform.test.googletest
+
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
-import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
-import static org.junit.Assume.*
+
+import static org.junit.Assume.assumeTrue
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class GoogleTestSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
-    @Rule public final Sample googleTest = sample(temporaryFolder, 'google-test')
-
-    private static Sample sample(TestDirectoryProvider testDirectoryProvider, String name) {
-        return new Sample(testDirectoryProvider, "native-binaries/${name}", name)
-    }
+    @Rule public final Sample googleTest = new Sample(temporaryFolder, 'native-binaries/google-test')
 
     def "googleTest"() {
         given:


### PR DESCRIPTION
Instead of configuring the testSampleDirName, the UsesSample annotation
should be used.
