### PR TITLE
Do not compile a build script when the classpath for that script cannot be built and also some tooling API promotions

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -180,6 +180,36 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         executed ":pluginDependencyA:jar", ":jar"
     }
 
+    def "can develop a buildscript dependency that is used by multiple projects of main build"() {
+        given:
+        buildA.settingsFile << """
+            include 'a1'
+            include 'a2'
+        """
+        buildA.file("a1/build.gradle") << """
+            buildscript {
+                dependencies {
+                    classpath 'org.test:pluginDependencyA:1.0'
+                }
+            }
+        """
+        buildA.file("a2/build.gradle") << """
+            buildscript {
+                dependencies {
+                    classpath 'org.test:pluginDependencyA:1.0'
+                }
+            }
+        """
+
+        includeBuild pluginDependencyA
+
+        when:
+        execute(buildA, "help")
+
+        then:
+        executed ":pluginDependencyA:jar"
+    }
+
     def "can use an included build that provides both a buildscript dependency and a compile dependency"() {
         given:
         def buildB = multiProjectBuild("buildB", ['b1', 'b2']) {
@@ -307,7 +337,6 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         then:
         executed ":pluginBuild:jar"
         outputContains("taskFromPluginBuild")
-
 
         when:
         includeBuild pluginBuild

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskFailureIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskFailureIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.composite
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
+import spock.lang.Issue
 
 class CompositeBuildTaskFailureIntegrationTest extends AbstractCompositeBuildIntegrationTest {
     BuildTestFile buildB
@@ -32,11 +33,11 @@ class CompositeBuildTaskFailureIntegrationTest extends AbstractCompositeBuildInt
 """
         }
         includedBuilds << buildB
-        dependency("org.test:buildB:1.0")
     }
 
     def "does not run task when dependency in another build fails"() {
         given:
+        dependency("org.test:buildB:1.0")
         buildB.file("src/main/java/B.java") << """
             broken!
         """
@@ -64,8 +65,10 @@ class CompositeBuildTaskFailureIntegrationTest extends AbstractCompositeBuildInt
         failure.assertHasDescription("Execution failed for task ':buildB:compileJava'.")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/5714")
     def "build fails when finalizer task in included build that is not a dependency of any other task fails"() {
         given:
+        dependency("org.test:buildB:1.0")
         buildB.buildFile << """
             task broken {
                 doLast { throw new RuntimeException("broken") }
@@ -80,6 +83,27 @@ class CompositeBuildTaskFailureIntegrationTest extends AbstractCompositeBuildInt
         result.assertTaskExecuted(":buildB:broken")
         failure.assertHasFailures(1)
         failure.assertHasDescription("Execution failed for task ':buildB:broken'.")
+    }
+
+    def "does not compile build script when build script classpath cannot be built"() {
+        given:
+        buildB.file("src/main/java/B.java") << """
+            broken!
+        """
+        buildA.buildFile << """
+            buildscript {
+                dependencies { classpath "org.test:buildB:1.0" }
+            }
+            new B()
+        """
+
+        when:
+        fails(buildA, "help")
+
+        then:
+        failure.assertHasFailures(1)
+        failure.assertHasDescription("Execution failed for task ':buildB:compileJava'.")
+        failure.assertHasCause("Compilation failed; see the compiler error output for details.")
     }
 
     @Rule
@@ -98,6 +122,7 @@ class CompositeBuildTaskFailureIntegrationTest extends AbstractCompositeBuildInt
             }
             processResources.dependsOn(broken)
         """
+        dependency("org.test:buildB:1.0")
         buildB.buildFile << """
             task broken {
                 doLast { 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
@@ -54,7 +54,7 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
         }
 
         IncludedBuildState build = buildRegistry.getIncludedBuild(buildId);
-        final DefaultIncludedBuildController newBuildController = new DefaultIncludedBuildController(build);
+        DefaultIncludedBuildController newBuildController = new DefaultIncludedBuildController(build);
         buildControllers.put(buildId, newBuildController);
         executorService.submit(new BuildOpRunnable(newBuildController, rootBuildOperation));
         return newBuildController;
@@ -83,7 +83,7 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
     @Override
     public void awaitTaskCompletion(Collection<? super Throwable> taskFailures) {
         for (IncludedBuildController buildController : buildControllers.values()) {
-            buildController.stopTaskExecution(taskFailures);
+            buildController.awaitTaskCompletion(taskFailures);
         }
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -25,6 +25,7 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.util.Path;
 
+import java.util.Collection;
 import java.util.List;
 
 public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
@@ -47,13 +48,12 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
     }
 
     @Override
-    public void awaitCompletion(BuildIdentifier targetBuild, String taskPath) {
+    public void awaitTaskCompletion(Collection<? super Throwable> taskFailures) {
         // Start task execution if necessary: this is required for building plugin artifacts,
         // since these are built on-demand prior to the regular start signal for included builds.
         includedBuilds.populateTaskGraphs();
         includedBuilds.startTaskExecution();
-
-        getBuildController(targetBuild).awaitCompletion(taskPath);
+        includedBuilds.awaitTaskCompletion(taskFailures);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildController.java
@@ -20,16 +20,14 @@ import java.util.Collection;
 public interface IncludedBuildController {
     void queueForExecution(String taskPath);
 
-    void awaitCompletion(String taskPath);
-
     IncludedBuildTaskResource.State getTaskState(String taskPath);
+
+    boolean populateTaskGraph();
 
     void startTaskExecution();
 
     /**
      * Awaits completion of task execution, collecting any task failures into the given collection.
      */
-    void stopTaskExecution(Collection<? super Throwable> taskFailures);
-
-    boolean populateTaskGraph();
+    void awaitTaskCompletion(Collection<? super Throwable> taskFailures);
 }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildTaskGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildTaskGraph.java
@@ -18,10 +18,15 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 
+import java.util.Collection;
+
 public interface IncludedBuildTaskGraph {
     void addTask(BuildIdentifier requestingBuild, BuildIdentifier targetBuild, String taskPath);
 
-    void awaitCompletion(BuildIdentifier targetBuild, String taskPath);
+    /**
+     * Awaits completion of task execution, collecting any task failures into the given collection.
+     */
+    void awaitTaskCompletion(Collection<? super Throwable> taskFailures);
 
     IncludedBuildTaskResource.State getTaskState(BuildIdentifier targetBuild, String taskPath);
 }

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
@@ -126,8 +126,8 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
             Path identityPath = project.getIdentityPath();
             String displayName = "Configure project " + identityPath.toString();
 
-            String progressDisplayName = project.getPath();
-            if (progressDisplayName.equals(":")) {
+            String progressDisplayName = identityPath.toString();
+            if (identityPath.equals(Path.ROOT)) {
                 progressDisplayName = "root project";
             }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -66,6 +66,10 @@ The following are the features that have been promoted in this Gradle release.
 
 The dependency insight report is now considered stable.
 
+### Tooling API types and methods
+
+Many types and methods that were previously marked `@Incubating` are now considered stable. 
+
 ## Fixed issues
 
 ## Deprecations

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -33,7 +33,7 @@ public class GroupedOutputFixture {
      */
     private final static String TASK_HEADER = "> Task (:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n?";
 
-    private final static String EMBEDDED_BUILD_START = "> :\\w* > root project";
+    private final static String EMBEDDED_BUILD_START = "> :\\w* > :\\w+";
     private final static String COMPILING_INTO_CACHE = "> :\\w* > Compiling[^\\n]+cache";
     private final static String BUILD_STATUS_FOOTER = "BUILD SUCCESSFUL";
     private final static String BUILD_FAILED_FOOTER = "BUILD FAILED";

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -374,7 +374,7 @@ BUILD SUCCESSFUL in 6s
 > Task :helloWorld
 Hello, World!
 
-> :otherBuild > root project"""
+> :otherBuild > :abc"""
 
         when:
         GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -24,16 +24,17 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 
-class BuildStatusRendererFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
+abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
-
     GradleHandle gradle
 
     def setup() {
-        executer.withConsole(ConsoleOutput.Rich)
+        executer.withConsole(consoleType)
         server.start()
     }
+
+    abstract ConsoleOutput getConsoleType()
 
     def "shows progress bar and percent phase completion"() {
         settingsFile << """
@@ -44,7 +45,6 @@ class BuildStatusRendererFunctionalTest extends AbstractIntegrationSpec implemen
             ${server.callFromBuild('root-build-script')}
             task hello { 
                 doFirst {
-                    println 'hello world' 
                     ${server.callFromBuild('task1')}
                 } 
             }
@@ -92,8 +92,8 @@ class BuildStatusRendererFunctionalTest extends AbstractIntegrationSpec implemen
         assertHasBuildPhase("50% EXECUTING")
         task2.releaseAll()
 
-        cleanup:
-        gradle?.waitForFinish()
+        and:
+        gradle.waitForFinish()
     }
 
     def "shows progress bar and percent phase completion with included build"() {
@@ -110,11 +110,13 @@ class BuildStatusRendererFunctionalTest extends AbstractIntegrationSpec implemen
                 } 
             }
         """
+        file("child/settings.gradle") << """
+            include 'a', 'b'
+        """
         file("child/build.gradle") << """
             ${server.callFromBuild('child-build-script')}
             task hello { 
                 doFirst {
-                    println 'hello world' 
                     ${server.callFromBuild('task1')}
                 } 
             }
@@ -140,7 +142,7 @@ class BuildStatusRendererFunctionalTest extends AbstractIntegrationSpec implemen
 
         and:
         rootBuildScript.waitForAllPendingCalls()
-        assertHasBuildPhase("50% CONFIGURING")
+        assertHasBuildPhase("75% CONFIGURING")
         rootBuildScript.releaseAll()
 
         and:
@@ -153,17 +155,76 @@ class BuildStatusRendererFunctionalTest extends AbstractIntegrationSpec implemen
         assertHasBuildPhase("50% EXECUTING")
         task2.releaseAll()
 
-        cleanup:
-        gradle?.waitForFinish()
+        and:
+        gradle.waitForFinish()
     }
 
-    private void assertHasBuildPhase(String message) {
+    def "shows progress bar and percent phase completion with buildSrc build"() {
+        settingsFile << """
+            ${server.callFromBuild('settings')}
+        """
+        buildFile << """
+            ${server.callFromBuild('root-build-script')}
+            task hello { 
+                doFirst {
+                    ${server.callFromBuild('task2')}
+                } 
+            }
+        """
+        file("buildSrc/settings.gradle") << """
+            include 'a', 'b'
+        """
+        file("buildSrc/build.gradle") << """
+            ${server.callFromBuild('buildsrc-build-script')}
+            assemble.doFirst {
+                ${server.callFromBuild('buildsrc-task')}
+            }
+        """
+
+        given:
+        def childBuildScript = server.expectAndBlock('buildsrc-build-script')
+        def task1 = server.expectAndBlock('buildsrc-task')
+        def settings = server.expectAndBlock('settings')
+        def rootBuildScript = server.expectAndBlock('root-build-script')
+        def task2 = server.expectAndBlock('task2')
+        gradle = executer.withTasks("hello").start()
+
+        expect:
+        childBuildScript.waitForAllPendingCalls()
+        assertHasBuildPhase("0% INITIALIZING")
+        childBuildScript.releaseAll()
+
+        and:
+        task1.waitForAllPendingCalls()
+        assertHasBuildPhase("0% INITIALIZING")
+        task1.releaseAll()
+
+        and:
+        settings.waitForAllPendingCalls()
+        assertHasBuildPhase("0% INITIALIZING")
+        settings.releaseAll()
+
+        and:
+        rootBuildScript.waitForAllPendingCalls()
+        assertHasBuildPhase("0% CONFIGURING")
+        rootBuildScript.releaseAll()
+
+        and:
+        task2.waitForAllPendingCalls()
+        assertHasBuildPhase("0% EXECUTING")
+        task2.releaseAll()
+
+        and:
+        gradle.waitForFinish()
+    }
+
+    void assertHasBuildPhase(String message) {
         ConcurrentTestUtil.poll {
             assert gradle.standardOutput =~ regexFor(message)
         }
     }
 
-    private String regexFor(String message) {
+    String regexFor(String message) {
         /<.*> $message \[\d+s]/
     }
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleConfigurationProgressFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleConfigurationProgressFunctionalTest.groovy
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.RichConsoleStyling
+import org.gradle.integtests.fixtures.executer.GradleHandle
+import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+
+abstract class AbstractConsoleConfigurationProgressFunctionalTest extends AbstractIntegrationSpec implements RichConsoleStyling {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+    GradleHandle gradle
+
+    def setup() {
+        executer.withConsole(consoleType)
+        server.start()
+    }
+
+    abstract ConsoleOutput getConsoleType()
+
+    def "shows work in progress as projects are configured"() {
+        settingsFile << """
+            include "a", "b", "c", "d"
+        """
+        buildFile << """
+            ${server.callFromBuild('root-build-script')}
+            task hello 
+        """
+        file("b/build.gradle") << """
+            ${server.callFromBuild('b-build-script')}
+        """
+
+        given:
+        def rootBuildScript = server.expectAndBlock('root-build-script')
+        def bBuildScript = server.expectAndBlock('b-build-script')
+        gradle = executer.withTasks("hello").start()
+
+        expect:
+        rootBuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress("root project")
+        rootBuildScript.releaseAll()
+
+        and:
+        bBuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress(":b")
+        bBuildScript.releaseAll()
+
+        and:
+        gradle.waitForFinish()
+    }
+
+    def "shows work in progress with included build"() {
+        settingsFile << """
+            includeBuild "child"
+        """
+        buildFile << """
+            ${server.callFromBuild('root-build-script')}
+            task hello { 
+                dependsOn gradle.includedBuild("child").task(":hello")
+            }
+        """
+        file("child/settings.gradle") << """
+            include 'a', 'b'
+        """
+        file("child/build.gradle") << """
+            ${server.callFromBuild('child-build-script')}
+            task hello
+        """
+        file("child/a/build.gradle") << """
+            ${server.callFromBuild('child-a-build-script')}
+            task hello
+        """
+
+        given:
+        def childBuildScript = server.expectAndBlock('child-build-script')
+        def childABuildScript = server.expectAndBlock('child-a-build-script')
+        def rootBuildScript = server.expectAndBlock('root-build-script')
+        gradle = executer.withTasks("hello").start()
+
+        expect:
+        childBuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress(":child")
+        childBuildScript.releaseAll()
+
+        and:
+        childABuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress(":child:a")
+        childABuildScript.releaseAll()
+
+        and:
+        rootBuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress("root project")
+        rootBuildScript.releaseAll()
+
+        and:
+        gradle.waitForFinish()
+    }
+
+    def "shows work in progress with buildSrc build"() {
+        buildFile << """
+            ${server.callFromBuild('root-build-script')}
+            task hello 
+        """
+        file("buildSrc/settings.gradle") << """
+            include 'a', 'b'
+        """
+        file("buildSrc/build.gradle") << """
+            ${server.callFromBuild('buildsrc-build-script')}
+        """
+        file("buildSrc/a/build.gradle") << """
+            ${server.callFromBuild('buildsrc-a-build-script')}
+        """
+
+        given:
+        def childBuildScript = server.expectAndBlock('buildsrc-build-script')
+        def childABuildScript = server.expectAndBlock('buildsrc-a-build-script')
+        def rootBuildScript = server.expectAndBlock('root-build-script')
+        gradle = executer.withTasks("hello").start()
+
+        expect:
+        childBuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress("Building buildSrc > :buildSrc")
+        childBuildScript.releaseAll()
+
+        and:
+        childABuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress("Building buildSrc > :buildSrc:a")
+        childABuildScript.releaseAll()
+
+        and:
+        rootBuildScript.waitForAllPendingCalls()
+        assertHasWorkInProgress("root project")
+        rootBuildScript.releaseAll()
+
+        and:
+        gradle.waitForFinish()
+    }
+
+    void assertHasWorkInProgress(String message) {
+        ConcurrentTestUtil.poll {
+            assert gradle.standardOutput.contains(workInProgressLine("> " + message))
+        }
+    }
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/RichConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/RichConsoleBuildPhaseFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+
+class RichConsoleBuildPhaseFunctionalTest extends AbstractConsoleBuildPhaseFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Rich
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/RichConsoleConfigurationProgressFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/RichConsoleConfigurationProgressFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+
+class RichConsoleConfigurationProgressFunctionalTest extends AbstractConsoleConfigurationProgressFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Rich
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/VerboseConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/VerboseConsoleBuildPhaseFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+
+class VerboseConsoleBuildPhaseFunctionalTest extends AbstractConsoleBuildPhaseFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/VerboseConsoleConfigurationProgressFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/VerboseConsoleConfigurationProgressFunctionalTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.console
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+
+class VerboseConsoleConfigurationProgressFunctionalTest extends AbstractConsoleConfigurationProgressFunctionalTest {
+    ConsoleOutput consoleType = ConsoleOutput.Verbose
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildAction.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildAction.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 import java.io.Serializable;
 
 /**
@@ -28,7 +26,6 @@ import java.io.Serializable;
  * @param <T> The type of result produced by this action.
  * @since 1.8
  */
-@Incubating
 public interface BuildAction<T> extends Serializable {
     /**
      * Executes this action and returns the result.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionExecuter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionExecuter.java
@@ -24,7 +24,6 @@ import org.gradle.api.Incubating;
  * @param <T> The type of result produced by this executer.
  * @since 1.8
  */
-@Incubating
 public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildActionExecuter<T>> {
 
     /**
@@ -82,7 +81,6 @@ public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildAction
      * @return this
      * @since 3.5
      */
-    @Incubating
     BuildActionExecuter<T> forTasks(String... tasks);
 
     /**
@@ -94,7 +92,6 @@ public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildAction
      * @return this
      * @since 3.5
      */
-    @Incubating
     BuildActionExecuter<T> forTasks(Iterable<String> tasks);
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionFailureException.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionFailureException.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 /**
  * Thrown when a {@link BuildAction} fails.
  *
  * @since 1.8
  */
-@Incubating
 public class BuildActionFailureException extends GradleConnectionException {
     public BuildActionFailureException(String message, Throwable throwable) {
         super(message, throwable);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildCancelledException.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildCancelledException.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 /**
  * Thrown when a {@link org.gradle.tooling.LongRunningOperation} is cancelled before the operation completes.
  *
  * @since 2.1
  */
-@Incubating
 public class BuildCancelledException extends GradleConnectionException {
     public BuildCancelledException(String message) {
         super(message);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildController.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildController.java
@@ -17,7 +17,6 @@
 package org.gradle.tooling;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.Model;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
@@ -28,7 +27,6 @@ import javax.annotation.Nullable;
  *
  * @since 1.8
  */
-@Incubating
 public interface BuildController {
     /**
      * Fetches a snapshot of the model of the given type for the default project. The default project is generally the

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildLauncher.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.Launchable;
 import org.gradle.tooling.model.Task;
 
@@ -108,7 +107,6 @@ public interface BuildLauncher extends ConfigurableLauncher<BuildLauncher> {
      * @return this
      * @since 1.12
      */
-    @Incubating
     BuildLauncher forLaunchables(Launchable... launchables);
 
     /**
@@ -118,7 +116,6 @@ public interface BuildLauncher extends ConfigurableLauncher<BuildLauncher> {
      * @return this
      * @since 1.12
      */
-    @Incubating
     BuildLauncher forLaunchables(Iterable<? extends Launchable> launchables);
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/CancellationToken.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/CancellationToken.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 /**
  * Token that propagates notification that an operation should be cancelled. See {@link org.gradle.tooling.CancellationTokenSource} for details.
  *
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 2.1
  */
-@Incubating
 public interface CancellationToken {
     /**
      * Gets whether cancellation has been requested for this token.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/CancellationTokenSource.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/CancellationTokenSource.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 /**
  * A {@code CancellationTokenSource} allows you to issue cancellation requests to one or more {@link org.gradle.tooling.LongRunningOperation}
  * instances. To use a token source:
@@ -34,7 +32,6 @@ import org.gradle.api.Incubating;
  *
  * @since 2.1
  */
-@Incubating
 public interface CancellationTokenSource {
     /**
      * Initiates cancel request. All operations that have been associated with this token will be cancelled.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ConfigurableLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ConfigurableLauncher.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationType;
 
 import java.io.File;
@@ -64,7 +63,6 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends Lo
      * {@inheritDoc}
      * @since 2.3
      */
-    @Incubating
     @Override
     T setColorOutput(boolean colorOutput);
 
@@ -101,7 +99,6 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends Lo
      * @since 3.5
      */
     @Override
-    @Incubating
     T setEnvironmentVariables(Map<String, String> envVariables);
 
     /**
@@ -115,7 +112,6 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends Lo
      * {@inheritDoc}
      * @since 2.5
      */
-    @Incubating
     @Override
     T addProgressListener(org.gradle.tooling.events.ProgressListener listener);
 
@@ -123,7 +119,6 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends Lo
      * {@inheritDoc}
      * @since 2.5
      */
-    @Incubating
     @Override
     T addProgressListener(org.gradle.tooling.events.ProgressListener listener, Set<OperationType> eventTypes);
 
@@ -131,7 +126,6 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends Lo
      * {@inheritDoc}
      * @since 2.6
      */
-    @Incubating
     @Override
     T addProgressListener(org.gradle.tooling.events.ProgressListener listener, OperationType... operationTypes);
 
@@ -139,7 +133,6 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher> extends Lo
      * {@inheritDoc}
      * @since 2.3
      */
-    @Incubating
     @Override
     T withCancellationToken(CancellationToken cancellationToken);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/Failure.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/Failure.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -26,7 +24,6 @@ import java.util.List;
  *
  * @since 2.4
  */
-@Incubating
 public interface Failure {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ListenerFailedException.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ListenerFailedException.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 import java.util.List;
 
 /**
@@ -26,7 +24,6 @@ import java.util.List;
  *
  * @since 2.5
  */
-@Incubating
 public class ListenerFailedException extends GradleConnectionException {
     private final List<? extends Throwable> listenerFailures;
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/LongRunningOperation.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/LongRunningOperation.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationType;
 
 import javax.annotation.Nullable;
@@ -71,7 +70,6 @@ public interface LongRunningOperation {
      * @return this
      * @since 2.3
      */
-    @Incubating
     LongRunningOperation setColorOutput(boolean colorOutput);
 
     /**
@@ -187,7 +185,6 @@ public interface LongRunningOperation {
      * @return this
      * @since 3.5
      */
-    @Incubating
     LongRunningOperation setEnvironmentVariables(@Nullable Map<String, String> envVariables);
 
     /**
@@ -195,8 +192,7 @@ public interface LongRunningOperation {
      *
      * <p>This method is intended to be replaced by {@link #addProgressListener(org.gradle.tooling.events.ProgressListener)}. The new progress listener type
      * provides much richer information and much better handling of parallel operations that run during the build, such as tasks that run in parallel.
-     * You should prefer using the new listener interface where possible. Note, however, that the new interface is supported only for Gradle 2.5 and later
-     * and is currently {@link Incubating}. It may change in later Gradle releases.
+     * You should prefer using the new listener interface where possible. Note, however, that the new interface is supported only for Gradle 2.5.
      * </p>
      *
      * @param listener The listener
@@ -218,7 +214,6 @@ public interface LongRunningOperation {
      * @return this
      * @since 2.5
      */
-    @Incubating
     LongRunningOperation addProgressListener(org.gradle.tooling.events.ProgressListener listener);
 
     /**
@@ -235,7 +230,6 @@ public interface LongRunningOperation {
      * @return this
      * @since 2.5
      */
-    @Incubating
     LongRunningOperation addProgressListener(org.gradle.tooling.events.ProgressListener listener, Set<OperationType> operationTypes);
 
     /**
@@ -261,6 +255,5 @@ public interface LongRunningOperation {
      *
      * @since 2.1
      */
-    @Incubating
     LongRunningOperation withCancellationToken(CancellationToken cancellationToken);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ModelBuilder.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ModelBuilder.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 /**
  * A {@code ModelBuilder} allows you to fetch a snapshot of some model for a project or a build.
  * Instances of {@code ModelBuilder} are not thread-safe.
@@ -73,7 +71,6 @@ public interface ModelBuilder<T> extends ConfigurableLauncher<ModelBuilder<T>> {
      * @return this
      * @since 1.2
      */
-    @Incubating
     ModelBuilder<T> forTasks(String... tasks);
 
     /**
@@ -85,7 +82,6 @@ public interface ModelBuilder<T> extends ConfigurableLauncher<ModelBuilder<T>> {
      * @return this
      * @since 2.6
      */
-    @Incubating
     ModelBuilder<T> forTasks(Iterable<String> tasks);
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
@@ -102,7 +102,6 @@ public interface ProjectConnection {
      * @return The launcher.
      * @since 2.6
      */
-    @Incubating
     TestLauncher newTestLauncher();
 
     /**
@@ -146,7 +145,6 @@ public interface ProjectConnection {
      * @since 1.8
      * @see #action() if you want to hook into different points of the build lifecycle.
      */
-    @Incubating
     <T> BuildActionExecuter<T> action(BuildAction<T> buildAction);
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestExecutionException.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestExecutionException.java
@@ -16,15 +16,12 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
-
 /**
  * Thrown when the {@link org.gradle.tooling.TestLauncher} cannot run tests, or when one or more tests fail.
  * <p>
  *
  * @since 2.6
  */
-@Incubating
 public class TestExecutionException extends GradleConnectionException {
     public TestExecutionException(String message, Throwable throwable) {
         super(message, throwable);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.test.TestOperationDescriptor;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.tooling.events.test.TestOperationDescriptor;
  *
  * @since 2.6
  */
-@Incubating
 public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/FailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/FailureResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.Failure;
 
 import java.util.List;
@@ -26,7 +25,6 @@ import java.util.List;
  *
  * @since 2.4
  */
-@Incubating
 public interface FailureResult extends OperationResult {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/FinishEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/FinishEvent.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * An event that informs about an operation having finished its execution.
  *
  * @since 2.4
  */
-@Incubating
 public interface FinishEvent extends ProgressEvent {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationDescriptor.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import javax.annotation.Nullable;
@@ -29,7 +28,6 @@ import javax.annotation.Nullable;
  *
  * @since 2.4
  */
-@Incubating
 @HasInternalProtocol
 public interface OperationDescriptor {
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  *
  * @since 2.4
  */
-@Incubating
 @UsedByScanPlugin
 public interface OperationResult {
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationType.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationType.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * Enumerates the different types of operations for which progress events can be received.
  *
  * @see org.gradle.tooling.LongRunningOperation#addProgressListener(ProgressListener, java.util.Set)
  */
-@Incubating
 public enum OperationType {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/ProgressEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/ProgressEvent.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * Root interface for all events that signal progress while executing an operation. For example, an operation can be
  * the execution of a build, of a task, of a test, etc. A progress event can, for example, signal that a test has started, a
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 2.4
  */
-@Incubating
 public interface ProgressEvent {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/ProgressListener.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/ProgressListener.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * A listener which is notified when operations that are executed as part of running a build make progress.
  *
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  * @see org.gradle.tooling.LongRunningOperation#addProgressListener(ProgressListener, java.util.Set)
  * @since 2.5
  */
-@Incubating
 public interface ProgressListener {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/SkippedResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/SkippedResult.java
@@ -16,13 +16,10 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes how an operation was skipped.
  *
  * @since 2.4
  */
-@Incubating
 public interface SkippedResult extends OperationResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/StartEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/StartEvent.java
@@ -16,13 +16,10 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * An event that informs about an operation having started its execution.
  *
  * @since 2.4
  */
-@Incubating
 public interface StartEvent extends ProgressEvent {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/StatusEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/StatusEvent.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * An event that informs about an interim results of the operation.
  *
  * @since 3.5
  */
-@Incubating
 public interface StatusEvent extends ProgressEvent {
     /**
      * The amount of work already performed by the build operation.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/SuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/SuccessResult.java
@@ -16,13 +16,10 @@
 
 package org.gradle.tooling.events;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes how an operation finished successfully.
  *
  * @since 2.4
  */
-@Incubating
 public interface SuccessResult extends OperationResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/package-info.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/package-info.java
@@ -17,5 +17,4 @@
 /**
  * The interfaces and classes related to registering for event notifications and listening to dispatched events.
  */
-@org.gradle.api.Incubating
 package org.gradle.tooling.events;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFailureResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.FailureResult;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.FailureResult;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskFailureResult extends TaskOperationResult, FailureResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFinishEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFinishEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.FinishEvent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.FinishEvent;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskFinishEvent extends TaskProgressEvent, FinishEvent {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationDescriptor.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationDescriptor;
 
 /**
@@ -23,7 +22,6 @@ import org.gradle.tooling.events.OperationDescriptor;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskOperationDescriptor extends OperationDescriptor {
     /**
      * Returns the path of the task.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationResult;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.OperationResult;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskOperationResult extends OperationResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskProgressEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskProgressEvent.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.ProgressEvent;
 
 /**
@@ -23,7 +22,6 @@ import org.gradle.tooling.events.ProgressEvent;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskProgressEvent extends ProgressEvent {
     /**
      * Returns the description of the task for which progress is reported.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskSkippedResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskSkippedResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.SkippedResult;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.SkippedResult;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskSkippedResult extends TaskOperationResult, SkippedResult {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskStartEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskStartEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.StartEvent;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.StartEvent;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskStartEvent extends TaskProgressEvent, StartEvent {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskSuccessResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.task;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.SuccessResult;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.SuccessResult;
  *
  * @since 2.5
  */
-@Incubating
 public interface TaskSuccessResult extends TaskOperationResult, SuccessResult {
     /**
      * Returns whether this task was up-to-date.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/package-info.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Task execution specific interfaces and classes related to event notifications.
  */
-@org.gradle.api.Incubating
 package org.gradle.tooling.events.task;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/JvmTestKind.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/JvmTestKind.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
-
 /**
  * Enumerates the different kinds of JVM tests. This allows to differentiate between test suites, atomic tests, etc.
  *
  * @since 2.4
  */
-@Incubating
 public enum JvmTestKind {
 
     SUITE("Test suite"),

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/JvmTestOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/JvmTestOperationDescriptor.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 
 /**
@@ -26,7 +24,6 @@ import javax.annotation.Nullable;
  *
  * @since 2.4
  */
-@Incubating
 public interface JvmTestOperationDescriptor extends TestOperationDescriptor {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestFailureResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.FailureResult;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.FailureResult;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestFailureResult extends TestOperationResult, FailureResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestFinishEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestFinishEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.FinishEvent;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.tooling.events.FinishEvent;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestFinishEvent extends TestProgressEvent, FinishEvent {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestOperationDescriptor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationDescriptor;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.OperationDescriptor;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestOperationDescriptor extends OperationDescriptor {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestOperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestOperationResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationResult;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.OperationResult;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestOperationResult extends OperationResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestProgressEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestProgressEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.ProgressEvent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.ProgressEvent;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestProgressEvent extends ProgressEvent {
     /**
      * Returns the description of the test for which progress is reported. For JVM-based tests,

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestSkippedResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestSkippedResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.SkippedResult;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.SkippedResult;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestSkippedResult extends TestOperationResult, SkippedResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestStartEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestStartEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.StartEvent;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.StartEvent;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestStartEvent extends TestProgressEvent, StartEvent {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/TestSuccessResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.SuccessResult;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.SuccessResult;
  *
  * @since 2.4
  */
-@Incubating
 public interface TestSuccessResult extends TestOperationResult, SuccessResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/package-info.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Test execution specific interfaces and classes related to event notifications.
  */
-@org.gradle.api.Incubating
 package org.gradle.tooling.events.test;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/BuildIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/BuildIdentifier.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 import java.io.File;
 
 /**
@@ -28,7 +26,6 @@ import java.io.File;
  *
  * @since 2.13
  */
-@Incubating
 public interface BuildIdentifier extends Model {
     /**
      * The root directory of this build

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/BuildModel.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/BuildModel.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 /**
  * Represents a model that is associated with or represents some Gradle build.
  *
  * @since 3.0
  */
-@Incubating
 public interface BuildModel {
     /**
      * Returns the identifier for the build that this model is associated with.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ExternalDependency.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ExternalDependency.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 import java.io.File;
 
@@ -64,6 +62,5 @@ public interface ExternalDependency extends Dependency {
      * @since 1.1
      */
     @Nullable
-    @Incubating
     GradleModuleVersion getGradleModuleVersion();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/GradleModuleVersion.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/GradleModuleVersion.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 /**
  * Informs about a module version, i.e. group, name, version.
  *
  * @since 1.1
  */
-@Incubating
 public interface GradleModuleVersion {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/GradleProject.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/GradleProject.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.gradle.GradleScript;
 
 import javax.annotation.Nullable;
@@ -33,7 +32,6 @@ public interface GradleProject extends HierarchicalElement, BuildableElement, Pr
      *
      * @since 2.13
      */
-    @Incubating
     ProjectIdentifier getProjectIdentifier();
 
     /**
@@ -73,7 +71,6 @@ public interface GradleProject extends HierarchicalElement, BuildableElement, Pr
      * @since 1.8
      * @throws UnsupportedMethodException For Gradle versions older than 1.8, where this method is not supported.
      */
-    @Incubating
     GradleScript getBuildScript() throws UnsupportedMethodException;
 
     /**
@@ -83,7 +80,6 @@ public interface GradleProject extends HierarchicalElement, BuildableElement, Pr
      * @since 2.0
      * @throws UnsupportedMethodException For Gradle versions older than 2.0, where this method is not supported.
      */
-    @Incubating
     File getBuildDirectory() throws UnsupportedMethodException;
 
     /**
@@ -93,7 +89,6 @@ public interface GradleProject extends HierarchicalElement, BuildableElement, Pr
      * @since 2.4
      * @throws UnsupportedMethodException For Gradle versions older than 2.4, where this method is not supported.
      */
-    @Incubating
     File getProjectDirectory() throws UnsupportedMethodException;
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/Launchable.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/Launchable.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 
 /**
@@ -27,14 +25,12 @@ import javax.annotation.Nullable;
  *
  * @since 1.12
  */
-@Incubating
 public interface Launchable extends ProjectModel {
     /**
      * Returns the identifier for the Gradle project that this model originated from.
      *
      * @since 2.13
      */
-    @Incubating
     ProjectIdentifier getProjectIdentifier();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ProjectIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ProjectIdentifier.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 /**
  * Identifies a Gradle project.
  *
@@ -27,7 +25,6 @@ import org.gradle.api.Incubating;
  *
  * @since 2.13
  */
-@Incubating
 public interface ProjectIdentifier extends Model {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ProjectModel.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/ProjectModel.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 /**
  * Represents a model that is associated with some Gradle project.
  *
  * @since 3.0
  */
-@Incubating
 public interface ProjectModel {
     /**
      * Returns the identifier for the project that this model is associated with.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/Task.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/Task.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 
 /**
@@ -58,7 +56,6 @@ public interface Task extends Launchable {
      * @return the group a task belongs to.
      * @since 2.5
      */
-    @Incubating
     @Nullable
     String getGroup();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/TaskSelector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/TaskSelector.java
@@ -15,15 +15,12 @@
  */
 package org.gradle.tooling.model;
 
-import org.gradle.api.Incubating;
-
 /**
  * Represents a {@link Launchable} that uses task name to select tasks executed from a given project and its sub-projects. This is
  * roughly equivalent to running `gradle &lt;task-name&gt;` from the command-line.
  *
  * @since 1.12
  */
-@Incubating
 public interface TaskSelector extends Launchable {
     /**
      * Returns the name that will be used to select tasks.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/build/BuildEnvironment.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/build/BuildEnvironment.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.build;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.BuildIdentifier;
 import org.gradle.tooling.model.BuildModel;
 import org.gradle.tooling.model.Model;
@@ -48,7 +47,6 @@ public interface BuildEnvironment extends Model, BuildModel {
      *
      * @since 2.13
      */
-    @Incubating
     BuildIdentifier getBuildIdentifier();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/build/GradleEnvironment.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/build/GradleEnvironment.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model.build;
 
-import org.gradle.api.Incubating;
-
 import java.io.File;
 
 /**
@@ -34,7 +32,6 @@ public interface GradleEnvironment {
      *
      * @since 2.4
      */
-    @Incubating
     File getGradleUserHome();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/AccessRule.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/AccessRule.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
-
 /**
  * Access rule associated with an Eclipse classpath entry.
  *
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 3.0
  */
-@Incubating
 public interface AccessRule {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/ClasspathAttribute.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/ClasspathAttribute.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
-
 /**
  * Optional description associated with Eclipse classpath entries.
  *
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 2.14
  */
-@Incubating
 public interface ClasspathAttribute {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseBuildCommand.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseBuildCommand.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
-
 import java.util.Map;
 
 /**
@@ -26,7 +24,6 @@ import java.util.Map;
  *
  * @since 2.9
  */
-@Incubating
 public interface EclipseBuildCommand {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseClasspathContainer.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseClasspathContainer.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
-
 /**
  * Eclipse classpath entry used by third-party plugins to contribute to the project's classpath.
  *
  * @since 3.0
  */
-@Incubating
 public interface EclipseClasspathContainer extends EclipseClasspathEntry {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseClasspathEntry.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseClasspathEntry.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.UnsupportedMethodException;
 
@@ -24,7 +23,6 @@ import org.gradle.tooling.model.UnsupportedMethodException;
  *
  * @since 2.14
  */
-@Incubating
 public interface EclipseClasspathEntry {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseExternalDependency.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.ExternalDependency;
 
 /**
@@ -23,7 +22,6 @@ import org.gradle.tooling.model.ExternalDependency;
  *
  * @since 2.14
  */
-@Incubating
 public interface EclipseExternalDependency extends ExternalDependency, EclipseClasspathEntry {
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseJavaSourceSettings.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseJavaSourceSettings.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.tooling.model.UnsupportedMethodException;
 import org.gradle.tooling.model.java.InstalledJdk;
@@ -26,7 +25,6 @@ import org.gradle.tooling.model.java.InstalledJdk;
  *
  * @since 2.10
  */
-@Incubating
 public interface EclipseJavaSourceSettings {
     /**
      * Returns the Java source language level.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseOutputLocation.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseOutputLocation.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
-
 /**
  * The output location of an Eclipse project.
  *
  * @since 3.0
  */
-@Incubating
 public interface EclipseOutputLocation {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseProject.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseProject.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.GradleProject;
 import org.gradle.tooling.model.HasGradleProject;
@@ -48,7 +47,7 @@ public interface EclipseProject extends HierarchicalEclipseProject {
      * @throws UnsupportedMethodException For Gradle versions older than 2.10, where this method is not supported.
      * @since 2.10
      */
-    @Nullable @Incubating
+    @Nullable
     EclipseJavaSourceSettings getJavaSourceSettings() throws UnsupportedMethodException;
 
     /**
@@ -84,7 +83,6 @@ public interface EclipseProject extends HierarchicalEclipseProject {
      * @since 2.9
      * @throws UnsupportedMethodException For Gradle versions older than 2.9, where this method is not supported.
      */
-    @Incubating
     DomainObjectSet<? extends EclipseProjectNature> getProjectNatures() throws UnsupportedMethodException;
 
     /**
@@ -101,7 +99,6 @@ public interface EclipseProject extends HierarchicalEclipseProject {
      * @since 2.9
      * @throws UnsupportedMethodException For Gradle versions older than 2.9, where this method is not supported.
      */
-    @Incubating
     DomainObjectSet<? extends EclipseBuildCommand> getBuildCommands() throws UnsupportedMethodException;
 
     /**
@@ -111,7 +108,6 @@ public interface EclipseProject extends HierarchicalEclipseProject {
      * @since 3.0
      * @throws UnsupportedMethodException For Gradle versions older than 3.0, where this method is not supported.
      */
-    @Incubating
     DomainObjectSet<? extends EclipseClasspathContainer> getClasspathContainers() throws UnsupportedMethodException;
 
     /**
@@ -121,6 +117,5 @@ public interface EclipseProject extends HierarchicalEclipseProject {
      * @since 3.0
      * @throws UnsupportedMethodException For Gradle versions older than 3.0, where this method is not supported.
      */
-    @Incubating
     EclipseOutputLocation getOutputLocation() throws UnsupportedMethodException;
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseProjectNature.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseProjectNature.java
@@ -16,14 +16,11 @@
 
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
-
 /**
  * An Eclipse project nature definition.
  *
  * @since 2.9
  */
-@Incubating
 public interface EclipseProjectNature {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseSourceDirectory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseSourceDirectory.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.tooling.model.eclipse;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.SourceDirectory;
 import org.gradle.tooling.model.UnsupportedMethodException;
@@ -42,7 +41,6 @@ public interface EclipseSourceDirectory extends SourceDirectory, EclipseClasspat
      *
      * @since 3.0
      */
-    @Incubating
     List<String> getIncludes() throws UnsupportedMethodException;
 
     /**
@@ -53,7 +51,6 @@ public interface EclipseSourceDirectory extends SourceDirectory, EclipseClasspat
      *
      * @since 3.0
      */
-    @Incubating
     List<String> getExcludes() throws UnsupportedMethodException;
 
     /**
@@ -64,7 +61,6 @@ public interface EclipseSourceDirectory extends SourceDirectory, EclipseClasspat
      *
      * @since 3.0
      */
-    @Incubating
     @Nullable
     String getOutput() throws UnsupportedMethodException;
 
@@ -75,6 +71,5 @@ public interface EclipseSourceDirectory extends SourceDirectory, EclipseClasspat
      *
      * @since 3.0
      */
-    @Incubating
     DomainObjectSet<? extends ClasspathAttribute> getClasspathAttributes() throws UnsupportedMethodException;
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/BasicGradleProject.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/BasicGradleProject.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.gradle;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.Model;
 import org.gradle.tooling.model.ProjectIdentifier;
@@ -30,14 +29,12 @@ import java.io.File;
  *
  * @since 1.8
  */
-@Incubating
 public interface BasicGradleProject extends Model, ProjectModel {
     /**
      * Returns the identifier for this Gradle project.
      *
      * @since 2.13
      */
-    @Incubating
     ProjectIdentifier getProjectIdentifier();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/BuildInvocations.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/BuildInvocations.java
@@ -16,9 +16,12 @@
 
 package org.gradle.tooling.model.gradle;
 
-import org.gradle.api.Incubating;
+import org.gradle.tooling.model.DomainObjectSet;
+import org.gradle.tooling.model.Model;
 import org.gradle.tooling.model.ProjectIdentifier;
-import org.gradle.tooling.model.*;
+import org.gradle.tooling.model.ProjectModel;
+import org.gradle.tooling.model.Task;
+import org.gradle.tooling.model.TaskSelector;
 
 /**
  * A model providing access to {@link org.gradle.tooling.model.Launchable} instances that can be used
@@ -29,7 +32,6 @@ import org.gradle.tooling.model.*;
  *
  * @since 1.12
  */
-@Incubating
 public interface BuildInvocations extends Model, ProjectModel {
 
     /**
@@ -37,7 +39,6 @@ public interface BuildInvocations extends Model, ProjectModel {
      *
      * @since 2.13
      */
-    @Incubating
     ProjectIdentifier getProjectIdentifier();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.gradle;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.BuildIdentifier;
 import org.gradle.tooling.model.BuildModel;
 import org.gradle.tooling.model.DomainObjectSet;
@@ -27,14 +26,12 @@ import org.gradle.tooling.model.Model;
  *
  * @since 1.8
  */
-@Incubating
 public interface GradleBuild extends Model, BuildModel {
     /**
      * Returns the identifier for this Gradle build.
      *
      * @since 2.13
      */
-    @Incubating
     BuildIdentifier getBuildIdentifier();
 
     /**
@@ -56,6 +53,5 @@ public interface GradleBuild extends Model, BuildModel {
      *
      * @since 3.3
      */
-    @Incubating
     DomainObjectSet<? extends GradleBuild> getIncludedBuilds();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradlePublication.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradlePublication.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.gradle;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.GradleModuleVersion;
 import org.gradle.tooling.model.ProjectIdentifier;
 import org.gradle.tooling.model.ProjectModel;
@@ -26,7 +25,6 @@ import org.gradle.tooling.model.ProjectModel;
  *
  * @since 1.12
  */
-@Incubating
 public interface GradlePublication extends ProjectModel {
 
     /**
@@ -34,7 +32,6 @@ public interface GradlePublication extends ProjectModel {
      *
      * @since 3.3
      */
-    @Incubating
     ProjectIdentifier getProjectIdentifier();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleScript.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleScript.java
@@ -16,8 +16,6 @@
 
 package org.gradle.tooling.model.gradle;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 import java.io.File;
 
@@ -26,7 +24,6 @@ import java.io.File;
  *
  * @since 1.8
  */
-@Incubating
 public interface GradleScript {
     /**
      * Returns the source file for this script, or {@code null} if this script has no associated source file.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/ProjectPublications.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/ProjectPublications.java
@@ -16,10 +16,9 @@
 
 package org.gradle.tooling.model.gradle;
 
-import org.gradle.api.Incubating;
-import org.gradle.tooling.model.ProjectIdentifier;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.Model;
+import org.gradle.tooling.model.ProjectIdentifier;
 import org.gradle.tooling.model.ProjectModel;
 
 /**
@@ -27,7 +26,6 @@ import org.gradle.tooling.model.ProjectModel;
  *
  * @since 1.12
  */
-@Incubating
 public interface ProjectPublications extends Model, ProjectModel {
 
     /**
@@ -35,7 +33,6 @@ public interface ProjectPublications extends Model, ProjectModel {
      *
      * @since 2.13
      */
-    @Incubating
     ProjectIdentifier getProjectIdentifier();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/package-info.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/package-info.java
@@ -17,5 +17,4 @@
 /**
  * The tooling models for Gradle builds and projects.
  */
-@org.gradle.api.Incubating
 package org.gradle.tooling.model.gradle;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaContentRoot.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaContentRoot.java
@@ -45,7 +45,6 @@ public interface IdeaContentRoot {
      * @deprecated Use {@link IdeaContentRoot#getSourceDirectories()} in combination with  {@link IdeaSourceDirectory#isGenerated()} instead.
      */
     @Deprecated
-    @Incubating
     DomainObjectSet<? extends IdeaSourceDirectory> getGeneratedSourceDirectories();
 
     /**
@@ -60,7 +59,6 @@ public interface IdeaContentRoot {
      * @deprecated Use {@link IdeaContentRoot#getTestDirectories()} in combination with  {@link IdeaSourceDirectory#isGenerated()} instead.
      */
     @Deprecated
-    @Incubating
     DomainObjectSet<? extends IdeaSourceDirectory> getGeneratedTestDirectories();
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaJavaLanguageSettings.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaJavaLanguageSettings.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.idea;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.tooling.model.UnsupportedMethodException;
 import org.gradle.tooling.model.java.InstalledJdk;
@@ -26,7 +25,6 @@ import org.gradle.tooling.model.java.InstalledJdk;
  *
  * @since 2.11
  */
-@Incubating
 public interface IdeaJavaLanguageSettings {
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModule.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModule.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.idea;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.GradleProject;
 import org.gradle.tooling.model.HasGradleProject;
@@ -39,7 +38,7 @@ public interface IdeaModule extends HierarchicalElement, HasGradleProject {
      * @throws UnsupportedMethodException For Gradle versions older than 2.11, where this method is not supported.
      * @since 2.11
      */
-    @Nullable @Incubating
+    @Nullable
     IdeaJavaLanguageSettings getJavaLanguageSettings() throws UnsupportedMethodException;
 
     /**
@@ -48,7 +47,6 @@ public interface IdeaModule extends HierarchicalElement, HasGradleProject {
      * @return The name of the JDK.
      * @since 3.4
      */
-    @Incubating
     String getJdkName() throws UnsupportedMethodException;
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModuleIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaModuleIdentifier.java
@@ -15,13 +15,10 @@
  */
 package org.gradle.tooling.model.idea;
 
-import org.gradle.api.Incubating;
-
 /**
  * Identifies an Idea module.
  *
  * @since 2.14
  */
-@Incubating
 public interface IdeaModuleIdentifier {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaProject.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaProject.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.idea;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.DomainObjectSet;
 import org.gradle.tooling.model.HierarchicalElement;
 import org.gradle.tooling.model.UnsupportedMethodException;
@@ -35,7 +34,6 @@ public interface IdeaProject extends HierarchicalElement {
      * @throws UnsupportedMethodException For Gradle versions older than 1.0-milestone-8, where this method is not supported.
      * @since 2.11
      */
-    @Incubating
     IdeaJavaLanguageSettings getJavaLanguageSettings() throws UnsupportedMethodException;
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaSourceDirectory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/idea/IdeaSourceDirectory.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.idea;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.SourceDirectory;
 
 /**
@@ -31,6 +30,5 @@ public interface IdeaSourceDirectory extends SourceDirectory {
      * @return true if source directory is generated
      * @since 2.2
      */
-    @Incubating
     boolean isGenerated();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/java/InstalledJdk.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/java/InstalledJdk.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.java;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 
 import java.io.File;
@@ -26,7 +25,6 @@ import java.io.File;
  *
  * @since 2.11
  */
-@Incubating
 public interface InstalledJdk {
     /***
      * The version of the Java installation.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/java/JavaRuntime.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/java/JavaRuntime.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.model.java;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 
 import java.io.File;
@@ -26,7 +25,6 @@ import java.io.File;
  *
  * @since 2.11
  */
-@Incubating
 public interface JavaRuntime {
     /***
      * The Java version of the Java runtime installation.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/java/package-info.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/java/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Java-specific details for tooling models.
  */
-@org.gradle.api.Incubating
 package org.gradle.tooling.model.java;


### PR DESCRIPTION
### Context

This is a fix for https://github.com/gradle/gradle/issues/5714, which was a breakage introduced since 4.8 to error handling when building a classpath using included builds.

This PR also adds tweaks the status bar for project configuration and adds some test coverage for this.

This PR also promotes almost all of the incubating tooling API types and methods to stable. This change should have been made in a separate PR but I was too lazy to separate them.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
