### PR TITLE
Fix order dependent resolution when module is evicted

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.integtests.resolve
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
-import spock.lang.Ignore
 import spock.lang.Issue
+import spock.lang.Unroll
 
 import static org.hamcrest.Matchers.containsString
 
@@ -1309,7 +1309,6 @@ task checkDeps(dependsOn: configurations.compile) {
         noExceptionThrown()
     }
 
-    @NotYetImplemented
     def "previously selected transitive dependency is not used when it becomes orphaned because of selection of a different version of its dependent module"() {
         given:
         (1..10).each {
@@ -1349,7 +1348,6 @@ task checkDeps(dependsOn: configurations.compile) {
         noExceptionThrown()
     }
 
-    @NotYetImplemented
     def "evicted version removes range constraint from transitive dependency"() {
         given:
         (1..10).each {
@@ -1561,7 +1559,7 @@ task checkDeps(dependsOn: configurations.compile) {
         noExceptionThrown()
     }
 
-    @Ignore
+    @Unroll
     def 'order of dependency declaration does not effect transitive dependency versions'() {
         given:
         def foo11 = mavenRepo.module('org', 'foo', '1.1').publish()
@@ -1579,8 +1577,13 @@ task checkDeps(dependsOn: configurations.compile) {
                 conf
             }
             dependencies {
+                if ($barFirst) {
+                    conf 'org:bar:1.1' // WORKS IF THIS DEPENDENCY IS FIRST
+                }
                 conf 'org:baz:[1.0,2.0)'
-                conf 'org:bar:1.1' // WORKS IF THIS DEPENDENCY IS FIRST
+                if (!$barFirst) {
+                    conf 'org:bar:1.1' // FAILED IF HERE
+                }
                 conf 'org:foo:[1.0,2.0)'
             }
 """
@@ -1601,6 +1604,9 @@ task checkDeps(dependsOn: configurations.compile) {
                 edge('org:baz:[1.0,2.0)', 'org:baz:1.1')
             }
         }
+
+        where:
+        barFirst << [false, true]
     }
 
     @Issue("gradle/gradle-private#1268")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -48,7 +48,7 @@ class ModuleResolveState implements CandidateModule {
     private final ModuleIdentifier id;
     private final List<EdgeState> unattachedDependencies = new LinkedList<EdgeState>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<ModuleVersionIdentifier, ComponentState>();
-    private final List<SelectorState> selectors = Lists.newLinkedList();
+    private final List<SelectorState> selectors = Lists.newArrayListWithExpectedSize(4);
     private final VariantNameBuilder variantNameBuilder;
     private final ImmutableAttributesFactory attributesFactory;
     private ComponentState selected;
@@ -221,9 +221,18 @@ class ModuleResolveState implements CandidateModule {
         return moduleRevision;
     }
 
-    public void addSelector(SelectorState selector) {
+    void addSelector(SelectorState selector) {
+        assert !selectors.contains(selector) : "Inconsistent call to addSelector: should only be done if the selector isn't in use";
         selectors.add(selector);
         mergedAttributes = appendAttributes(mergedAttributes, selector);
+    }
+
+    void removeSelector(SelectorState selector) {
+        selectors.remove(selector);
+        mergedAttributes = ImmutableAttributes.EMPTY;
+        for (SelectorState selectorState : selectors) {
+            mergedAttributes = appendAttributes(mergedAttributes, selectorState);
+        }
     }
 
     public List<SelectorState> getSelectors() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -209,6 +209,7 @@ class NodeState implements DependencyGraphNode {
                     EdgeState dependencyEdge = new EdgeState(this, dependencyState, resolutionFilter, resolveState);
                     outgoingEdges.add(dependencyEdge);
                     discoveredEdges.add(dependencyEdge);
+                    dependencyEdge.getSelector().use();
                 }
             }
             previousTraversalExclusions = resolutionFilter;
@@ -306,9 +307,10 @@ class NodeState implements DependencyGraphNode {
         if (!outgoingEdges.isEmpty()) {
             for (EdgeState outgoingDependency : outgoingEdges) {
                 outgoingDependency.removeFromTargetConfigurations();
+                outgoingDependency.getSelector().release();
             }
-            outgoingEdges.clear();
         }
+        outgoingEdges.clear();
         previousTraversalExclusions = null;
     }
 


### PR DESCRIPTION
### Context

This PR fixes several ordering issues, due to the fact selectors
were still used during resolution even if the corresponding node was
evicted.

Fixes #5530
