### PR TITLE
Stop using atomic types in non-thread-safe contexts

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.api.tasks.incremental.InputFileDetails;
+import org.gradle.internal.MutableBoolean;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 import org.gradle.util.GFileUtils;
 
@@ -46,7 +47,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Generates parsers from Antlr grammars.
@@ -191,7 +191,7 @@ public class AntlrTask extends SourceTask {
     public void execute(IncrementalTaskInputs inputs) {
         final Set<File> grammarFiles = new HashSet<File>();
         final Set<File> sourceFiles = getSource().getFiles();
-        final AtomicBoolean cleanRebuild = new AtomicBoolean();
+        final MutableBoolean cleanRebuild = new MutableBoolean();
         inputs.outOfDate(
             new Action<InputFileDetails>() {
                 public void execute(InputFileDetails details) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/MutableBoolean.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/MutableBoolean.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal;
 
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serializable;
 
@@ -24,7 +23,7 @@ import java.io.Serializable;
  * A non-thread-safe type to hold a mutable boolean value.
  */
 @NotThreadSafe
-public final class MutableBoolean implements Serializable, Comparable<MutableBoolean> {
+public final class MutableBoolean implements Serializable {
     private boolean value;
 
     public MutableBoolean() {
@@ -41,29 +40,6 @@ public final class MutableBoolean implements Serializable, Comparable<MutableBoo
 
     public boolean get() {
         return value;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        MutableBoolean that = (MutableBoolean) o;
-        return value == that.value;
-    }
-
-    @Override
-    public int hashCode() {
-        return value ? 1 : 0;
-    }
-
-    @Override
-    public int compareTo(@Nonnull MutableBoolean o) {
-        return (value == o.value) ? 0 : (value ? 1 : -1);
     }
 
     @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/MutableBoolean.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/MutableBoolean.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
+
+/**
+ * A non-thread-safe type to hold a mutable boolean value.
+ */
+@NotThreadSafe
+public final class MutableBoolean implements Serializable, Comparable<MutableBoolean> {
+    private boolean value;
+
+    public MutableBoolean() {
+        this(false);
+    }
+
+    public MutableBoolean(boolean initialValue) {
+        this.value = initialValue;
+    }
+
+    public void set(boolean value) {
+        this.value = value;
+    }
+
+    public boolean get() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MutableBoolean that = (MutableBoolean) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value ? 1 : 0;
+    }
+
+    @Override
+    public int compareTo(@Nonnull MutableBoolean o) {
+        return (value == o.value) ? 0 : (value ? 1 : -1);
+    }
+
+    @Override
+    public String toString() {
+        return Boolean.toString(value);
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/MutableReference.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/MutableReference.java
@@ -49,24 +49,6 @@ public final class MutableReference<T> implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        MutableReference<?> that = (MutableReference<?>) o;
-        return value != null ? value.equals(that.value) : that.value == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return value != null ? value.hashCode() : 0;
-    }
-
-    @Override
     public String toString() {
         return String.valueOf(value);
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/MutableReference.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/MutableReference.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Serializable;
+
+/**
+ * A non-thread-safe type to hold a reference to a single value.
+ */
+@NotThreadSafe
+public final class MutableReference<T> implements Serializable {
+    private T value;
+
+    public static <T> MutableReference<T> empty() {
+        return of(null);
+    }
+
+    public static <T> MutableReference<T> of(@Nullable T initialValue) {
+        return new MutableReference<T>(initialValue);
+    }
+
+    private MutableReference(@Nullable T initialValue) {
+        this.value = initialValue;
+    }
+
+    public void set(@Nullable T value) {
+        this.value = value;
+    }
+
+    @Nullable
+    public T get() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MutableReference<?> that = (MutableReference<?>) o;
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/package-info.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.gradle.internal;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -18,6 +18,7 @@ package org.gradle.internal.work;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Transformer;
+import org.gradle.internal.MutableReference;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
@@ -26,7 +27,6 @@ import org.gradle.internal.resources.ResourceLockState;
 
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -139,7 +139,7 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
          * Gets the next ConditionalExecution object that is ready to be executed.
          */
         private ConditionalExecution getReadyExecution() {
-            final AtomicReference<ConditionalExecution> execution = new AtomicReference<ConditionalExecution>();
+            final MutableReference<ConditionalExecution> execution = MutableReference.empty();
             coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
                 @Override
                 public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -23,6 +23,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
 import org.gradle.concurrent.ParallelismConfiguration;
+import org.gradle.internal.MutableBoolean;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
@@ -40,9 +41,10 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.*;
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.lock;
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.tryLock;
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock;
 import static org.gradle.internal.resources.ResourceLockState.Disposition.FINISHED;
 
 public class DefaultWorkerLeaseService implements WorkerLeaseService, ParallelismConfigurationListener {
@@ -211,7 +213,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     }
 
     private boolean allLockedByCurrentThread(final Iterable<? extends ResourceLock> locks) {
-        final AtomicBoolean allLocked = new AtomicBoolean();
+        final MutableBoolean allLocked = new MutableBoolean();
         coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
             @Override
             public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableBooleanTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableBooleanTest.groovy
@@ -40,34 +40,4 @@ class MutableBooleanTest extends Specification {
         then:
         !value.get()
     }
-
-    def "equals works"() {
-        expect:
-        new MutableBoolean(true) == new MutableBoolean(true)
-        new MutableBoolean(false) == new MutableBoolean(false)
-        new MutableBoolean(true) != new MutableBoolean(false)
-        new MutableBoolean(false) != new MutableBoolean(true)
-    }
-
-    def "compare works"() {
-        expect:
-        new MutableBoolean(true) <=> new MutableBoolean(true) == 0
-        new MutableBoolean(false) <=> new MutableBoolean(false) == 0
-        new MutableBoolean(true) <=> new MutableBoolean(false) == 1
-        new MutableBoolean(false) <=> new MutableBoolean(true) == -1
-    }
-
-    def "hash code works"() {
-        def values = [
-            new MutableBoolean(true),
-            new MutableBoolean(true),
-            new MutableBoolean(false),
-            new MutableBoolean(false),
-        ] as Set
-        expect:
-        values == [
-            new MutableBoolean(true),
-            new MutableBoolean(false),
-        ] as Set
-    }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableBooleanTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableBooleanTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal
+
+import spock.lang.Specification
+
+class MutableBooleanTest extends Specification {
+
+    def "can create values"() {
+        expect:
+        new MutableBoolean(true).get()
+        !new MutableBoolean().get()
+        !new MutableBoolean(false).get()
+    }
+
+    def "can mutate values"() {
+        def value = new MutableBoolean()
+
+        when:
+        value.set(true)
+        then:
+        value.get()
+
+        when:
+        value.set(false)
+        then:
+        !value.get()
+    }
+
+    def "equals works"() {
+        expect:
+        new MutableBoolean(true) == new MutableBoolean(true)
+        new MutableBoolean(false) == new MutableBoolean(false)
+        new MutableBoolean(true) != new MutableBoolean(false)
+        new MutableBoolean(false) != new MutableBoolean(true)
+    }
+
+    def "compare works"() {
+        expect:
+        new MutableBoolean(true) <=> new MutableBoolean(true) == 0
+        new MutableBoolean(false) <=> new MutableBoolean(false) == 0
+        new MutableBoolean(true) <=> new MutableBoolean(false) == 1
+        new MutableBoolean(false) <=> new MutableBoolean(true) == -1
+    }
+
+    def "hash code works"() {
+        def values = [
+            new MutableBoolean(true),
+            new MutableBoolean(true),
+            new MutableBoolean(false),
+            new MutableBoolean(false),
+        ] as Set
+        expect:
+        values == [
+            new MutableBoolean(true),
+            new MutableBoolean(false),
+        ] as Set
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableReferenceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableReferenceTest.groovy
@@ -42,36 +42,4 @@ class MutableReferenceTest extends Specification {
         then:
         ref.get() == null
     }
-
-    def "equals works"() {
-        def ref1 = MutableReference.of(new String("A"))
-        def ref2 = MutableReference.of(new String("B"))
-        def emptyRef = MutableReference.empty()
-
-        expect:
-        ref1 == ref1
-        ref2 == ref2
-        emptyRef == emptyRef
-        ref1 != ref2
-        emptyRef != ref1
-        ref1 != emptyRef
-    }
-
-    def "hash code works"() {
-        def values = [
-            MutableReference.of(new String("A")),
-            MutableReference.of(new String("A")),
-            MutableReference.of(new String("B")),
-            MutableReference.of(new String("B")),
-            MutableReference.empty(),
-            MutableReference.empty(),
-        ] as Set
-
-        expect:
-        values == [
-            MutableReference.of(new String("A")),
-            MutableReference.of(new String("B")),
-            MutableReference.empty(),
-        ] as Set
-    }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableReferenceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableReferenceTest.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal
+
+import spock.lang.Specification
+
+class MutableReferenceTest extends Specification {
+
+    def "initial value is kept"() {
+        def object = "object"
+        expect:
+        MutableReference.empty().get() == null
+        MutableReference.of(null).get() == null
+        MutableReference.of(object).get() is object
+    }
+
+    def "can mutate value"() {
+        def object = "object"
+        def ref = MutableReference.empty()
+
+        when:
+        ref.set(object)
+        then:
+        ref.get() is object
+
+        when:
+        ref.set(null)
+        then:
+        ref.get() == null
+    }
+
+    def "equals works"() {
+        def ref1 = MutableReference.of(new String("A"))
+        def ref2 = MutableReference.of(new String("B"))
+        def emptyRef = MutableReference.empty()
+
+        expect:
+        ref1 == ref1
+        ref2 == ref2
+        emptyRef == emptyRef
+        ref1 != ref2
+        emptyRef != ref1
+        ref1 != emptyRef
+    }
+
+    def "hash code works"() {
+        def values = [
+            MutableReference.of(new String("A")),
+            MutableReference.of(new String("A")),
+            MutableReference.of(new String("B")),
+            MutableReference.of(new String("B")),
+            MutableReference.empty(),
+            MutableReference.empty(),
+        ] as Set
+
+        expect:
+        values == [
+            MutableReference.of(new String("A")),
+            MutableReference.of(new String("B")),
+            MutableReference.empty(),
+        ] as Set
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.work
 
 import org.gradle.api.Transformer
+import org.gradle.internal.MutableBoolean
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -25,11 +26,11 @@ import org.gradle.internal.resources.ResourceLockState
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
-import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.*
-
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.lock
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.tryLock
+import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock
 
 class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
     def coordinationService = new DefaultResourceLockCoordinationService();
@@ -293,7 +294,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
     }
 
     boolean lockIsHeld(final ResourceLock resourceLock) {
-        AtomicBoolean held = new AtomicBoolean()
+        MutableBoolean held = new MutableBoolean()
         coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
             @Override
             ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -30,13 +30,13 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
+import org.gradle.internal.MutableBoolean;
 
 import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.gradle.util.ConfigureUtil.configure;
 
@@ -64,7 +64,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     @Override
     public boolean isEmpty() {
-        final AtomicBoolean found = new AtomicBoolean();
+        final MutableBoolean found = new MutableBoolean();
         visit(new EmptyFileVisitor() {
             public void visitFile(FileVisitDetails fileDetails) {
                 found.set(true);
@@ -109,7 +109,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
      * Visits all the files of this tree.
      */
     protected boolean visitAll() {
-        final AtomicBoolean hasContent = new AtomicBoolean();
+        final MutableBoolean hasContent = new MutableBoolean();
         visit(new FileVisitor() {
             public void visitDir(FileVisitDetails dirDetails) {
                 dirDetails.getFile();

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskPlanExecutor.java
@@ -23,6 +23,8 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.BuildCancellationToken;
+import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.MutableReference;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -35,9 +37,7 @@ import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.Collection;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock;
 import static org.gradle.internal.resources.ResourceLockState.Disposition.FINISHED;
@@ -156,8 +156,8 @@ public class DefaultTaskPlanExecutor implements TaskPlanExecutor {
          * @return true if there are more work waiting to execute, false if all work has been executed.
          */
         private boolean executeWithWork(final WorkerLease workerLease, final Action<WorkInfo> workExecutor) {
-            final AtomicReference<WorkInfo> selected = new AtomicReference<WorkInfo>();
-            final AtomicBoolean workRemaining = new AtomicBoolean();
+            final MutableReference<WorkInfo> selected = MutableReference.empty();
+            final MutableBoolean workRemaining = new MutableBoolean();
             coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
                 @Override
                 public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/collections/MapFileTreeTest.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file.collections;
 import org.gradle.api.Action;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.file.TestFiles;
+import org.gradle.internal.MutableReference;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.testfixtures.internal.NativeServicesTestFixture;
@@ -30,7 +31,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.api.file.FileVisitorUtil.assertCanStopVisiting;
 import static org.gradle.api.file.FileVisitorUtil.assertVisits;
@@ -38,7 +38,9 @@ import static org.gradle.api.internal.file.TestFiles.directoryFileTreeFactory;
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTypes;
 import static org.gradle.util.WrapUtil.toList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MapFileTreeTest {
     @Rule
@@ -131,7 +133,7 @@ public class MapFileTreeTest {
 
     @Test
     public void overwritesFileWhenGeneratedContentChanges() {
-        final AtomicReference<String> currentContentReference = new AtomicReference<String>("content");
+        final MutableReference<String> currentContentReference = MutableReference.of("content");
 
         tree.add("path/file.txt", new Action<OutputStream>() {
             @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
@@ -32,11 +32,10 @@ import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Actions
+import org.gradle.internal.MutableBoolean
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
-
-import java.util.concurrent.atomic.AtomicBoolean
 
 import static org.junit.Assert.assertFalse
 
@@ -206,8 +205,8 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
     }
 
     def onlyIfPredicateIsTrueWhenTaskIsEnabledAndAllPredicatesAreTrue() {
-        final AtomicBoolean condition1 = new AtomicBoolean(true)
-        final AtomicBoolean condition2 = new AtomicBoolean(true)
+        final MutableBoolean condition1 = new MutableBoolean(true)
+        final MutableBoolean condition2 = new MutableBoolean(true)
 
         AbstractTask task = getTask()
         task.onlyIf {
@@ -248,7 +247,7 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
     }
 
     def canReplaceOnlyIfSpec() {
-        final AtomicBoolean condition1 = new AtomicBoolean(true)
+        final MutableBoolean condition1 = new MutableBoolean(true)
         AbstractTask task = getTask()
         task.onlyIf(Mock(Spec))
         task.setOnlyIf {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -27,11 +27,10 @@ import org.gradle.api.internal.project.taskfactory.ITaskFactory
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Actions
+import org.gradle.internal.MutableBoolean
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
-
-import java.util.concurrent.atomic.AtomicBoolean
 
 import static org.junit.Assert.assertTrue
 
@@ -179,8 +178,8 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
 
     def "onlyIf predicate is true when task is enabled and all predicates are true"() {
         given:
-        final AtomicBoolean condition1 = new AtomicBoolean(true)
-        final AtomicBoolean condition2 = new AtomicBoolean(true)
+        final MutableBoolean condition1 = new MutableBoolean(true)
+        final MutableBoolean condition2 = new MutableBoolean(true)
 
         def task = getTask()
         task.onlyIf(new Spec<Task>() {
@@ -227,7 +226,7 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
 
     def "can replace onlyIf spec"() {
         given:
-        final AtomicBoolean condition1 = new AtomicBoolean(true)
+        final MutableBoolean condition1 = new MutableBoolean(true)
         final task = getTask()
         final Spec spec = Mock(Spec.class)
         task.onlyIf(spec)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/RuleSourceBackedRuleActionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/RuleSourceBackedRuleActionTest.groovy
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.rules
 
+import org.gradle.internal.MutableReference
 import org.gradle.model.Mutate
 import org.gradle.model.internal.type.ModelType
 import spock.lang.Specification
-
-import java.util.concurrent.atomic.AtomicReference
 
 import static org.gradle.model.ModelTypeTesting.fullyQualifiedNameOf
 
@@ -69,10 +68,10 @@ class RuleSourceBackedRuleActionTest extends Specification {
         action = RuleSourceBackedRuleAction.create(listType, new RuleSourceWithTypedParams())
 
         then:
-        action.inputTypes == [AtomicReference, Map, Set]
+        action.inputTypes == [MutableReference, Map, Set]
 
         when:
-        action.execute(collector, [new AtomicReference<String>("foo"), [2: "bar"], [4, 5] as Set])
+        action.execute(collector, [MutableReference.of("foo"), [2: "bar"], [4, 5] as Set])
 
         then:
         collector == ["foo", "2", "bar", "4", "5"]
@@ -80,7 +79,7 @@ class RuleSourceBackedRuleActionTest extends Specification {
 
     static class RuleSourceWithTypedParams {
         @Mutate
-        void theRule(List<String> subject, AtomicReference<String> input1, Map<Integer, String> input2, Set<Number> input3) {
+        void theRule(List<String> subject, MutableReference<String> input1, Map<Integer, String> input2, Set<Number> input3) {
             subject.add(input1.get())
             subject.addAll(input2.keySet().collect({ it.toString() }))
             subject.addAll(input2.values())

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/typeregistration/BaseInstanceFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/typeregistration/BaseInstanceFactory.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.internal.Cast;
+import org.gradle.internal.MutableReference;
 import org.gradle.internal.reflect.Types.TypeVisitor;
 import org.gradle.model.Managed;
 import org.gradle.model.internal.core.MutableModelNode;
@@ -33,7 +34,6 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.gradle.internal.reflect.Types.walkTypeHierarchy;
 
@@ -91,14 +91,15 @@ public class BaseInstanceFactory<PUBLIC> implements InstanceFactory<PUBLIC> {
         if (!isManaged(publicType)) {
             throw new IllegalArgumentException(String.format("Type '%s' is not managed", publicType));
         }
-        final AtomicReference<ImplementationInfoImpl<S>> implementationInfo = new AtomicReference<ImplementationInfoImpl<S>>();
+        final MutableReference<ImplementationInfoImpl<S>> implementationInfo = MutableReference.empty();
         walkTypeHierarchy(publicType.getConcreteClass(), new RegistrationHierarchyVisitor<S>() {
             @Override
             protected void visitRegistration(TypeRegistration<? extends PUBLIC> registration) {
                 if (registration == null || registration.implementationRegistration == null) {
                     return;
                 }
-                if (implementationInfo.get() == null || implementationInfo.get().implementationRegistration.implementationType.isAssignableFrom(registration.implementationRegistration.implementationType)) {
+                ImplementationInfoImpl<S> currentImplementationInfo = implementationInfo.get();
+                if (currentImplementationInfo == null || currentImplementationInfo.implementationRegistration.implementationType.isAssignableFrom(registration.implementationRegistration.implementationType)) {
                     implementationInfo.set(new ImplementationInfoImpl<S>(publicType, registration.implementationRegistration, getInternalViews(publicType)));
                 }
             }

--- a/subprojects/model-groovy/src/main/java/org/gradle/model/dsl/internal/NonTransformedModelDslBacking.java
+++ b/subprojects/model-groovy/src/main/java/org/gradle/model/dsl/internal/NonTransformedModelDslBacking.java
@@ -25,6 +25,7 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.ClosureBackedAction;
 import org.gradle.internal.Actions;
+import org.gradle.internal.MutableBoolean;
 import org.gradle.model.internal.core.ModelActionRole;
 import org.gradle.model.internal.core.ModelPath;
 import org.gradle.model.internal.core.ModelReference;
@@ -37,8 +38,6 @@ import org.gradle.model.internal.core.rule.describe.SimpleModelRuleDescriptor;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.model.internal.type.ModelType;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static org.gradle.model.internal.core.DefaultNodeInitializerRegistry.DEFAULT_REFERENCE;
 import static org.gradle.model.internal.core.NodeInitializerContext.forType;
 
@@ -50,13 +49,13 @@ public class NonTransformedModelDslBacking extends GroovyObjectSupport {
 
     private final ModelPath modelPath;
     private final ModelRegistry modelRegistry;
-    private AtomicBoolean executingDsl;
+    private final MutableBoolean executingDsl;
 
     public NonTransformedModelDslBacking(ModelRegistry modelRegistry) {
-        this(new AtomicBoolean(), null, modelRegistry);
+        this(new MutableBoolean(), null, modelRegistry);
     }
 
-    private NonTransformedModelDslBacking(AtomicBoolean executingDsl, ModelPath modelPath, ModelRegistry modelRegistry) {
+    private NonTransformedModelDslBacking(MutableBoolean executingDsl, ModelPath modelPath, ModelRegistry modelRegistry) {
         this.executingDsl = executingDsl;
         this.modelPath = modelPath;
         this.modelRegistry = modelRegistry;

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandlerTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandlerTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.cache.internal.locklistener
 
+import org.gradle.internal.MutableBoolean
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.remote.internal.inet.InetAddressFactory
 import org.gradle.util.ConcurrentSpecification
-
-import java.util.concurrent.atomic.AtomicBoolean
 
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 
@@ -36,8 +35,8 @@ class DefaultFileLockContentionHandlerTest extends ConcurrentSpecification {
     }
 
     def "manages contention for multiple locks"() {
-        def action1 = new AtomicBoolean()
-        def action2 = new AtomicBoolean()
+        def action1 = new MutableBoolean()
+        def action2 = new MutableBoolean()
 
         when:
         int port = handler.reservePort()
@@ -114,7 +113,7 @@ class DefaultFileLockContentionHandlerTest extends ConcurrentSpecification {
     }
 
     private void canHandleMoreRequests() {
-        def executed = new AtomicBoolean()
+        def executed = new MutableBoolean()
         int port = handler.reservePort();
         handler.start(15, { executed.set(true) } as Runnable)
         client.maybePingOwner(port, 15, "lock", 50000)


### PR DESCRIPTION
Fixes #5812 

- Replace `AtomicReference` with `MutableReference`
- Replace `AtomicBoolean` with `MutableBoolean`

Doing so makes it clear that there is no concurrency involved when reading the code, and the new `Mutable*` types are cheaper to execute.