### PR TITLE
Add support for specifying TLS protocols

### DIFF
--- a/subprojects/internal-performance-testing/src/integTest/groovy/org/gradle/performance/fixture/MavenDownloaderTest.groovy
+++ b/subprojects/internal-performance-testing/src/integTest/groovy/org/gradle/performance/fixture/MavenDownloaderTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.fixture
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.UncheckedIOException
 import org.gradle.testing.internal.util.RetryUtil
 import org.gradle.util.Requires
@@ -37,6 +38,9 @@ class MavenDownloaderTest extends Specification {
     def setup() {
         installRoot = tmpDir.newFolder()
         downloader = new MavenInstallationDownloader(installRoot)
+        if (JavaVersion.current().isJava7()) {
+            System.setProperty("https.protocols", "TLSv1.2")
+        }
     }
 
     @Unroll

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -88,6 +88,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     NOT_UNKNOWN_OS({
         !UNKNOWN_OS.fulfilled
     }),
+    JDK7({
+        JavaVersion.current() == JavaVersion.VERSION_1_7
+    }),
     JDK7_OR_EARLIER({
         JavaVersion.current() <= JavaVersion.VERSION_1_7
     }),

--- a/subprojects/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerIntegrationTest.groovy
+++ b/subprojects/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerIntegrationTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory
+import org.apache.http.impl.client.HttpClientBuilder
+import org.gradle.testing.internal.util.Specification
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+class HttpClientConfigurerIntegrationTest extends Specification {
+
+    @Requires(TestPrecondition.JDK7)
+    def 'configures TLSv1.2 protocol with Java 7'() {
+        given:
+        def settings = DefaultHttpSettings.builder()
+                                            .withAuthenticationSettings(Collections.emptyList())
+                                            .allowUntrustedConnections().build()
+        def builder = new HttpClientBuilder()
+
+        when:
+        new HttpClientConfigurer(settings).configure(builder)
+
+        then:
+        SSLConnectionSocketFactory socketFactory = builder.sslSocketFactory
+        socketFactory.supportedProtocols == ['TLSv1', 'TLSv1.1', 'TLSv1.2'] as String[]
+    }
+}


### PR DESCRIPTION
Following changes in Maven Central, only TLSv1.2 is accepted. While
there is a workaround for standard JDK SSL connections, the use of
HttpClient in Gradle did not allow any customization.
This will default TLS protocols to `["TLSv1", "TLSv1.1", "TLSv1.2"]` for Java 7.
It also adds support using the same system property as the one used by JDK
SSL.

It also adds that property to tests that do interact with Maven Central.

