### PR TITLE
Rename CacheLockingManager to ArtifactCacheLockingManager

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingManagerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingManagerIntegrationTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.test.fixtures.maven.MavenModule
 
 import static java.util.concurrent.TimeUnit.DAYS
 
-class DefaultCacheLockingManagerIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture {
+class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture {
     private final static long MAX_CACHE_AGE_IN_DAYS = LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_EXTERNAL_CACHE_ENTRIES
 
     def snapshotModule = mavenHttpRepo.module('org.example', 'example', '1.0-SNAPSHOT').publish().allowAll()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -24,8 +24,8 @@ import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.component.DefaultComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailureRepositoryBlacklister;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.RepositoryBlacklister;
@@ -188,17 +188,17 @@ class DependencyManagementBuildScopeServices {
         return new AttributeContainerSerializer(attributesFactory, NamedObjectInstantiator.INSTANCE);
     }
 
-    ModuleRepositoryCacheProvider createModuleRepositoryCacheProvider(BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+    ModuleRepositoryCacheProvider createModuleRepositoryCacheProvider(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                                       ArtifactCacheMetadata artifactCacheMetadata, AttributeContainerSerializer attributeContainerSerializer, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, SimpleMapInterner stringInterner,
                                                                       ArtifactIdentifierFileStore artifactIdentifierFileStore) {
         ModuleRepositoryCaches caches = new ModuleRepositoryCaches(
             new DefaultModuleVersionsCache(
                 timeProvider,
-                cacheLockingManager,
+                artifactCacheLockingManager,
                 moduleIdentifierFactory),
             new DefaultModuleMetadataCache(
                 timeProvider,
-                cacheLockingManager,
+                artifactCacheLockingManager,
                 artifactCacheMetadata,
                 moduleIdentifierFactory,
                 attributeContainerSerializer,
@@ -207,12 +207,12 @@ class DependencyManagementBuildScopeServices {
                 stringInterner),
             new DefaultModuleArtifactsCache(
                 timeProvider,
-                cacheLockingManager
+                artifactCacheLockingManager
             ),
             new DefaultModuleArtifactCache(
                 "module-artifact",
                 timeProvider,
-                cacheLockingManager,
+                artifactCacheLockingManager,
                 artifactIdentifierFileStore.getFileAccessTracker()
             )
         );
@@ -225,11 +225,11 @@ class DependencyManagementBuildScopeServices {
         return new ModuleRepositoryCacheProvider(caches, inMemoryCaches);
     }
 
-    ByUrlCachedExternalResourceIndex createArtifactUrlCachedResolutionIndex(BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, ExternalResourceFileStore externalResourceFileStore) {
+    ByUrlCachedExternalResourceIndex createArtifactUrlCachedResolutionIndex(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ExternalResourceFileStore externalResourceFileStore) {
         return new ByUrlCachedExternalResourceIndex(
             "resource-at-url",
             timeProvider,
-            cacheLockingManager,
+            artifactCacheLockingManager,
             externalResourceFileStore.getFileAccessTracker()
         );
     }
@@ -270,7 +270,7 @@ class DependencyManagementBuildScopeServices {
                                                                 TemporaryFileProvider temporaryFileProvider,
                                                                 ByUrlCachedExternalResourceIndex externalResourceIndex,
                                                                 BuildCommencedTimeProvider buildCommencedTimeProvider,
-                                                                CacheLockingManager cacheLockingManager,
+                                                                ArtifactCacheLockingManager artifactCacheLockingManager,
                                                                 List<ResourceConnectorFactory> resourceConnectorFactories,
                                                                 BuildOperationExecutor buildOperationExecutor,
                                                                 ProducerGuard<ExternalResourceName> producerGuard,
@@ -282,7 +282,7 @@ class DependencyManagementBuildScopeServices {
             temporaryFileProvider,
             externalResourceIndex,
             buildCommencedTimeProvider,
-            cacheLockingManager,
+            artifactCacheLockingManager,
             buildOperationExecutor,
             startParameterResolutionOverride,
             producerGuard,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -16,9 +16,9 @@
 
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
-import org.gradle.api.internal.artifacts.ivyservice.DefaultCacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformInfoFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformedFileCache;
 import org.gradle.api.internal.artifacts.transform.TransformInfoDependencyResolver;
@@ -61,8 +61,8 @@ public class DependencyServices extends AbstractPluginServiceRegistry {
     }
 
     private static class DependencyManagementBuildSessionServices {
-        CacheLockingManager createCacheLockingManager(CacheRepository cacheRepository, ArtifactCacheMetadata artifactCacheMetadata, FileAccessTimeJournal fileAccessTimeJournal, CleanupActionFactory cleanupActionFactory) {
-            return new DefaultCacheLockingManager(cacheRepository, artifactCacheMetadata, fileAccessTimeJournal, cleanupActionFactory);
+        ArtifactCacheLockingManager createArtifactCacheLockingManager(CacheRepository cacheRepository, ArtifactCacheMetadata artifactCacheMetadata, FileAccessTimeJournal fileAccessTimeJournal, CleanupActionFactory cleanupActionFactory) {
+            return new DefaultArtifactCacheLockingManager(cacheRepository, artifactCacheMetadata, fileAccessTimeJournal, cleanupActionFactory);
         }
 
         TransformedFileCache createTransformedFileCache(ArtifactCacheMetadata artifactCacheMetadata, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory cacheDecoratorFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheLockingManager.java
@@ -24,7 +24,7 @@ import org.gradle.internal.serialize.Serializer;
  * Provides synchronized access to the artifact cache.
  */
 @ThreadSafe
-public interface CacheLockingManager extends CacheAccess {
+public interface ArtifactCacheLockingManager extends CacheAccess {
     /**
      * Creates a cache implementation that is managed by this locking manager. This method may be used at any time.
      *

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManager.java
@@ -39,10 +39,10 @@ import java.io.Closeable;
 import static org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_EXTERNAL_CACHE_ENTRIES;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
-public class DefaultCacheLockingManager implements CacheLockingManager, Closeable {
+public class DefaultArtifactCacheLockingManager implements ArtifactCacheLockingManager, Closeable {
     private final PersistentCache cache;
 
-    public DefaultCacheLockingManager(CacheRepository cacheRepository, ArtifactCacheMetadata cacheMetaData, FileAccessTimeJournal fileAccessTimeJournal, CleanupActionFactory cleanupActionFactory) {
+    public DefaultArtifactCacheLockingManager(CacheRepository cacheRepository, ArtifactCacheMetadata cacheMetaData, FileAccessTimeJournal fileAccessTimeJournal, CleanupActionFactory cleanupActionFactory) {
         cache = cacheRepository
                 .cache(cacheMetaData.getCacheDir())
                 .withCrossVersionCache(CacheBuilder.LockTarget.CacheDirectory)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCache.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.metadata.ComponentArtifactIdentifierSerializer;
 import org.gradle.api.internal.artifacts.metadata.ModuleComponentFileArtifactIdentifierSerializer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
@@ -43,8 +43,8 @@ public class DefaultModuleArtifactCache extends AbstractCachedIndex<ArtifactAtRe
     private final BuildCommencedTimeProvider timeProvider;
     private final Map<ArtifactAtRepositoryKey, CachedArtifact> inMemoryCache = Maps.newConcurrentMap();
 
-    public DefaultModuleArtifactCache(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, FileAccessTracker fileAccessTracker) {
-        super(persistentCacheFile, KEY_SERIALIZER, VALUE_SERIALIZER, cacheLockingManager, fileAccessTracker);
+    public DefaultModuleArtifactCache(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker) {
+        super(persistentCacheFile, KEY_SERIALIZER, VALUE_SERIALIZER, artifactCacheLockingManager, fileAccessTracker);
         this.timeProvider = timeProvider;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactsCache.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
 import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer;
 import org.gradle.api.internal.artifacts.metadata.ComponentArtifactMetadataSerializer;
 import org.gradle.cache.PersistentIndexedCache;
@@ -33,13 +33,13 @@ import java.math.BigInteger;
 import java.util.Set;
 
 public class DefaultModuleArtifactsCache extends InMemoryModuleArtifactsCache {
-    private final CacheLockingManager cacheLockingManager;
+    private final ArtifactCacheLockingManager artifactCacheLockingManager;
 
     private PersistentIndexedCache<ArtifactsAtRepositoryKey, ModuleArtifactsCacheEntry> cache;
 
-    public DefaultModuleArtifactsCache(BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager) {
+    public DefaultModuleArtifactsCache(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager) {
         super(timeProvider);
-        this.cacheLockingManager = cacheLockingManager;
+        this.artifactCacheLockingManager = artifactCacheLockingManager;
     }
 
     private PersistentIndexedCache<ArtifactsAtRepositoryKey, ModuleArtifactsCacheEntry> getCache() {
@@ -50,7 +50,7 @@ public class DefaultModuleArtifactsCache extends InMemoryModuleArtifactsCache {
     }
 
     private PersistentIndexedCache<ArtifactsAtRepositoryKey, ModuleArtifactsCacheEntry> initCache() {
-        return cacheLockingManager.createCache("module-artifacts", new ModuleArtifactsKeySerializer(), new ModuleArtifactsCacheEntrySerializer());
+        return artifactCacheLockingManager.createCache("module-artifacts", new ModuleArtifactsKeySerializer(), new ModuleArtifactsCacheEntrySerializer());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/DefaultModuleVersionsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/DefaultModuleVersionsCache.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions;
 
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
@@ -28,14 +28,14 @@ import java.util.Set;
 
 public class DefaultModuleVersionsCache extends InMemoryModuleVersionsCache {
 
-    private final CacheLockingManager cacheLockingManager;
+    private final ArtifactCacheLockingManager artifactCacheLockingManager;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
     private PersistentIndexedCache<ModuleAtRepositoryKey, ModuleVersionsCacheEntry> cache;
 
-    public DefaultModuleVersionsCache(BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+    public DefaultModuleVersionsCache(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
         super(timeProvider);
-        this.cacheLockingManager = cacheLockingManager;
+        this.artifactCacheLockingManager = artifactCacheLockingManager;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
     }
 
@@ -47,7 +47,7 @@ public class DefaultModuleVersionsCache extends InMemoryModuleVersionsCache {
     }
 
     private PersistentIndexedCache<ModuleAtRepositoryKey, ModuleVersionsCacheEntry> initCache() {
-        return cacheLockingManager.createCache("module-versions", new ModuleKeySerializer(moduleIdentifierFactory), new ModuleVersionsCacheEntrySerializer());
+        return artifactCacheLockingManager.createCache("module-versions", new ModuleKeySerializer(moduleIdentifierFactory), new ModuleVersionsCacheEntrySerializer());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.credentials.Credentials;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultExternalResourceCachePolicy;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
@@ -51,7 +51,7 @@ public class RepositoryTransportFactory {
     private final CachedExternalResourceIndex<String> cachedExternalResourceIndex;
     private final ProgressLoggerFactory progressLoggerFactory;
     private final BuildCommencedTimeProvider timeProvider;
-    private final CacheLockingManager cacheLockingManager;
+    private final ArtifactCacheLockingManager artifactCacheLockingManager;
     private final BuildOperationExecutor buildOperationExecutor;
     private final StartParameterResolutionOverride startParameterResolutionOverride;
     private final ProducerGuard<ExternalResourceName> producerGuard;
@@ -62,7 +62,7 @@ public class RepositoryTransportFactory {
                                       TemporaryFileProvider temporaryFileProvider,
                                       CachedExternalResourceIndex<String> cachedExternalResourceIndex,
                                       BuildCommencedTimeProvider timeProvider,
-                                      CacheLockingManager cacheLockingManager,
+                                      ArtifactCacheLockingManager artifactCacheLockingManager,
                                       BuildOperationExecutor buildOperationExecutor,
                                       StartParameterResolutionOverride startParameterResolutionOverride,
                                       ProducerGuard<ExternalResourceName> producerGuard,
@@ -71,7 +71,7 @@ public class RepositoryTransportFactory {
         this.temporaryFileProvider = temporaryFileProvider;
         this.cachedExternalResourceIndex = cachedExternalResourceIndex;
         this.timeProvider = timeProvider;
-        this.cacheLockingManager = cacheLockingManager;
+        this.artifactCacheLockingManager = artifactCacheLockingManager;
         this.buildOperationExecutor = buildOperationExecutor;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
         this.producerGuard = producerGuard;
@@ -111,7 +111,7 @@ public class RepositoryTransportFactory {
         // 1) we don't cache their files
         // 2) we don't do progress logging for "downloading"
         if (schemes.equals(Collections.singleton("file"))) {
-            return new FileTransport(name, fileRepository, cachedExternalResourceIndex, temporaryFileProvider, timeProvider, cacheLockingManager, producerGuard);
+            return new FileTransport(name, fileRepository, cachedExternalResourceIndex, temporaryFileProvider, timeProvider, artifactCacheLockingManager, producerGuard);
         }
         ResourceConnectorSpecification connectionDetails = new DefaultResourceConnectorSpecification(authentications);
 
@@ -121,7 +121,7 @@ public class RepositoryTransportFactory {
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
         cachePolicy = startParameterResolutionOverride.overrideExternalResourceCachePolicy(cachePolicy);
 
-        return new ResourceConnectorRepositoryTransport(name, progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, cacheLockingManager, resourceConnector, buildOperationExecutor, cachePolicy, producerGuard, fileRepository);
+        return new ResourceConnectorRepositoryTransport(name, progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, artifactCacheLockingManager, resourceConnector, buildOperationExecutor, cachePolicy, producerGuard, fileRepository);
     }
 
     private void validateSchemes(Set<String> schemes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/AbstractCachedIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/AbstractCachedIndex.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.cached;
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.internal.Factory;
 import org.gradle.internal.resource.local.FileAccessTracker;
@@ -28,17 +28,17 @@ public abstract class AbstractCachedIndex<K, V extends CachedItem> {
     private final String persistentCacheName;
     private final Serializer<K> keySerializer;
     private final Serializer<V> valueSerializer;
-    private final CacheLockingManager cacheLockingManager;
+    private final ArtifactCacheLockingManager artifactCacheLockingManager;
     private final FileAccessTracker fileAccessTracker;
 
     private PersistentIndexedCache<K, V> persistentCache;
 
-    public AbstractCachedIndex(String persistentCacheName, Serializer<K> keySerializer, Serializer<V> valueSerializer, CacheLockingManager cacheLockingManager, FileAccessTracker fileAccessTracker) {
+    public AbstractCachedIndex(String persistentCacheName, Serializer<K> keySerializer, Serializer<V> valueSerializer, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker) {
 
         this.persistentCacheName = persistentCacheName;
         this.keySerializer = keySerializer;
         this.valueSerializer = valueSerializer;
-        this.cacheLockingManager = cacheLockingManager;
+        this.artifactCacheLockingManager = artifactCacheLockingManager;
         this.fileAccessTracker = fileAccessTracker;
     }
 
@@ -50,13 +50,13 @@ public abstract class AbstractCachedIndex<K, V extends CachedItem> {
     }
 
     private PersistentIndexedCache<K, V> initPersistentCache() {
-        return cacheLockingManager.createCache(persistentCacheName, keySerializer, valueSerializer);
+        return artifactCacheLockingManager.createCache(persistentCacheName, keySerializer, valueSerializer);
     }
 
     public V lookup(final K key) {
         assertKeyNotNull(key);
 
-        V result = cacheLockingManager.useCache(new Factory<V>() {
+        V result = artifactCacheLockingManager.useCache(new Factory<V>() {
             public V create() {
                 V found = getPersistentCache().get(key);
                 if (found == null) {
@@ -78,7 +78,7 @@ public abstract class AbstractCachedIndex<K, V extends CachedItem> {
     }
 
     protected void storeInternal(final K key, final V entry) {
-        cacheLockingManager.useCache(new Runnable() {
+        artifactCacheLockingManager.useCache(new Runnable() {
             public void run() {
                 getPersistentCache().put(key, entry);
             }
@@ -99,7 +99,7 @@ public abstract class AbstractCachedIndex<K, V extends CachedItem> {
 
     public void clear(final K key) {
         assertKeyNotNull(key);
-        cacheLockingManager.useCache(new Runnable() {
+        artifactCacheLockingManager.useCache(new Runnable() {
             public void run() {
                 getPersistentCache().remove(key);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ByUrlCachedExternalResourceIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ByUrlCachedExternalResourceIndex.java
@@ -16,13 +16,13 @@
 
 package org.gradle.internal.resource.cached;
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 public class ByUrlCachedExternalResourceIndex extends DefaultCachedExternalResourceIndex<String> {
-    public ByUrlCachedExternalResourceIndex(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, FileAccessTracker fileAccessTracker) {
-        super(persistentCacheFile, BaseSerializerFactory.STRING_SERIALIZER, timeProvider, cacheLockingManager, fileAccessTracker);
+    public ByUrlCachedExternalResourceIndex(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker) {
+        super(persistentCacheFile, BaseSerializerFactory.STRING_SERIALIZER, timeProvider, artifactCacheLockingManager, fileAccessTracker);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndex.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.cached;
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.internal.hash.HashValue;
 import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
@@ -34,8 +34,8 @@ public class DefaultCachedExternalResourceIndex<K extends Serializable> extends 
     private static final CachedExternalResourceSerializer CACHED_EXTERNAL_RESOURCE_SERIALIZER = new CachedExternalResourceSerializer();
     private final BuildCommencedTimeProvider timeProvider;
 
-    public DefaultCachedExternalResourceIndex(String persistentCacheFile, Serializer<K> keySerializer, BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, FileAccessTracker fileAccessTracker) {
-        super(persistentCacheFile, keySerializer, CACHED_EXTERNAL_RESOURCE_SERIALIZER, cacheLockingManager, fileAccessTracker);
+    public DefaultCachedExternalResourceIndex(String persistentCacheFile, Serializer<K> keySerializer, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker) {
+        super(persistentCacheFile, keySerializer, CACHED_EXTERNAL_RESOURCE_SERIALIZER, artifactCacheLockingManager, fileAccessTracker);
         this.timeProvider = timeProvider;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
@@ -20,7 +20,7 @@ import com.google.common.io.Files;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.cache.internal.ProducerGuard;
@@ -59,17 +59,17 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
     private final CachedExternalResourceIndex<String> cachedExternalResourceIndex;
     private final BuildCommencedTimeProvider timeProvider;
     private final TemporaryFileProvider temporaryFileProvider;
-    private final CacheLockingManager cacheLockingManager;
+    private final ArtifactCacheLockingManager artifactCacheLockingManager;
     private final ExternalResourceCachePolicy externalResourceCachePolicy;
     private final ProducerGuard<ExternalResourceName> producerGuard;
     private final FileResourceRepository fileResourceRepository;
 
-    public DefaultCacheAwareExternalResourceAccessor(ExternalResourceRepository delegate, CachedExternalResourceIndex<String> cachedExternalResourceIndex, BuildCommencedTimeProvider timeProvider, TemporaryFileProvider temporaryFileProvider, CacheLockingManager cacheLockingManager, ExternalResourceCachePolicy externalResourceCachePolicy, ProducerGuard<ExternalResourceName> producerGuard, FileResourceRepository fileResourceRepository) {
+    public DefaultCacheAwareExternalResourceAccessor(ExternalResourceRepository delegate, CachedExternalResourceIndex<String> cachedExternalResourceIndex, BuildCommencedTimeProvider timeProvider, TemporaryFileProvider temporaryFileProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ExternalResourceCachePolicy externalResourceCachePolicy, ProducerGuard<ExternalResourceName> producerGuard, FileResourceRepository fileResourceRepository) {
         this.delegate = delegate;
         this.cachedExternalResourceIndex = cachedExternalResourceIndex;
         this.timeProvider = timeProvider;
         this.temporaryFileProvider = temporaryFileProvider;
-        this.cacheLockingManager = cacheLockingManager;
+        this.artifactCacheLockingManager = artifactCacheLockingManager;
         this.externalResourceCachePolicy = externalResourceCachePolicy;
         this.producerGuard = producerGuard;
         this.fileResourceRepository = fileResourceRepository;
@@ -213,7 +213,7 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
     }
 
     private LocallyAvailableExternalResource moveIntoCache(final ExternalResourceName source, final File destination, final ResourceFileStore fileStore, final ExternalResourceMetaData metaData) {
-        return cacheLockingManager.useCache(new Factory<LocallyAvailableExternalResource>() {
+        return artifactCacheLockingManager.useCache(new Factory<LocallyAvailableExternalResource>() {
             public LocallyAvailableExternalResource create() {
                 LocallyAvailableResource cachedResource = fileStore.moveIntoCache(destination);
                 File fileInFileStore = cachedResource.getFile();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.transport;
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.cache.internal.ProducerGuard;
@@ -42,7 +42,7 @@ public class ResourceConnectorRepositoryTransport extends AbstractRepositoryTran
                                                 TemporaryFileProvider temporaryFileProvider,
                                                 CachedExternalResourceIndex<String> cachedExternalResourceIndex,
                                                 BuildCommencedTimeProvider timeProvider,
-                                                CacheLockingManager cacheLockingManager,
+                                                ArtifactCacheLockingManager artifactCacheLockingManager,
                                                 ExternalResourceConnector connector,
                                                 BuildOperationExecutor buildOperationExecutor,
                                                 ExternalResourceCachePolicy cachePolicy,
@@ -52,7 +52,7 @@ public class ResourceConnectorRepositoryTransport extends AbstractRepositoryTran
         ProgressLoggingExternalResourceUploader loggingUploader = new ProgressLoggingExternalResourceUploader(connector, progressLoggerFactory);
         ProgressLoggingExternalResourceAccessor loggingAccessor = new ProgressLoggingExternalResourceAccessor(connector, progressLoggerFactory);
         repository = new DefaultExternalResourceRepository(name, connector, connector, connector, loggingAccessor, loggingUploader, buildOperationExecutor);
-        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy, producerGuard, fileResourceRepository);
+        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, fileResourceRepository);
     }
 
     public ExternalResourceRepository getRepository() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.internal.resource.transport.file;
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager;
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultExternalResourceCachePolicy;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
@@ -38,11 +38,11 @@ public class FileTransport extends AbstractRepositoryTransport {
     private final FileResourceRepository repository;
     private final FileCacheAwareExternalResourceAccessor resourceAccessor;
 
-    public FileTransport(String name, FileResourceRepository repository, CachedExternalResourceIndex<String> cachedExternalResourceIndex, TemporaryFileProvider temporaryFileProvider, BuildCommencedTimeProvider timeProvider, CacheLockingManager cacheLockingManager, ProducerGuard<ExternalResourceName> producerGuard) {
+    public FileTransport(String name, FileResourceRepository repository, CachedExternalResourceIndex<String> cachedExternalResourceIndex, TemporaryFileProvider temporaryFileProvider, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ProducerGuard<ExternalResourceName> producerGuard) {
         super(name);
         this.repository = repository;
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
-        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy, producerGuard, repository));
+        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, repository));
     }
 
     public boolean isLocal() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.lang.Subject
 
-class DefaultCacheLockingManagerTest extends Specification {
+class DefaultArtifactCacheLockingManagerTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
     def cacheRepository = new DefaultCacheRepository(null, new InMemoryCacheFactory())
@@ -44,7 +44,7 @@ class DefaultCacheLockingManagerTest extends Specification {
     }
 
     @Subject @AutoCleanup
-    def cacheLockingManager = new DefaultCacheLockingManager(cacheRepository, artifactCacheMetadata, fileAccessTimeJournal, cleanupActionFactory)
+    def cacheLockingManager = new DefaultArtifactCacheLockingManager(cacheRepository, artifactCacheMetadata, fileAccessTimeJournal, cleanupActionFactory)
 
     def "cleans up resources"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManager
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager
 import org.gradle.cache.PersistentIndexedCache
 import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
@@ -31,7 +31,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
 
     @Rule TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider()
 
-    CacheLockingManager cacheLockingManager = Mock(CacheLockingManager)
+    ArtifactCacheLockingManager cacheLockingManager = Mock(ArtifactCacheLockingManager)
     BuildCommencedTimeProvider timeProvider = Mock(BuildCommencedTimeProvider)
     PersistentIndexedCache persistentIndexedCache = Mock(PersistentIndexedCache)
     CachedArtifact cachedArtifact = Stub(CachedArtifact)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/AbstractCachedIndexTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/AbstractCachedIndexTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.cached
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManagerStub
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManagerStub
 import org.gradle.internal.resource.local.FileAccessTracker
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
@@ -33,7 +33,7 @@ class AbstractCachedIndexTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
     static final CACHE_NAME = "my-cache"
-    def cacheLockingManager = new CacheLockingManagerStub()
+    def cacheLockingManager = new ArtifactCacheLockingManagerStub()
     def fileAccessTracker = Mock(FileAccessTracker)
     def valueSerializer = new Serializer<CachedItem>() {
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.cached
 
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManagerStub
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManagerStub
 import org.gradle.internal.hash.HashValue
 import org.gradle.internal.resource.local.FileAccessTracker
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData
@@ -36,7 +36,7 @@ class DefaultArtifactResolutionCacheTest extends Specification {
         getCurrentTime() >> 1234L
     }
 
-    def cacheLockingManager = new CacheLockingManagerStub()
+    def cacheLockingManager = new ArtifactCacheLockingManagerStub()
     def fileAccessTracker = Stub(FileAccessTracker)
 
     DefaultCachedExternalResourceIndex<String> index

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.resource.transfer
 
 import org.gradle.api.Transformer
-import org.gradle.api.internal.artifacts.ivyservice.CacheLockingManagerStub
+import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManagerStub
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultExternalResourceCachePolicy
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.cache.internal.ProducerGuard
@@ -51,7 +51,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
     final temporaryFileProvider = Stub(TemporaryFileProvider) {
         createTemporaryFile(_, _, _) >> tempFile
     }
-    final cacheLockingManager = new CacheLockingManagerStub()
+    final cacheLockingManager = new ArtifactCacheLockingManagerStub()
     final fileRepository = Mock(FileResourceRepository)
     final cachePolicy = new DefaultExternalResourceCachePolicy()
     final ProducerGuard<URI> producerGuard = Stub() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheLockingManagerStub.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheLockingManagerStub.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.Factory
 import org.gradle.internal.serialize.Serializer
 import org.gradle.testfixtures.internal.InMemoryIndexedCache
 
-class CacheLockingManagerStub implements CacheLockingManager {
+class ArtifactCacheLockingManagerStub implements ArtifactCacheLockingManager {
     private final Map<String, PersistentIndexedCache<?, ?>> caches = [:]
 
     PersistentIndexedCache<?, ?> getCache(String cacheName) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionRetryRuleTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionRetryRuleTest.groovy
@@ -29,7 +29,7 @@ class CrossVersionRetryRuleTest extends CrossVersionIntegrationSpec {
         iteration++
 
         when:
-        throwWhen(new ServiceCreationException("Could not create service of type CacheLockingManager using DependencyManagementBuildScopeServices.createCacheLockingManager().",
+        throwWhen(new ServiceCreationException("Could not create service of type ArtifactCacheLockingManager using DependencyManagementBuildScopeServices.createArtifactCacheLockingManager().",
             new UncheckedIOException("Unable to create directory 'metadata-2.1'")), iteration == 1)
 
         then:

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailureTest.groovy
@@ -348,19 +348,19 @@ Some text before
 FAILURE: broken
 
 * Exception is:
-org.gradle.internal.service.ServiceCreationException: Could not create service of type CacheLockingManager
+org.gradle.internal.service.ServiceCreationException: Could not create service of type ArtifactCacheLockingManager
     at org.gradle.internal.service.DefaultServiceRegistry.some(DefaultServiceRegistry.java:604)
 Caused by: java.io.IOException: Something in the middle
-    at org.gradle.api.internal.artifacts.ivyservice.DefaultCacheLockingManager.initMetaDataStoreDir(DefaultCacheLockingManager.java:59)
+    at org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCacheLockingManager.initMetaDataStoreDir(DefaultArtifactCacheLockingManager.java:59)
 Caused by: org.gradle.api.UncheckedIOException: Unable to create directory 'metadata-2.1'
-    at org.gradle.api.internal.artifacts.ivyservice.DefaultCacheLockingManager.initMetaDataStoreDir(DefaultCacheLockingManager.java:59)
+    at org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCacheLockingManager.initMetaDataStoreDir(DefaultArtifactCacheLockingManager.java:59)
 """
         when:
         def failure = OutputScrapingExecutionFailure.from(output, "")
 
         then:
         failure.exception.class.simpleName == 'ServiceCreationException'
-        failure.exception.message == 'Could not create service of type CacheLockingManager'
+        failure.exception.message == 'Could not create service of type ArtifactCacheLockingManager'
         failure.exception.cause.class.simpleName == 'IOException'
         failure.exception.cause.message == 'Something in the middle'
         failure.exception.cause.cause.class.simpleName == 'UncheckedIOException'


### PR DESCRIPTION
The name CacheLockingManager suggested it was used to manage locking of caches in general instead of just for the artifacts cache.

Resolves gradle/gradle-private#1338.