### PR TITLE
Don't run play tests in build branch accept

### DIFF
--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -114,6 +114,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?) : BaseGr
                     if (shouldBeSkipped(subProject, testCoverage)) {
                         return@forEach
                     }
+                    if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+                        return@forEach
+                    }
                     if (subProject.unitTests && testCoverage.testType.unitTests) {
                         dependency(testCoverage.asConfigurationId(model, subProject.name)) { snapshot {} }
                     } else if (subProject.functionalTests && testCoverage.testType.functionalTests) {

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -12,7 +12,7 @@ import model.Stage
 import model.TestType
 import model.Trigger
 
-class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?) : BaseGradleBuildType(model, init = {
+class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean) : BaseGradleBuildType(model, init = {
     uuid = "${model.projectPrefix}Stage_${stage.id}_Trigger"
     id = uuid
     name = stage.name + " (Trigger)"
@@ -130,6 +130,10 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?) : BaseGr
                     snapshot {}
                 }
             }
+        }
+
+        if (containsDeferredTests) {
+            dependency("deferred_tests") { snapshot {} }
         }
     }
 })

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -21,11 +21,12 @@ data class CIBuildModel (
                     specificBuilds = listOf(
                             SpecificBuild.SanityCheck),
                     functionalTests = listOf(
-                            TestCoverage(TestType.quick, OS.linux, JvmVersion.java8))),
+                            TestCoverage(TestType.quick, OS.linux, JvmVersion.java8)), omitsSlowProjects = true),
             Stage("Quick Feedback", "Run checks and functional tests (embedded executer)",
                     functionalTests = listOf(
                             TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
-                    functionalTestsDependOnSpecificBuilds = true),
+                    functionalTestsDependOnSpecificBuilds = true,
+                    omitsSlowProjects = true),
             Stage("Branch Build Accept", "Run performance and functional tests (against distribution)",
                     specificBuilds = listOf(
                             SpecificBuild.BuildDistributions,
@@ -34,7 +35,8 @@ data class CIBuildModel (
                     functionalTests = listOf(
                             TestCoverage(TestType.platform, OS.linux, JvmVersion.java7),
                             TestCoverage(TestType.platform, OS.windows, JvmVersion.java8)),
-                    performanceTests = listOf(PerformanceTestType.test)),
+                    performanceTests = listOf(PerformanceTestType.test),
+                    omitsSlowProjects = true),
             Stage("Master Accept", "Rerun tests in different environments / 3rd party components",
                     trigger = Trigger.eachCommit,
                     functionalTests = listOf(
@@ -111,7 +113,7 @@ data class CIBuildModel (
             GradleSubproject("platformBase"),
             GradleSubproject("platformJvm"),
             GradleSubproject("platformNative"),
-            GradleSubproject("platformPlay"),
+            GradleSubproject("platformPlay", containsSlowTests = true),
             GradleSubproject("pluginDevelopment"),
             GradleSubproject("pluginUse", crossVersionTests = true),
             GradleSubproject("plugins"),
@@ -150,7 +152,7 @@ data class CIBuildModel (
     )
 }
 
-data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false) {
+data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false) {
     fun asDirectoryName(): String {
         return name.replace(Regex("([A-Z])"), { "-" + it.groups[1]!!.value.toLowerCase()})
     }
@@ -179,7 +181,7 @@ object NoBuildCache : BuildCache {
     }
 }
 
-data class Stage(val name: String, val description: String, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false, val runsIndependent: Boolean = false) {
+data class Stage(val name: String, val description: String, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false, val runsIndependent: Boolean = false, val omitsSlowProjects : Boolean = false) {
     val id = name.replace(" ", "").replace("-", "")
 }
 

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -16,58 +16,7 @@ data class CIBuildModel (
         val parentBuildCache: BuildCache = RemoteBuildCache("%gradle.cache.remote.url%"),
         val childBuildCache: BuildCache = RemoteBuildCache("%gradle.cache.remote.url%"),
         val buildScanTags: List<String> = emptyList(),
-        val stages: List<Stage> = listOf(
-            Stage("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer)",
-                    specificBuilds = listOf(
-                            SpecificBuild.SanityCheck),
-                    functionalTests = listOf(
-                            TestCoverage(TestType.quick, OS.linux, JvmVersion.java8)), omitsSlowProjects = true),
-            Stage("Quick Feedback", "Run checks and functional tests (embedded executer)",
-                    functionalTests = listOf(
-                            TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
-                    functionalTestsDependOnSpecificBuilds = true,
-                    omitsSlowProjects = true),
-            Stage("Branch Build Accept", "Run performance and functional tests (against distribution)",
-                    specificBuilds = listOf(
-                            SpecificBuild.BuildDistributions,
-                            SpecificBuild.Gradleception,
-                            SpecificBuild.SmokeTests),
-                    functionalTests = listOf(
-                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java7),
-                            TestCoverage(TestType.platform, OS.windows, JvmVersion.java8)),
-                    performanceTests = listOf(PerformanceTestType.test),
-                    omitsSlowProjects = true),
-            Stage("Master Accept", "Rerun tests in different environments / 3rd party components",
-                    trigger = Trigger.eachCommit,
-                    functionalTests = listOf(
-                            TestCoverage(TestType.quickFeedbackCrossVersion, OS.linux, JvmVersion.java7),
-                            TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java7),
-                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java10),
-                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java7, JvmVendor.ibm))),
-            Stage("Release Accept", "Once a day: Rerun tests in more environments",
-                    trigger = Trigger.daily,
-                    functionalTests = listOf(
-                            TestCoverage(TestType.soak, OS.linux, JvmVersion.java8),
-                            TestCoverage(TestType.soak, OS.windows, JvmVersion.java8),
-                            TestCoverage(TestType.allVersionsCrossVersion, OS.linux, JvmVersion.java7),
-                            TestCoverage(TestType.allVersionsCrossVersion, OS.windows, JvmVersion.java7),
-                            TestCoverage(TestType.noDaemon, OS.linux, JvmVersion.java8),
-                            TestCoverage(TestType.noDaemon, OS.windows, JvmVersion.java8),
-                            TestCoverage(TestType.platform, OS.macos, JvmVersion.java8),
-                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java9)),
-                    performanceTests = listOf(
-                            PerformanceTestType.experiment)),
-            Stage("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions",
-                    trigger = Trigger.weekly,
-                    performanceTests = listOf(
-                            PerformanceTestType.historical)),
-            Stage("Experimental", "On demand: Run experimental tests",
-                    trigger = Trigger.never,
-                    runsIndependent = true,
-                    functionalTests = listOf(TestCoverage(TestType.platform, OS.linux, JvmVersion.java11))))
-    ) {
-
-    val subProjects = listOf(
+        val subProjects: List<GradleSubproject> = listOf(
             GradleSubproject("announce"),
             GradleSubproject("antlr"),
             GradleSubproject("baseServices"),
@@ -149,8 +98,57 @@ data class CIBuildModel (
             GradleSubproject("performance", unitTests = false, functionalTests = false),
             GradleSubproject("runtimeApiInfo", unitTests = false, functionalTests = false),
             GradleSubproject("smokeTest", unitTests = false, functionalTests = false)
+        ),
+        val stages: List<Stage> = listOf(
+            Stage("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer)",
+                    specificBuilds = listOf(
+                            SpecificBuild.SanityCheck),
+                    functionalTests = listOf(
+                            TestCoverage(TestType.quick, OS.linux, JvmVersion.java8)), omitsSlowProjects = true),
+            Stage("Quick Feedback", "Run checks and functional tests (embedded executer)",
+                    functionalTests = listOf(
+                            TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
+                    functionalTestsDependOnSpecificBuilds = true,
+                    omitsSlowProjects = true),
+            Stage("Branch Build Accept", "Run performance and functional tests (against distribution)",
+                    specificBuilds = listOf(
+                            SpecificBuild.BuildDistributions,
+                            SpecificBuild.Gradleception,
+                            SpecificBuild.SmokeTests),
+                    functionalTests = listOf(
+                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java7),
+                            TestCoverage(TestType.platform, OS.windows, JvmVersion.java8)),
+                    performanceTests = listOf(PerformanceTestType.test),
+                    omitsSlowProjects = true),
+            Stage("Master Accept", "Rerun tests in different environments / 3rd party components",
+                    trigger = Trigger.eachCommit,
+                    functionalTests = listOf(
+                            TestCoverage(TestType.quickFeedbackCrossVersion, OS.linux, JvmVersion.java7),
+                            TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java7),
+                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java10),
+                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java7, JvmVendor.ibm))),
+            Stage("Release Accept", "Once a day: Rerun tests in more environments",
+                    trigger = Trigger.daily,
+                    functionalTests = listOf(
+                            TestCoverage(TestType.soak, OS.linux, JvmVersion.java8),
+                            TestCoverage(TestType.soak, OS.windows, JvmVersion.java8),
+                            TestCoverage(TestType.allVersionsCrossVersion, OS.linux, JvmVersion.java7),
+                            TestCoverage(TestType.allVersionsCrossVersion, OS.windows, JvmVersion.java7),
+                            TestCoverage(TestType.noDaemon, OS.linux, JvmVersion.java8),
+                            TestCoverage(TestType.noDaemon, OS.windows, JvmVersion.java8),
+                            TestCoverage(TestType.platform, OS.macos, JvmVersion.java8),
+                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java9)),
+                    performanceTests = listOf(
+                            PerformanceTestType.experiment)),
+            Stage("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions",
+                    trigger = Trigger.weekly,
+                    performanceTests = listOf(
+                            PerformanceTestType.historical)),
+            Stage("Experimental", "On demand: Run experimental tests",
+                    trigger = Trigger.never,
+                    runsIndependent = true,
+                    functionalTests = listOf(TestCoverage(TestType.platform, OS.linux, JvmVersion.java11))))
     )
-}
 
 data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false) {
     fun asDirectoryName(): String {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -16,6 +16,10 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
         if (shouldBeSkipped(subProject, testConfig)) {
             return@forEach
         }
+        if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+            return@forEach
+        }
+
         if (subProject.unitTests && testConfig.testType.unitTests) {
             buildType(FunctionalTest(model, testConfig, subProject.name, stage))
         } else if (subProject.functionalTests && testConfig.testType.functionalTests) {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -17,6 +17,7 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
             return@forEach
         }
         if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+            addMissingTestCoverage(testConfig)
             return@forEach
         }
 
@@ -28,4 +29,12 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
             buildType(FunctionalTest(model, testConfig, subProject.name, stage))
         }
     }
-})
+}){
+    companion object {
+        val missingTestCoverage = mutableListOf<TestCoverage>()
+
+        private fun addMissingTestCoverage(coverage: TestCoverage) {
+            this.missingTestCoverage.add(coverage)
+        }
+    }
+}

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -26,9 +26,12 @@ class RootProject(model: CIBuildModel) : Project({
     }
 
     var prevStage: Stage? = null
+    var deferredAlreadyDeclared = false
     model.stages.forEach { stage ->
-        buildType(StagePasses(model, stage, prevStage))
-        subProject(StageProject(model, stage))
+        val containsDeferredTests = !stage.omitsSlowProjects && !deferredAlreadyDeclared
+        deferredAlreadyDeclared = deferredAlreadyDeclared || containsDeferredTests
+        buildType(StagePasses(model, stage,  prevStage, containsDeferredTests))
+        subProject(StageProject(model, stage, containsDeferredTests))
         prevStage = stage
     }
 

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -54,6 +54,9 @@ class CIConfigIntegrationTests {
 
                 stage.functionalTests.forEach { testCoverage ->
                     m.subProjects.forEach { subProject ->
+                        if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+                            return@forEach
+                        }
                         if (shouldBeSkipped(subProject, testCoverage)) {
                             return@forEach
                         }
@@ -91,7 +94,8 @@ class CIConfigIntegrationTests {
                                     SpecificBuild.BuildDistributions),
                             functionalTests = listOf(
                                     TestCoverage(TestType.quick, OS.linux, JvmVersion.java8),
-                                    TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)))
+                                    TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
+                            omitsSlowProjects = true)
                 )
         )
         val p = RootProject(m)

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -104,6 +104,44 @@ class CIConfigIntegrationTests {
     }
 
     @Test
+    fun canDeferSlowTestsToLaterStage() {
+        val ft = listOf(TestCoverage(TestType.quick, OS.linux, JvmVersion.java8), TestCoverage(TestType.quick, OS.windows, JvmVersion.java7))
+        val m = CIBuildModel(
+            projectPrefix = "",
+            parentBuildCache = NoBuildCache,
+            childBuildCache = NoBuildCache,
+            stages = listOf(
+                Stage("Stage1", "Stage1 description",
+                    functionalTests = listOf(
+                        TestCoverage(TestType.quick, OS.linux, JvmVersion.java7),
+                        TestCoverage(TestType.quick, OS.windows, JvmVersion.java7)),
+                    omitsSlowProjects = true),
+                Stage("Stage2", "Stage2 description",
+                    functionalTests = listOf(
+                        TestCoverage(TestType.noDaemon, OS.linux, JvmVersion.java7),
+                        TestCoverage(TestType.noDaemon, OS.windows, JvmVersion.java7)),
+                    omitsSlowProjects = true),
+                Stage("Stage3", "Stage3 description",
+                    functionalTests = listOf(
+                        TestCoverage(TestType.platform, OS.linux, JvmVersion.java7),
+                       TestCoverage(TestType.platform, OS.windows, JvmVersion.java7)),
+                    omitsSlowProjects = false),
+                Stage("Stage4", "Stage4 description",
+                    functionalTests = listOf(
+                        TestCoverage(TestType.parallel, OS.linux, JvmVersion.java7),
+                        TestCoverage(TestType.parallel, OS.windows, JvmVersion.java7)),
+                    omitsSlowProjects = false)
+            ),
+            subProjects = listOf(
+                GradleSubproject("fastBuild"),
+                GradleSubproject("slowBuild", containsSlowTests = true)
+            )
+        )
+        val p = RootProject(m)
+        printTree(p)
+    }
+
+    @Test
     fun allSubprojectsAreListed() {
         val m = CIBuildModel()
         subProjectFolderList().forEach {


### PR DESCRIPTION
This PR resolves https://github.com/gradle/gradle-private/issues/1011#issuecomment-389476371

The ignored tests are executed as part of the master accept, so we can remove them from quick feedback and from the build branch accept stage.

This is my first take on the solution. I had a couple of tries to modify the TC configuration, but we have too many things tangled together. Maybe we should revisit how we declare our build types, especially with the new DSL introduced with the latest TC release.