### PR TITLE
Use inception time of journal as fallback

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildScriptClasspathIntegrationSpec.groovy
@@ -27,8 +27,6 @@ import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.junit.Rule
 import spock.lang.Unroll
 
-import static java.util.concurrent.TimeUnit.DAYS
-
 class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implements FileAccessTimeJournalFixture {
     static final long MAX_CACHE_AGE_IN_DAYS = LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES
 
@@ -235,9 +233,8 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
 
         when:
         run '--stop' // ensure daemon does not cache file access times in memory
-        assert journal.delete()
-        markForCleanup(gcFile)
-        markForCleanup(jar.parentFile)
+        gcFile.lastModified = daysAgo(2)
+        writeLastFileAccessTimeToJournal(jar.parentFile, daysAgo(MAX_CACHE_AGE_IN_DAYS + 1))
 
         and:
         createBuildFileThatPrintsClasspathURLs()
@@ -274,8 +271,5 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         return getUserHomeCacheDir().file(DefaultCachedClasspathTransformer.CACHE_KEY)
     }
 
-    void markForCleanup(File file) {
-        file.lastModified = System.currentTimeMillis() - DAYS.toMillis(MAX_CACHE_AGE_IN_DAYS + 1)
-    }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java
@@ -38,7 +38,7 @@ public class DefaultFileAccessTimeJournal implements FileAccessTimeJournal, Stop
 
     public static final String CACHE_KEY = "journal-1";
     public static final String FILE_ACCESS_CACHE_NAME = "file-access";
-    public static final String META_PROPERTIES_FILE_NAME = "meta.properties";
+    public static final String FILE_ACCESS_PROPERTIES_FILE_NAME = FILE_ACCESS_CACHE_NAME + ".properties";
     public static final String INCEPTION_TIMESTAMP_KEY = "inceptionTimestamp";
 
     private final PersistentCache cache;
@@ -61,7 +61,7 @@ public class DefaultFileAccessTimeJournal implements FileAccessTimeJournal, Stop
         return cache.useCache(new Factory<Long>() {
             @Override
             public Long create() {
-                File propertiesFile = new File(cache.getBaseDir(), META_PROPERTIES_FILE_NAME);
+                File propertiesFile = new File(cache.getBaseDir(), FILE_ACCESS_PROPERTIES_FILE_NAME);
                 if (propertiesFile.exists()) {
                     Properties properties = GUtil.loadProperties(propertiesFile);
                     String inceptionTimestamp = properties.getProperty(INCEPTION_TIMESTAMP_KEY);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.cache.CacheDecorator
 import org.gradle.cache.internal.DefaultCacheRepository
 import org.gradle.cache.internal.DefaultCacheScopeMapping
 import org.gradle.internal.resource.local.FileAccessTimeJournal
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.InMemoryCacheFactory
 import org.gradle.util.GradleVersion
@@ -27,11 +28,17 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
 
+import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.CACHE_KEY
+import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.INCEPTION_TIMESTAMP_KEY
+import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.META_PROPERTIES_FILE_NAME
+import static org.gradle.util.GUtil.loadProperties
+
 class DefaultFileAccessTimeJournalTest extends Specification {
 
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
 
-    def cacheScopeMapping = new DefaultCacheScopeMapping(tmpDir.createDir("user-home"), null, GradleVersion.current())
+    def userHome = tmpDir.createDir("user-home")
+    def cacheScopeMapping = new DefaultCacheScopeMapping(userHome, null, GradleVersion.current())
     def cacheRepository = new DefaultCacheRepository(cacheScopeMapping, new InMemoryCacheFactory())
     def cacheDecoratorFactory = Stub(InMemoryCacheDecoratorFactory) {
         decorator(_, _) >> Stub(CacheDecorator) {
@@ -62,33 +69,60 @@ class DefaultFileAccessTimeJournalTest extends Specification {
         journal.getLastAccessTime(file) == 42
     }
 
-    def "falls back to and stores modification time when no value was written previously"() {
+    def "falls back to and stores inception time when no value was written previously"() {
+        given:
+        def startTime = System.currentTimeMillis()
+
         when:
-        def lastModified = file.lastModified()
+        def inceptionTimestamp = loadInceptionTimestamp()
 
         then:
-        journal.getLastAccessTime(file) == lastModified
+        inceptionTimestamp <= startTime
 
         when:
         file.makeOlder()
 
         then:
-        journal.getLastAccessTime(file) == lastModified
+        journal.getLastAccessTime(file) == inceptionTimestamp
     }
 
     def "deletes last access time when asked to do so"() {
-        when:
-        def originalLastModified = file.lastModified()
-
-        then:
-        journal.getLastAccessTime(file) == originalLastModified
+        given:
+        def inceptionTimestamp = loadInceptionTimestamp()
 
         when:
-        file.makeOlder()
-        def changedLastModified = file.lastModified()
+        journal.setLastAccessTime(file, 42)
         journal.deleteLastAccessTime(file)
 
         then:
-        journal.getLastAccessTime(file) == changedLastModified
+        journal.getLastAccessTime(file) == inceptionTimestamp
+    }
+
+    def "loads and uses previously stored inception time"() {
+        given:
+        journal.stop()
+        writeInceptionTimestamp(42)
+        journal = new DefaultFileAccessTimeJournal(cacheRepository, cacheDecoratorFactory)
+
+        when:
+        def inceptionTimestamp = loadInceptionTimestamp()
+
+        then:
+        inceptionTimestamp == 42
+
+        then:
+        journal.getLastAccessTime(file) == inceptionTimestamp
+    }
+
+    private long loadInceptionTimestamp() {
+        Long.parseLong(loadProperties(metaPropertiesFile).getProperty(INCEPTION_TIMESTAMP_KEY))
+    }
+
+    private void writeInceptionTimestamp(long millis) {
+        metaPropertiesFile.text = "${INCEPTION_TIMESTAMP_KEY} = $millis"
+    }
+
+    private TestFile getMetaPropertiesFile() {
+        userHome.file("caches", CACHE_KEY, META_PROPERTIES_FILE_NAME)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
@@ -30,7 +30,8 @@ import spock.lang.Subject
 
 import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.CACHE_KEY
 import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.INCEPTION_TIMESTAMP_KEY
-import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.META_PROPERTIES_FILE_NAME
+import static org.gradle.api.internal.changedetection.state.DefaultFileAccessTimeJournal.FILE_ACCESS_PROPERTIES_FILE_NAME
+import static org.gradle.cache.internal.DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME
 import static org.gradle.util.GUtil.loadProperties
 
 class DefaultFileAccessTimeJournalTest extends Specification {
@@ -115,14 +116,14 @@ class DefaultFileAccessTimeJournalTest extends Specification {
     }
 
     private long loadInceptionTimestamp() {
-        Long.parseLong(loadProperties(metaPropertiesFile).getProperty(INCEPTION_TIMESTAMP_KEY))
+        Long.parseLong(loadProperties(fileAccessPropertiesFile).getProperty(INCEPTION_TIMESTAMP_KEY))
     }
 
     private void writeInceptionTimestamp(long millis) {
-        metaPropertiesFile.text = "${INCEPTION_TIMESTAMP_KEY} = $millis"
+        fileAccessPropertiesFile.text = "${INCEPTION_TIMESTAMP_KEY} = $millis"
     }
 
-    private TestFile getMetaPropertiesFile() {
-        userHome.file("caches", CACHE_KEY, META_PROPERTIES_FILE_NAME)
+    private TestFile getFileAccessPropertiesFile() {
+        userHome.file(GLOBAL_CACHE_DIR_NAME, CACHE_KEY, FILE_ACCESS_PROPERTIES_FILE_NAME)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/AbstractCopyTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/AbstractCopyTaskTest.groovy
@@ -26,9 +26,10 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.WorkspaceTest
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
 import spock.lang.Unroll
 
-@SuppressWarnings("GroovyPointlessBoolean")
+@UsesNativeServices
 class AbstractCopyTaskTest extends WorkspaceTest {
 
     def taskPropertiesWithOutput = Mock(TaskProperties) {
@@ -64,8 +65,10 @@ class AbstractCopyTaskTest extends WorkspaceTest {
     def "task output caching is disabled when #description is used"() {
         when:
         method(task)
+
         then:
-        task.outputs.getCachingState(taskPropertiesWithOutput).enabled == false
+        def cachingState = task.outputs.getCachingState(taskPropertiesWithOutput)
+        !cachingState.enabled
 
         where:
         description                 | method

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -17,15 +17,14 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
-import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
 
-import static java.util.concurrent.TimeUnit.DAYS
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -919,9 +918,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         when:
         run '--stop' // ensure daemon does not cache file access times in memory
         def beforeCleanup = MILLISECONDS.toSeconds(System.currentTimeMillis())
-        markForCleanup(outputDir1)
-        markForCleanup(gcFile)
-        assert journal.delete()
+        writeLastFileAccessTimeToJournal(outputDir1, daysAgo(MAX_CACHE_AGE_IN_DAYS + 1))
+        gcFile.lastModified = daysAgo(2)
 
         and:
         // start as new process so journal is not restored from in-memory cache
@@ -1117,8 +1115,5 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         return getUserHomeCacheDir().file(CacheLayout.TRANSFORMS.getKey())
     }
 
-    void markForCleanup(File file) {
-        file.lastModified = System.currentTimeMillis() - DAYS.toMillis(MAX_CACHE_AGE_IN_DAYS + 1)
-    }
 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
@@ -20,9 +20,11 @@ import groovy.transform.SelfType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
 
+import static org.gradle.cache.internal.DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME
+
 @SelfType(AbstractIntegrationSpec)
 trait CachingIntegrationFixture {
     TestFile getUserHomeCacheDir() {
-        return executer.gradleUserHomeDir.file("caches")
+        return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME)
     }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/WorkspaceTest.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/WorkspaceTest.groovy
@@ -19,7 +19,8 @@ package org.gradle.test.fixtures.file
 import org.junit.Rule
 import spock.lang.Specification
 
-class WorkspaceTest extends Specification {
+@CleanupTestDirectory
+abstract class WorkspaceTest extends Specification {
 
     @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 


### PR DESCRIPTION
Prior to this commit the file modification timestamp was used as
fallback when the last access time was unknown. That lead to a lot of
files being deleted when first using the new Gradle distribution that
includes cleaning up of shared caches. In particular for dependencies
that have not been updated in the last 30 days and were not used in the
first build, lots of files would have to be redownloaded

This commit persists the inception time of the file access time journal
and uses it as the fallback for unknown files. This way, less files will
be cleaned up initially.