### PR TITLE
Add toString() implementation for Conf2ScopeMapping

### DIFF
--- a/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/Conf2ScopeMapping.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/Conf2ScopeMapping.java
@@ -92,4 +92,9 @@ public class Conf2ScopeMapping {
         result = 31 * result + (scope != null ? scope.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "Conf2ScopeMapping{scope='" + scope + "', configuration='" + configuration.getName() + "'}";
+    }
 }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/pom/DefaultConf2ScopeMappingContainerTest.java
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/pom/DefaultConf2ScopeMappingContainerTest.java
@@ -19,6 +19,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.maven.Conf2ScopeMapping;
 import org.gradle.util.JUnit4GroovyMockery;
+import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.junit.Before;
 import org.junit.Test;
@@ -109,15 +110,26 @@ public class DefaultConf2ScopeMappingContainerTest {
         assertThat(conf2ScopeMappingContainer.getMapping(asList(testConf1, testConf2)), equalTo(
                 new Conf2ScopeMapping(TEST_PRIORITY_2, testConf2, TEST_SCOPE_2)));
     }
-    
+
     @Test(expected = InvalidUserDataException.class)
     public void mappingWithSamePrioritiesDifferentConfsSameScope() {
+        context.checking(new Expectations() {{
+            one(testConf1).getName();
+            one(testConf2).getName();
+        }});
+
         conf2ScopeMappingContainer.addMapping(TEST_PRIORITY_1, testConf2, TEST_SCOPE_1);
         conf2ScopeMappingContainer.getMapping(asList(testConf1, testConf2));
     }
 
     @Test(expected = InvalidUserDataException.class)
     public void mappingWithSamePrioritiesDifferentConfsDifferentScopes() {
+        context.checking(new Expectations() {{
+            one(testConf1).getName();
+            one(testConf2).getName();
+            one(testConf3).getName();
+        }});
+
         conf2ScopeMappingContainer.addMapping(TEST_PRIORITY_1, testConf2, TEST_SCOPE_1);
         conf2ScopeMappingContainer.addMapping(TEST_PRIORITY_1, testConf3, TEST_SCOPE_2);
         conf2ScopeMappingContainer.getMapping(asList(testConf1, testConf2, testConf3));


### PR DESCRIPTION
Signed-off-by: Nickolay Chameyev <nickolay.chameyev@corp.badoo.com>

### Context

Currently, when DefaultConf2ScopeMappingContainer throws `InvalidUserDataException` it's not clear what scopes or configurations producing the issue. For example:

```
Caused by: org.gradle.api.InvalidUserDataException: The configuration to scope mapping is not unique. 
The following configurations have the same priority: 
[org.gradle.api.artifacts.maven.Conf2ScopeMapping@ac312b65, 
org.gradle.api.artifacts.maven.Conf2ScopeMapping@1c62e299]
```

With this fix, users can more easily identify the underlying problem.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] (not required) Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] (not required) Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] (not required) Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
