### PR TITLE
Use immutable file collections whenever possible

### DIFF
--- a/subprojects/announce/src/main/java/org/gradle/api/plugins/announce/AnnouncePluginExtension.java
+++ b/subprojects/announce/src/main/java/org/gradle/api/plugins/announce/AnnouncePluginExtension.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.announce;
 
 import org.gradle.api.Project;
+import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -39,7 +40,7 @@ public class AnnouncePluginExtension {
 
     public AnnouncePluginExtension(ProjectInternal project) {
         this.project = project;
-        this.announcerFactory = new DefaultAnnouncerFactory(this, project, new DefaultIconProvider(project.getServices().get(CurrentGradleInstallation.class).getInstallation()));
+        this.announcerFactory = new DefaultAnnouncerFactory(this, project.getServices().get(ProcessOperations.class), new DefaultIconProvider(project.getServices().get(CurrentGradleInstallation.class).getInstallation()));
         this.onDemandLocalAnnouncer = new LocalAnnouncer(this);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileResolver.java
@@ -63,12 +63,15 @@ public abstract class AbstractFileResolver implements FileResolver {
         return new BaseDirFileResolver(fileSystem, baseDir, patternSetFactory);
     }
 
+    @Override
     public File resolve(Object path) {
         return resolve(path, PathValidation.NONE);
     }
 
+    @Override
     public NotationParser<Object, File> asNotationParser() {
         return new NotationParser<Object, File>() {
+            @Override
             public File parseNotation(Object notation) throws UnsupportedNotationException {
                 // TODO Further differentiate between unsupported notation errors and others (particularly when we remove the deprecated 'notation.toString()' resolution)
                 return resolve(notation, PathValidation.NONE);
@@ -81,6 +84,7 @@ public abstract class AbstractFileResolver implements FileResolver {
         };
     }
 
+    @Override
     public File resolve(Object path, PathValidation validation) {
         File file = doResolve(path);
 
@@ -91,8 +95,7 @@ public abstract class AbstractFileResolver implements FileResolver {
         return file;
     }
 
-
-    @Nullable
+    @Override
     public URI resolveUri(Object path) {
         return convertObjectToURI(path);
     }
@@ -149,6 +152,7 @@ public abstract class AbstractFileResolver implements FileResolver {
         }
     }
 
+    @Override
     public FileCollectionInternal resolveFiles(Object... paths) {
         if (paths.length == 1 && paths[0] instanceof FileCollection) {
             return Cast.cast(FileCollectionInternal.class, paths[0]);
@@ -156,14 +160,17 @@ public abstract class AbstractFileResolver implements FileResolver {
         return new DefaultConfigurableFileCollection(this, null, paths);
     }
 
+    @Override
     public FileTreeInternal resolveFilesAsTree(Object... paths) {
         return Cast.cast(FileTreeInternal.class, resolveFiles(paths).getAsFileTree());
     }
 
+    @Override
     public FileTreeInternal compositeFileTree(List<? extends FileTree> fileTrees) {
         return new DefaultCompositeFileTree(CollectionUtils.checkedCast(FileTreeInternal.class, fileTrees));
     }
 
+    @Override
     public ReadableResourceInternal resolveResource(Object path) {
         if (path instanceof ReadableResourceInternal) {
             return (ReadableResourceInternal) path;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -122,7 +122,12 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
     }
 
     @Override
-    public FileCollection files(Object... paths) {
+    public ConfigurableFileCollection files(Object... paths) {
+        return new DefaultConfigurableFileCollection(fileResolver, taskResolver, paths);
+    }
+
+    @Override
+    public FileCollection immutableFiles(Object... paths) {
         return ImmutableFileCollection.usingResolver(fileResolver, paths);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DeleteSpec;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.file.archive.TarFileTree;
@@ -30,6 +31,7 @@ import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollectio
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileTreeAdapter;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.file.copy.FileCopier;
 import org.gradle.api.internal.file.delete.Deleter;
@@ -79,7 +81,7 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         this(fileResolver, taskResolver, temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, execFactory, null);
     }
 
-    public DefaultFileOperations(FileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory, TextResourceLoader textResourceLoader) {
+    public DefaultFileOperations(FileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable TemporaryFileProvider temporaryFileProvider, Instantiator instantiator, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher, ExecFactory execFactory, @Nullable TextResourceLoader textResourceLoader) {
         this.fileResolver = fileResolver;
         this.taskResolver = taskResolver;
         this.temporaryFileProvider = temporaryFileProvider;
@@ -94,34 +96,52 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         this.deleter = new Deleter(fileResolver, fileSystem);
     }
 
+    @Override
     public File file(Object path) {
         return fileResolver.resolve(path);
     }
 
+    @Override
     public File file(Object path, PathValidation validation) {
         return fileResolver.resolve(path, validation);
     }
 
+    @Override
     public URI uri(Object path) {
         return fileResolver.resolveUri(path);
     }
 
-    public ConfigurableFileCollection files(Object... paths) {
+    @Override
+    public ConfigurableFileCollection configurableFiles() {
+        return new DefaultConfigurableFileCollection(fileResolver, taskResolver);
+    }
+
+    @Override
+    public ConfigurableFileCollection configurableFiles(Object... paths) {
         return new DefaultConfigurableFileCollection(fileResolver, taskResolver, paths);
     }
 
+    @Override
+    public FileCollection files(Object... paths) {
+        return ImmutableFileCollection.usingResolver(fileResolver, paths);
+    }
+
+    @Override
     public ConfigurableFileTree fileTree(Object baseDir) {
         return new DefaultConfigurableFileTree(baseDir, fileResolver, taskResolver, fileCopier, directoryFileTreeFactory);
     }
 
+    @Override
     public ConfigurableFileTree fileTree(Map<String, ?> args) {
         return new DefaultConfigurableFileTree(args, fileResolver, taskResolver, fileCopier, directoryFileTreeFactory);
     }
 
+    @Override
     public FileTree zipTree(Object zipPath) {
         return new FileTreeAdapter(new ZipFileTree(file(zipPath), getExpandDir(), fileSystem, directoryFileTreeFactory, fileHasher), fileResolver.getPatternSetFactory());
     }
 
+    @Override
     public FileTree tarTree(Object tarPath) {
         File tarFile = null;
         ReadableResourceInternal resource;
@@ -142,10 +162,12 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         return temporaryFileProvider.newTemporaryFile("expandedArchives");
     }
 
+    @Override
     public String relativePath(Object path) {
         return fileResolver.resolveAsRelativePath(path);
     }
 
+    @Override
     public File mkdir(Object path) {
         File dir = fileResolver.resolve(path);
         if (dir.isFile()) {
@@ -155,18 +177,22 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         return dir;
     }
 
+    @Override
     public boolean delete(Object... paths) {
         return deleter.delete(paths);
     }
 
+    @Override
     public WorkResult delete(Action<? super DeleteSpec> action) {
         return deleter.delete(action);
     }
 
+    @Override
     public WorkResult copy(Action<? super CopySpec> action) {
         return fileCopier.copy(action);
     }
 
+    @Override
     public WorkResult sync(Action<? super CopySpec> action) {
         return fileCopier.sync(action);
     }
@@ -182,22 +208,26 @@ public class DefaultFileOperations implements FileOperations, ProcessOperations 
         return instantiator.newInstance(DefaultCopySpec.class, fileResolver, instantiator);
     }
 
+    @Override
     public FileResolver getFileResolver() {
         return fileResolver;
     }
 
+    @Override
     public ExecResult javaexec(Action<? super JavaExecSpec> action) {
         JavaExecAction javaExecAction = execFactory.forContext(fileResolver, instantiator).newDecoratedJavaExecAction();
         action.execute(javaExecAction);
         return javaExecAction.execute();
     }
 
+    @Override
     public ExecResult exec(Action<? super ExecSpec> action) {
         ExecAction execAction = execFactory.forContext(fileResolver, instantiator).newDecoratedExecAction();
         action.execute(execAction);
         return execAction.execute();
     }
 
+    @Override
     public DefaultResourceHandler getResources() {
         return resourceHandler;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DeleteSpec;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.WorkResult;
@@ -40,7 +41,11 @@ public interface FileOperations {
 
     String relativePath(Object path);
 
-    ConfigurableFileCollection files(Object... paths);
+    ConfigurableFileCollection configurableFiles();
+
+    ConfigurableFileCollection configurableFiles(Object... paths);
+
+    FileCollection files(Object... paths);
 
     ConfigurableFileTree fileTree(Object baseDir);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
@@ -41,11 +41,34 @@ public interface FileOperations {
 
     String relativePath(Object path);
 
+    /**
+     * @deprecated Use {@link #immutableFiles(Object...)} to create an immutable file collection,
+     * or {@link #configurableFiles(Object...)} or {@link #configurableFiles()}
+     * to create a mutable file collection.
+     */
+    // Used by Kotlin DSL 0.18.1
+    @Deprecated
+    ConfigurableFileCollection files(Object... paths);
+
+    /**
+     * Creates an empty mutable file collection.
+     */
     ConfigurableFileCollection configurableFiles();
 
+    /**
+     * Creates a mutable file collection and initializes it with the given paths.
+     */
     ConfigurableFileCollection configurableFiles(Object... paths);
 
-    FileCollection files(Object... paths);
+    /**
+     * Creates an immutable file collection with the given paths. The paths are resolved
+     * with the file resolver.
+     *
+     * If no resolution is required, use {@link org.gradle.api.internal.file.collections.ImmutableFileCollection#of(File...)} instead.
+     *
+     * @see #getFileResolver()
+.     */
+    FileCollection immutableFiles(Object... paths);
 
     ConfigurableFileTree fileTree(Object baseDir);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
@@ -25,7 +25,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.WorkResult;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.util.Map;
@@ -35,7 +34,6 @@ public interface FileOperations {
 
     File file(Object path, PathValidation validation);
 
-    @Nullable
     URI uri(Object path);
 
     FileResolver getFileResolver();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileResolver.java
@@ -24,7 +24,6 @@ import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.typeconversion.NotationParser;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.util.List;
@@ -40,7 +39,6 @@ public interface FileResolver extends RelativeFilePathResolver, PathToFileResolv
 
     FileTreeInternal compositeFileTree(List<? extends FileTree> fileTrees);
 
-    @Nullable
     URI resolveUri(Object path);
 
     NotationParser<Object, File> asNotationParser();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/HasFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/HasFileOperations.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+public interface HasFileOperations {
+    FileOperations getFileOperations();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -55,7 +55,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         this(displayName, fileResolver, taskResolver, null);
     }
 
-    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, Collection<?> files) {
+    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable Collection<?> files) {
         this.displayName = displayName;
         this.resolver = fileResolver;
         this.files = new LinkedHashSet<Object>();
@@ -65,38 +65,46 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         buildDependency = new DefaultTaskDependency(taskResolver);
     }
 
+    @Override
     public String getDisplayName() {
         return displayName;
     }
 
+    @Override
     public Set<Object> getFrom() {
         return files;
     }
 
+    @Override
     public void setFrom(Iterable<?> path) {
         files.clear();
         files.add(path);
     }
 
+    @Override
     public void setFrom(Object... paths) {
         files.clear();
         GUtil.addToCollection(files, Arrays.asList(paths));
     }
 
+    @Override
     public ConfigurableFileCollection from(Object... paths) {
         GUtil.addToCollection(files, Arrays.asList(paths));
         return this;
     }
 
+    @Override
     public ConfigurableFileCollection builtBy(Object... tasks) {
         buildDependency.add(tasks);
         return this;
     }
 
+    @Override
     public Set<Object> getBuiltBy() {
         return buildDependency.getMutableValues();
     }
 
+    @Override
     public ConfigurableFileCollection setBuiltBy(Iterable<?> tasks) {
         buildDependency.setValues(tasks);
         return this;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
@@ -69,7 +69,7 @@ public abstract class ImmutableFileCollection extends AbstractFileCollection {
 
     @Override
     public String getDisplayName() {
-        return "immutable file collection";
+        return "file collection";
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -823,8 +823,9 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
         return foundTasks;
     }
 
+    @Override
     @Inject
-    protected FileOperations getFileOperations() {
+    public FileOperations getFileOperations() {
         // Decoration takes care of the implementation
         throw new UnsupportedOperationException();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -23,9 +23,7 @@ import org.gradle.api.UnknownProjectException;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.ExtensionContainerInternal;
@@ -46,7 +44,7 @@ import org.gradle.util.Path;
 import javax.annotation.Nullable;
 
 @UsedByScanPlugin
-public interface ProjectInternal extends Project, ProjectIdentifier, FileOperations, ProcessOperations, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
+public interface ProjectInternal extends Project, ProjectIdentifier, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
 
     // These constants are defined here and not with the rest of their kind in HelpTasksPlugin because they are referenced
     // in the ‘core’ modules, which don't depend on ‘plugins’ where HelpTasksPlugin is defined.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.HasFileOperations;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.ExtensionContainerInternal;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
@@ -44,7 +45,7 @@ import org.gradle.util.Path;
 import javax.annotation.Nullable;
 
 @UsedByScanPlugin
-public interface ProjectInternal extends Project, ProjectIdentifier, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
+public interface ProjectInternal extends Project, ProjectIdentifier, HasFileOperations, DomainObjectContext, DependencyMetaDataProvider, ModelRegistryScope, PluginAwareInternal {
 
     // These constants are defined here and not with the rest of their kind in HelpTasksPlugin because they are referenced
     // in the ‘core’ modules, which don't depend on ‘plugins’ where HelpTasksPlugin is defined.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
@@ -42,7 +42,7 @@ public class DefaultTextResourceFactory implements TextResourceFactory {
 
     @Override
     public TextResource fromFile(Object file, String charset) {
-        return new FileCollectionBackedTextResource(tempFileProvider, fileOperations.files(file), Charset.forName(charset));
+        return new FileCollectionBackedTextResource(tempFileProvider, fileOperations.immutableFiles(file), Charset.forName(charset));
     }
 
     @Override
@@ -53,7 +53,7 @@ public class DefaultTextResourceFactory implements TextResourceFactory {
 
     @Override
     public TextResource fromArchiveEntry(Object archive, String entryPath, String charset) {
-        return new FileCollectionBackedArchiveTextResource(fileOperations, tempFileProvider, fileOperations.files(archive), entryPath, Charset.forName(charset));
+        return new FileCollectionBackedArchiveTextResource(fileOperations, tempFileProvider, fileOperations.immutableFiles(archive), entryPath, Charset.forName(charset));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
@@ -35,23 +35,28 @@ public class DefaultTextResourceFactory implements TextResourceFactory {
         this.textResourceLoader = textResourceLoader;
     }
 
+    @Override
     public TextResource fromString(String string) {
         return new StringBackedTextResource(tempFileProvider, string);
     }
 
+    @Override
     public TextResource fromFile(Object file, String charset) {
         return new FileCollectionBackedTextResource(tempFileProvider, fileOperations.files(file), Charset.forName(charset));
     }
 
+    @Override
     public TextResource fromFile(Object file) {
         return fromFile(file, Charset.defaultCharset().name());
 
     }
 
+    @Override
     public TextResource fromArchiveEntry(Object archive, String entryPath, String charset) {
         return new FileCollectionBackedArchiveTextResource(fileOperations, tempFileProvider, fileOperations.files(archive), entryPath, Charset.forName(charset));
     }
 
+    @Override
     public TextResource fromArchiveEntry(Object archive, String entryPath) {
         return fromArchiveEntry(archive, entryPath, Charset.defaultCharset().name());
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.gradle.api.internal.resources;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
@@ -21,8 +21,6 @@ import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.DynamicObjectUtil;
-import org.gradle.api.internal.ProcessOperations;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.BeanDynamicObject;
@@ -33,7 +31,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import java.io.PrintStream;
 import java.util.Map;
 
-public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, FileOperations, ProcessOperations, DynamicObjectAware {
+public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, DynamicObjectAware {
     private StandardOutputCapture standardOutputCapture;
     private Object target;
     private ScriptDynamicObject dynamicObject = new ScriptDynamicObject(this);

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
@@ -21,6 +21,7 @@ import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.DynamicObjectUtil;
+import org.gradle.api.internal.file.HasFileOperations;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
 import org.gradle.internal.metaobject.BeanDynamicObject;
@@ -31,7 +32,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import java.io.PrintStream;
 import java.util.Map;
 
-public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, DynamicObjectAware {
+public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, HasFileOperations, DynamicObjectAware {
     private StandardOutputCapture standardOutputCapture;
     private Object target;
     private ScriptDynamicObject dynamicObject = new ScriptDynamicObject(this);

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -98,7 +98,6 @@ public abstract class DefaultScript extends BasicScript {
         providerFactory = services.get(ProviderFactory.class);
     }
 
-    @Override
     public FileResolver getFileResolver() {
         return fileOperations.getFileResolver();
     }
@@ -204,12 +203,10 @@ public abstract class DefaultScript extends BasicScript {
         return copy(ConfigureUtil.configureUsing(closure));
     }
 
-    @Override
     public WorkResult copy(Action<? super CopySpec> action) {
         return fileOperations.copy(action);
     }
 
-    @Override
     public WorkResult sync(Action<? super CopySpec> action) {
         return fileOperations.sync(action);
     }
@@ -219,7 +216,6 @@ public abstract class DefaultScript extends BasicScript {
         return Actions.with(copySpec(), ConfigureUtil.configureUsing(closure));
     }
 
-    @Override
     public CopySpec copySpec() {
         return fileOperations.copySpec();
     }
@@ -234,7 +230,6 @@ public abstract class DefaultScript extends BasicScript {
         return fileOperations.delete(paths);
     }
 
-    @Override
     public WorkResult delete(Action<? super DeleteSpec> action) {
         return fileOperations.delete(action);
     }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.HasFileOperations;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
@@ -83,8 +84,8 @@ public abstract class DefaultScript extends BasicScript {
         StreamHasher streamHasher = services.get(StreamHasher.class);
         FileHasher fileHasher = services.get(FileHasher.class);
         TextResourceLoader textResourceLoader = services.get(TextResourceLoader.class);
-        if (target instanceof FileOperations) {
-            fileOperations = (FileOperations) target;
+        if (target instanceof HasFileOperations) {
+            fileOperations = ((HasFileOperations) target).getFileOperations();
         } else {
             File sourceFile = getScriptSource().getResource().getLocation().getFile();
             if (sourceFile != null) {
@@ -100,6 +101,11 @@ public abstract class DefaultScript extends BasicScript {
 
     public FileResolver getFileResolver() {
         return fileOperations.getFileResolver();
+    }
+
+    @Override
+    public FileOperations getFileOperations() {
+        return fileOperations;
     }
 
     private DefaultObjectConfigurationAction createObjectConfigurationAction() {

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -155,12 +155,12 @@ public abstract class DefaultScript extends BasicScript {
 
     @Override
     public ConfigurableFileCollection files(Object... paths) {
-        return fileOperations.files(paths);
+        return fileOperations.configurableFiles(paths);
     }
 
     @Override
     public ConfigurableFileCollection files(Object paths, Closure configureClosure) {
-        return ConfigureUtil.configure(configureClosure, fileOperations.files(paths));
+        return ConfigureUtil.configure(configureClosure, fileOperations.configurableFiles(paths));
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -201,6 +201,14 @@ The following types/formats are supported:
         normalize(provider2, baseDir) == baseDir.file("value")
     }
 
+    def "does not allow resolving null URI"() {
+        when:
+        resolver(tmpDir.testDirectory).resolveUri(null)
+        then:
+        def ex = thrown UnsupportedNotationException
+        ex.message.contains "Cannot convert a null value to a File or URI."
+    }
+
     def createLink(File link, File target) {
         createLink(link, target.absolutePath)
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -119,7 +119,7 @@ class DefaultFileOperationsTest extends Specification {
 
     def resolvesImmutableFilesInOrder() {
         when:
-        def fileCollection = fileOperations.files('a', 'b', 'c')
+        def fileCollection = fileOperations.immutableFiles('a', 'b', 'c')
 
         then:
         fileCollection instanceof ImmutableFileCollection

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.file.archive.ZipFileTree
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
+import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.internal.classloader.ClasspathUtil
@@ -95,7 +96,7 @@ class DefaultFileOperationsTest extends Specification {
 
     def resolvesFilesInOrder() {
         when:
-        def fileCollection = fileOperations.files('a', 'b', 'c')
+        def fileCollection = fileOperations.configurableFiles('a', 'b', 'c')
 
         then:
         fileCollection instanceof DefaultConfigurableFileCollection
@@ -114,6 +115,25 @@ class DefaultFileOperationsTest extends Specification {
         then:
         files*.name as List == ['a', 'b', 'c']
         0 * _
+    }
+
+    def resolvesImmutableFilesInOrder() {
+        when:
+        def fileCollection = fileOperations.files('a', 'b', 'c')
+
+        then:
+        fileCollection instanceof ImmutableFileCollection
+
+        when:
+        def files = fileCollection.files
+        files*.name as List == ['a', 'b', 'c']
+
+        then:
+        1 * resolver.resolve('a') >> new File('a')
+        then:
+        1 * resolver.resolve('b') >> new File('b')
+        then:
+        1 * resolver.resolve('c') >> new File('c')
     }
 
     def createsFileTree() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/ImmutableFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/ImmutableFileCollectionTest.groovy
@@ -76,7 +76,7 @@ class ImmutableFileCollectionTest extends Specification {
 
         then:
         def exception = thrown(UnsupportedOperationException)
-        exception.message == "Immutable file collection does not allow modification."
+        exception.message == "File collection does not allow modification."
 
         where:
         description        | collection

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/DefaultXcodeProject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/DefaultXcodeProject.java
@@ -84,10 +84,10 @@ public class DefaultXcodeProject implements XcodeProject {
 
         @Inject
         public Groups(FileOperations fileOperations) {
-            this.sources = fileOperations.files();
-            this.tests = fileOperations.files();
-            this.headers = fileOperations.files();
-            this.root = fileOperations.files();
+            this.sources = fileOperations.configurableFiles();
+            this.tests = fileOperations.configurableFiles();
+            this.headers = fileOperations.configurableFiles();
+            this.root = fileOperations.configurableFiles();
         }
 
         public ConfigurableFileCollection getRoot() {

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodeTarget.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/XcodeTarget.java
@@ -56,9 +56,9 @@ public class XcodeTarget implements Named {
     public XcodeTarget(String name, String id, FileOperations fileOperations, ObjectFactory objectFactory) {
         this.name = name;
         this.id = id;
-        this.sources = fileOperations.files();
-        this.headerSearchPaths = fileOperations.files();
-        this.compileModules = fileOperations.files();
+        this.sources = fileOperations.configurableFiles();
+        this.headerSearchPaths = fileOperations.configurableFiles();
+        this.compileModules = fileOperations.configurableFiles();
         this.swiftSourceCompatibility = objectFactory.property(SwiftVersion.class);
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -98,7 +98,7 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
                     new Transformer<FileCollection, Reference<?>>() {
                         @Override
                         public FileCollection transform(Reference<?> result) {
-                            ConfigurableFileCollection singleton = fileOperations.files(result.get().getFile());
+                            ConfigurableFileCollection singleton = fileOperations.configurableFiles(result.get().getFile());
                             singleton.builtBy(result.getBuildDependencies());
                             return singleton;
                         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -90,7 +90,7 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
 
     @Override
     public FileCollection getIdeProjectFiles(final Class<? extends IdeProjectMetadata> type) {
-        return fileOperations.files(new Callable<List<FileCollection>>() {
+        return fileOperations.immutableFiles(new Callable<List<FileCollection>>() {
             @Override
             public List<FileCollection> call() {
                 return CollectionUtils.collect(

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/AntGroovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/AntGroovydoc.java
@@ -58,7 +58,7 @@ public class AntGroovydoc {
             final Set<Groovydoc.Link> links, final Iterable<File> groovyClasspath, Iterable<File> classpath, Project project) {
 
         final File tmpDir = new File(project.getBuildDir(), "tmp/groovydoc");
-        FileOperations fileOperations = ((ProjectInternal) project).getServices().get(FileOperations.class);
+        FileOperations fileOperations = ((ProjectInternal) project).getFileOperations();
         fileOperations.delete(tmpDir);
         fileOperations.copy(new Action<CopySpec>() {
             public void execute(CopySpec copySpec) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/AntGroovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/AntGroovydoc.java
@@ -58,7 +58,7 @@ public class AntGroovydoc {
             final Set<Groovydoc.Link> links, final Iterable<File> groovyClasspath, Iterable<File> classpath, Project project) {
 
         final File tmpDir = new File(project.getBuildDir(), "tmp/groovydoc");
-        FileOperations fileOperations = (ProjectInternal) project;
+        FileOperations fileOperations = ((ProjectInternal) project).getServices().get(FileOperations.class);
         fileOperations.delete(tmpDir);
         fileOperations.copy(new Action<CopySpec>() {
             public void execute(CopySpec copySpec) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -77,11 +77,11 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     }
 
     protected FileCollection createDirView(final ConfigurableFileCollection dirs, final String conventionLocation) {
-        return fileOperations.files(new Callable<Object>() {
+        return fileOperations.immutableFiles(new Callable<Object>() {
             @Override
             public Object call() {
                 if (dirs.getFrom().isEmpty()) {
-                    return fileOperations.files(conventionLocation);
+                    return fileOperations.immutableFiles(conventionLocation);
                 }
                 return dirs;
             }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -57,7 +57,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         this.name = name;
         this.fileOperations = fileOperations;
         cppSource = createSourceView("src/" + name + "/cpp", Arrays.asList("cpp", "c++", "cc"));
-        privateHeaders = fileOperations.files();
+        privateHeaders = fileOperations.configurableFiles();
         privateHeadersWithConvention = createDirView(privateHeaders, "src/" + name + "/headers");
         baseName = objectFactory.property(String.class);
         names = Names.of(name);
@@ -79,7 +79,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
     protected FileCollection createDirView(final ConfigurableFileCollection dirs, final String conventionLocation) {
         return fileOperations.files(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 if (dirs.getFrom().isEmpty()) {
                     return fileOperations.files(conventionLocation);
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -65,7 +65,7 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
         this.runtimeElementsProperty = objectFactory.property(Configuration.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -58,7 +58,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         super(name, fileOperations, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(CppBinary.class);
-        publicHeaders = fileOperations.files();
+        publicHeaders = fileOperations.configurableFiles();
         publicHeadersWithConvention = createDirView(publicHeaders, "src/" + name + "/public");
 
         linkage = new LockableSetProperty<Linkage>(objectFactory.setProperty(Linkage.class));

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -61,7 +61,7 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -61,7 +61,7 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/DefaultNativeComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/DefaultNativeComponent.java
@@ -35,7 +35,7 @@ public abstract class DefaultNativeComponent {
         // TODO - introduce a new 'var' data structure that allows these conventions to be configured explicitly
         this.fileOperations = fileOperations;
 
-        source = fileOperations.files();
+        source = fileOperations.configurableFiles();
     }
 
     public abstract DisplayName getDisplayName();

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/DefaultNativeComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/DefaultNativeComponent.java
@@ -58,9 +58,9 @@ public abstract class DefaultNativeComponent {
         for (String sourceExtension : sourceExtensions) {
             patternSet.include("**/*." + sourceExtension);
         }
-        return fileOperations.files(new Callable<Object>() {
+        return fileOperations.immutableFiles(new Callable<Object>() {
             @Override
-            public Object call() throws Exception {
+            public Object call() {
                 FileTree tree;
                 if (source.getFrom().isEmpty()) {
                     tree = fileOperations.fileTree(defaultLocation);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -66,7 +66,7 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
         this.debuggerExecutableFile = projectLayout.fileProperty();
         this.runtimeElementsProperty = objectFactory.property(Configuration.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -62,7 +62,7 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -62,7 +62,7 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
@@ -29,7 +29,7 @@ class DefaultCppApplicationTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
-    def application = new DefaultCppApplication("main", project.objects, project)
+    def application = new DefaultCppApplication("main", project.objects, project.fileOperations)
 
     def "has display name"() {
         expect:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
@@ -34,7 +34,7 @@ class DefaultCppLibraryTest extends Specification {
     DefaultCppLibrary library
 
     def setup() {
-        library = new DefaultCppLibrary("main", project.objects, project, project.configurations)
+        library = new DefaultCppLibrary("main", project.objects, project.fileOperations, project.configurations)
     }
 
     def "has display name"() {
@@ -172,8 +172,8 @@ class DefaultCppLibraryTest extends Specification {
     def "uses component name to determine header directories"() {
         def h1 = tmpDir.createFile("src/a/public")
         def h2 = tmpDir.createFile("src/b/public")
-        def c1 = new DefaultCppLibrary("a", project.objects, project, project.configurations)
-        def c2 = new DefaultCppLibrary("b", project.objects, project, project.configurations)
+        def c1 = new DefaultCppLibrary("a", project.objects, project.fileOperations, project.configurations)
+        def c2 = new DefaultCppLibrary("b", project.objects, project.fileOperations, project.configurations)
 
         expect:
         c1.publicHeaderDirs.files == [h1] as Set

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftApplicationTest.groovy
@@ -30,7 +30,7 @@ class DefaultSwiftApplicationTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
-    def app = new DefaultSwiftApplication("main", project.objects, project)
+    def app = new DefaultSwiftApplication("main", project.objects, project.fileOperations)
 
     def "has display name"() {
         expect:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -36,7 +36,7 @@ class DefaultSwiftLibraryTest extends Specification {
     DefaultSwiftLibrary library
 
     def setup() {
-        library = new DefaultSwiftLibrary("main", project.objects, project, project.configurations)
+        library = new DefaultSwiftLibrary("main", project.objects, project.fileOperations, project.configurations)
     }
 
     def "has display name"() {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/JavaScriptMinify.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/JavaScriptMinify.java
@@ -148,7 +148,7 @@ public class JavaScriptMinify extends SourceTask {
             final File outputFileDir = new File(destinationDir, fileDetails.getRelativePath().getParent().getPathString());
 
             // Copy the raw form
-            FileOperations fileOperations = ((ProjectInternal) getProject()).getServices().get(FileOperations.class);
+            FileOperations fileOperations = ((ProjectInternal) getProject()).getFileOperations();
             fileOperations.copy(new Action<CopySpec>() {
                 @Override
                 public void execute(CopySpec copySpec) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/JavaScriptMinify.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/JavaScriptMinify.java
@@ -148,7 +148,7 @@ public class JavaScriptMinify extends SourceTask {
             final File outputFileDir = new File(destinationDir, fileDetails.getRelativePath().getParent().getPathString());
 
             // Copy the raw form
-            FileOperations fileOperations = (ProjectInternal) getProject();
+            FileOperations fileOperations = ((ProjectInternal) getProject()).getServices().get(FileOperations.class);
             fileOperations.copy(new Action<CopySpec>() {
                 @Override
                 public void execute(CopySpec copySpec) {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
@@ -25,6 +25,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -65,7 +66,7 @@ public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTes
         this.installationDirectory = projectLayout.directoryProperty();
         this.linkTaskProperty = objects.property(LinkExecutable.class);
         this.installTaskProperty = objects.property(InstallExecutable.class);
-        this.outputs = fileOperations.files();
+        this.outputs = fileOperations.configurableFiles();
         this.runTask = objects.property(RunTestExecutable.class);
     }
 
@@ -112,7 +113,7 @@ public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTes
             public FileCollection call() throws Exception {
                 CppComponent tested = testedComponent.getOrNull();
                 if (tested == null) {
-                    return getFileOperations().files();
+                    return ImmutableFileCollection.of();
                 }
                 return ((DefaultCppComponent) tested).getAllHeaderDirs();
             }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
@@ -108,7 +108,7 @@ public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTes
     @Override
     public FileCollection getCompileIncludePath() {
         // TODO: This should be modeled differently, perhaps as a dependency on the implementation configuration
-        return super.getCompileIncludePath().plus(getFileOperations().files(new Callable<FileCollection>() {
+        return super.getCompileIncludePath().plus(getFileOperations().immutableFiles(new Callable<FileCollection>() {
             @Override
             public FileCollection call() throws Exception {
                 CppComponent tested = testedComponent.getOrNull();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
@@ -50,7 +50,7 @@ public class DefaultSwiftXCTestExecutable extends DefaultSwiftXCTestBinary imple
         debuggerExecutableFile = projectLayout.fileProperty();
         linkTask = objectFactory.property(LinkExecutable.class);
         installTask = objectFactory.property(InstallExecutable.class);
-        files = fileOperations.files();
+        files = fileOperations.configurableFiles();
     }
 
     @Override

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.cpp.internal
 
+import org.gradle.api.internal.file.FileOperations
 import org.gradle.language.cpp.CppPlatform
 import org.gradle.language.cpp.internal.NativeVariantIdentity
 import org.gradle.nativeplatform.OperatingSystemFamily
@@ -30,25 +31,20 @@ class DefaultCppTestSuiteTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
+    def testSuite = new DefaultCppTestSuite("test", project.objects, project.services.get(FileOperations))
 
     def "has display name"() {
-        def testSuite = new DefaultCppTestSuite("test", project.objects, project)
-
         expect:
         testSuite.displayName.displayName == "C++ test suite 'test'"
         testSuite.toString() == "C++ test suite 'test'"
     }
 
     def "has implementation dependencies"() {
-        def testSuite = new DefaultCppTestSuite("test", project.objects, project)
-
         expect:
         testSuite.implementationDependencies == project.configurations['testImplementation']
     }
 
     def "can add executable"() {
-        def testSuite = new DefaultCppTestSuite("test", project.objects, project)
-
         expect:
         def exe = testSuite.addExecutable("exe", identity, Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
         exe.name == 'testExe'

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.xctest.internal
 
+import org.gradle.api.internal.file.FileOperations
 import org.gradle.language.cpp.internal.NativeVariantIdentity
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.nativeplatform.OperatingSystemFamily
@@ -30,9 +31,9 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
+    def testSuite = new DefaultSwiftXCTestSuite("test", project.services.get(FileOperations), project.objects)
 
     def "has display name"() {
-        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
 
         expect:
         testSuite.displayName.displayName == "XCTest suite 'test'"
@@ -40,8 +41,6 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
     }
 
     def "has implementation dependencies"() {
-        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
-
         expect:
         testSuite.implementationDependencies == project.configurations.testImplementation
     }
@@ -50,7 +49,6 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
         def targetPlatform = Stub(SwiftPlatform)
         def toolChain = Stub(NativeToolChainInternal)
         def platformToolProvider = Stub(PlatformToolProvider)
-        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
 
         expect:
         def exe = testSuite.addExecutable("Executable", identity, targetPlatform, toolChain, platformToolProvider)
@@ -61,8 +59,6 @@ class DefaultSwiftXCTestSuiteTest extends Specification {
     }
 
     def "can add a test bundle"() {
-        def testSuite = new DefaultSwiftXCTestSuite("test", project, project.objects)
-
         expect:
         def exe = testSuite.addBundle("Executable", identity, Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider))
         exe.name == 'testExecutable'


### PR DESCRIPTION
We've made use of the new `ImmutableFileCollection` in many places, but we still create mutable ones where we used to call `FileOperations.files()` directly. This method is now deprecated in favor of three new methods:

- `configurableFiles(Object...)` is the replacement for `files(Object...)`
- `configurableFiles()` is a slightly cheaper version of calling the old `files()` without a parameter to create an empty `ConfigurableFileCollection`
- `immutableFiles(Object...)` creates an immutable file collection

A few more changes that are part of this PR:

- `FileResolver.resolveUri()` is not `@Nullable` anymore: it never returned a `null` value before either, so it's just clarification
- `BasicScript` (the base class for Groovy build scripts) and `DefaultProject` used to implement `FileOperations` (and `ProcessOperations` too) – this is no longer the case. Since all the types involved in the change are internal, and the actual implementations of the methods are left in place, I don't think we should have any problems with backwards compatibility.
- `FileOperations.files(Object...)` is now deprecated, as it is still used by the Kotlin DSL plugin. Once this PR is merged the Kotlin DSL code should switch to the new methods, too.