### PR TITLE
Add @Nonnull annotation to apply in Plugin

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Plugin.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Plugin.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api;
 
+import javax.annotation.Nonnull;
+
 /**
  * <p>A <code>Plugin</code> represents an extension to Gradle. A plugin applies some configuration to a target object.
  * Usually, this target object is a {@link org.gradle.api.Project}, but plugins can be applied to any type of
@@ -28,5 +30,5 @@ public interface Plugin<T> {
      *
      * @param target The target object
      */
-    void apply(T target);
+    void apply(@Nonnull T target);
 }


### PR DESCRIPTION
This will help IDE's intelligently generate the overridden function in Kotlin.

By default when implementing the `Plugin` interface in Kotlin, IntelliJ implements it like this:
```kotlin
open class WhateverPlugin : Plugin<Project> {
    override fun apply(target: Project?) {
    }
}
```
It should implement it this way:
```kotlin
open class WhateverPlugin : Plugin<Project> {
    override fun apply(target: Project) {
    }
}
```

@eskatos @bamboo Thoughts?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
