### PR TITLE
Fix tests on Java 9, 10, and 11-ea

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testkit.runner
 
 import groovy.transform.Sortable
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AbstractMultiTestRunner
 import org.gradle.integtests.fixtures.RetryRuleUtil
@@ -155,6 +156,21 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
 
     ExecutionFailure execFailure(BuildResult buildResult) {
         OutputScrapingExecutionFailure.from(buildResult.output, buildResult.output)
+    }
+
+    static String determineMinimumVersionThatRunsOnCurrentJavaVersion(String desiredGradleVersion) {
+        if (JavaVersion.current().isJava11Compatible()) {
+            def compatibleVersion = GradleVersion.version("4.8.1") // see https://github.com/gradle/gradle/issues/4860
+            if (GradleVersion.version(desiredGradleVersion).compareTo(compatibleVersion) < 0) {
+                return compatibleVersion.version
+            }
+        } else if (JavaVersion.current().isJava9Compatible()) {
+            def compatibleVersion = GradleVersion.version("4.3.1") // see https://github.com/gradle/gradle/issues/2992
+            if (GradleVersion.version(desiredGradleVersion).compareTo(compatibleVersion) < 0) {
+                return compatibleVersion.version
+            }
+        }
+        return desiredGradleVersion
     }
 
     @Rule

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
@@ -89,7 +89,7 @@ class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTe
 
         when:
         runner("writeValue", "--parallel")
-            .withGradleVersion("4.1")
+            .withGradleVersion(determineMinimumVersionThatRunsOnCurrentJavaVersion("4.1"))
             .build()
 
         then:

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerGradleVersionIntegrationTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Shared
 @NonCrossVersion
 @Requires(TestPrecondition.ONLINE)
 class GradleRunnerGradleVersionIntegrationTest extends BaseGradleRunnerIntegrationTest {
-    public static final String VERSION = "4.1"
+    public static final String VERSION = determineMinimumVersionThatRunsOnCurrentJavaVersion("4.1")
 
     @Shared
     DistributionLocator locator = new DistributionLocator()


### PR DESCRIPTION
The broken tests used Gradle 4.1 which does not run on 9/10.0.x and 11-ea. This commit ensures a compatible version is used depending on the current version of Java the tests are executed with.