### PR TITLE
Don't use `JavaCompile.include` to filter `.java` files

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -16,7 +16,9 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
@@ -24,8 +26,11 @@ import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
+
+import static org.gradle.internal.FileUtils.hasExtension;
 
 /**
  * A Java {@link Compiler} which does some normalization of the compile configuration and behaviour before delegating to some other compiler.
@@ -40,15 +45,24 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
 
     @Override
     public WorkResult execute(JavaCompileSpec spec) {
-        resolveSourceFiles(spec);
+        resolveAndFilterSourceFiles(spec);
         resolveNonStringsInCompilerArgs(spec);
         logSourceFiles(spec);
         logCompilerArguments(spec);
         return delegateAndHandleErrors(spec);
     }
 
-    private void resolveSourceFiles(JavaCompileSpec spec) {
-        spec.setSourceFiles(ImmutableSet.copyOf(spec.getSourceFiles()));
+    private void resolveAndFilterSourceFiles(JavaCompileSpec spec) {
+        // this mimics the behavior of the Ant javac task (and therefore AntJavaCompiler),
+        // which silently excludes files not ending in .java
+        Iterable<File> javaOnly = Iterables.filter(spec.getSourceFiles(), new Predicate<File>() {
+            @Override
+            public boolean apply(@Nullable File input) {
+                return hasExtension(input, ".java");
+            }
+        });
+
+        spec.setSourceFiles(ImmutableSet.copyOf(javaOnly));
     }
 
     private void resolveNonStringsInCompilerArgs(JavaCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -72,10 +72,6 @@ public class JavaCompile extends AbstractCompile {
         CompileOptions compileOptions = getServices().get(ObjectFactory.class).newInstance(CompileOptions.class);
         this.compileOptions = compileOptions;
         CompilerForkUtils.doNotCacheIfForkingViaExecutable(compileOptions, getOutputs());
-
-        // this mimics the behavior of the Ant javac task (and therefore AntJavaCompiler),
-        // which silently excludes files not ending in .java
-        include("**/*.java");
     }
 
     /**

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
@@ -48,6 +48,18 @@ class NormalizingJavaCompilerTest extends Specification {
         }
     }
 
+    def "silently excludes source files not ending in .java"() {
+        spec.sourceFiles = files("House.scala", "Person1.java", "package.html", "Person2.java")
+
+        when:
+        compiler.execute(spec)
+
+        then:
+        1 * target.execute(spec) >> {
+            assert spec.sourceFiles == files("Person1.java", "Person2.java")
+        }
+    }
+
     def "delegates to target compiler after resolving source and processor path"() {
         WorkResult workResult = Mock()
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.java.compile
 
+import spock.lang.Issue
+
 abstract class JavaCompilerIntegrationSpec extends BasicJavaCompilerIntegrationSpec {
     def setup() {
         buildFile << """
@@ -104,5 +106,21 @@ abstract class JavaCompilerIntegrationSpec extends BasicJavaCompilerIntegrationS
         succeeds("compileJava")
         javaClassFile("compile/test/Person.class").exists()
         javaClassFile("compile/test/Person2.class").exists()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/5750")
+    def "include narrows down source files to compile"() {
+        given:
+        goodCode()
+
+        and:
+        file('src/main/java/Bar.java') << 'class Bar {}'
+        buildFile << 'compileJava.include "**/Person*.java"'
+
+        expect:
+        succeeds("compileJava")
+        javaClassFile("compile/test/Person.class").exists()
+        javaClassFile("compile/test/Person2.class").exists()
+        !javaClassFile("Bar.class").exists()
     }
 }


### PR DESCRIPTION
If we use `include`, then user provided `include` statements are
ignored, since `include` means "union".

See #5750.
