### PR TITLE
 Support snapshot plugin versions

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -94,8 +94,8 @@ class PluginBuilder {
 
         // The implementation jar module.
         def module = mavenRepo.module(group, artifact, version)
-        def artifactFile = module.getArtifactFile()
         def pluginModule = module.publish()
+        def artifactFile = module.getArtifactFile()
 
         def markerModules = new ArrayList<Module>()
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingSnapshotFromPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingSnapshotFromPluginRepositorySpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.test.fixtures.Repository
+import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.test.fixtures.plugin.PluginBuilder
+
+@LeaksFileHandles
+class ResolvingSnapshotFromPluginRepositorySpec extends AbstractDependencyResolutionTest {
+
+
+    private publishTestPlugin() {
+        publishTestPlugin(mavenRepo)
+    }
+
+    private publishTestPlugin(Repository repository) {
+        def pluginBuilder = new PluginBuilder(testDirectory.file("plugin"))
+
+        def message = "from plugin"
+        def taskName = "pluginTask"
+
+        pluginBuilder.addPluginWithPrintlnTask(taskName, message, "org.example.plugin")
+        pluginBuilder.publishAs("org.example.plugin:plugin:1.0-SNAPSHOT", repository, executer)
+    }
+
+    private void useCustomRepository(String resolutionStrategy = "") {
+        settingsFile << """
+          pluginManagement {
+            $resolutionStrategy
+            repositories {
+                maven {
+                    url "${mavenRepo.uri}"
+                }
+            }
+          }
+        """
+    }
+
+
+    def 'Can specify snapshot version'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin" version '1.0-SNAPSHOT'
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository()
+
+        when:
+        succeeds("pluginTask")
+
+        then:
+        output.contains("I'm here")
+    }
+
+    def 'setting different snapshot version in resolutionStrategy will affect plugin choice'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin" version '1000'
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository("""
+            resolutionStrategy.eachPlugin {
+                if(requested.id.name == 'plugin') {
+                    useVersion('1.0-SNAPSHOT')
+                }
+            }
+        """)
+
+        when:
+        succeeds("pluginTask")
+
+        then:
+        output.contains("I'm here")
+    }
+
+    def 'can specify a snapshot artifact to use'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin"
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository("""
+            resolutionStrategy.eachPlugin {
+                if(requested.id.name == 'plugin') {
+                    useModule('org.example.plugin:plugin:1.0-SNAPSHOT')
+                }
+            }
+        """)
+
+        when:
+        succeeds "pluginTask"
+
+        then:
+        output.contains("I'm here")
+    }
+
+}

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -69,11 +69,6 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
             return;
         }
 
-        if (markerVersion.endsWith("-SNAPSHOT")) {
-            result.notFound(SOURCE_NAME, "snapshot plugin versions are not supported");
-            return;
-        }
-
         if (versionSelectorScheme.parseSelector(markerVersion).isDynamic()) {
             result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported");
             return;


### PR DESCRIPTION
Using snapshot plugins previously ended up in a blockingerror with a `Plugin Repositories (snapshot plugin versions are not supported)` message.

With this commit, it is now possible to use snapshot plugins like:
```
plugins {
    id 'org.springframework.boot' version '2.0.0.BUILD-SNAPSHOT'
}
```

Fix #3902