### PR TITLE
TaskProvider should implement Named

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.Named;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 
@@ -28,7 +29,7 @@ import org.gradle.api.provider.Provider;
  * @since 4.8
  */
 @Incubating
-public interface TaskProvider<T extends Task> extends Provider<T> {
+public interface TaskProvider<T extends Task> extends Provider<T>, Named {
     /**
      * Configures the task with the given action. Actions are run in the order added.
      *
@@ -36,4 +37,12 @@ public interface TaskProvider<T extends Task> extends Provider<T> {
      * @since 4.8
      */
     void configure(Action<? super T> action);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.9
+     */
+    @Override
+    String getName();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.tasks;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Named;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
@@ -109,7 +108,7 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
         return Cast.uncheckedCast(getInstantiator().newInstance(ExistingTaskProvider.class, this, task, taskIdentity));
     }
 
-    protected abstract class DefaultTaskProvider<I extends Task> extends AbstractProvider<I> implements Named, TaskProvider<I> {
+    protected abstract class DefaultTaskProvider<I extends Task> extends AbstractProvider<I> implements TaskProvider<I> {
 
         final TaskIdentity<I> identity;
         boolean removed = false;


### PR DESCRIPTION
This way the name of lazy tasks can be figured out without instantiating them.