### PR TITLE
Prefer first non-synthetic extension public type when inferring the public type

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
@@ -244,7 +244,20 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
         if (extension instanceof HasPublicType) {
             return uncheckedCast(((HasPublicType) extension).getPublicType());
         }
-        return TypeOf.<Object>typeOf(defaultType);
+        return TypeOf.<Object>typeOf(firstNonSyntheticClassOf(defaultType));
+    }
+
+    private Class<?> firstNonSyntheticClassOf(Class<?> clazz) {
+        if (!clazz.isSynthetic()) {
+            return clazz;
+        }
+        Class<?> next;
+        while ((next = clazz.getSuperclass()) != null) {
+            if (!next.isSynthetic()) {
+                return next;
+            }
+        }
+        return clazz;
     }
 
     private <T> T instantiate(Class<? extends T> instanceType, Object[] constructionArguments) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -244,13 +244,19 @@ class ExtensionContainerTest extends Specification {
         given:
         container.create Parent, 'foo', Child
         container.create Capability, 'bar', Impl
+        container.create 'boo', Child
         container.add new TypeOf<List<String>>() {}, 'baz', []
+        container.add "cat", new Thing("gizmo")
+        container.add "meo", container.instantiator.newInstance(Thing, "w")
 
         expect:
         container.schema == [ext: typeOf(ExtraPropertiesExtension),
                              foo: typeOf(Parent),
                              bar: typeOf(Capability),
-                             baz: new TypeOf<List<String>>() {}]
+                             boo: typeOf(Child),
+                             baz: new TypeOf<List<String>>() {},
+                             cat: typeOf(Thing),
+                             meo: typeOf(Thing)]
     }
 
     def "can configure extensions by name"() {


### PR DESCRIPTION
Fix for gradle/kotlin-dsl/issues/932