### PR TITLE
Minor doc tweak

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
@@ -61,7 +61,7 @@ public interface TaskOutputs extends CompatibilityAdapterForTaskOutputs {
      * or if any of the predicates passed to {@link #doNotCacheIf(String, Spec)} returns {@code true}. If {@code cacheIf()} is not specified,
      * the task will not be cached unless the {@literal @}{@link CacheableTask} annotation is present on the task type.</p>
      *
-     * <p>Consider using {@link #cacheIf(String, Spec)} instead for also providing a reason for disabling caching.</p>
+     * <p>Consider using {@link #cacheIf(String, Spec)} instead for also providing a reason for enabling caching.</p>
      *
      * @param spec specifies if the results of the task should be cached.
      *


### PR DESCRIPTION
 - Alternatively, could be replaced with `<p>Consider using {@link #doNotCacheIf(String, Spec)} instead for also providing a reason for disabling caching.</p>`

Signed-off-by: Kyle Moore <github@kylemoore.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
~- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
~- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
~- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`~

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
