### PR TITLE
De-incubate dependency insight report

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.result.DependencyResult;
@@ -90,7 +89,6 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.UserInput;
  * For more information please refer to {@link DependencyInsightReportTask#setDependencySpec(Object)}
  * and {@link DependencyInsightReportTask#setConfiguration(String)}
  */
-@Incubating
 public class DependencyInsightReportTask extends DefaultTask {
 
     private Configuration configuration;

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -11,6 +11,19 @@ you don't need to hardcode it into the build script - you can just run `gradle r
 
 This release of Gradle includes a [new Publishing Overview chapter](/userguide/publishing_overview.html) in the user manual and updates throughout the documentation regarding publishing artifacts using Maven and Ivy.  
 
+### Improved dependency insight report
+
+The dependency insight report is the distant ancestor of [build scans](https://scans.gradle.com) and helps you diagnose dependency management problems locally.
+This release of Gradle implements several improvements:
+
+- using `failOnVersionConflict()` no longer fails the dependency insight report in case of conflict
+- all participants of conflict resolution are shown
+- modules which were rejected by a rule are displayed
+- modules which didn't match the version selector but were considered in selection are shown
+- all custom reasons for a component selection are shown
+- ability to restrict the report to one path to each dependency, for readability
+- resolution failures are displayed in the report
+
 <!--
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
@@ -26,9 +39,9 @@ See the User guide section on the “[Feature Lifecycle](userguide/feature_lifec
 
 The following are the features that have been promoted in this Gradle release.
 
-<!--
-### Example promoted
--->
+### Dependency insight report
+
+The dependency insight report is now considered stable.
 
 ## Fixed issues
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -13,7 +13,7 @@ This release of Gradle includes a [new Publishing Overview chapter](/userguide/p
 
 ### Improved dependency insight report
 
-The dependency insight report is the distant ancestor of [build scans](https://scans.gradle.com) and helps you diagnose dependency management problems locally.
+The [dependency insight report](/userguide/inspecting_dependencies.html#sec:identifying_reason_dependency_selection) is the distant ancestor of [build scans](https://scans.gradle.com) and helps you diagnose dependency management problems locally.
 This release of Gradle implements several improvements:
 
 - using `failOnVersionConflict()` no longer fails the dependency insight report in case of conflict

--- a/subprojects/docs/src/docs/userguide/inspectingDependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/inspectingDependencies.adoc
@@ -77,7 +77,7 @@ The dependency tree in a link:https://scans.gradle.com/[build scan] renders the 
 </figure>
 +++++
 
-Every Gradle project provides the task `dependencyInsight` to render the so-called  _dependency insight report_ from the command line. Given a dependency in the dependency graph you can identify the selection reason and track down the origin of the dependency selection. You can think of the dependency insight report as the inverse representation of the dependency report for a given dependency. When executing the task you have to provide the mandatory parameter `--dependency` to specify the coordinates of the dependency under inspection. The parameter `--configuration` is optional but helps with filtering the output.
+Every Gradle project provides the task `dependencyInsight` to render the so-called  _dependency insight report_ from the command line. Given a dependency in the dependency graph you can identify the selection reason and track down the origin of the dependency selection. You can think of the dependency insight report as the inverse representation of the dependency report for a given dependency. When executing the task you have to provide the mandatory parameter `--dependency` to specify the coordinates of the dependency under inspection. The parameters `--configuration` and `--singlepath` are optional but help with filtering the output.
 
 ++++
 <sample id="dependencyInsightReport" dir="userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport" title="Using the dependency insight report for a given dependency">


### PR DESCRIPTION
## Context

This PR adds release notes for the dependency insight report improvements, and, probably as important, de-incubates it!

