### PR TITLE
Remove `ModuleVersionSelector.versionConstraint`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -75,4 +75,13 @@ public interface DependencyConstraint extends ModuleVersionSelector, HasConfigur
      */
     @Incubating
     DependencyConstraint attributes(Action<? super AttributeContainer> configureAction);
+
+    /**
+     * Returns the version constraint to be used during selection.
+     * @return the version constraint
+     *
+     * @since 4.4
+     */
+    @Incubating
+    VersionConstraint getVersionConstraint();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -79,9 +79,6 @@ public interface DependencyConstraint extends ModuleVersionSelector, HasConfigur
     /**
      * Returns the version constraint to be used during selection.
      * @return the version constraint
-     *
-     * @since 4.4
      */
-    @Incubating
     VersionConstraint getVersionConstraint();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalDependency.java
@@ -48,4 +48,13 @@ public interface ExternalDependency extends ModuleDependency, ModuleVersionSelec
      */
     @Incubating
     void version(Action<? super MutableVersionConstraint> configureAction);
+
+    /**
+     * Returns the version constraint to be used during selection.
+     * @return the version constraint
+     *
+     * @since 4.4
+     */
+    @Incubating
+    VersionConstraint getVersionConstraint();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
@@ -49,15 +49,6 @@ public interface ModuleVersionSelector {
     String getVersion();
 
     /**
-     * Returns the version constraint to be used during selection.
-     * @return the version constraint
-     *
-     * @since 4.4
-     */
-    @Incubating
-    VersionConstraint getVersionConstraint();
-
-    /**
      * To match strictly means that the given identifier needs to have
      * equal group, module name and version.
      * It does not smartly match dynamic versions,

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
@@ -18,6 +18,8 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
+
 /**
  * Selects a module version.
  * If you need to change this interface, you're probably doing it wrong:
@@ -41,11 +43,12 @@ public interface ModuleVersionSelector {
     String getName();
 
     /**
-     * The version of the module
+     * The version of the module. May be null.
      *
      * @return module version
      *
      */
+    @Nullable
     String getVersion();
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
@@ -16,27 +16,27 @@
 
 package org.gradle.api.internal.artifacts;
 
+import com.google.common.base.Objects;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
 
 public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
     private final ModuleIdentifier module;
-    private final VersionConstraint moduleVersionConstraint;
+    private final String version;
 
-    private DefaultModuleVersionSelector(ModuleIdentifier module, VersionConstraint versionConstraint) {
+    private DefaultModuleVersionSelector(ModuleIdentifier module, String versionConstraint) {
         this.module = module;
-        this.moduleVersionConstraint = versionConstraint;
+        this.version = versionConstraint;
     }
 
     // DO NOT USE THIS CONSTRUCTOR DIRECTLY
     // It's only there for backwards compatibility with the Nebula plugin
     public DefaultModuleVersionSelector(String group, String name, String version) {
-        this(DefaultModuleIdentifier.newId(group, name), new DefaultMutableVersionConstraint(version));
+        this(DefaultModuleIdentifier.newId(group, name), version);
     }
 
     public String getGroup() {
@@ -48,12 +48,7 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
     }
 
     public String getVersion() {
-        return moduleVersionConstraint.getPreferredVersion();
-    }
-
-    @Override
-    public VersionConstraint getVersionConstraint() {
-        return moduleVersionConstraint;
+        return version;
     }
 
     public boolean matchesStrictly(ModuleVersionIdentifier identifier) {
@@ -67,7 +62,7 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
     @Override
     public String toString() {
-        return String.format("%s:%s", module, moduleVersionConstraint.getPreferredVersion());
+        return String.format("%s:%s", module, version);
     }
 
     @Override
@@ -80,33 +75,24 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
         }
 
         DefaultModuleVersionSelector that = (DefaultModuleVersionSelector) o;
-
-        if (module != null ? !module.equals(that.module) : that.module != null) {
-            return false;
-        }
-        if (moduleVersionConstraint != null ? !moduleVersionConstraint.equals(that.moduleVersionConstraint) : that.moduleVersionConstraint != null) {
-            return false;
-        }
-
-        return true;
+        return Objects.equal(module, that.module)
+            && Objects.equal(version, that.version);
     }
 
     @Override
     public int hashCode() {
-        int result = module != null ? module.hashCode() : 0;
-        result = 31 * result + moduleVersionConstraint.hashCode();
-        return result;
+        return Objects.hashCode(module, version);
     }
 
-    public static ModuleVersionSelector newSelector(ModuleIdentifier module, String preferredVersion) {
-        return new DefaultModuleVersionSelector(module, new DefaultMutableVersionConstraint(preferredVersion));
-    }
-
-    public static ModuleVersionSelector newSelector(ModuleIdentifier module, VersionConstraint version) {
+    public static ModuleVersionSelector newSelector(ModuleIdentifier module, String version) {
         return new DefaultModuleVersionSelector(module, version);
     }
 
+    public static ModuleVersionSelector newSelector(ModuleIdentifier module, VersionConstraint version) {
+        return new DefaultModuleVersionSelector(module, version.getPreferredVersion());
+    }
+
     public static ModuleVersionSelector newSelector(ModuleComponentSelector selector) {
-        return new DefaultModuleVersionSelector(selector.getModuleIdentifier(), selector.getVersionConstraint());
+        return new DefaultModuleVersionSelector(selector.getModuleIdentifier(), selector.getVersion());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionSelector.java
@@ -20,7 +20,6 @@ import com.google.common.base.Objects;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
-import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 
 public class DefaultModuleVersionSelector implements ModuleVersionSelector {
@@ -86,10 +85,6 @@ public class DefaultModuleVersionSelector implements ModuleVersionSelector {
 
     public static ModuleVersionSelector newSelector(ModuleIdentifier module, String version) {
         return new DefaultModuleVersionSelector(module, version);
-    }
-
-    public static ModuleVersionSelector newSelector(ModuleIdentifier module, VersionConstraint version) {
-        return new DefaultModuleVersionSelector(module, version.getPreferredVersion());
     }
 
     public static ModuleVersionSelector newSelector(ModuleComponentSelector selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.dependencies;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Strings;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleIdentifier;
@@ -66,10 +67,9 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         return moduleIdentifier.getName();
     }
 
-    @Nullable
     @Override
     public String getVersion() {
-        return versionConstraint.getPreferredVersion();
+        return Strings.emptyToNull(versionConstraint.getPreferredVersion());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsers.java
@@ -20,7 +20,6 @@ import org.gradle.api.IllegalDependencyNotation;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
-import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
@@ -60,7 +59,7 @@ public class ModuleVersionSelectorParsers {
         }
 
         protected ModuleVersionSelector parseMap(@MapKey("group") String group, @MapKey("name") String name, @MapKey("version") String version) {
-            return newSelector(DefaultModuleIdentifier.newId(group, name), new DefaultImmutableVersionConstraint(version));
+            return newSelector(DefaultModuleIdentifier.newId(group, name), version);
         }
     }
 
@@ -85,7 +84,7 @@ public class ModuleVersionSelectorParsers {
                         "Invalid format: '" + notation + "'. Group, name and version cannot be empty. Correct example: "
                                 + "'org.gradle:gradle-core:1.0'");
             }
-            result.converted(newSelector(DefaultModuleIdentifier.newId(parsed.getGroup(), parsed.getName()), new DefaultImmutableVersionConstraint(parsed.getVersion())));
+            result.converted(newSelector(DefaultModuleIdentifier.newId(parsed.getGroup(), parsed.getName()), parsed.getVersion()));
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultModuleVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultModuleVersionSelectorTest.groovy
@@ -17,8 +17,6 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.ModuleIdentifier
-import org.gradle.api.artifacts.VersionConstraint
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier.newId
@@ -28,17 +26,14 @@ class DefaultModuleVersionSelectorTest extends Specification {
 
     private final static ModuleIdentifier UTIL = DefaultModuleIdentifier.newId("org", "util")
 
-    static VersionConstraint v(String version) {
-        new DefaultMutableVersionConstraint(version)
-    }
 
     def "equality"() {
-        def selector = newSelector(UTIL, v("1.0"))
+        def selector = newSelector(UTIL, "1.0")
 
-        def same = newSelector(UTIL, v("1.0"))
-        def diffGroup = newSelector(DefaultModuleIdentifier.newId("foo", "util"), v("1.0"))
-        def diffName = newSelector(DefaultModuleIdentifier.newId("org", "foo"), v("1.0"))
-        def diffVersion = newSelector(UTIL, v("2.0"))
+        def same = newSelector(UTIL, "1.0")
+        def diffGroup = newSelector(DefaultModuleIdentifier.newId("foo", "util"), "1.0")
+        def diffName = newSelector(DefaultModuleIdentifier.newId("org", "foo"), "1.0")
+        def diffVersion = newSelector(UTIL, "2.0")
 
         expect:
         selector == same
@@ -48,7 +43,7 @@ class DefaultModuleVersionSelectorTest extends Specification {
     }
 
     def "knows if matches the id"() {
-        def selector = newSelector(UTIL, v("1.0"))
+        def selector = newSelector(UTIL, "1.0")
         def matching = newId(UTIL, "1.0")
 
         def differentGroup = newId("xorg", "util", "1.0")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsersTest.groovy
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.dsl;
-
+package org.gradle.api.internal.artifacts.dsl
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import spock.lang.Specification
 
@@ -52,7 +50,7 @@ class ModuleVersionSelectorParsersTest extends Specification {
 
     def "allows exact type on input"() {
         def module = DefaultModuleIdentifier.newId("org.foo", "bar")
-        def id = newSelector(module, new DefaultMutableVersionConstraint("2.0"))
+        def id = newSelector(module, "2.0")
 
         when:
         def v = multiParser().parseNotation(id) as List
@@ -66,7 +64,7 @@ class ModuleVersionSelectorParsersTest extends Specification {
 
     def "allows list of objects on input"() {
         def module = DefaultModuleIdentifier.newId("org.foo", "bar")
-        def id = newSelector(module, new DefaultMutableVersionConstraint("2.0"))
+        def id = newSelector(module,"2.0")
 
         when:
         def v = multiParser().parseNotation([id, ["hey:man:1.0"], [group:'i', name:'like', version:'maps']]) as List

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ModuleVersionSelectorParsersTest.groovy
@@ -38,8 +38,6 @@ class ModuleVersionSelectorParsersTest extends Specification {
         v[0].group == 'org.foo'
         v[0].name  == 'bar'
         v[0].version  == '1.0'
-        v[0].versionConstraint.preferredVersion == '1.0'
-        v[0].versionConstraint.rejectedVersions == []
     }
 
     def "works with CharSequences"() {
@@ -64,8 +62,6 @@ class ModuleVersionSelectorParsersTest extends Specification {
         v[0].group == 'org.foo'
         v[0].name  == 'bar'
         v[0].version  == '2.0'
-        v[0].versionConstraint.preferredVersion == '2.0'
-        v[0].versionConstraint.rejectedVersions == []
     }
 
     def "allows list of objects on input"() {
@@ -91,8 +87,6 @@ class ModuleVersionSelectorParsersTest extends Specification {
         v[0].group == 'org.foo'
         v[0].name  == 'bar'
         v[0].version  == '1.0'
-        v[0].versionConstraint.preferredVersion == '1.0'
-        v[0].versionConstraint.rejectedVersions == []
     }
 
     def "fails for unknown types"() {
@@ -159,7 +153,5 @@ class ModuleVersionSelectorParsersTest extends Specification {
         v.group == 'org.foo'
         v.name  == 'bar'
         v.version  == '1.0'
-        v.versionConstraint.preferredVersion == '1.0'
-        v.versionConstraint.rejectedVersions == []
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultUnresolvedDependencySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultUnresolvedDependencySpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
 
 class DefaultUnresolvedDependencySpec extends Specification {
@@ -26,14 +25,12 @@ class DefaultUnresolvedDependencySpec extends Specification {
     def "provides module details"() {
         when:
         def module = DefaultModuleIdentifier.newId("org.foo", "foo")
-        def dep = new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector(module, new DefaultMutableVersionConstraint('1.0', ['2.0'])), new RuntimeException("boo!"))
+        def dep = new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector(module, '1.0'), new RuntimeException("boo!"))
 
         then:
         dep.selector.group == 'org.foo'
         dep.selector.name == 'foo'
         dep.selector.version == '1.0'
-        dep.selector.versionConstraint.preferredVersion == '1.0'
-        dep.selector.versionConstraint.rejectedVersions == ['2.0']
         dep.toString() == 'org.foo:foo:1.0'
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -242,6 +242,6 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
     private static ModuleVersionSelector newVersionSelector(String group, String name, String version) {
         def mid = DefaultModuleIdentifier.newId(group, name)
-        return DefaultModuleVersionSelector.newSelector(mid, new DefaultImmutableVersionConstraint(version))
+        return DefaultModuleVersionSelector.newSelector(mid, version)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -90,7 +90,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         substitutions.allWithDependencyResolveDetails(action, componentSelectorConverter)
 
         def mid = DefaultModuleIdentifier.newId("org.utils", "api")
-        def moduleOldRequested = DefaultModuleVersionSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.5"))
+        def moduleOldRequested = DefaultModuleVersionSelector.newSelector(mid, "1.5")
         def moduleTarget = DefaultModuleComponentSelector.newSelector(moduleOldRequested)
         def moduleDetails = Mock(DependencySubstitutionInternal)
 
@@ -106,7 +106,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         })
         0 * _
 
-        def projectOldRequested = DefaultModuleVersionSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.5"))
+        def projectOldRequested = DefaultModuleVersionSelector.newSelector(mid, "1.5")
         def projectTarget = TestComponentIdentifiers.newSelector(":api")
         def projectDetails = Mock(DependencySubstitutionInternal)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -108,8 +108,8 @@ class DefaultResolutionStrategySpec extends Specification {
         _ * dependencySubstitutions.ruleAction >> Actions.doNothing()
         _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
         _ * details.getRequested() >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
-        _ * details.getOldRequested() >> newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("2.0")), VersionSelectionReasons.FORCED)
+        _ * details.getOldRequested() >> newSelector(mid, "1.0")
+        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, "2.0"), VersionSelectionReasons.FORCED)
         0 * details._
     }
 
@@ -137,8 +137,8 @@ class DefaultResolutionStrategySpec extends Specification {
         then: //forced modules:
         dependencySubstitutions.ruleAction >> substitutionAction
         _ * details.requested >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
-        _ * details.oldRequested >> newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("2.0")), VersionSelectionReasons.FORCED)
+        _ * details.oldRequested >> newSelector(mid, "1.0")
+        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, "2.0"), VersionSelectionReasons.FORCED)
         _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
 
         then: //user rules follow:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRuleSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRuleSpec.groovy
@@ -17,11 +17,9 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy
 
 import org.gradle.api.artifacts.ModuleIdentifier
-import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import spock.lang.Specification
@@ -36,10 +34,6 @@ class ModuleForcingResolveRuleSpec extends Specification {
         }
     }
 
-    private static VersionConstraint v(String version) {
-        new DefaultMutableVersionConstraint(version)
-    }
-
     private static ModuleIdentifier mid(String group, String name) {
         DefaultModuleIdentifier.newId(group, name)
     }
@@ -50,25 +44,25 @@ class ModuleForcingResolveRuleSpec extends Specification {
 
         when:
         new ModuleForcingResolveRule([
-            newSelector(mid("org", "module1"), v("1.0")),
-            newSelector(mid("org", "module2"), v("2.0")),
+            newSelector(mid("org", "module1"), "1.0"),
+            newSelector(mid("org", "module2"), "2.0"),
             //exotic module with colon in the name
-            newSelector(mid("org", "module:with:colon"), v("3.0")),
-            newSelector(mid("org:with:colon", "module2"), v("4.0"))
+            newSelector(mid("org", "module:with:colon"), "3.0"),
+            newSelector(mid("org:with:colon", "module2"), "4.0")
         ], moduleIdentifierFactory).execute(details)
 
         then:
         _ * details.requested >> DefaultModuleComponentSelector.newSelector(requested)
         _ * details.getOldRequested() >> requested
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid(requested.group, requested.name), v(forcedVersion)), VersionSelectionReasons.FORCED)
+        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid(requested.group, requested.name), forcedVersion), VersionSelectionReasons.FORCED)
         0 * details._
 
         where:
-        requested                                                             | forcedVersion
-        newSelector(mid("org", "module2"), v("0.9"))            | "2.0"
-        newSelector(mid("org", "module2"), v("2.1"))            | "2.0"
-        newSelector(mid("org", "module:with:colon"), v("2.0"))  | "3.0"
-        newSelector(mid("org:with:colon", "module2"), v("5.0")) | "4.0"
+        requested                                            | forcedVersion
+        newSelector(mid("org", "module2"), "0.9")            | "2.0"
+        newSelector(mid("org", "module2"), "2.1")            | "2.0"
+        newSelector(mid("org", "module:with:colon"), "2.0")  | "3.0"
+        newSelector(mid("org:with:colon", "module2"), "5.0") | "4.0"
     }
 
     def "does not force modules if they dont match"() {
@@ -77,10 +71,10 @@ class ModuleForcingResolveRuleSpec extends Specification {
 
         when:
         new ModuleForcingResolveRule([
-            newSelector(mid("org", "module1"), v("1.0")),
-            newSelector(mid("org", "module2"), v("2.0")),
-            newSelector(mid("org", "module:with:colon"), v("3.0")),
-            newSelector(mid("org:with:colon", "module2"), v("4.0"))
+            newSelector(mid("org", "module1"), "1.0"),
+            newSelector(mid("org", "module2"), "2.0"),
+            newSelector(mid("org", "module:with:colon"), "3.0"),
+            newSelector(mid("org:with:colon", "module2"), "4.0")
         ], moduleIdentifierFactory).execute(details)
 
         then:
@@ -89,12 +83,12 @@ class ModuleForcingResolveRuleSpec extends Specification {
 
         where:
         requested << [
-            newComponentSelector("orgX", "module2", v("0.9")),
-            newComponentSelector("org", "moduleX", v("2.9")),
-            newComponentSelector("orgX", "module:with:colon", v("2.9")),
-            newComponentSelector("org:with:colon", "moduleX", v("2.9")),
-            newComponentSelector("org:with", "colon:module2", v("2.9")),
-            newComponentSelector("org", "with:colon:module2", v("2.9")),
+            newComponentSelector("orgX", "module2", "0.9"),
+            newComponentSelector("org", "moduleX", "2.9"),
+            newComponentSelector("orgX", "module:with:colon", "2.9"),
+            newComponentSelector("org:with:colon", "moduleX", "2.9"),
+            newComponentSelector("org:with", "colon:module2", "2.9"),
+            newComponentSelector("org", "with:colon:module2", "2.9"),
         ]
     }
 
@@ -108,7 +102,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
         0 * details._
     }
 
-    static newComponentSelector(String group, String name, VersionConstraint versionConstraint) {
-        DefaultModuleComponentSelector.newSelector(mid(group, name), versionConstraint)
+    static newComponentSelector(String group, String name, String version) {
+        DefaultModuleComponentSelector.newSelector(mid(group, name), version)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
@@ -93,7 +93,7 @@ class CachingDependencyResultFactoryTest extends Specification {
     }
 
     def moduleVersionSelector(String group='a', String module='a', String version='1') {
-        newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version))
+        newSelector(DefaultModuleIdentifier.newId(group, module), version)
     }
 
     private static ComponentSelectionReason selectedByRule() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyResult
 import org.gradle.internal.DisplayName
@@ -256,7 +255,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
 
     private DependencyResult dep(String requested, Exception failure = null, String selected = requested) {
         def selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("x", requested), DefaultImmutableVersionConstraint.of("1"))
-        def moduleVersionSelector = newSelector(DefaultModuleIdentifier.newId("x", requested), new DefaultMutableVersionConstraint("1"))
+        def moduleVersionSelector = newSelector(DefaultModuleIdentifier.newId("x", requested), "1")
         failure = failure == null ? null : new ModuleVersionResolveException(moduleVersionSelector, failure)
         new DummyInternalDependencyResult(requested: selector, selected: id(selected), failure: failure)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
@@ -61,7 +61,7 @@ class DependencyResultSerializerTest extends Specification {
     def "serializes failed dependency result"() {
         def mid = DefaultModuleIdentifier.newId("x", "y")
         def requested = DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
-        def failure = new ModuleVersionResolveException(newSelector(mid, new DefaultMutableVersionConstraint("1.2")), new RuntimeException("Boo!"))
+        def failure = new ModuleVersionResolveException(newSelector(mid, "1.2"), new RuntimeException("Boo!"))
 
         def failed = Mock(DependencyGraphEdge) {
             getSelector() >> Stub(DependencyGraphSelector) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionResolveExceptionTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/ModuleVersionResolveExceptionTest.groovy
@@ -16,9 +16,7 @@
 package org.gradle.internal.resolve
 
 import org.gradle.api.artifacts.ModuleIdentifier
-import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.newSelector
@@ -26,16 +24,13 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class ModuleVersionResolveExceptionTest extends Specification {
-    private static VersionConstraint v(String version) {
-        new DefaultMutableVersionConstraint(version)
-    }
 
     private static ModuleIdentifier mid(String group, String name) {
         DefaultModuleIdentifier.newId(group, name)
     }
 
     def "provides default message that includes selector"() {
-        def exception1 = new ModuleVersionResolveException(newSelector(mid("org", "a"), v("1.2")), new RuntimeException())
+        def exception1 = new ModuleVersionResolveException(newSelector(mid("org", "a"), "1.2"), new RuntimeException())
 
         expect:
         exception1.message == 'Could not resolve org:a:1.2.'
@@ -47,7 +42,7 @@ class ModuleVersionResolveExceptionTest extends Specification {
         def c = newId(mid("org", "c"), "1.0")
 
         def cause = new RuntimeException()
-        def exception = new ModuleVersionResolveException(newSelector(mid("a", "b"), v("c")), cause)
+        def exception = new ModuleVersionResolveException(newSelector(mid("a", "b"), "c"), cause)
         def onePath = exception.withIncomingPaths([[a, b, c]])
         def twoPaths = exception.withIncomingPaths([[a, b, c], [a, c]])
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
@@ -74,7 +73,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "cannot get id when resolve failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
 
         when:
         result.failed(failure)
@@ -86,7 +85,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "cannot get meta-data when resolve failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
 
         when:
         result.failed(failure)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.resolve.result
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import spock.lang.Specification
@@ -45,7 +44,7 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
 
         when:
         descriptor.failed(failure)
@@ -114,7 +113,7 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
 
     def "cannot get meta-data when failed"() {
         given:
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
         descriptor.failed(failure)
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleVersionListingResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleVersionListingResolveResultTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.internal.resolve.result
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.newSelector
-import static org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult.State.*
+import static org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult.State.Failed
+import static org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult.State.Listed
+import static org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult.State.Unknown
 
 class DefaultBuildableModuleVersionListingResolveResultTest extends Specification {
     def descriptor = new DefaultBuildableModuleVersionListingResolveResult()
@@ -44,7 +45,7 @@ class DefaultBuildableModuleVersionListingResolveResultTest extends Specificatio
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
 
         when:
         descriptor.failed(failure)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -40,7 +40,7 @@ class ResolutionResultDataBuilder {
 
     static DefaultUnresolvedDependencyResult newUnresolvedDependency(String group='x', String module='x', String version='1', String selectedVersion='1') {
         def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version))
-        new DefaultUnresolvedDependencyResult(requested, VersionSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version)), "broken"))
+        new DefaultUnresolvedDependencyResult(requested, VersionSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), version), "broken"))
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1',

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,5 +1,20 @@
 {
     "acceptedApiChanges": [
-        
+        {
+            "type": "org.gradle.api.artifacts.DependencyConstraint",
+            "member": "Method org.gradle.api.artifacts.DependencyConstraint.getVersionConstraint()",
+            "acceptation": "Incubating method was pushed down from supertype. Has effectively been part of API since first introduced.",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.ExternalDependency",
+            "member": "Method org.gradle.api.artifacts.ExternalDependency.getVersionConstraint()",
+            "acceptation": "Incubating method pushed down from supertype: left original @since 4.4",
+            "changes": [
+                "Method added to interface"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
This new construct is not required on the legacy API.