### PR TITLE
Restore compatibility with error-prone plugin

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/ClassSetAnalysisUpdater.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/ClassSetAnalysisUpdater.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassDependenc
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.CompilationResultAnalyzer;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
+import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
@@ -73,7 +74,8 @@ public class ClassSetAnalysisUpdater {
     }
 
     private void visitAnnotationProcessingResult(JavaCompileSpec spec, WorkResult result, CompilationResultAnalyzer analyzer) {
-        if (!spec.getEffectiveAnnotationProcessors().isEmpty()) {
+        Set<AnnotationProcessorDeclaration> processors = spec.getEffectiveAnnotationProcessors();
+        if (processors != null && !processors.isEmpty()) {
             AnnotationProcessingResult annotationProcessingResult = null;
             if (result instanceof JdkJavaCompilerResult) {
                 annotationProcessingResult = ((JdkJavaCompilerResult) result).getAnnotationProcessingResult();


### PR DESCRIPTION
The error-prone plugin uses a bunch of internals to
hook in its own compiler, which doesn't properly set
up the effective annotation processors. As a result,
they can be null when we do our incremental analysis.

Fixes #5848