### PR TITLE
Treat `latest.xxx` differently when dependency locking is in action

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -329,7 +329,10 @@ class DependencyManagementBuildScopeServices {
             versionComparator,
             moduleExclusions,
             componentSelectorConverter,
-            attributesFactory, versionSelectorScheme, versionParser, componentMetadataSupplierRuleExecutor);
+            attributesFactory,
+            versionSelectorScheme,
+            versionParser,
+            componentMetadataSupplierRuleExecutor);
     }
 
     ProjectPublicationRegistry createProjectPublicationRegistry() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelector.java
@@ -55,4 +55,33 @@ public class LatestVersionSelector extends AbstractStringVersionSelector {
     public boolean canShortCircuitWhenVersionAlreadyPreselected() {
         return false;
     }
+
+    public VersionSelector forLocking() {
+        return new LockingAwareLatestVersionSelector(getSelector());
+    }
+
+    private static class LockingAwareLatestVersionSelector extends LatestVersionSelector {
+        private LockingAwareLatestVersionSelector(String selector) {
+            super(selector);
+        }
+
+        @Override
+        public boolean accept(String candidate) {
+            // This is not right, we should really call accept with ComponentMetadata because
+            // we need to check if the status of the candidate is matching. However, this is
+            // only used in the context of dependency locking, and this method will only be
+            // called with a candidate which is assumed to pass the test.
+            return true;
+        }
+
+        @Override
+        public boolean matchesUniqueVersion() {
+            return false;
+        }
+
+        @Override
+        public boolean canShortCircuitWhenVersionAlreadyPreselected() {
+            return true;
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -76,16 +76,20 @@ public class DependencyGraphBuilder {
     private final CapabilitiesConflictHandler capabilitiesConflictHandler;
     private final VersionSelectorScheme versionSelectorScheme;
 
-    public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver, ComponentMetaDataResolver componentMetaDataResolver,
+    public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver,
+                                  ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
                                   ModuleConflictHandler moduleConflictHandler,
                                   CapabilitiesConflictHandler capabilitiesConflictHandler,
                                   Spec<? super DependencyMetadata> edgeFilter,
                                   AttributesSchemaInternal attributesSchema,
                                   ModuleExclusions moduleExclusions,
-                                  BuildOperationExecutor buildOperationExecutor, ModuleReplacementsData moduleReplacementsData,
-                                  DependencySubstitutionApplicator dependencySubstitutionApplicator, ComponentSelectorConverter componentSelectorConverter,
-                                  ImmutableAttributesFactory attributesFactory, VersionSelectorScheme versionSelectorScheme) {
+                                  BuildOperationExecutor buildOperationExecutor,
+                                  ModuleReplacementsData moduleReplacementsData,
+                                  DependencySubstitutionApplicator dependencySubstitutionApplicator,
+                                  ComponentSelectorConverter componentSelectorConverter,
+                                  ImmutableAttributesFactory attributesFactory,
+                                  VersionSelectorScheme versionSelectorScheme) {
         this.idResolver = componentIdResolver;
         this.metaDataResolver = componentMetaDataResolver;
         this.moduleResolver = resolveContextToComponentResolver;


### PR DESCRIPTION
### Context

This commit adds special handling for the "latest" selector in case
dependency locking is used. This is technically a workaround so that
the expectation from a user point of view matches the principle of
least surprise. In particular, before this commit, if the --update-locks
flag was used on module A, and that module B had "latest.xxx" as
requested version, then we would also upgrade the version of module B,
because "latest.xxx" means "the latest xxx", not "the latest xxx matching
other requirements" (where other requirements = locked version).

Fixes #5531
