### PR TITLE
Expose the task name through the `TaskProvider`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
@@ -36,4 +36,14 @@ public interface TaskProvider<T extends Task> extends Provider<T> {
      * @since 4.8
      */
     void configure(Action<? super T> action);
+
+    /**
+     * The task name referenced by this provider.
+     * <p>
+     * Must be constant for the life of the object.
+     *
+     * @return The task name. Never null.
+     * @since 4.9
+     */
+    String getName();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -409,6 +409,46 @@ class DefaultTaskContainerTest extends Specification {
         0 * rule._
     }
 
+    void "can query task name and type from task provider after registration"() {
+        given:
+        def provider = null
+
+        when:
+        provider = container.register("a")
+
+        then:
+        provider.type == DefaultTask
+        provider.name == "a"
+
+        when:
+        provider = container.register("b", Mock(Action))
+
+        then:
+        provider.type == DefaultTask
+        provider.name == "b"
+
+        when:
+        provider = container.register("c", CustomTask)
+
+        then:
+        provider.type == CustomTask
+        provider.name == "c"
+
+        when:
+        provider = container.register("d", CustomTask, Mock(Action))
+
+        then:
+        provider.type == CustomTask
+        provider.name == "d"
+
+        when:
+        provider = container.register("e", CustomTask, "some", "constructor", "args")
+
+        then:
+        provider.type == CustomTask
+        provider.name == "e"
+    }
+
     void "can define task to create and configure later given name and type"() {
         def action = Mock(Action)
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native-private/issues/130

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fcore%2Fadd-get-name-to-task-provider)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
