### PR TITLE
Delete empty parent dirs of deleted cache entries

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultCacheLockingManagerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultCacheLockingManagerIntegrationTest.groovy
@@ -95,6 +95,10 @@ class DefaultCacheLockingManagerIntegrationTest extends AbstractHttpDependencyRe
         resource.assertDoesNotExist()
         files[0].assertDoesNotExist()
         files[1].assertDoesNotExist()
+
+        and: // deletes empty parent directories
+        findFiles(cacheDir, 'resources-*/*').isEmpty()
+        findFiles(cacheDir, 'files-*/*').isEmpty()
     }
 
     def "downloads deleted files again when they are referenced"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -928,7 +928,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         executer.withTasks("tasks").start().waitForFinish()
 
         then:
-        outputDir1.assertDoesNotExist()
+        outputDir1.parentFile.assertDoesNotExist()
         outputDir2.assertExists()
         gcFile.lastModified() >= SECONDS.toMillis(beforeCleanup)
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -46,11 +46,23 @@ public abstract class AbstractCacheCleanup implements CleanupAction {
             if (shouldDelete(file)) {
                 if (FileUtils.deleteQuietly(file)) {
                     handleDeletion(file);
-                    filesDeleted++;
+                    filesDeleted += 1 + deleteEmptyParentDirectories(cleanableStore.getBaseDir(), file.getParentFile());
                 }
             }
         }
         LOGGER.info("{} cleanup deleted {} files/directories.", cleanableStore.getDisplayName(), filesDeleted);
+    }
+
+    private int deleteEmptyParentDirectories(File baseDir, File dir) {
+        if (dir.equals(baseDir)) {
+            return 0;
+        }
+        File[] files = dir.listFiles();
+        if (files != null && files.length == 0 && dir.delete()) {
+            handleDeletion(dir);
+            return 1 + deleteEmptyParentDirectories(baseDir, dir.getParentFile());
+        }
+        return 0;
     }
 
     protected abstract boolean shouldDelete(File file);


### PR DESCRIPTION
Prior to this commit parent directories of deleted cache entries were
not checked whether they're eligible for deletion. Now, parent
directories that are now empty are checked up to the base directory.

For the artifact transforms cache the following directories marked with
(+) are now also deleted once all subdirectories (*) have been deleted:

 - files-1.1
   - artifact-a (+)
     - hash 1 (*)
       - hash 1.1
       - ...
     - hash 2 (*)
     - ...
   - ... (+)

For the artifact cache:

 - modules-2
   - files-2.1
     - groupId (+)
       - artifactId (+)
         - version (+)
           - hash1 (*)
             - file
           - hash2 (*)
             - file
   - resources-2.1
     - 0 (+)
       - hash 1 (*)
       - hash 2 (*)
       - ...
     - ... (+)

Resolves gradle/gradle-private#1339.