### PR TITLE
Add missing @Nullable annotations on org.gradle.internal types

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/NonNullApi.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/NonNullApi.java
@@ -30,6 +30,9 @@ import java.lang.annotation.Target;
  *
  * All parameter and return types are assumed to be {@link Nonnull} unless specifically marked as {@link Nullable}.
  *
+ * All types of an annotated package inherit the package rule.
+ * Subpackages do not inherit nullability rules and must be annotated.
+ *
  * @since 4.2
  */
 @Target({ElementType.TYPE, ElementType.PACKAGE})

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
@@ -187,7 +187,7 @@ public abstract class Actions {
      * @param runnable The runnable to run for the action execution.
      * @return An action that runs the given runnable, ignoring the argument.
      */
-    public static <T> Action<T> toAction(Runnable runnable) {
+    public static <T> Action<T> toAction(@Nullable Runnable runnable) {
         //TODO SF this method accepts Closure instance as parameter but does not work correctly for it
         if (runnable == null) {
             return Actions.doNothing();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Cast.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Cast.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal;
 
+import javax.annotation.Nullable;
+
 public abstract class Cast {
 
     /**
@@ -32,8 +34,8 @@ public abstract class Cast {
      * @param <I> The type of the object to be vast
      * @return The input object, cast to the output type
      */
-
-    public static <O, I> O cast(Class<O> outputType, I object) {
+    @Nullable
+    public static <O, I> O cast(Class<O> outputType, @Nullable I object) {
         try {
             return outputType.cast(object);
         } catch (ClassCastException e) {
@@ -44,7 +46,8 @@ public abstract class Cast {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> T uncheckedCast(Object object) {
+    @Nullable
+    public static <T> T uncheckedCast(@Nullable Object object) {
         return (T) object;
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/IoActions.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/IoActions.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
 
+import javax.annotation.Nullable;
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
@@ -98,7 +99,7 @@ public abstract class IoActions {
      *
      * @param resource The resource to be closed
      */
-    public static void uncheckedClose(Closeable resource) {
+    public static void uncheckedClose(@Nullable Closeable resource) {
         try {
             if (resource != null) {
                 resource.close();
@@ -113,7 +114,7 @@ public abstract class IoActions {
      *
      * @param resource The resource to be closed
      */
-    public static void closeQuietly(Closeable resource) {
+    public static void closeQuietly(@Nullable Closeable resource) {
         try {
             if (resource != null) {
                 resource.close();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Pair.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Pair.java
@@ -22,7 +22,10 @@ import javax.annotation.Nullable;
 
 public final class Pair<L, R> {
 
+    @Nullable
     public final L left;
+
+    @Nullable
     public final R right;
 
     private Pair(@Nullable L left, @Nullable R right) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Pair.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Pair.java
@@ -18,33 +18,39 @@ package org.gradle.internal;
 
 import com.google.common.base.Function;
 
+import javax.annotation.Nullable;
+
 public final class Pair<L, R> {
 
     public final L left;
     public final R right;
 
-    private Pair(L left, R right) {
+    private Pair(@Nullable L left, @Nullable R right) {
         this.left = left;
         this.right = right;
     }
 
+    @Nullable
     public L getLeft() {
         return left;
     }
 
+    @Nullable
     public R getRight() {
         return right;
     }
 
+    @Nullable
     public L left() {
         return left;
     }
 
+    @Nullable
     public R right() {
         return right;
     }
 
-    public static <L, R> Pair<L, R> of(L left, R right) {
+    public static <L, R> Pair<L, R> of(@Nullable L left, @Nullable R right) {
         return new Pair<L, R>(left, right);
     }
 
@@ -72,6 +78,7 @@ public final class Pair<L, R> {
         return of(left, function.apply(right));
     }
 
+    @Nullable
     public <T> T map(Function<? super Pair<L, R>, ? extends T> function) throws Exception {
         return function.apply(this);
     }


### PR DESCRIPTION
As a follow up to this change https://github.com/gradle/gradle/pull/5813/files#diff-3b7f5d54ed8d807240b29e2421a18a4c that broke Kotlin consumers that use `JSR305` in strict mode.
