### PR TITLE
Allow ProjectBuilder tests when classpath contains relative paths

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/EffectiveClassPath.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/EffectiveClassPath.java
@@ -60,7 +60,7 @@ public class EffectiveClassPath extends DefaultClassPath {
 
     private static void addClasspathFile(File classpathFile, List<File> classpathFiles) {
         if (classpathFile.exists() && !classpathFiles.contains(classpathFile)) {
-            classpathFiles.add(classpathFile);
+            classpathFiles.add(classpathFile.getAbsoluteFile());
             addManifestClasspathFiles(classpathFile, classpathFiles);
         }
     }


### PR DESCRIPTION
The Gradle classpath is now used as part of our immutable
file store roots. These roots are expected to be absolute
paths. This change makes sure they are converted early if
the classpath contains relative URLs.