### PR TITLE
Fix "Unexpected parent dependency" error

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -119,10 +119,12 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     public void removeFromTargetConfigurations() {
-        for (NodeState targetConfiguration : targetNodes) {
-            targetConfiguration.removeIncomingEdge(this);
+        if (!targetNodes.isEmpty()) {
+            for (NodeState targetConfiguration : targetNodes) {
+                targetConfiguration.removeIncomingEdge(this);
+            }
+            targetNodes.clear();
         }
-        targetNodes.clear();
         targetNodeSelectionFailure = null;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -139,8 +139,10 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     public void restart() {
-        removeFromTargetConfigurations();
-        attachToTargetConfigurations();
+        if (from.isSelected()) {
+            removeFromTargetConfigurations();
+            attachToTargetConfigurations();
+        }
     }
 
     public ImmutableAttributes getAttributes() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -194,7 +194,8 @@ class ModuleResolveState implements CandidateModule {
 
     private void restartUnattachedDependencies() {
         if (unattachedDependencies.size() == 1) {
-            unattachedDependencies.get(0).restart();
+            EdgeState singleDependency = unattachedDependencies.get(0);
+            singleDependency.restart();
         } else {
             for (EdgeState dependency : new ArrayList<EdgeState>(unattachedDependencies)) {
                 dependency.restart();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -303,10 +303,12 @@ class NodeState implements DependencyGraphNode {
     }
 
     private void removeOutgoingEdges() {
-        for (EdgeState outgoingDependency : outgoingEdges) {
-            outgoingDependency.removeFromTargetConfigurations();
+        if (!outgoingEdges.isEmpty()) {
+            for (EdgeState outgoingDependency : outgoingEdges) {
+                outgoingDependency.removeFromTargetConfigurations();
+            }
+            outgoingEdges.clear();
         }
-        outgoingEdges.clear();
         previousTraversalExclusions = null;
     }
 
@@ -325,7 +327,8 @@ class NodeState implements DependencyGraphNode {
 
     private void restartIncomingEdges() {
         if (incomingEdges.size() == 1) {
-            incomingEdges.iterator().next().restart();
+            EdgeState singleEdge = incomingEdges.iterator().next();
+            singleEdge.restart();
         } else {
             for (EdgeState dependency : new ArrayList<EdgeState>(incomingEdges)) {
                 dependency.restart();


### PR DESCRIPTION
### Context

It was possible for an edge to be reintegrated in the graph even if its
source node wasn't selected. This would result in an inconsistency when
writing, then reading the generated serialized graph. In particular,
when a node had a replacement, an that another edge in the graph caused
an upgrade of the source dependency, the older version of the source
node could have been seen as selected when it wasn't.

Fixes #4785

This PR is on `master`. If everything is fine, I'm going to backport it to `release` so that it can make it to 4.8.1, but timing is a bit short.
