### PR TITLE
Fix regression in resolution error handling

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDepe
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.test.fixtures.server.http.MavenHttpModule
 import spock.lang.Unroll
 
 class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -344,4 +345,56 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         mavenHttpRepo.module('org.foo', 'app-dep').publish().allowAll()
     }
 
+    def "failed resolved configurations are exposed via build operation"() {
+        given:
+        MavenHttpModule a
+        MavenHttpModule b
+        MavenHttpModule leaf1
+        MavenHttpModule leaf2
+        mavenHttpRepo.with {
+            a = module('org', 'a', '1.0').dependsOn('org', 'leaf', '1.0').publish()
+            b = module('org', 'b', '1.0').dependsOn('org', 'leaf', '2.0').publish()
+            leaf1 = module('org', 'leaf', '1.0').publish()
+            leaf2 = module('org', 'leaf', '2.0').publish()
+        }
+
+        when:
+        buildFile << """    
+            repositories {
+                maven { url = '${mavenHttpRepo.uri}' }
+            }
+            
+            configurations {
+                compile {
+                    resolutionStrategy.failOnVersionConflict()
+                }
+            }
+                        
+            dependencies {
+               compile 'org:a:1.0'
+               compile 'org:b:1.0'
+            }
+            
+            task resolve {
+              doLast {
+                  println(configurations.compile.files.name)
+              }
+            }
+"""
+        a.pom.expectGet()
+        b.pom.expectGet()
+        leaf1.pom.expectGet()
+        leaf2.pom.expectGet()
+
+        then:
+        fails "resolve"
+
+        and:
+        def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
+        op.details.configurationName == "compile"
+        op.failure == "org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':compile'."
+        failure.assertHasCause("""A conflict was found between the following modules:
+  - org:leaf:1.0
+  - org:leaf:2.0""")
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
@@ -148,6 +148,17 @@ public class DefaultResolverResults implements ResolverResults {
     }
 
     @Override
+    public Throwable getFailure() {
+        if (fatalFailure != null) {
+            return fatalFailure;
+        }
+        if (nonFatalFailure != null) {
+            return nonFatalFailure;
+        }
+        return null;
+    }
+
+    @Override
     public boolean hasResolutionResult() {
         return resolutionResult != null;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -71,7 +71,20 @@ public interface ResolverResults {
      */
     void artifactsResolved(ResolvedConfiguration resolvedConfiguration, VisitedArtifactSet visitedArtifacts);
 
+    /**
+     * Consumes the failure, allowing to either throw or do something else with it. Consuming effectively
+     * removes the exception from the underlying resolver results, meaning that subsequent calls to consume
+     * will return null.
+     */
     ResolveException consumeNonFatalFailure();
+
+    /**
+     * Returns the failure, fatal or non fatal, or null if there's no failure. Used internally to
+     * set the failure on the resolution build operation result. In opposite to {@link #consumeNonFatalFailure()},
+     * this doesn't consume the error, so subsequent calls will return the same instance, unless the error was
+     * consumed in between.
+     */
+    Throwable getFailure();
 
     boolean hasResolutionResult();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -541,12 +541,21 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 dependencyResolutionListeners.getSource().afterResolve(incoming);
                 // Discard listeners
                 dependencyResolutionListeners.removeAll();
-                context.setResult(new ResolveConfigurationDependenciesBuildOperationType.Result() {
-                    @Override
-                    public ResolvedComponentResult getRootComponent() {
-                        return incoming.getResolutionResult().getRoot();
-                    }
-                });
+                captureBuildOperationResult(context, incoming);
+            }
+
+            private void captureBuildOperationResult(BuildOperationContext context, final ResolvableDependencies incoming) {
+                Throwable failure = cachedResolverResults.getFailure();
+                if (failure != null) {
+                    context.failed(failure);
+                } else {
+                    context.setResult(new ResolveConfigurationDependenciesBuildOperationType.Result() {
+                        @Override
+                        public ResolvedComponentResult getRootComponent() {
+                            return incoming.getResolutionResult().getRoot();
+                        }
+                    });
+                }
             }
 
             @Override


### PR DESCRIPTION
## Context

This PR fixes a regression in 4.9 which is easily illustrated by a build scan error (failure to upload the scan) whenever a resolution error is detected _too late_. This can happen now that we defer throwing exceptions during resolution up to the point we actually need the resolution result.
