### PR TITLE
Enable all supported cipher suites on Java 7

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
@@ -123,8 +123,7 @@ task copyFiles(type:Copy) {
         succeeds 'resolveDependencies'
     }
 
-    @Requires(value = [TestPrecondition.ONLINE, TestPrecondition.JDK8_OR_LATER])
-    @Issue('https://github.com/gradle/gradle-private/issues/1341')
+    @Requires(TestPrecondition.ONLINE)
     // This emulates the behaviour of the Spring Dependency Management plugin when applying dependency excludes from a BOM
     def "can use beforeResolve hook to modify excludes for a dependency shared with an already-resolved configuration"() {
         mavenRepo.module('org.test', 'module1', '1.0').publish()

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -31,8 +31,7 @@ import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.NO
 import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.YES
 import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.writeToStdInAndClose
 
-@Requires(value = [TestPrecondition.ONLINE, TestPrecondition.JDK8_OR_LATER])
-@Issue('https://github.com/gradle/gradle-private/issues/1341')
+@Requires(TestPrecondition.ONLINE)
 @LeaksFileHandles
 class AutoAppliedPluginsFunctionalTest extends AbstractIntegrationSpec {
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
@@ -208,8 +208,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
         repoType << [IVY, MAVEN]
     }
 
-    @Requires(value = [TestPrecondition.ONLINE, TestPrecondition.JDK8_OR_LATER])
-    @Issue('https://github.com/gradle/gradle-private/issues/1341')
+    @Requires(TestPrecondition.ONLINE)
     def "Can opt-in to plugin portal"() {
         given:
         publishPlugins(MAVEN)

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -20,13 +20,11 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.Issue
 
 import static org.hamcrest.Matchers.startsWith
 
 //These tests depend on https://plugins.gradle.org
-@Requires(value = [TestPrecondition.ONLINE, TestPrecondition.JDK8_OR_LATER])
-@Issue('https://github.com/gradle/gradle-private/issues/1341')
+@Requires(TestPrecondition.ONLINE)
 @LeaksFileHandles
 class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
 

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -62,6 +62,7 @@ import org.gradle.authentication.Authentication;
 import org.gradle.authentication.http.BasicAuthentication;
 import org.gradle.authentication.http.DigestAuthentication;
 import org.gradle.internal.Cast;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.authentication.AllSchemesAuthentication;
 import org.gradle.internal.authentication.AuthenticationInternal;
 import org.gradle.internal.resource.UriTextResource;
@@ -72,8 +73,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.ProxySelector;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -102,50 +105,11 @@ public class HttpClientConfigurer {
         if (cipherSuites != null) {
             return cipherSuites.split(",");
         } else if (JavaVersion.current().isJava7()) {
-            // https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
-            return new String[]{
-                "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-                "TLS_RSA_WITH_AES_256_CBC_SHA256",
-                "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-                "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
-                "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
-                "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-                "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-                "TLS_RSA_WITH_AES_256_CBC_SHA",
-                "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-                "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-                "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
-                "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-                "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-                "TLS_RSA_WITH_AES_128_CBC_SHA256",
-                "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-                "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
-                "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
-                "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-                "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-                "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-                "TLS_RSA_WITH_AES_128_CBC_SHA",
-                "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-                "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
-                "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
-                "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-                "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-                "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-                "SSL_RSA_WITH_RC4_128_SHA",
-                "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
-                "TLS_ECDH_RSA_WITH_RC4_128_SHA",
-                "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
-                "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
-                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
-                "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
-                "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
-                "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
-                "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
-                "SSL_RSA_WITH_RC4_128_MD5",
-                "TLS_EMPTY_RENEGOTIATION_INFO_SCSV2"
-            };
+            try {
+                return SSLContext.getDefault().getSocketFactory().getSupportedCipherSuites();
+            } catch (NoSuchAlgorithmException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
         } else {
             return null;
         }


### PR DESCRIPTION
### Context

Also see https://github.com/gradle/gradle-private/issues/1341

Some weak cipher algorithm might be disabled by default, which might cause SSL handshake throw unexpected exception. This PR enables all supported cipher suites for Java 7 to avoid such exceptions.