### PR TITLE
Canonicalize relative wrapper distribution URIs

### DIFF
--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -67,7 +67,13 @@ public class WrapperExecutor {
         URI source = readDistroUrl();
         if (source.getScheme() == null) {
             //no scheme means someone passed a relative url. In our context only file relative urls make sense.
-            return new File(propertiesFile.getParentFile(), source.getSchemeSpecificPart()).toURI();
+            File file = new File(propertiesFile.getParentFile(), source.getSchemeSpecificPart());
+            try {
+                file = file.getCanonicalFile();
+            } catch (IOException e) {
+                // ignore failed attempt to canonicalize and use original file
+            }
+            return file.toURI();
         } else {
             return source;
         }

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.wrapper
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 
 class WrapperExecutorTest extends Specification {
@@ -167,5 +168,19 @@ class WrapperExecutorTest extends Specification {
         //distribution uri should resolve into absolute path
         wrapper.distribution.schemeSpecificPart != 'some/relative/url/to/bin.zip'
         wrapper.distribution.schemeSpecificPart.endsWith 'some/relative/url/to/bin.zip'
+    }
+
+    @Issue("gradle/gradle#2844")
+    def "canonicalizes relative distribution url"() {
+        given:
+        properties.distributionUrl = '../../some/relative/url/to/bin.zip'
+        propertiesFile.withOutputStream { properties.store(it, 'header') }
+
+        when:
+        WrapperExecutor wrapper = WrapperExecutor.forWrapperPropertiesFile(propertiesFile)
+
+        then:
+        //distribution uri should resolve into absolute path
+        wrapper.distribution == tmpDir.file('some/relative/url/to/bin.zip').toURI()
     }
 }


### PR DESCRIPTION
Prior to this PR relative file URIs used in wrapper.properties were not canonicalized which led (in some cases) to lots of duplicate distributions in wrapper/dist because each URI had a different hash. Now we attempt to canonicalize the file path before converting it into and URI. In case that fails, we fall back to the old behavior.

Fixes #2844.