### PR TITLE
Allow build JVM configuration

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -20,18 +20,18 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
     val buildScanValues = mapOf(
             "coverageOs" to testCoverage.os.name,
             "coverageJvmVendor" to testCoverage.vendor.name,
-            "coverageJvmVersion" to testCoverage.version.name
+            "coverageJvmVersion" to testCoverage.testJvmVersion.name
     )
     applyDefaults(model, this, testTask, notQuick = !quickTest, os = testCoverage.os,
             extraParameters = (
-                    listOf(""""-PtestJavaHome=%${testCoverage.os}.${testCoverage.version}.${testCoverage.vendor}.64bit%"""")
+                    listOf(""""-PtestJavaHome=%${testCoverage.os}.${testCoverage.testJvmVersion}.${testCoverage.vendor}.64bit%"""")
                             + buildScanTags.map { buildScanTag(it) }
                             + buildScanValues.map { buildScanCustomValue(it.key, it.value) }
                     ).joinToString(separator = " "),
             timeout = testCoverage.testType.timeout)
 
     params {
-        param("env.JAVA_HOME", "%${testCoverage.os}.java8.oracle.64bit%")
+        param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.oracle.64bit%")
         if (testCoverage.os == OS.linux) {
             param("env.ANDROID_HOME", "/opt/android/sdk")
         }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -41,7 +41,7 @@ data class CIBuildModel (
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.linux, JvmVersion.java7),
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java7),
                             TestCoverage(TestType.platform, OS.linux, JvmVersion.java10),
-                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java7, JvmVendor.ibm))),
+                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java7, JvmVersion.java8, JvmVendor.ibm))),
             Stage("Release Accept", "Once a day: Rerun tests in more environments",
                     trigger = Trigger.daily,
                     functionalTests = listOf(
@@ -62,13 +62,14 @@ data class CIBuildModel (
             Stage("Experimental", "On demand: Run experimental tests",
                     trigger = Trigger.never,
                     runsIndependent = true,
-                    functionalTests = listOf(TestCoverage(TestType.platform, OS.linux, JvmVersion.java11))))
+                    functionalTests = listOf(TestCoverage(TestType.platform, OS.linux, JvmVersion.java8, JvmVersion.java9))))
     ) {
 
     val subProjects = listOf(
             GradleSubproject("announce"),
             GradleSubproject("antlr"),
             GradleSubproject("baseServices"),
+            GradleSubproject("baseServicesJava9"),
             GradleSubproject("baseServicesGroovy", functionalTests = false),
             GradleSubproject("buildCache"),
             GradleSubproject("buildCacheHttp"),
@@ -183,9 +184,9 @@ data class Stage(val name: String, val description: String, val specificBuilds: 
     val id = name.replace(" ", "").replace("-", "")
 }
 
-data class TestCoverage(val testType: TestType, val os: OS, val version: JvmVersion, val vendor: JvmVendor = JvmVendor.oracle) {
+data class TestCoverage(val testType: TestType, val os: OS, val testJvmVersion: JvmVersion, val buildJvmVersion: JvmVersion = JvmVersion.java8, val vendor: JvmVendor = JvmVendor.oracle) {
     fun asId(model : CIBuildModel): String {
-        return "${model.projectPrefix}${testType.name.capitalize()}_${version.name.capitalize()}_${vendor.name.capitalize()}_${os.name.capitalize()}"
+        return "${model.projectPrefix}${testType.name.capitalize()}_${testJvmVersion.name.capitalize()}_${vendor.name.capitalize()}_${os.name.capitalize()}"
     }
 
     fun asConfigurationId(model : CIBuildModel, subproject: String = ""): String {
@@ -194,7 +195,7 @@ data class TestCoverage(val testType: TestType, val os: OS, val version: JvmVers
     }
 
     fun asName(): String {
-        return "Test Coverage - ${testType.name.capitalize()} ${version.name.capitalize()} ${vendor.name.capitalize()} ${os.name.capitalize()}"
+        return "Test Coverage - ${testType.name.capitalize()} ${testJvmVersion.name.capitalize()} ${vendor.name.capitalize()} ${os.name.capitalize()}"
     }
 }
 


### PR DESCRIPTION
Previously we always use Java 8 as the bootstrap JVM. To migrate to Java 9,
this PR adds a configuration of "build JVM version" with default version Java 8.
Experiemental pipeline is also set to Java 9 to verify migration work.

`mvn test` has been passed locally.