### PR TITLE
Set timeout for AbstractIntegrationSpec

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.caching.http.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.keystore.TestKeyStore
 
+@IntegrationTestTimeout(120)
 class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec implements HttpBuildCacheFixture {
 
     static final String ORIGINAL_HELLO_WORLD = """

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -18,9 +18,7 @@ package org.gradle.caching.http.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.keystore.TestKeyStore
-import spock.lang.Timeout
 
-@Timeout(120)
 class HttpBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec implements HttpBuildCacheFixture {
 
     static final String ORIGINAL_HELLO_WORLD = """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -19,11 +19,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
-import spock.lang.Timeout
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
-@Timeout(300)
 class InitScriptExecutionIntegrationTest extends AbstractIntegrationSpec {
     def "executes init.gradle from user home dir"() {
         given:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -17,11 +17,13 @@ package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
+@IntegrationTestTimeout(300)
 class InitScriptExecutionIntegrationTest extends AbstractIntegrationSpec {
     def "executes init.gradle from user home dir"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
@@ -20,9 +20,6 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Issue
-import spock.lang.Timeout
-
-import java.util.concurrent.TimeUnit
 
 class ArtifactResolutionQueryIntegrationTest extends AbstractHttpDependencyResolutionTest {
     @Rule
@@ -33,7 +30,6 @@ class ArtifactResolutionQueryIntegrationTest extends AbstractHttpDependencyResol
     }
 
     @Issue('https://github.com/gradle/gradle/issues/3579')
-    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     def 'can use artifact resolution queries in parallel to file resolution'() {
         given:
         def module = mavenHttpRepo.module('group', "artifact", '1.0').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.artifactreuse
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Issue
@@ -30,6 +31,7 @@ class ArtifactResolutionQueryIntegrationTest extends AbstractHttpDependencyResol
     }
 
     @Issue('https://github.com/gradle/gradle/issues/3579')
+    @IntegrationTestTimeout(60)
     def 'can use artifact resolution queries in parallel to file resolution'() {
         given:
         def module = mavenHttpRepo.module('group', "artifact", '1.0').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/RecoverFromBrokenResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/RecoverFromBrokenResolutionIntegrationTest.groovy
@@ -17,12 +17,14 @@
 package org.gradle.integtests.resolve.caching
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.hamcrest.Matchers
 
 import static org.gradle.util.Matchers.matchesRegexp
 
+@IntegrationTestTimeout(120)
 class RecoverFromBrokenResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
     MavenHttpRepository repo

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/RecoverFromBrokenResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/RecoverFromBrokenResolutionIntegrationTest.groovy
@@ -20,11 +20,9 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.hamcrest.Matchers
-import spock.lang.Timeout
 
 import static org.gradle.util.Matchers.matchesRegexp
 
-@Timeout(120)
 class RecoverFromBrokenResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
     MavenHttpRepository repo

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
@@ -17,9 +17,11 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Issue
 
+@IntegrationTestTimeout(300)
 class BuildSourceBuilderIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2032")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
@@ -19,9 +19,7 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Issue
-import spock.lang.Timeout
 
-@Timeout(300)
 class BuildSourceBuilderIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2032")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -23,13 +23,11 @@ import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import spock.lang.Issue
-import spock.lang.Timeout
 import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.StaleOutputJavaProject.JAR_TASK_NAME
 import static org.gradle.util.GFileUtils.forceDelete
 
-@Timeout(120)
 class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
     private final ReleasedVersionDistributions releasedVersionDistributions = new ReleasedVersionDistributions()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.StaleOutputJavaProject
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -28,6 +29,7 @@ import spock.lang.Unroll
 import static org.gradle.integtests.fixtures.StaleOutputJavaProject.JAR_TASK_NAME
 import static org.gradle.util.GFileUtils.forceDelete
 
+@IntegrationTestTimeout(120)
 class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
     private final ReleasedVersionDistributions releasedVersionDistributions = new ReleasedVersionDistributions()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -27,6 +27,7 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -48,6 +49,7 @@ import static org.gradle.util.Matchers.normalizedLineSeparators
  */
 @CleanupTestDirectory
 @SuppressWarnings("IntegrationTestFixtures")
+@IntegrationTestTimeout(600)
 class AbstractIntegrationSpec extends Specification {
 
     @Rule

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -40,6 +40,7 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.junit.Rule
 
+import static org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout.*
 import static org.gradle.util.Matchers.normalizedLineSeparators
 
 /**
@@ -49,7 +50,7 @@ import static org.gradle.util.Matchers.normalizedLineSeparators
  */
 @CleanupTestDirectory
 @SuppressWarnings("IntegrationTestFixtures")
-@IntegrationTestTimeout(600)
+@IntegrationTestTimeout(DEFAULT_TIMEOUT_SECONDS)
 class AbstractIntegrationSpec extends Specification {
 
     @Rule

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -34,6 +34,7 @@ import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer;
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeoutInterceptor;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.UncheckedException;
@@ -81,6 +82,7 @@ import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.Cli
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NOT_DEFINED;
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NO_DAEMON;
 import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.STACK_TRACE_ELEMENT;
+import static org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout.*;
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES;
 import static org.gradle.util.CollectionUtils.collect;
 import static org.gradle.util.CollectionUtils.join;
@@ -803,8 +805,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
      * Performs cleanup at completion of the test.
      */
     public void cleanup() {
-        stopRunningBuilds();
-        cleanupIsolatedDaemons();
+        new IntegrationTestTimeoutInterceptor(DEFAULT_TIMEOUT_SECONDS).intercept(new Action<Void>() {
+            @Override
+            public void execute(Void ignored) {
+                stopRunningBuilds();
+                cleanupIsolatedDaemons();
+            }
+        });
     }
 
     private void stopRunningBuilds() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeout.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeout.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.timeout;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Indicates that the execution of a method should time out
+ * after the given duration has elapsed. The default time unit is seconds.
+ *
+ * This annotation can be used in similar way with {@link spock.lang.Timeout}, but shouldn't
+ * be used together with {@link spock.lang.Timeout}. It should be annotated on
+ * {@link org.gradle.integtests.fixtures.AbstractIntegrationSpec}. Upon timeout,
+ * all threads' stack traces of current JVM (embedded executer) or forked JVM (forking executer)
+ * are printed to help us debug deadlock issues.
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(IntegrationTestTimeoutExtension.class)
+public @interface IntegrationTestTimeout {
+    /**
+     * Returns the duration after which the execution of the annotated feature or fixture
+     * method times out.
+     *
+     * @return the duration after which the execution of the annotated feature or
+     * fixture method times out
+     */
+    int value();
+
+    /**
+     * Returns the duration's time unit.
+     *
+     * @return the duration's time unit
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+}
+

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeout.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeout.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @ExtensionAnnotation(IntegrationTestTimeoutExtension.class)
 public @interface IntegrationTestTimeout {
+    int DEFAULT_TIMEOUT_SECONDS = 600;
     /**
      * Returns the duration after which the execution of the annotated feature or fixture
      * method times out.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutExtension.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutExtension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.timeout;
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.MethodInfo;
+import org.spockframework.runtime.model.SpecInfo;
+
+public class IntegrationTestTimeoutExtension extends AbstractAnnotationDrivenExtension<IntegrationTestTimeout> {
+    @Override
+    public void visitSpecAnnotation(IntegrationTestTimeout timeout, SpecInfo spec) {
+        for (FeatureInfo feature : spec.getFeatures()) {
+            if (!feature.getFeatureMethod().getReflection().isAnnotationPresent(IntegrationTestTimeout.class)) {
+                visitFeatureAnnotation(timeout, feature);
+            }
+        }
+    }
+
+    @Override
+    public void visitFeatureAnnotation(IntegrationTestTimeout timeout, FeatureInfo feature) {
+        feature.getFeatureMethod().addInterceptor(new IntegrationTestTimeoutInterceptor(timeout));
+    }
+
+    @Override
+    public void visitFixtureAnnotation(IntegrationTestTimeout timeout, MethodInfo fixtureMethod) {
+        fixtureMethod.addInterceptor(new IntegrationTestTimeoutInterceptor(timeout));
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
@@ -149,6 +149,8 @@ class IntegrationTestTimeoutInterceptor extends TimeoutInterceptor {
         process.consumeProcessOutput(stdout, stderr)
 
         if (process.waitFor() == 0) {
+            println("Command $command stdout: ${stdout}")
+            println("Command $command stderr: ${stderr}")
             return new StdoutAndPatterns(stdout.toString())
         } else {
             def logFile = IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir.file("error-${System.currentTimeMillis()}.log")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.timeout
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.InProcessGradleExecuter
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.internal.os.OperatingSystem
+import org.spockframework.runtime.SpockAssertionError
+import org.spockframework.runtime.SpockTimeoutError
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.extension.builtin.TimeoutInterceptor
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+class IntegrationTestTimeoutInterceptor extends TimeoutInterceptor {
+    private static final Pattern UNIX_JAVA_COMMAND_PATTERN = ~/(?i)([^\s]+\/bin\/java)/
+    private static final Pattern WINDOWS_JAVA_COMMAND_PATTERN = ~/(?i)^"(.*[\/\\]bin[\/\\]java\.exe)"/
+    private static final Pattern WINDOWS_PID_PATTERN = ~/([0-9]+)\s*$/
+    private static final Pattern UNIX_PID_PATTERN = ~/([0-9]+)/
+
+    IntegrationTestTimeoutInterceptor(IntegrationTestTimeout timeout) {
+        super(new TimeoutAdapter(timeout))
+    }
+
+    @Override
+    void intercept(final IMethodInvocation invocation) throws Throwable {
+        try {
+            super.intercept(invocation)
+        } catch (SpockTimeoutError e) {
+            Object instance = invocation.getInstance()
+            if (instance instanceof AbstractIntegrationSpec) {
+                String allThreadStackTraces = getAllThreads((AbstractIntegrationSpec) instance)
+                throw new SpockAssertionError(allThreadStackTraces, e)
+            } else {
+                throw e
+            }
+        } catch (Throwable t) {
+            throw t
+        }
+    }
+
+    static String getAllThreads(AbstractIntegrationSpec spec) {
+        try {
+            if (spec.executer.gradleExecuter.class == InProcessGradleExecuter) {
+                return getAllThreadsInCurrentJVM()
+            } else {
+                return getAllThreadsByJstack()
+            }
+        } catch (Throwable e) {
+            def stream = new ByteArrayOutputStream()
+            e.printStackTrace(new PrintStream(stream))
+            return stream.toString()
+        }
+    }
+
+    @EqualsAndHashCode
+    @ToString
+    static class JavaProcessInfo {
+        String pid
+        String javaCommand
+
+        String getJstackCommand() {
+            if (javaCommand.endsWith('java')) {
+                return javaCommand[0..-5] + 'jstack'
+            } else if (javaCommand.endsWith('java.exe')) {
+                return javaCommand[0..-9] + 'jstack.exe'
+            } else {
+                throw new RuntimeException("Unknown java command： $javaCommand")
+            }
+        }
+
+        String jstack() {
+            def process = "${jstackCommand} -F ${pid}".execute()
+            def stdout = new StringBuffer()
+            def stderr = new StringBuffer()
+            process.consumeProcessOutput(stdout, stderr)
+            process.waitFor()
+            return "Run ${jstackCommand} -F ${pid}:\n${stdout}\n---------\n${stderr}\n"
+        }
+    }
+
+    static class StdoutAndPatterns {
+        String stdout
+        Pattern pidPattern
+        Pattern javaCommandPattern
+
+        StdoutAndPatterns(String stdout) {
+            this.stdout = stdout
+            if (OperatingSystem.current().isWindows()) {
+                pidPattern = WINDOWS_PID_PATTERN
+                javaCommandPattern = WINDOWS_JAVA_COMMAND_PATTERN
+            } else {
+                pidPattern = UNIX_PID_PATTERN
+                javaCommandPattern = UNIX_JAVA_COMMAND_PATTERN
+            }
+        }
+
+        List<JavaProcessInfo> getSuspiciousDaemons() {
+            stdout.readLines().findAll(this.&isSuspiciousDaemon).collect(this.&extractProcessInfo)
+        }
+
+        private JavaProcessInfo extractProcessInfo(String line) {
+            Matcher javaCommandMatcher = javaCommandPattern.matcher(line)
+            Matcher pidMatcher = pidPattern.matcher(line)
+
+            javaCommandMatcher.find()
+            pidMatcher.find()
+            return new JavaProcessInfo(pid: pidMatcher.group(1), javaCommand: javaCommandMatcher.group(1))
+        }
+
+        private boolean isSuspiciousDaemon(String line) {
+            return !isTeamCityAgent(line) && javaCommandPattern.matcher(line).find() && pidPattern.matcher(line).find()
+        }
+
+        private boolean isTeamCityAgent(String line) {
+            return line.contains('jetbrains.buildServer.agent.AgentMain')
+        }
+    }
+
+    private static StdoutAndPatterns ps() {
+        String command = OperatingSystem.current().isWindows() ? "wmic process get processid,commandline" : "ps x"
+        Process process = command.execute()
+
+        def stdout = new StringBuffer()
+        def stderr = new StringBuffer()
+
+        process.consumeProcessOutput(stdout, stderr)
+
+        if (process.waitFor() == 0) {
+            return new StdoutAndPatterns(stdout.toString())
+        } else {
+            def logFile = IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir.file("error-${System.currentTimeMillis()}.log")
+            logFile << "stdout:\n"
+            logFile << stdout
+            logFile << "stderr:\n"
+            logFile << stderr
+
+            throw new RuntimeException("Error when fetching processes, see log file ${logFile.absolutePath}")
+        }
+    }
+
+    static String getAllThreadsByJstack() {
+        return ps().getSuspiciousDaemons().collect { it.jstack() }.join("\n")
+    }
+
+    static String getAllThreadsInCurrentJVM() {
+        Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces()
+        StringBuilder sb = new StringBuilder()
+        sb.append("Threads in current JVM:\n")
+        sb.append("--------------------------\n")
+        allStackTraces.each { Thread thread, StackTraceElement[] stackTraces ->
+            sb.append("Thread ${thread.getId()}: ${thread.getName()}\n")
+            sb.append("--------------------------\n")
+            stackTraces.each {
+                sb.append("${it}\n")
+            }
+            sb.append("--------------------------\n")
+        }
+
+        return sb.toString()
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/TimeoutAdapter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/TimeoutAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.timeout;
+
+import spock.lang.Timeout;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutAdapter implements Timeout {
+
+    IntegrationTestTimeout timeout;
+
+    TimeoutAdapter(IntegrationTestTimeout timeout) {
+        this.timeout = timeout;
+    }
+
+    @Override
+    public int value() {
+        return timeout.value();
+    }
+
+    @Override
+    public TimeUnit unit() {
+        return timeout.unit();
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return getClass();
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/TimeoutAdapter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/TimeoutAdapter.java
@@ -23,20 +23,27 @@ import java.util.concurrent.TimeUnit;
 
 public class TimeoutAdapter implements Timeout {
 
-    IntegrationTestTimeout timeout;
+    private int timeout;
+    private TimeUnit unit;
 
     TimeoutAdapter(IntegrationTestTimeout timeout) {
+        this.timeout = timeout.value();
+        this.unit = timeout.unit();
+    }
+
+    TimeoutAdapter(int timeout, TimeUnit unit) {
         this.timeout = timeout;
+        this.unit = unit;
     }
 
     @Override
     public int value() {
-        return timeout.value();
+        return timeout;
     }
 
     @Override
     public TimeUnit unit() {
-        return timeout.unit();
+        return unit;
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptorSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptorSpec.groovy
@@ -83,29 +83,42 @@ cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcage
     }
 
     @Unroll
-    def 'can locate jstack'() {
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def 'can locate jstack on Unix'() {
         expect:
         new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
 
         where:
         javaCommand                                                | jstackCommand
-        "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"           | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
-        "C:\\Program Files\\Java\\jdk1.8/bin/java.exe"             | "C:\\Program Files\\Java\\jdk1.8/bin/jstack.exe"
         '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java' | '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/jstack'
         '/opt/jdk/oracle-jdk-8/bin/java'                           | '/opt/jdk/oracle-jdk-8/bin/jstack'
+        '/opt/jdk/oracle-jdk-8/jre/bin/java'                       | '/opt/jdk/oracle-jdk-8/bin/jstack'
+    }
+
+    @Unroll
+    @Requires(TestPrecondition.WINDOWS)
+    def 'can locate jstack on Windows'() {
+        expect:
+        new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
+
+        where:
+        javaCommand                                           | jstackCommand
+        "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"      | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
+        "C:\\Program Files\\Java\\jdk1.8\\jre\\bin\\java.exe" | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
+        "C:\\Program Files\\Java\\jdk1.8/bin/java.exe"        | "C:\\Program Files\\Java\\jdk1.8/bin/jstack.exe"
     }
 
     def 'can print all threads in current JVM'() {
         expect:
-        IntegrationTestTimeoutInterceptor.getAllThreadsInCurrentJVM().contains("Thread ${Thread.currentThread().getId()}: ${Thread.currentThread().getName()}")
+        IntegrationTestTimeoutInterceptor.getAllStackTracesInCurrentJVM().contains("Thread ${Thread.currentThread().getId()}: ${Thread.currentThread().getName()}")
     }
 
     def 'can print all threads of all running JVM by jstack'() {
         when:
-        String stacktraces = IntegrationTestTimeoutInterceptor.getAllThreadsByJstack()
+        String stacktraces = IntegrationTestTimeoutInterceptor.getAllStackTracesByJstack()
 
         then:
-        stacktraces.contains("Deadlock Detection:")
+        stacktraces.contains("Full thread dump")
         stacktraces.contains("${getClass().getName()}.\$spock_feature")
 //        - org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethod0(java.lang.Class, java.lang.Object, java.lang.String) @bci=6, line=189 (Interpreted frame)
 //        - org.gradle.integtests.fixtures.timeout.IntegrationTestTimeoutInterceptorSpec.$spock_feature_1_4() @bci=98, line=105 (Interpreted frame)

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptorSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptorSpec.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.timeout
+
+import org.gradle.testing.internal.util.Specification
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Unroll
+
+class IntegrationTestTimeoutInterceptorSpec extends Specification {
+
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def 'can extract process info from unix ps()'() {
+        given:
+        def output = '''
+          PID TTY      STAT   TIME COMMAND
+ 1401 ?        Ss     0:05 /lib/systemd/systemd --user
+ 1409 ?        S      0:00 (sd-pam)
+ 2040 ?        Sl     8:07 /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java -ea -cp ../launcher/lib/launcher.jar jetbrains.buildServer.agent.Launcher -ea -Xmx384m -Dteamcity_logs=../logs/ -Dlog4j.configuration=file:../conf/teamcity-agent-log4j.xml jetbrains.buildServer.agent.AgentMain -file ../conf/buildAgent.properties
+ 2215 ?        Sl   473:09 /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -ea -Xmx384m -Dteamcity_logs=../logs/ -Dlog4j.configuration=file:../conf/teamcity-agent-log4j.xml -classpath /home/tcagent1/agent/lib/idea-settings.jar:/home/tcagent1/agent/lib/coverage-agent-common.jar:/home/tcagent1/agent/lib/coverage-report.jar:/home/tcagent1/agent/lib/log4j-1.2.12.jar:/home/tcagent1/agent/lib/commons-httpclient-3.1.jar:/home/tcagent1/agent/lib/log4j-1.2.12-json-layout-1.0.9.jar:/home/tcagent1/agent/lib/freemarker.jar:/home/tcagent1/agent/lib/launcher-api.jar:/home/tcagent1/agent/lib/commons-io-1.3.2.jar:/home/tcagent1/agent/lib/agent-openapi.jar:/home/tcagent1/agent/lib/slf4j-api-1.7.5.jar:/home/tcagent1/agent/lib/trove-3.0.3.jar:/home/tcagent1/agent/lib/processesTerminator.jar:/home/tcagent1/agent/lib/slf4j-log4j12-1.7.5.jar:/home/tcagent1/agent/lib/trove4j.jar:/home/tcagent1/agent/lib/common-impl.jar:/home/tcagent1/agent/lib/ehcache-1.6.0-patch.jar:/home/tcagent1/agent/lib/buildAgent-updates-applying.jar:/home/tcagent1/agent/lib/agent-upgrade.jar:/home/tcagent1/agent/lib/commons-beanutils-core.jar:/home/tcagent1/agent/lib/app-wrapper.jar:/home/tcagent1/agent/lib/ehcache-1.7.2.jar:/home/tcagent1/agent/lib/jdom.jar:/home/tcagent1/agent/lib/spring-scripting/spring-scripting-jruby.jar:/home/tcagent1/agent/lib/spring-scripting/spring-scripting-bsh.jar:/home/tcagent1/agent/lib/spring-scripting/spring-scripting-groovy.jar:/home/tcagent1/agent/lib/xstream-1.4.10-custom.jar:/home/tcagent1/agent/lib/common-runtime.jar:/home/tcagent1/agent/lib/gson.jar:/home/tcagent1/agent/lib/xmlrpc-2.0.1.jar:/home/tcagent1/agent/lib/jaxen-1.1.1.jar:/home/tcagent1/agent/lib/duplicator-util.jar:/home/tcagent1/agent/lib/nuget-utils.jar:/home/tcagent1/agent/lib/annotations.jar:/home/tcagent1/agent/lib/serviceMessages.jar:/home/tcagent1/agent/lib/util.jar:/home/tcagent1/agent/lib/patches-impl.jar:/home/tcagent1/agent/lib/xml-rpc-wrapper.jar:/home/tcagent1/agent/lib/inspections-util.jar:/home/tcagent1/agent/lib/common.jar:/home/tcagent1/agent/lib/messages.jar:/home/tcagent1/agent/lib/commons-logging.jar:/home/tcagent1/agent/lib/commons-collections-3.2.2.jar:/home/tcagent1/agent/lib/openapi.jar:/home/tcagent1/agent/lib/launcher.jar:/home/tcagent1/agent/lib/agent-launcher.jar:/home/tcagent1/agent/lib/xercesImpl.jar:/home/tcagent1/agent/lib/jdk-searcher.jar:/home/tcagent1/agent/lib/resources_en.jar:/home/tcagent1/agent/lib/agent-installer-ui.jar:/home/tcagent1/agent/lib/agent.jar:/home/tcagent1/agent/lib/xpp3-1.1.4c.jar:/home/tcagent1/agent/lib/runtime-util.jar:/home/tcagent1/agent/lib/server-logging.jar:/home/tcagent1/agent/lib/commons-compress-1.9.jar:/home/tcagent1/agent/lib/commons-codec.jar:/home/tcagent1/agent/lib/joda-time.jar:/home/tcagent1/agent/lib/spring.jar:/home/tcagent1/agent/lib/xz-1.5.jar:/home/tcagent1/agent/lib/patches.jar:/home/tcagent1/agent/lib/agent-configurator.jar:/home/tcagent1/agent/lib/cloud-shared.jar jetbrains.buildServer.agent.AgentMain -file ../conf/buildAgent.properties -launcher.version 51228
+ 2477 ?        Sl     2:12 /opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java -Djava.security.manager=worker.org.gradle.process.internal.worker.child.BootstrapSecurityManager -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp /home/tcagent1/.gradle/caches/4.9-20180607113442+0000/workerMain/gradle-worker.jar worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Worker Daemon 199\'
+ 7367 pts/0    R+     0:00 ps x
+15818 ?        Sl     2:15 /opt/jdk/oracle-jdk-8/bin/java -DintegTest.gradleHomeDir=/home/tcagent1/agent/work/668602365d1521fc/subprojects/test-kit/build/integ test -DintegTest.gradleUserHomeDir=/home/tcagent1/agent/work/668602365d1521fc/intTestHomeDir -DintegTest.toolingApiShadedJarDir=/home/tcagent1/agent/work/668602365d1521fc/subprojects/tooling-api/build/shaded-jar -Djava.security.manager=worker.org.gradle.process.internal.worker.child.BootstrapSecurityManager -Dorg.gradle.ci.agentCount=2 -Dorg.gradle.ci.agentNum=1 -Dorg.gradle.integtest.daemon.registry=/home/tcagent1/agent/work/668602365d1521fc/build/daemon -Dorg.gradle.integtest.executer=embedded -Dorg.gradle.integtest.mirrors.google=http://dev12.gradle.org:8081/artifactory/google -Dorg.gradle.integtest.mirrors.gradle=http://dev12.gradle.org:8081/artifactory/gradle-repo/ -Dorg.gradle.integtest.mirrors.jboss=http://dev12.gradle.org:8081/artifactory/jboss/ -Dorg.gradle.integtest.mirrors.jcenter=http://dev12.gradle.org:8081/artifactory/jcenter -Dorg.gradle.integtest.mirrors.lightbendmaven=http://dev12.gradle.org:8081/artifactory/typesafe-maven-releases -Dorg.gradle.integtest.mirrors.ligthbendivy -Dorg.gradle.integtest.mirrors.mavencentral=http://dev12.gradle.org:8081/artifactory/repo1 -Dorg.gradle.integtest.mirrors.restlet=http://dev12.gradle.org:8081/artifactory/restlet/ -Dorg.gradle.integtest.mirrors.springreleases=http://dev12.gradle.org:8081/artifactory/spring-releases/ -Dorg.gradle.integtest.mirrors.springsnapshots=http://dev12.gradle.org:8081/artifactory/spring-snapshots/ -Dorg.gradle.integtest.multiversion=default -Dorg.gradle.integtest.native.toolChains=default -Dorg.gradle.integtest.versions=latest -Dorg.gradle.native=false -Dorg.gradle.test.maxParallelForks=4 -XX:+HeapDumpOnOutOfMemoryError -Xmx512m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -ea -cp /home/tcagent1/.gradle/caches/4.9-20180607113442+0000/workerMain/gradle-worker.jar worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Test Executor 61\'
+24438 ?        Sl     3:46 /opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java -Dorg.gradle.daemon.idletimeout=120000 -Dorg.gradle.daemon.registry.base=/home/tcagent1/agent/work/668602365d1521fc/build/daemon -Dorg.gradle.native.dir=/home/tcagent1/agent/work/668602365d1521fc/intTestHomeDir/worker-1/native -Dorg.gradle.deprecation.trace=true -Djava.io.tmpdir=/home/tcagent1/agent/work/668602365d1521fc/subprojects/test-kit/build/tmp -Dfile.encoding=UTF-8 -Dorg.gradle.classloaderscope.strict=true -Dgradle.internal.noSearchUpwards=true -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false -ea -ea -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/home/tcagent1/agent/work/668602365d1521fc/intTestHomeDir/worker-1 -Dorg.gradle.appname=gradle -classpath /home/tcagent1/agent/work/668602365d1521fc/subprojects/test-kit/build/integ test/lib/gradle-launcher-4.9.jar org.gradle.launcher.GradleMain --init-script /home/tcagent1/agent/work/668602365d1521fc/subprojects/test-kit/build/tmp/test files/GradleRunnerConsoleInputEndUserIntegrationTest/can_capture_user_in..._provided/xkpwb/testKitDirInit.gradle --no-daemon --stacktrace --gradle-user-home /home/tcagent1/agent/work/668602365d1521fc/intTestHomeDir/worker-1 --warning-mode=all build
+27347 pts/0    S      0:00 bash
+32167 ?        Ssl    8:50 /opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx2500m -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/home/tcagent1/agent/temp/buildTmp -Duser.country=US -Duser.language=en -Duser.variant -cp /home/tcagent1/.gradle/wrapper/dists/gradle-4.9-20180607113442+0000-bin/6o1ijseqszb59y1oe4hyx3o6o/gradle-4.9-20180607113442+0000/lib/gradle-launcher-4.9.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 4.9-20180607113442+0000
+'''
+        when:
+        def suspiciousDaemons = new IntegrationTestTimeoutInterceptor.StdoutAndPatterns(output).getSuspiciousDaemons()
+
+        then:
+        suspiciousDaemons == [
+            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '2477', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
+            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '15818', javaCommand: '/opt/jdk/oracle-jdk-8/bin/java'),
+            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '24438', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
+            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '32167', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
+        ]
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def 'can extract process info from windows wmic'() {
+        given:
+        def output = '''
+CommandLine ProcessId 
+\\SystemRoot\\System32\\smss.exe            244    
+%SystemRoot%\\system32\\csrss.exe ObjectDirectory=\\Windows SharedSection=1024,20480,768 Windows=On SubSystemType=Windows ServerDll=basesrv,1 ServerDll=winsrv:UserServerDllInitialization,3 ServerDll=winsrv:ConServerDllInitialization,2 ServerDll=sxssrv,4 ProfileControl=Off MaxRequestThreads=16               312    
+C:\\Windows\\system32\\svchost.exe -k LocalServiceAndNoImpersonation                           1168    
+c:\\salt\\nssm.exe                   1316    
+"C:\\Windows\\system32\\Dwm.exe"            1436    
+C:\\Windows\\Explorer.EXE               1460    
+"taskhost.exe"                    1592    
+"C:\\Program Files\\Java\\jdk1.8\\bin\\java" -Xrs -Djava.library.path="../launcher/lib;../launcher/bin" -classpath "../launcher/lib/wrapper.jar;../launcher/lib/launcher.jar" -Dwrapper.key="ywQQx5XMpKTXa1_y" -Dwrapper.port=32000 -Dwrapper.jvm.port.min=31000 -Dwrapper.jvm.port.max=31999 -Dwrapper.pid=1964 -Dwrapper.version="3.2.3" -Dwrapper.native_library="wrapper" -Dwrapper.service="TRUE" -Dwrapper.cpu.timeout="10" -Dwrapper.jvmid=2 org.tanukisoftware.wrapper.WrapperSimpleApp jetbrains.buildServer.agent.StandAloneLauncher -ea -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -Xrs -Dlog4j.configuration=file:../conf/teamcity-agent-log4j.xml -Dteamcity_logs=../logs/ jetbrains.buildServer.agent.AgentMain -file ../conf/buildAgent.properties 8084    
+"C:\\Program Files\\Java\\jdk1.8\\jre\\bin\\java" -ea -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -Xrs -Dlog4j.configuration=file:../conf/teamcity-agent-log4j.xml -Dteamcity_logs=../logs/ -classpath C:\\tcagent1\\lib\\agent-configurator.jar;C:\\tcagent1\\lib\\agent-installer-ui.jar;C:\\tcagent1\\lib\\agent-launcher.jar;C:\\tcagent1\\lib\\agent-openapi.jar;C:\\tcagent1\\lib\\agent-upgrade.jar;C:\\tcagent1\\lib\\agent.jar;C:\\tcagent1\\lib\\annotations.jar;C:\\tcagent1\\lib\\app-wrapper.jar;C:\\tcagent1\\lib\\buildAgent-updates-applying.jar;C:\\tcagent1\\lib\\cloud-shared.jar;C:\\tcagent1\\lib\\common-impl.jar;C:\\tcagent1\\lib\\common-runtime.jar;C:\\tcagent1\\lib\\common.jar;C:\\tcagent1\\lib\\commons-beanutils-core.jar;C:\\tcagent1\\lib\\commons-codec.jar;C:\\tcagent1\\lib\\commons-collections-3.2.2.jar;C:\\tcagent1\\lib\\commons-compress-1.9.jar;C:\\tcagent1\\lib\\commons-httpclient-3.1.jar;C:\\tcagent1\\lib\\commons-io-1.3.2.jar;C:\\tcagent1\\lib\\commons-logging.jar;C:\\tcagent1\\lib\\coverage-agent-common.jar;C:\\tcagent1\\lib\\coverage-report.jar;C:\\tcagent1\\lib\\duplicator-util.jar;C:\\tcagent1\\lib\\ehcache-1.6.0-patch.jar;C:\\tcagent1\\lib\\ehcache-1.7.2.jar;C:\\tcagent1\\lib\\freemarker.jar;C:\\tcagent1\\lib\\gson.jar;C:\\tcagent1\\lib\\idea-settings.jar;C:\\tcagent1\\lib\\inspections-util.jar;C:\\tcagent1\\lib\\jaxen-1.1.1.jar;C:\\tcagent1\\lib\\jdk-searcher.jar;C:\\tcagent1\\lib\\jdom.jar;C:\\tcagent1\\lib\\joda-time.jar;C:\\tcagent1\\lib\\launcher-api.jar;C:\\tcagent1\\lib\\launcher.jar;C:\\tcagent1\\lib\\log4j-1.2.12-json-layout-1.0.9.jar;C:\\tcagent1\\lib\\log4j-1.2.12.jar;C:\\tcagent1\\lib\\messages.jar;C:\\tcagent1\\lib\\nuget-utils.jar;C:\\tcagent1\\lib\\openapi.jar;C:\\tcagent1\\lib\\patches-impl.jar;C:\\tcagent1\\lib\\patches.jar;C:\\tcagent1\\lib\\processesTerminator.jar;C:\\tcagent1\\lib\\resources_en.jar;C:\\tcagent1\\lib\\runtime-util.jar;C:\\tcagent1\\lib\\server-logging.jar;C:\\tcagent1\\lib\\serviceMessages.jar;C:\\tcagent1\\lib\\slf4j-api-1.7.5.jar;C:\\tcagent1\\lib\\slf4j-log4j12-1.7.5.jar;C:\\tcagent1\\lib\\spring-scripting\\spring-scripting-bsh.jar;C:\\tcagent1\\lib\\spring-scripting\\spring-scripting-groovy.jar;C:\\tcagent1\\lib\\spring-scripting\\spring-scripting-jruby.jar;C:\\tcagent1\\lib\\spring.jar;C:\\tcagent1\\lib\\trove-3.0.3.jar;C:\\tcagent1\\lib\\trove4j.jar;C:\\tcagent1\\lib\\util.jar;C:\\tcagent1\\lib\\xercesImpl.jar;C:\\tcagent1\\lib\\xml-rpc-wrapper.jar;C:\\tcagent1\\lib\\xmlrpc-2.0.1.jar;C:\\tcagent1\\lib\\xpp3-1.1.4c.jar;C:\\tcagent1\\lib\\xstream-1.4.10-custom.jar;C:\\tcagent1\\lib\\xz-1.5.jar jetbrains.buildServer.agent.AgentMain -file ../conf/buildAgent.properties -launcher.version 51228 4956    
+usr\\bin\\mintty.exe -o AppID=GitForWindows.Bash -o RelaunchCommand="C:\\Program Files\\Git\\git-bash.exe" -o RelaunchDisplayName="Git Bash" -i /mingw64/share/git/git-for-windows.ico /usr/bin/bash --login -i      7788    
+\\??\\C:\\Windows\\system32\\conhost.exe "472490228-68470907838922115481214932-363220106-1296027029-1014590852-1678361664 7824    
+"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Tools\\MSVC\\14.14.26428\\bin\\HostX64\\x86\\VCTIP.EXE"  11880   
+"C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe" -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx2500m -Dfile.encoding=UTF-8 -Djava.io.tmpdir=C:\\tcagent1\\temp\\buildTmp -Duser.country=US -Duser.language=en -Duser.variant -cp C:\\Users\\tcagent1\\.gradle\\wrapper\\dists\\gradle-4.9-20180624235932+0000-bin\\8osj55b0zpcwza9pdf19suxvr\\gradle-4.9-20180624235932+0000\\lib\\gradle-launcher-4.9.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 4.9-20180624235932+0000         1368    
+cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcagent1\\plugins\\gradle-runner\\scripts\\init.gradle -PmaxParallelForks=4 -s --daemon --continue -I C:\\tcagent1\\work\\668602365d1521fc/gradle/init-scripts/build-scan.init.gradle.kts "-Djava7Home=C:\\Program Files\\Java\\jdk1.7" "-Djava9Home=C:\\Program Files\\Java\\jdk1.9" -Dorg.gradle.internal.tasks.createops --build-cache -Dgradle.cache.remote.url="https://e.grdev.net/cache/" -Dgradle.cache.remote.username="gradle" -Dgradle.cache.remote.password="Pw2^8w2PHN6JUCOTo7R3" "-PtestJavaHome=C:\\Program Files\\Java\\jdk1.8" -Dscan.tag.FunctionalTest -Dscan.value.coverageOs=windows -Dscan.value.coverageJvmVendor=oracle -Dscan.value.coverageJvmVersion=java8 -PteamCityUsername=TeamcityRestBot -PteamCityPassword=DxQyNUvR2Yx6P5z6 -PteamCityBuildId=13871238 -Dscan.tag.Check -Dscan.tag.BranchBuildAccept -Dorg.gradle.daemon=false clean buildCacheHttp:platformTest 4100    
+"C:\\Program Files\\Java\\jdk1.8/bin/java.exe" -Xmx128m -Dfile.encoding=UTF-8 -XX:MaxPermSize=512m "-Djava.io.tmpdir=C:\\tcagent1\\temp\\buildTmp" "-Dorg.gradle.appname=gradlew" -classpath "C:\\tcagent1\\work\\668602365d1521fc\\\\gradle\\wrapper\\gradle-wrapper.jar" org.gradle.wrapper.GradleWrapperMain --init-script C:\\tcagent1\\plugins\\gradle-runner\\scripts\\init.gradle -PmaxParallelForks=4 -s --daemon --continue -I C:\\tcagent1\\work\\668602365d1521fc/gradle/init-scripts/build-scan.init.gradle.kts "-Djava7Home=C:\\Program Files\\Java\\jdk1.7" "-Djava9Home=C:\\Program Files\\Java\\jdk1.9" -Dorg.gradle.internal.tasks.createops --build-cache -Dgradle.cache.remote.url="https://e.grdev.net/cache/" -Dgradle.cache.remote.username="gradle" -Dgradle.cache.remote.password="Pw2^8w2PHN6JUCOTo7R3" "-PtestJavaHome=C:\\Program Files\\Java\\jdk1.8" -Dscan.tag.FunctionalTest -Dscan.value.coverageOs=windows -Dscan.value.coverageJvmVendor=oracle -Dscan.value.coverageJvmVersion=java8 -PteamCityUsername=TeamcityRestBot -PteamCityPassword=DxQyNUvR2Yx6P5z6 -PteamCityBuildId=13871238 -Dscan.tag.Check -Dscan.tag.BranchBuildAccept -Dorg.gradle.daemon=false clean buildCacheHttp:platformTest 3908    
+'''
+        when:
+        def suspiciousDaemons = new IntegrationTestTimeoutInterceptor.StdoutAndPatterns(output).getSuspiciousDaemons()
+
+        then:
+        suspiciousDaemons == [
+            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '1368', javaCommand: "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"),
+            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '3908', javaCommand: "C:\\Program Files\\Java\\jdk1.8/bin/java.exe")
+        ]
+    }
+
+    @Unroll
+    def 'can locate jstack'() {
+        expect:
+        new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
+
+        where:
+        javaCommand                                                | jstackCommand
+        "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"           | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
+        "C:\\Program Files\\Java\\jdk1.8/bin/java.exe"             | "C:\\Program Files\\Java\\jdk1.8/bin/jstack.exe"
+        '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java' | '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/jstack'
+        '/opt/jdk/oracle-jdk-8/bin/java'                           | '/opt/jdk/oracle-jdk-8/bin/jstack'
+    }
+
+    def 'can print all threads in current JVM'() {
+        expect:
+        IntegrationTestTimeoutInterceptor.getAllThreadsInCurrentJVM().contains("Thread ${Thread.currentThread().getId()}: ${Thread.currentThread().getName()}")
+    }
+
+    def 'can print all threads of all running JVM by jstack'() {
+        when:
+        String stacktraces = IntegrationTestTimeoutInterceptor.getAllThreadsByJstack()
+
+        then:
+        stacktraces.contains("Deadlock Detection:")
+        stacktraces.contains("${getClass().getName()}.\$spock_feature")
+//        - org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethod0(java.lang.Class, java.lang.Object, java.lang.String) @bci=6, line=189 (Interpreted frame)
+//        - org.gradle.integtests.fixtures.timeout.IntegrationTestTimeoutInterceptorSpec.$spock_feature_1_4() @bci=98, line=105 (Interpreted frame)
+//        - sun.reflect.NativeMethodAccessorImpl.invoke0(java.lang.reflect.Method, java.lang.Object, java.lang.Object[]) @bci=0 (Interpreted frame)
+    }
+}

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptorSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptorSpec.groovy
@@ -105,7 +105,7 @@ cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcage
         javaCommand                                           | jstackCommand
         "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"      | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
         "C:\\Program Files\\Java\\jdk1.8\\jre\\bin\\java.exe" | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
-        "C:\\Program Files\\Java\\jdk1.8/bin/java.exe"        | "C:\\Program Files\\Java\\jdk1.8/bin/jstack.exe"
+        "C:\\Program Files\\Java\\jdk1.8/bin/java.exe"        | "C:\\Program Files\\Java\\jdk1.8\\bin\\jstack.exe"
     }
 
     def 'can print all threads in current JVM'() {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.launcher.daemon
 
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.launcher.daemon.logging.DaemonMessages
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.GradleVersion
@@ -60,6 +61,7 @@ task sleep {
         }
     }
 
+    @IntegrationTestTimeout(25)
     def "promptly shows decent message when daemon cannot be started"() {
         when:
         executer.withArguments("-Dorg.gradle.jvmargs=-Xyz").run()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -22,7 +22,6 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.Timeout
 
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
@@ -61,7 +60,6 @@ task sleep {
         }
     }
 
-    @Timeout(25)
     def "promptly shows decent message when daemon cannot be started"() {
         when:
         executer.withArguments("-Dorg.gradle.jvmargs=-Xyz").run()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -24,10 +24,8 @@ import org.gradle.util.GFileUtils
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(300)
 class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
     static final EXPIRATION_CHECK_FREQUENCY = 50
     public static final String EXPIRATION_EVENT = "expiration_event.txt"

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.launcher.daemon.server.scaninfo
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.launcher.daemon.client.SingleUseDaemonClient
 import org.gradle.util.GFileUtils
 import org.gradle.util.Requires
@@ -26,6 +27,7 @@ import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+@IntegrationTestTimeout(300)
 class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
     static final EXPIRATION_CHECK_FREQUENCY = 50
     public static final String EXPIRATION_EVENT = "expiration_event.txt"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
@@ -15,9 +15,6 @@
  */
 package org.gradle.groovy.compile
 
-import spock.lang.Timeout
-
-@Timeout(300)
 class InProcessGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
 
     def setup() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InProcessGroovyCompilerIntegrationTest.groovy
@@ -15,6 +15,9 @@
  */
 package org.gradle.groovy.compile
 
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
+
+@IntegrationTestTimeout(300)
 class InProcessGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
 
     def setup() {

--- a/subprojects/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
+++ b/subprojects/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
@@ -17,9 +17,11 @@
 package org.gradle.process.internal.health.memory
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 
 class MemoryStatusUpdateIntegrationTest extends AbstractIntegrationSpec {
 
+    @IntegrationTestTimeout(20)
     def "can register a listener for JVM and OS memory status update events"() {
         given:
         buildFile << waitForMemoryEventsTask()

--- a/subprojects/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
+++ b/subprojects/process-services/src/integTest/groovy/org/gradle/process/internal/health/memory/MemoryStatusUpdateIntegrationTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.process.internal.health.memory
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.Timeout
 
 class MemoryStatusUpdateIntegrationTest extends AbstractIntegrationSpec {
 
-    @Timeout(20)
     def "can register a listener for JVM and OS memory status update events"() {
         given:
         buildFile << waitForMemoryEventsTask()

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -17,9 +17,12 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.util.GradleVersion
 
 class SecurityManagerIntegrationTest extends AbstractIntegrationSpec {
+
+    @IntegrationTestTimeout(120)
     def "should not hang when running with security manager"() {
         given:
         buildFile << """ 

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -18,12 +18,8 @@ package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.GradleVersion
-import spock.lang.Timeout
-
-import java.util.concurrent.TimeUnit
 
 class SecurityManagerIntegrationTest extends AbstractIntegrationSpec {
-    @Timeout(value = 120, unit = TimeUnit.SECONDS)
     def "should not hang when running with security manager"() {
         given:
         buildFile << """ 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
@@ -24,6 +25,7 @@ import spock.lang.Unroll
 
 import static org.gradle.testing.fixture.JUnitCoverage.*
 
+@IntegrationTestTimeout(240)
 @TargetCoverage({ JUNIT_4_LATEST + JUNIT_VINTAGE })
 class ParallelTestExecutionIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -20,12 +20,10 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.junit.Rule
-import spock.lang.Timeout
 import spock.lang.Unroll
 
 import static org.gradle.testing.fixture.JUnitCoverage.*
 
-@Timeout(240)
 @TargetCoverage({ JUNIT_4_LATEST + JUNIT_VINTAGE })
 class ParallelTestExecutionIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/NoIsolationWorkerExecutorSampleIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/NoIsolationWorkerExecutorSampleIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.junit.Rule
 
+@IntegrationTestTimeout(60)
 class NoIsolationWorkerExecutorSampleIntegrationTest extends AbstractWorkerExecutorSampleIntegrationTest {
     @Rule
     Sample workerExecutorSample = new Sample(temporaryFolder, "workerApi/noIsolation")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/NoIsolationWorkerExecutorSampleIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/NoIsolationWorkerExecutorSampleIntegrationTest.groovy
@@ -18,10 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.Sample
 import org.junit.Rule
-import spock.lang.Timeout
 
-
-@Timeout(60)
 class NoIsolationWorkerExecutorSampleIntegrationTest extends AbstractWorkerExecutorSampleIntegrationTest {
     @Rule
     Sample workerExecutorSample = new Sample(temporaryFolder, "workerApi/noIsolation")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WaitForCompletionWorkerExecutorSampleIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WaitForCompletionWorkerExecutorSampleIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.util.TextUtil
 import org.junit.Rule
 
-
+@IntegrationTestTimeout(60)
 class WaitForCompletionWorkerExecutorSampleIntegrationTest extends AbstractWorkerExecutorSampleIntegrationTest {
     @Rule
     Sample workerExecutorSample = new Sample(temporaryFolder, "workerApi/waitForCompletion")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WaitForCompletionWorkerExecutorSampleIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WaitForCompletionWorkerExecutorSampleIntegrationTest.groovy
@@ -19,10 +19,8 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.util.TextUtil
 import org.junit.Rule
-import spock.lang.Timeout
 
 
-@Timeout(60)
 class WaitForCompletionWorkerExecutorSampleIntegrationTest extends AbstractWorkerExecutorSampleIntegrationTest {
     @Rule
     Sample workerExecutorSample = new Sample(temporaryFolder, "workerApi/waitForCompletion")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.Timeout
 
-@Timeout(60)
 class WorkerDaemonExpirationIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 
+@IntegrationTestTimeout(60)
 class WorkerDaemonExpirationIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -22,13 +22,11 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Assume
-import spock.lang.Timeout
 
 import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 import static org.hamcrest.CoreMatchers.notNullValue
 
-@Timeout(90)
 class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     def "sets the working directory to the project directory by default during worker execution"() {
         withRunnableClassInBuildScript()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -27,6 +28,7 @@ import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 import static org.hamcrest.CoreMatchers.notNullValue
 
+@IntegrationTestTimeout(90)
 class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     def "sets the working directory to the project directory by default during worker execution"() {
         withRunnableClassInBuildScript()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
+
+@IntegrationTestTimeout(120)
 class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationSpec {
     String logSnapshot = ""
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -16,9 +16,6 @@
 
 package org.gradle.workers.internal
 
-import spock.lang.Timeout
-
-@Timeout(120)
 class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationSpec {
     String logSnapshot = ""
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonWorkerExecutorSampleIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonWorkerExecutorSampleIntegrationTest.groovy
@@ -18,10 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.Sample
 import org.junit.Rule
-import spock.lang.Timeout
 
-
-@Timeout(60)
 class WorkerDaemonWorkerExecutorSampleIntegrationTest extends AbstractWorkerExecutorSampleIntegrationTest {
     @Rule
     Sample workerExecutorSample = new Sample(temporaryFolder, "workerApi/workerDaemon")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonWorkerExecutorSampleIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonWorkerExecutorSampleIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.junit.Rule
 
+@IntegrationTestTimeout(60)
 class WorkerDaemonWorkerExecutorSampleIntegrationTest extends AbstractWorkerExecutorSampleIntegrationTest {
     @Rule
     Sample workerExecutorSample = new Sample(temporaryFolder, "workerApi/workerDaemon")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -18,10 +18,8 @@ package org.gradle.workers.internal
 
 import org.gradle.internal.jvm.Jvm
 import org.gradle.workers.IsolationMode
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(60)
 class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Unroll
     def "produces a sensible error when there is a failure in the worker runnable in #isolationMode"() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -16,10 +16,12 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
 import org.gradle.workers.IsolationMode
 import spock.lang.Unroll
 
+@IntegrationTestTimeout(60)
 class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Unroll
     def "produces a sensible error when there is a failure in the worker runnable in #isolationMode"() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.workers.internal
 
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import spock.lang.Unroll
 
+@IntegrationTestTimeout(120)
 class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
@@ -18,10 +18,8 @@ package org.gradle.workers.internal
 
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(120)
 class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Unroll
 
+@IntegrationTestTimeout(60)
 @Unroll
 class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -19,10 +19,8 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(60)
 @Unroll
 class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.workers.internal
 
+import spock.lang.Timeout
 import spock.lang.Unroll
 
+@Timeout(60)
 class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
@@ -16,10 +16,8 @@
 
 package org.gradle.workers.internal
 
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(60)
 class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -16,10 +16,8 @@
 
 package org.gradle.workers.internal
 
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(120)
 class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import spock.lang.Unroll
 
+@IntegrationTestTimeout(120)
 class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -17,13 +17,12 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.IgnoreIf
-import spock.lang.Timeout
 import spock.lang.Unroll
 
-@Timeout(60)
 @IgnoreIf({ GradleContextualExecuter.parallel })
 class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Rule

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+@IntegrationTestTimeout(60)
 @IgnoreIf({ GradleContextualExecuter.parallel })
 class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Rule


### PR DESCRIPTION
We have been bitten by CI build exection timeout for a long time.
This PR introduces timeout for `AbstractIntegrationSpec` in order to
monitor execution timeout. Upon timeout, a spock interceptor can
print all threads' stack traces in all JVMs so that we can diagnose
the potential issues in other JVMs (daemons, test workers, etc.).