### PR TITLE
Backport of the "jdt" block from the old eclipse.gradle file

### DIFF
--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -129,11 +129,18 @@ open class IdePlugin : Plugin<Project> {
                         // Remove references to other project's binaries
                         entries.removeAll { it is AbstractClasspathEntry && it.path.contains("/subprojects") && it.kind == "lib" }
                         // Add needed resources for running gradle as a non daemon java application
-                        entries.add(SourceFolder("build/generated-resources/main", null))
+                        if (file("build/generated-resources/main").exists()) {
+                            entries.add(SourceFolder("build/generated-resources/main", null))
+                        }
                         if (file("build/generated-resources/test").exists()) {
                             entries.add(SourceFolder("build/generated-resources/test", null))
                         }
                     })
+                }
+                jdt {
+                    sourceCompatibility = JavaVersion.VERSION_1_8
+                    targetCompatibility = JavaVersion.VERSION_1_8
+                    javaRuntimeName = "JavaSE-1.8"
                 }
             }
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseJdt.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseJdt.java
@@ -34,9 +34,9 @@ import javax.inject.Inject;
  * eclipse {
  *   jdt {
  *     //if you want to alter the java versions (by default they are configured with gradle java plugin settings):
- *     sourceCompatibility = 1.6
- *     targetCompatibility = 1.5
- *     javaRuntimeName = "J2SE-1.5"
+ *     sourceCompatibility = JavaVersion.VERSION_1_8
+ *     targetCompatibility = JavaVersion.VERSION_1_8
+ *     javaRuntimeName = "JavaSE-1.8"
  *
  *     file {
  *       //whenMerged closure is the highest voodoo


### PR DESCRIPTION
### Context
[issue #5830](https://github.com/gradle/gradle/issues/5830)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
