### PR TITLE
Cleanup unused version-specific caches and corresponding wrapper distributions

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.GradleVersion
+
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.NOT_RECENTLY_USED
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.RECENTLY_USED
+
+class VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+
+    def "cleans up unused version-specific cache directories and corresponding distributions"() {
+        given:
+        requireOwnGradleUserHomeDir() // because we delete caches and distributions
+
+        and:
+        def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), RECENTLY_USED)
+        def oldNotRecentlyUsedVersion = GradleVersion.version("2.3.4")
+        def oldCacheDir = createVersionSpecificCacheDir(oldNotRecentlyUsedVersion, NOT_RECENTLY_USED)
+        def oldDist = createDistributionDir(oldNotRecentlyUsedVersion, "bin")
+        def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_RECENTLY_USED)
+        def currentDist = createDistributionDir(GradleVersion.current(), "all")
+
+        when:
+        succeeds("tasks")
+
+        then:
+        oldButRecentlyUsedCacheDir.assertExists()
+        oldCacheDir.assertDoesNotExist()
+        oldDist.assertDoesNotExist()
+        currentCacheDir.assertExists()
+        currentDist.assertExists()
+    }
+
+    @Override
+    TestFile getGradleUserHomeDir() {
+        return executer.gradleUserHomeDir
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 
-import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.NOT_RECENTLY_USED
-import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.RECENTLY_USED
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.NOT_USED_WITHIN_30_DAYS
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.USED_TODAY
 
 class VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
 
@@ -30,11 +30,11 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest ex
         requireOwnGradleUserHomeDir() // because we delete caches and distributions
 
         and:
-        def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), RECENTLY_USED)
+        def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), USED_TODAY)
         def oldNotRecentlyUsedVersion = GradleVersion.version("2.3.4")
-        def oldCacheDir = createVersionSpecificCacheDir(oldNotRecentlyUsedVersion, NOT_RECENTLY_USED)
+        def oldCacheDir = createVersionSpecificCacheDir(oldNotRecentlyUsedVersion, NOT_USED_WITHIN_30_DAYS)
         def oldDist = createDistributionDir(oldNotRecentlyUsedVersion, "bin")
-        def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_RECENTLY_USED)
+        def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_USED_WITHIN_30_DAYS)
         def currentDist = createDistributionDir(GradleVersion.current(), "all")
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
@@ -46,6 +46,7 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest ex
         oldDist.assertDoesNotExist()
         currentCacheDir.assertExists()
         currentDist.assertExists()
+        getGcFile(currentCacheDir).assertExists()
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
@@ -32,12 +32,14 @@ import java.io.IOException;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 public class CrossBuildFileHashCache implements Closeable, TaskHistoryStore {
+    public static final String FILE_HASHES_CACHE_KEY = "fileHashes";
+
     private final PersistentCache cache;
     private final InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory;
 
     public CrossBuildFileHashCache(@Nullable File cacheDir, CacheRepository repository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
         this.inMemoryCacheDecoratorFactory = inMemoryCacheDecoratorFactory;
-        CacheBuilder cacheBuilder = cacheDir != null ? repository.cache(cacheDir) : repository.cache("fileHashes");
+        CacheBuilder cacheBuilder = cacheDir != null ? repository.cache(cacheDir) : repository.cache(FILE_HASHES_CACHE_KEY);
         cache = cacheBuilder
             .withDisplayName("file hash cache")
             .withLockOptions(mode(FileLockManager.LockMode.None)) // Lock on demand

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheScopeMapping.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCacheScopeMapping.java
@@ -25,13 +25,15 @@ import javax.annotation.Nullable;
 import java.io.File;
 
 public class DefaultCacheScopeMapping implements CacheScopeMapping {
+    public static final String GLOBAL_CACHE_DIR_NAME = "caches";
+
     private final File globalCacheDir;
     private final File projectCacheDir;
     private final GradleVersion version;
 
     public DefaultCacheScopeMapping(File userHomeDir, @Nullable File projectCacheDir, GradleVersion version) {
         this.version = version;
-        this.globalCacheDir = new File(userHomeDir, "caches");
+        this.globalCacheDir = new File(userHomeDir, GLOBAL_CACHE_DIR_NAME);
         this.projectCacheDir = projectCacheDir;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.time.Time;
+import org.gradle.internal.time.Timer;
+import org.gradle.util.GradleVersion;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.commons.io.filefilter.FileFilterUtils.directoryFileFilter;
+import static org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache.FILE_HASHES_CACHE_KEY;
+
+public class VersionSpecificCacheAndWrapperDistributionCleanupService implements Stoppable {
+
+    static final String MARKER_FILE_PATH = FILE_HASHES_CACHE_KEY + "/" + FILE_HASHES_CACHE_KEY + ".lock";
+    private static final Logger LOGGER = Logging.getLogger(VersionSpecificCacheAndWrapperDistributionCleanupService.class);
+    private static final long MAX_UNUSED_DAYS = 30;
+    private static final ImmutableList<String> DISTRIBUTION_TYPES = ImmutableList.of("bin", "all");
+
+    private final GradleVersion currentVersion;
+    private final File gradleUserHomeDirectory;
+
+    public VersionSpecificCacheAndWrapperDistributionCleanupService(GradleVersion currentVersion, File gradleUserHomeDirectory) {
+        this.currentVersion = currentVersion;
+        this.gradleUserHomeDirectory = gradleUserHomeDirectory;
+    }
+
+    @Override
+    public void stop() {
+        Timer timer = Time.startTimer();
+        long minimumTimestamp = Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_UNUSED_DAYS));
+        for (File subDir : listVersionSpecificCacheDirs()) {
+            try {
+                processCacheSubDirectory(subDir, minimumTimestamp);
+            } catch (Exception e) {
+                LOGGER.error("Failed to process/clean up version-specific cache directory: {}", subDir, e);
+            }
+        }
+        LOGGER.debug("Processed version-specific caches for cleanup in {}", timer.getElapsed());
+    }
+
+    private Collection<File> listVersionSpecificCacheDirs() {
+        FileFilter combinedFilter = FileFilterUtils.and(directoryFileFilter(), new RegexFileFilter("^\\d.*"));
+        File cachesDir = new File(gradleUserHomeDirectory, DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME);
+        File[] result = cachesDir.listFiles(combinedFilter);
+        return result == null ? Collections.<File>emptySet() : Arrays.asList(result);
+    }
+
+    private void processCacheSubDirectory(File dir, long minimumTimestamp) throws Exception {
+        GradleVersion version;
+        try {
+            version = GradleVersion.version(dir.getName());
+        } catch (Exception e) {
+            LOGGER.debug("Ignoring directory with unparsable version: {}", dir, e);
+            return;
+        }
+        processVersionSpecificCacheDir(dir, version, minimumTimestamp);
+    }
+
+    private void processVersionSpecificCacheDir(File dir, GradleVersion version, long minimumTimestamp) throws IOException {
+        if (version.compareTo(currentVersion) < 0) {
+            if (shouldDelete(dir, minimumTimestamp)) {
+                LOGGER.debug("Deleting version-specific cache directory for {} at {}", version, dir);
+                FileUtils.deleteDirectory(dir);
+                deleteDistributions(version);
+            }
+        }
+    }
+
+    private boolean shouldDelete(File dir, long minimumTimestamp) {
+        File markerFile = new File(dir, MARKER_FILE_PATH);
+        return markerFile.exists() && markerFile.lastModified() < minimumTimestamp;
+    }
+
+    private void deleteDistributions(GradleVersion version) throws IOException {
+        File distsDir = new File(gradleUserHomeDirectory, "wrapper/dists");
+        for (String distributionType : DISTRIBUTION_TYPES) {
+            File dir = new File(distsDir, "gradle-" + version.getVersion() + "-" + distributionType);
+            if (dir.isDirectory()) {
+                LOGGER.info("Deleting Gradle distribution at {}", dir);
+                FileUtils.deleteDirectory(dir);
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupService.java
@@ -143,7 +143,7 @@ public class VersionSpecificCacheAndWrapperDistributionCleanupService implements
             }
             if (cleanupCondition.isSatisfiedBy(cacheDir)) {
                 try {
-                    deleteCacheDir(cacheDir);
+                    deleteCacheDir(cacheDir.getDir());
                     deleteDistributions(cacheDir.getVersion());
                 } catch (Exception e) {
                     LOGGER.error("Failed to process/clean up version-specific cache directory: {}", cacheDir.getDir(), e);
@@ -153,16 +153,16 @@ public class VersionSpecificCacheAndWrapperDistributionCleanupService implements
         return true;
     }
 
-    private void deleteCacheDir(VersionSpecificCacheDirectory cacheDir) throws IOException {
-        LOGGER.debug("Deleting version-specific cache directory for {} at {}", cacheDir.getVersion(), cacheDir.getDir());
-        FileUtils.deleteDirectory(cacheDir.getDir());
+    private void deleteCacheDir(File cacheDir) throws IOException {
+        LOGGER.debug("Deleting version-specific cache directory at {}", cacheDir);
+        FileUtils.deleteDirectory(cacheDir);
     }
 
     private void deleteDistributions(GradleVersion version) throws IOException {
         for (String distributionType : DISTRIBUTION_TYPES) {
             File dir = new File(distsDir, "gradle-" + version.getVersion() + "-" + distributionType);
             if (dir.isDirectory()) {
-                LOGGER.info("Deleting Gradle distribution at {}", dir);
+                LOGGER.debug("Deleting Gradle distribution at {}", dir);
                 FileUtils.deleteDirectory(dir);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -53,6 +53,7 @@ import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.DefaultFileContentCacheFactory;
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.cache.internal.FileContentCacheFactory;
+import org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupService;
 import org.gradle.groovy.scripts.internal.CrossBuildInMemoryCachingScriptClassCache;
 import org.gradle.groovy.scripts.internal.DefaultScriptSourceHasher;
 import org.gradle.groovy.scripts.internal.RegistryAwareClassLoaderHierarchyHasher;
@@ -90,6 +91,7 @@ import org.gradle.process.internal.worker.WorkerProcessFactory;
 import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider;
 import org.gradle.util.GradleVersion;
 
+import java.io.File;
 import java.util.List;
 
 /**
@@ -103,10 +105,12 @@ public class GradleUserHomeScopeServices {
     }
 
     public void configure(ServiceRegistration registration, GradleUserHomeDirProvider userHomeDirProvider) {
-        registration.addProvider(new CacheRepositoryServices(userHomeDirProvider.getGradleUserHomeDirectory(), null));
+        File userHomeDir = userHomeDirProvider.getGradleUserHomeDirectory();
+        registration.addProvider(new CacheRepositoryServices(userHomeDir, null));
         for (PluginServiceRegistry plugin : globalServices.getAll(PluginServiceRegistry.class)) {
             plugin.registerGradleUserHomeServices(registration);
         }
+        registration.add(VersionSpecificCacheAndWrapperDistributionCleanupService.class, new VersionSpecificCacheAndWrapperDistributionCleanupService(GradleVersion.current(), userHomeDir));
     }
 
     ListenerManager createListenerManager(ListenerManager parent) {

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.GradleVersion
+import org.junit.Rule
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.MISSING_MARKER_FILE
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.NOT_RECENTLY_USED
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.RECENTLY_USED
+
+class VersionSpecificCacheAndWrapperDistributionCleanupServiceTest extends Specification implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+
+    @Rule
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+
+    GradleVersion currentVersion = GradleVersion.version("3.14")
+    TestFile userHomeDir = temporaryFolder.file("user-home").createDir()
+
+    @Subject def cleanupService = new VersionSpecificCacheAndWrapperDistributionCleanupService(currentVersion, userHomeDir)
+
+    def "cleans up unused version-specific cache directories"() {
+        given:
+        def ancientVersionWithoutMarkerFile = createVersionSpecificCacheDir(GradleVersion.version("0.0.1"), MISSING_MARKER_FILE)
+        def oldestCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.2.3"), NOT_RECENTLY_USED)
+        def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), RECENTLY_USED)
+        def oldCacheDir = createVersionSpecificCacheDir(GradleVersion.version("2.3.4"), NOT_RECENTLY_USED)
+        def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_RECENTLY_USED)
+        def newerCacheDir = createVersionSpecificCacheDir(GradleVersion.current().getNextMajor(), NOT_RECENTLY_USED)
+
+        when:
+        cleanupService.stop()
+
+        then:
+        ancientVersionWithoutMarkerFile.assertExists()
+        oldestCacheDir.assertDoesNotExist()
+        oldButRecentlyUsedCacheDir.assertExists()
+        oldCacheDir.assertDoesNotExist()
+        currentCacheDir.assertExists()
+        newerCacheDir.assertExists()
+    }
+
+    def "deletes distributions for unused versions"() {
+        given:
+        def oldVersion = GradleVersion.version("2.3.4")
+        def oldCacheDir = createVersionSpecificCacheDir(oldVersion, NOT_RECENTLY_USED)
+        def oldAllDist = createDistributionDir(oldVersion, "all")
+        def oldBinDist = createDistributionDir(oldVersion, "bin")
+        def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_RECENTLY_USED)
+        def currentAllDist = createDistributionDir(GradleVersion.current(), "all")
+        def currentBinDist = createDistributionDir(GradleVersion.current(), "bin")
+
+        when:
+        cleanupService.stop()
+
+        then:
+        oldCacheDir.assertDoesNotExist()
+        oldAllDist.assertDoesNotExist()
+        oldBinDist.assertDoesNotExist()
+        currentCacheDir.assertExists()
+        currentAllDist.assertExists()
+        currentBinDist.assertExists()
+    }
+
+    def "ignores directories that are not version-specific caches"() {
+        given:
+        def sharedCacheDir = createCacheSubDir("some-cache-42")
+        def dirWithUnparsableVersion = createCacheSubDir("42 foo")
+
+        when:
+        cleanupService.stop()
+
+        then:
+        sharedCacheDir.assertExists()
+        dirWithUnparsableVersion.assertExists()
+    }
+
+    @Override
+    TestFile getGradleUserHomeDir() {
+        return userHomeDir
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.cache.internal
 
+import org.gradle.internal.time.CountdownTimer
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
@@ -180,6 +181,25 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceTest extends Speci
         then:
         snapshot.assertExists()
         latestSnapshot.assertExists()
+    }
+
+    def "aborts cleanup when timeout has expired"() {
+        given:
+        def oldestCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.2.3"), NOT_USED_WITHIN_30_DAYS)
+        def oldCacheDir = createVersionSpecificCacheDir(GradleVersion.version("2.3.4"), NOT_USED_WITHIN_30_DAYS)
+        def timer = Mock(CountdownTimer)
+
+        when:
+        cleanupService.performCleanup(timer)
+
+        then:
+        1 * timer.hasExpired() >> false
+        1 * timer.hasExpired() >> true
+
+        and:
+        getGcFile(currentCacheDir).assertDoesNotExist()
+        oldestCacheDir.assertDoesNotExist()
+        oldCacheDir.assertExists()
     }
 
     @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
@@ -44,6 +44,10 @@ trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
         return versionDir
     }
 
+    TestFile getGcFile(TestFile currentCacheDir) {
+        currentCacheDir.file("gc.properties")
+    }
+
     abstract TestFile getGradleUserHomeDir()
 
     static enum MarkerFileType {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
@@ -22,6 +22,7 @@ import org.gradle.util.GradleVersion
 import java.util.concurrent.TimeUnit
 
 import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupService.MARKER_FILE_PATH
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupService.WRAPPER_DISTRIBUTION_FILE_PATH
 import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.MISSING_MARKER_FILE
 
 trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
@@ -39,7 +40,7 @@ trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
     }
 
     TestFile createDistributionDir(GradleVersion version, String distributionType) {
-        def cachesDir = getGradleUserHomeDir().file("wrapper/dists").createDir()
+        def cachesDir = getGradleUserHomeDir().file(WRAPPER_DISTRIBUTION_FILE_PATH).createDir()
         def versionDir = cachesDir.file("gradle-${version.version}-$distributionType").createDir()
         return versionDir
     }
@@ -52,18 +53,26 @@ trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
 
     static enum MarkerFileType {
 
-        RECENTLY_USED {
+        USED_TODAY {
             @Override
             void process(TestFile markerFile) {
                 markerFile.createFile()
             }
         },
 
-        NOT_RECENTLY_USED {
+        NOT_USED_WITHIN_30_DAYS {
             @Override
             void process(TestFile markerFile) {
                 markerFile.createFile()
                 markerFile.lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(31)
+            }
+        },
+
+        NOT_USED_WITHIN_7_DAYS {
+            @Override
+            void process(TestFile markerFile) {
+                markerFile.createFile()
+                markerFile.lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8)
             }
         },
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.GradleVersion
+
+import java.util.concurrent.TimeUnit
+
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupService.MARKER_FILE_PATH
+import static org.gradle.cache.internal.VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.MarkerFileType.MISSING_MARKER_FILE
+
+trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+
+    TestFile createVersionSpecificCacheDir(GradleVersion version, MarkerFileType type = MISSING_MARKER_FILE) {
+        return createCacheSubDir(version.version, type)
+    }
+
+    TestFile createCacheSubDir(String name, MarkerFileType type = MISSING_MARKER_FILE) {
+        def cachesDir = getGradleUserHomeDir().file(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME).createDir()
+        def versionDir = cachesDir.file(name).createDir()
+        def markerFile = versionDir.file(MARKER_FILE_PATH)
+        type.process(markerFile)
+        return versionDir
+    }
+
+    TestFile createDistributionDir(GradleVersion version, String distributionType) {
+        def cachesDir = getGradleUserHomeDir().file("wrapper/dists").createDir()
+        def versionDir = cachesDir.file("gradle-${version.version}-$distributionType").createDir()
+        return versionDir
+    }
+
+    abstract TestFile getGradleUserHomeDir()
+
+    static enum MarkerFileType {
+
+        RECENTLY_USED {
+            @Override
+            void process(TestFile markerFile) {
+                markerFile.createFile()
+            }
+        },
+
+        NOT_RECENTLY_USED {
+            @Override
+            void process(TestFile markerFile) {
+                markerFile.createFile()
+                markerFile.lastModified = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(31)
+            }
+        },
+
+        MISSING_MARKER_FILE
+
+        void process(TestFile markerFile) {}
+    }
+}


### PR DESCRIPTION
The `VersionSpecificCacheAndWrapperDistributionCleanupService` introduced by this PR scans `$GRADLE_USER_HOME/caches` for version-specific cache directories. It then checks when each directory was last used (by reading the modification timestamp of `fileHashes/fileHashes.lock`) and deletes those that have not been used for 30 days. In addition, it deletes the corresponding wrapper distributions in `$GRADLE_USER_HOME/wrapper/dists`. Versions greater than or equal to the current version are ignored because they might be using a different, potentially conflicting, cleanup strategy.

Caches specific to snapshot versions are purged when they have not been used for 7 days if there exists another version-specific cache directory for a later version with the same base version.

Each Gradle version performs cleanup at most every 24 hours by checking/touching a `gc.properties` file at the root of its own version-specific cache directory.

Addresses part of #1085.
