### PR TITLE
Add a Gradle 4.x upgrade chapter

### DIFF
--- a/subprojects/docs/src/docs/userguide/plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/plugins.adoc
@@ -199,6 +199,38 @@ Hello!
 BUILD SUCCEEDED
 ----
 
+[[sec:buildsrc_plugins_dsl]]
+==== Applying plugins from the _buildSrc_ directory
+
+You can apply plugins that reside in a project's _buildSrc_ directory as long as they have a defined ID. The following example shows how to tie a plugin implementation class — `my.MyPlugin` — defined in _buildSrc_ to the ID "my-plugin":
+
+.Defining a buildSrc plugin with an ID
+====
+[.multi-language-sample]
+=====
+.buildSrc/build.gradle
+[source,groovy]
+----
+include::{samplesPath}/plugins/dslWithBuildSrc/buildSrc/build.gradle[tag=main-block]
+----
+=====
+====
+
+The plugin can then be applied by ID as normal:
+
+.Applying a plugin from buildSrc
+====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+include::{samplesPath}/plugins/dslWithBuildSrc/build.gradle[tag=use-plugin]
+----
+=====
+====
+
+
 [[sec:plugin_management]]
 ==== Plugin Management
 

--- a/subprojects/docs/src/docs/userguide/upgrade_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrade_version_4.adoc
@@ -1,0 +1,483 @@
+// Copyright 2018 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[upgrade_version_4]]
+= Upgrading Gradle Version 4.x to 5.0
+
+This chapter provides the information you need to migrate your older Gradle 4.x builds to the latest version. In most cases, you will need to apply the changes from all versions that come after the one you're upgrading from. For example, if you're upgrading from Gradle 4.3, you will also need to apply the changes from 4.4, 4.5, etc.
+
+A few pointers about upgrading:
+
+ * Run `gradle help` with the version of Gradle you're upgrading to in order to see any deprecations that apply to your build.
+ * Make sure you update the versions of plugins you use in your build when upgrading the Gradle version. Some plugins will break with newer versions of Gradle.
+ * In most cases, deprecated features, properties and methods will be removed in Gradle 5.0, resulting in build errors if you try to use them.
+
+The most significant changes include the following:
+
+ * A recommendation to <<#rel4.7:switch_to_publishing_plugins, switch to the Maven Publish and Ivy Publish plugins>> if you're not already using them. They now support digital signatures with the Signing Plugin.
+ * A change that means you should <<#rel4.7:configure_internal_tasks,configure existing `wrapper` and `init` tasks>> rather than defining your own.
+ * The <<#rel4.7:pom_wildcard_exclusions,honoring of implicit wildcards in Maven POM exclusions>>, which may result in dependencies being excluded that weren't before.
+ * A <<#upgrade_4.5,recommendation to enable the new and improved POM support>> in your builds.
+ * A <<#rel4.5:annotation_processor_configuration,change to the way you add Java annotation processors to a project>>.
+ * The <<custom_tasks.adoc#worker_api,Worker API>> for enabling units of work to execute in parallel.
+
+There are many other changes that we list by Gradle version in the rest of the guide.
+
+[[upgrade_4.8]]
+== From 4.8
+
+ * TBD
+
+[[upgrade_4.7]]
+== From 4.7
+
+ * <<#rel4.7:switch_to_publishing_plugins,Switch to the Maven Publish and Ivy Publish plugins>>
+ * <<#rel4.7:switch_to_core_dependency_locking,Switch to the built-in dependency lock mechanism>>
+ * <<#rel4.7:deferred_configuration,Use deferred configuration with the publishing plugins>>
+ * <<#rel4.7:configure_internal_tasks,Configure existing `wrapper` and `init` tasks>> rather than defining your own
+ * Use <<java_testing.adoc#test_filtering,test filtering>> rather than the <<java_testing.adoc#sec:single_test_execution_via_system_properties,old system properties>> like `-Dtest.single`
+ * Use the `--debug-jvm` command-line option rather than `-Dtest.debug`
+
+=== Deprecated classes, methods and properties
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * `SimpleFileCollection` — use link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:files(java.lang.Object++[]++)[Project.files(Object...)] instead
+ * link:{javadocPath}/org/gradle/api/file/FileCollection.html#add-org.gradle.api.file.FileCollection-[FileCollection.add(FileCollection)]
+ * link:{javadocPath}/org/gradle/api/file/FileCollection.html#stopExecutionIfEmpty--[FileCollection.stopExecutionIfEmpty()]
+ * link:{javadocPath}/org/gradle/plugins/signing/Signature.html#getToSignArtifact--[Signature.toSignArtifact]
+
+=== Potential breaking changes
+
+ * Build will now fail if a specified init script is not found.
+ * `TaskContainer.remove()` now actually removes the given task — some plugins may have accidentally relied on the old behavior.
+ * link:{javadocPath}/org/gradle/plugins/signing/Signature.html#setFile-java.io.File-[Signature.setFile(File)] no longer does anything and is deprecated.
+ * <<#rel4.7:pom_wildcard_exclusions,Gradle now honors implicit wildcards in Maven POM exclusions>>.
+ * The Kotlin DSL now respects JSR-305 package annotations.
++
+This will lead to some types annotated according to JSR-305 being treated as nullable where they were treated as non-nullable before. This may lead to compilation errors in the build script. See https://github.com/gradle/kotlin-dsl/releases/tag/v0.17.4[the relevant Kotlin DSL release notes] for details.
+ * Error messages will be directed to standard error rather than standard output now, unless a console is attached to both standard output and standard error. This may affect tools that scrape a build's plain console output. Ignore this change if you're upgrading from an earlier version of Gradle.
+
+[[upgrade_4.6]]
+== From 4.6
+
+=== Deprecated classes, methods and properties
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * link:{javadocPath}/org/gradle/api/file/FileCollection.html#asType-java.lang.Class-[FileCollection.asType(Class)] for file types, such as `File` and `FileTree`. This method is used by Groovy's `as` keyword, e.g. `someFileCollection as File[]`
+ * link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:deleteAllActions()[Task.deleteAllActions()] — this has no replacement
+
+=== Other deprecations
+
+ * The new location by convention of Checkstyle configuration files is in the root project's _config/checkstyle_ directory, not that of the subprojects.
++
+For now, by-convention config files in subprojects will override any in the root project in order to maintain backwards compatibility.
+
+=== Potential breaking changes
+
+ * The structure of Gradle's <<#rel4.6:plain_console_output,plain console output>> has changed, which may break tools that scrape that output.
+ * The APIs of many native tasks related to compilation, linking and installation <<rel:4.6:native_task_api_changes,have changed in breaking ways>>.
+ * [Kotlin DSL] Delegated properties used to access Gradle's build properties — defined in _gradle.properties_ for example — must now be explicitly typed.
+ * [Kotlin DSL] Declaring a `plugins {}` block inside a nested scope now throws an exception.
+ * [Kotlin DSL] Only one `pluginManagement {}` block is allowed now.
+ * The cache control DSL provided by the `org.gradle.api.artifacts.cache.*` interfaces are no longer available.
+ * `getEnabledDirectoryReportDestinations()`, `getEnabledFileReportDestinations()` and `getEnabledReportNames()` have all been removed from `org.gradle.api.reporting.ReportContainer`.
+ * link:{javadocPath}/org/gradle/StartParameter.html#getProjectProperties--[StartParameter.projectProperties] and link:{javadocPath}/org/gradle/StartParameter.html#getSystemPropertiesArgs--[StartParameter.systemPropertiesArgs] now return immutable maps.
+
+[[upgrade_4.5]]
+== From 4.5
+
+There is now improved POM support in Gradle that will be enabled by default in Gradle 5.0. Add the line
+
+    enableFeaturePreview('IMPROVED_POM_SUPPORT')
+
+to your _settings.gradle_ file to get the following:
+
+ * <<#rel4.5:bom_import,BOM import>>
+ * <<#rel4.5:pom_optional_dependencies,Support for optional dependencies when consuming POMs>>
+ * <<#rel4.5:pom_compile_runtime_separation,Separation of compile and runtime dependencies when consuming POMs>>
+
+Note that some of these features may break your build.
+
+=== Deprecated classes, methods and properties
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * link:{javadocPath}/org/gradle/api/file/FileCollection.html#asType-java.lang.Class-[FileCollection.asType(Class)] for file types, such as `File` and `FileTree`. This method is used by Groovy's `as` keyword, e.g. `someFileCollection as File[]`
+ * link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:deleteAllActions()[Task.deleteAllActions()] — this has no replacement
+ * link:{javadocPath}/org/gradle/caching/local/DirectoryBuildCache.html#setTargetSizeInMB-long-[DirectoryBuildCache.setTargetSizeInMB(long)], i.e. the `targetSizeInMB` configuration property for local build caches
+
+=== Other deprecations
+
+[[rel4.5:annotation_processor_configuration]]
+ * You should not put annotation processors on the compile classpath or declare them with the `-processorpath` compiler argument.
++
+They should be added to the `annotationProcessor` configuration instead. If you don't want any processing, but your compile classpath contains a processor unintentionally (e.g. as part of a library you depend on), use the `-proc:none` compiler argument to ignore it.
+ * Upgrade from Play 2.2 to a newer version.
+ * Use link:{javadocPath}/org/gradle/process/CommandLineArgumentProvider.html[CommandLineArgumentProvider] in place of link:{javadocPath}/org/gradle/api/tasks/compile/CompilerArgumentProvider.html[CompilerArgumentProvider].
+
+=== Potential breaking changes
+
+ * The Java plugins now add a `__sourceSet__AnnotationProcessor` configuration for each source set, which might break if any of them match existing configurations you have. We recommend you remove your conflicting configuration declarations.
+ * The `StartParameter.taskOutputCacheEnabled` property has been replaced by link:{javadocPath}/org/gradle/StartParameter.html#setBuildCacheEnabled-boolean-[StartParameter.setBuildCacheEnabled(boolean)].
+ * The Visual Studio integration now only <<#rel4.5:visual_studio_single_solution,configures a single solution for all components in a build>>.
+ * Gradle has replaced HttpClient 4.4.1 with version 4.5.5.
+ * Gradle now bundles the `kotlin-stdlib-jdk8` artifact instead of `kotlin-stdlib-jre8`. This may affect your build. Please see the http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages[Kotlin documentation] for more details.
+
+[[upgrade_4.4]]
+== From 4.4
+
+ * Make sure you have a _settings.gradle_ file: it avoids a performance penalty and allows you to set the root project's name. Also, the `-u`/`--no-search-upward` command line option that allowed you to bypass the performance penalty is now deprecated.
+ * Gradle now ignores the build cache configuration of included builds (<<composite_builds.adoc#composite_builds,composite builds>>) and instead uses the root build's configuration for all the builds.
+
+=== Potential breaking changes
+
+ * Two overloaded `ValidateTaskProperties.setOutputFile()` methods were removed. They are replaced with auto-generated setters when the task is accessed from a build script, but that won't be the case from plugins and other code outside of the build script.
+ * The Maven Publish Plugin now produces more complete maven-metadata.xml files, including maintaining a list of `<snapshotVersion>` elements. Some older versions of Maven may not be able to consume this metadata.
+ * <<#rel4.4:http_build_cache_no_follow_redirects,`HttpBuildCache` no longer follows redirects>>.
+ * The `Depend` task type has been removed.
+ * link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(Object)] no longer normalizes case for file paths on case-insensitive file systems. It now ignores case in such circumstances and does not touch the file system.
+ * link:{javadocPath}/org/gradle/api/provider/ListProperty.html[ListProperty] no longer extends link:{javadocPath}/org/gradle/api/provider/Property.html[Property].
+
+[[upgrade_4.3]]
+== From 4.3
+
+ * Don't use the `-a`/`--no-rebuild` command-line option: it will be removed in Gradle 5.0.
+
+=== Potential breaking changes
+
+ * link:{groovyDslPath}/org.gradle.api.tasks.testing.AbstractTestTask.html[AbstractTestTask] is now extended by non-JVM test tasks as well as link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test]. Plugins should beware configuring all tasks of type `AbstractTestTask` because of this.
+ * The default output location for link:{groovyDslPath}/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.html#org.gradle.plugins.ide.eclipse.model.EclipseClasspath:defaultOutputDir[EclipseClasspath.defaultOutputDir] has changed from __``$projectDir``/bin__ to __``$projectDir``/bin/default__.
+ * The deprecated `InstallExecutable.setDestinationDir(Provider)` was removed — use link:{groovyDslPath}/org.gradle.nativeplatform.tasks.InstallExecutable.html#org.gradle.nativeplatform.tasks.InstallExecutable:installDirectory[InstallExecutable.installDirectory] instead.
+ * The deprecated `InstallExecutable.setExecutable(Provider)` was removed — use link:{groovyDslPath}/org.gradle.nativeplatform.tasks.InstallExecutable.html#org.gradle.nativeplatform.tasks.InstallExecutable:executableFile[InstallExecutable.executableFile] instead.
+ * Gradle will no longer prefer a version of Visual Studio found on the path over other locations. It is now a last resort.
++
+You can bypass the toolchain discovery by specifying the installation directory of the version of Visual Studio you want via link:{groovyDslPath}/org.gradle.nativeplatform.toolchain.VisualCpp.html#org.gradle.nativeplatform.toolchain.VisualCpp:installDir[VisualCpp.setInstallDir(Object)].
+ * `pluginManagement.repositories` is now of type link:{groovyDslPath}/org.gradle.api.artifacts.dsl.RepositoryHandler.html[RepositoryHandler] rather than `PluginRepositoriesSpec`, which has been removed.
+ * 5xx HTTP errors during dependency resolution will now trigger exceptions in the build.
+ * The embedded Apache Ant has been upgraded from 1.9.6 to 1.9.9.
+ * <<#rel4.3:security_library_upgrades,Several third-party libraries used by Gradle have been upgraded>> to fix security issues.
+
+[[upgrade_4.2]]
+== From 4.2
+
+ * The `plugins {}` block can now be <<plugins.adoc#sec:subprojects_plugins_dsl,used in subprojects>> and for <<plugins.adoc#sec:buildsrc_plugins_dsl,plugins in the _buildSrc_ directory>>.
+
+=== Deprecated classes, methods and properties
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * `TaskInternal.execute()` — this was sometimes used to invoke a task directly from plugins or other tasks in a mistaken attempt to reuse code. Do not execute tasks directly. Consider using task dependencies, task rules, reusable utility methods, or the <<custom_tasks.adoc#worker_api,Worker API>> instead.
+ * link:{javadocPath}/org/gradle/api/tasks/TaskDestroyables.html#file-java.lang.Object-[TaskDestroyables.file(Object)]
+ * link:{javadocPath}/org/gradle/api/tasks/TaskDestroyables.html#files-java.lang.Object++...++-[TaskDestroyables.files(Object...)]
+ * link:{javadocPath}/org/gradle/api/provider/PropertyState.html[PropertyState]
+ * link:{javadocPath}/org/gradle/api/file/DirectoryVar.html[DirectoryVar]
+ * link:{javadocPath}/org/gradle/api/file/RegularFileVar.html[RegularFileVar]
+ * link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#newDirectoryVar--[ProjectLayout.newDirectoryVar()]
+ * link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#newFileVar--[ProjectLayout.newFileVar()]
+ * link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:property(java.lang.Class)[Project.property(Class)]
+ * link:{javadocPath}/org/gradle/api/Script.html#property-java.lang.Class-[Script.property(Class)]
+ * link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#property-java.lang.Class-[ProviderFactory.property(Class)]
+ * link:{groovyDslPath}/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:bootClasspath[CompileOptions.bootClasspath]
+
+=== Other deprecations
+
+ * You should no longer run Gradle versions older than 2.6 via the Tooling API.
+ * You should no longer run any version of Gradle via an older version of the Tooling API than 3.0.
+ * You should no longer chain link:{javadocPath}/org/gradle/api/tasks/TaskInputs.html#property-java.lang.String-java.lang.Object-[TaskInputs.property(String,Object)] and link:{javadocPath}/org/gradle/api/tasks/TaskInputs.html#properties-java.util.Map-[TaskInputs.properties(Map)] methods.
+ * You should not call link:{javadocPath}/org/gradle/api/tasks/TaskInputs.html#file-java.lang.Object-[TaskInputs.file(Object)] with an argument that resolves to anything other than a single regular file.
+ * You should not call link:{javadocPath}/org/gradle/api/tasks/TaskInputs.html#dir-java.lang.Object-[TaskInputs.dir(Object)] with an argument that resolves to anything other than a single directory.
+ * You should no longer use the `--recompile-scripts` command-line option.
+
+=== Potential breaking changes
+
+ * link:{javadocPath}/org/gradle/api/DefaultTask.html#newOutputDirectory--[DefaultTask.newOutputDirectory()] now returns a `DirectoryProperty` instead of a `DirectoryVar`.
+ * link:{javadocPath}/org/gradle/api/DefaultTask.html#newOutputFile--[DefaultTask.newOutputFile()] now returns a `RegularFileProperty` instead of a `RegularFileVar`.
+ * link:{javadocPath}/org/gradle/api/DefaultTask.html#newInputFile--[DefaultTask.newInputFile()] now returns a `RegularFileProperty` instead of a `RegularFileVar`.
+ * link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#getBuildDirectory--[ProjectLayout.buildDirectory] now returns a `DirectoryProperty` instead of a `DirectoryVar`.
+ * link:{groovyDslPath}/org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.html#org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask:compilerArgs[AbstractNativeCompileTask.compilerArgs] is now of type `ListProperty<String>` instead of `List<String>`.
+ * link:{groovyDslPath}/org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.html#org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask:objectFileDir[AbstractNativeCompileTask.objectFileDir] is now of type `DirectoryProperty` instead of `File`.
+ * link:{groovyDslPath}/org.gradle.nativeplatform.tasks.AbstractLinkTask.html#org.gradle.nativeplatform.tasks.AbstractLinkTask:linkerArgs[AbstractLinkTask.linkerArgs] is now of type `ListProperty<String>` instead of `List<String>`.
+ * `TaskDestroyables.getFiles()` is no longer part of the public API.
+ * Overlapping version ranges for a dependency now result in Gradle picking a version that satisfies all declared ranges.
++
+For example, if a dependency on `some-module` is found with a version range of `[3,6]` and also transitively with a range of `[4,8]`, Gradle now selects version 6 instead of 8. The prior behavior was to select 8.
+ * The order of elements in `Iterable` properties marked with either `@OutputFiles` or `@OutputDirectories` now matters. If the order changes, the property is no longer considered up to date.
++
+Prefer using separate properties with `@OutputFile`/`@OutputDirectory` annotations or use `Map` properties with `@OutputFiles`/`@OutputDirectories` instead.
+ * Gradle will no longer ignore dependency resolution errors from a repository when there is another repository it can check. Dependency resolution will fail instead. This results in more deterministic behavior with respect to resolution results.
+
+[[upgrade_4.1]]
+== From 4.1
+
+=== Deprecations
+
+ * You should no longer use any of the following characters in domain object names, such as project and task names: <space> `/ \ : < > " ? * |`. You should also not use `.` as a leading or trailing character.
+
+=== Potential breaking changes
+
+ * The `withPathSensitivity()` methods on link:{javadocPath}/org/gradle/api/tasks/TaskFilePropertyBuilder.html[TaskFilePropertyBuilder] and link:{javadocPath}/org/gradle/api/tasks/TaskOutputFilePropertyBuilder.html[TaskOutputFilePropertyBuilder] have been removed.
+ * The bundled `bndlib` has been upgraded from 3.2.0 to 3.4.0.
+ * The FindBugs Plugin no longer renders progress information from its analysis. If you rely on that output in any way, you can enable it with link:{groovyDslPath}/org.gradle.api.plugins.quality.FindBugs.html#org.gradle.api.plugins.quality.FindBugs:showProgress[FindBugs.showProgress].
+
+[[upgrade_4.0]]
+== From 4.0
+
+ * Consider using the new <<custom_tasks.adoc#worker_api,Worker API>> to enable units of work within your build to run in parallel.
+
+=== Deprecated classes, methods and properties
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * link:{javadocPath}/org/gradle/api/tasks/scala/ScalaDocOptions.html#getStyleSheet--[ScalaDocOptions.styleSheet] — the Scaladoc Ant task in Scala 2.11.8 and later no longer support this property.
+ * link:{javadocPath}/org/gradle/api/Nullable.html[Nullable]
+ * link:{javadocPath}/org/gradle/api/Task.html#dependsOnTaskDidWork--[Task.dependsOnTaskDidWork()]
+
+=== Potential breaking changes
+
+ * Non-Java projects that have a <<dependency_types.adoc#sub:project_dependencies,project dependency>> on a Java project now consume the `runtimeElements` configuration by default instead of the `default` configuration.
++
+To override this behavior, you can explicitly declare the configuration to use in the project dependency. For example: `project(path: ':myJavaProject', configuration: 'default')`.
+ * Default Zinc compiler upgraded from 0.3.13 to 0.3.15.
+ * [Kotlin DSL] Base package renamed from `org.gradle.script.lang.kotlin` to `org.gradle.kotlin.dsl`.
+
+
+== Changes in detail
+
+[[rel4.7:switch_to_publishing_plugins]]
+=== [4.7] Switch to the Maven Publish and Ivy Publish Plugins
+
+Now that the publishing plugins are stable, the <<artifact_management.adoc#artifact_management,legacy publishing>> mechanism based on `Upload` tasks is deprecated. You should replace `upload<Conf>` configuration with a `publishing` block instead. See the <<publishing_overview.adoc#publishing_overview,publishing overview chapter>> for information on how to use the publishing plugins.
+
+[[rel4.7:deferred_configuration]]
+=== [4.7] Use deferred configuration for publishing plugins
+
+Prior to Gradle 4.8, the `publishing {}` block was implicitly treated as if all the logic inside it was executed after the project was evaluated.
+This was confusing, because it was the only block that behaved that way.
+As part of the stabilization effort in Gradle 4.8, we are deprecating this behavior and asking all users to migrate their build.
+
+The new, stable behavior can be switched on by adding the following to your settings file:
+
+    enableFeaturePreview('STABLE_PUBLISHING')
+
+We recommend doing a test run with a local repository to see whether all artifacts still have the expected coordinates. In most cases everything should work as before and you are done. However, your publishing block may rely on the implicit deferred configuration, particularly if it relies on values that may change during the configuration phase of the build.
+
+For example, under the new behavior, the following logic assumes that `jar.baseName` doesn't change after `artifactId` is set:
+
+[source,groovy]
+----
+subprojects {
+    publishing {
+        publications {
+            mavenJava {
+                from components.java
+                artifactId = jar.baseName
+            }
+        }
+    }
+}
+----
+
+If that assumption is incorrect or might possibly be incorrect in the future, the `artifactId` must be set within an `afterEvaluate {}` block, like so:
+
+
+[source,groovy]
+----
+subprojects {
+    publishing {
+        publications {
+            mavenJava {
+                from components.java
+                afterEvaluate {
+                    artifactId = jar.baseName
+                }
+            }
+        }
+    }
+}
+----
+
+[[rel4.7:switch_to_core_dependency_locking]]
+=== [4.7] Switch to the built-in dependency lock mechanism
+
+++[There is no migration information available right now]++
+
+[[rel4.7:configure_internal_tasks]]
+=== [4.7] Configure existing `wrapper` and `init` tasks
+
+You should no longer define your own `wrapper` and `init` tasks. Configure the existing tasks instead, for example by converting this:
+
+----
+task wrapper(type: Wrapper) {
+    ...
+}
+----
+
+to this:
+
+----
+wrapper {
+    ...
+}
+----
+
+[[rel4.7:pom_wildcard_exclusions]]
+=== [4.7] Gradle now honors implicit wildcards in Maven POM exclusions
+
+If an exclusion in a Maven POM was missing either a `groupId` or `artifactId`, Gradle used to ignore the exclusion. Now the missing elements are treated as implicit wildcards — e.g. `<groupId>*</groupId>` — which means that some of your dependencies may now be excluded where they weren't before.
+
+You will need to explicitly declare any missing dependencies that you need.
+
+[[rel4.6:plain_console_output]]
+=== [4.6] Changes to the structure of Gradle's plain console output
+
+The plain console mode now formats output consistently with the rich console, which means that the output format has changed. For example:
+
+ * The output produced by a given task is now grouped together, even when other tasks execute in parallel with it.
+ * Task execution headers are printed with a "> Task" prefix.
+ * All output produced during build execution is written to the standard output file handle. This includes messages written to System.err unless you're are redirecting standard error to a file or any other non-console destination.
+
+This may break tools that scrape details from the plain console output.
+
+[[rel:4.6:native_task_api_changes]]
+=== [4.6] Changes to the APIs of native tasks related to compilation, linking and installation
+
+Many tasks related to compiling, linking and installing native libraries and applications have been converted to the Provider API so that they support <<lazy_configuration.adoc#lazy_configuration,lazy configuration>>. This conversion has introduced some breaking changes to the APIs of the tasks so that they match the conventions of the Provider API.
+
+The following tasks have been changed:
+
+link:{groovyDslPath}/org.gradle.nativeplatform.tasks.AbstractLinkTask.html[AbstractLinkTask] and its subclasses::
+ * `getDestinationDir()` was replaced by `getDestinationDirectory()`.
+ * `getBinaryFile()`, `getOutputFile()` was replaced by `getLinkedFile()`.
+ * `setOutputFile(File)` was removed. Use `Property.set()` instead.
+ * `setOutputFile(Provider)` was removed. Use `Property.set()` instead.
+ * `getTargetPlatform()` was changed to return a `Property`.
+ * `setTargetPlatform(NativePlatform)` was removed. Use `Property.set()` instead.
+ * `getToolChain()` was changed to return a `Property`.
+ * `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
+
+link:{groovyDslPath}/org.gradle.nativeplatform.tasks.CreateStaticLibrary.html[CreateStaticLibrary]::
+ * `getOutputFile()` was changed to return a `Property`.
+ * `setOutputFile(File)` was removed. Use `Property.set()` instead.
+ * `setOutputFile(Provider)` was removed. Use `Property.set()` instead.
+ * `getTargetPlatform()` was changed to return a `Property`.
+ * `setTargetPlatform(NativePlatform)` was removed. Use `Property.set()` instead.
+ * `getToolChain()` was changed to return a `Property`.
+ * `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
+ * `getStaticLibArgs()` was changed to return a `ListProperty`.
+ * `setStaticLibArgs(List)` was removed. Use `ListProperty.set()` instead.
+
+link:{groovyDslPath}/org.gradle.nativeplatform.tasks.InstallExecutable.html[InstallExecutable]::
+ * `getSourceFile()` was replaced by `getExecutableFile()`.
+ * `getPlatform()` was replaced by `getTargetPlatform()`.
+ * `setTargetPlatform(NativePlatform)` was removed. Use `Property.set()` instead.
+ * `getToolChain()` was changed to return a `Property`.
+ * `setToolChain(NativeToolChain)` was removed. Use `Property.set()` instead.
+
+The following have also seen similar changes:
+
+ * link:{groovyDslPath}/org.gradle.language.assembler.tasks.Assemble.html[Assemble]
+ * link:{groovyDslPath}/org.gradle.language.rc.tasks.WindowsResourceCompile.html[WindowsResourceCompile]
+ * link:{javadocPath}/org/gradle/nativeplatform/tasks/StripSymbols.html[StripSymbols]
+ * link:{javadocPath}/org/gradle/nativeplatform/tasks/ExtractSymbols.html[ExtractSymbols]
+ * link:{javadocPath}/org/gradle/language/swift/tasks/SwiftCompile.html[SwiftCompile]
+ * link:{javadocPath}/org/gradle/nativeplatform/tasks/LinkMachOBundle.html[LinkMachOBundle]
+
+[[rel4.5:bom_import]]
+=== [4.5] BOM import
+
+Gradle now provides support for importing bill of materials (BOM) files, which are effectively POM files that use `<dependencyManagement>` sections to control the versions of direct and transitive dependencies. All you need to do is declare the POM as just another dependency.
+
+The following example picks the versions of the `gson` and `dom4j` dependencies from the declared Spring Boot BOM:
+
+----
+dependencies {
+    // import a BOM
+    implementation 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE'
+
+    // define dependencies without versions
+    implementation 'com.google.code.gson:gson'
+    implementation 'dom4j:dom4j'
+}
+----
+
+
+[[rel4.5:pom_optional_dependencies]]
+=== [4.5] Support for optional dependencies when consuming POMs
+
+Gradle now creates a <<managing_transitive_dependencies.adoc#sec:dependency_constraints,dependency constraint>> for each dependency declaration in a POM file with an `<optional>true</optional>` element. This results in the expected behavior:
+
+ * The dependency module is ignored if it is only ever declared as optional.
+ * If the dependency module is also declared elsewhere as not optional, then the constraint derived from the optional dependency declaration is considered when picking the version.
+
+In other words, if an optional dependency has a declared version higher than another, non-optional one, the optional dependency's version is used. However, Gradle does not resolve optional dependencies.
+
+[[rel4.5:pom_compile_runtime_separation]]
+=== [4.5] Separation of compile and runtime dependencies when consuming POMs
+
+Since Gradle 1.0, runtime-scoped dependencies have been included in the Java compilation classpath, which has some drawbacks:
+
+ * The compilation classpath is much larger than it needs to be, slowing down compilation.
+ * The compilation classpath includes runtime-scoped files that do not impact compilation, resulting in unnecessary re-compilation when those files change.
+
+With this new behavior, the Java and Java Library plugins both honor the <<java_library_plugin.adoc#sec:java_library_separation,separation of compile and runtime scopes>>. This means that the compilation classpath only includes compile-scoped dependencies, while the runtime classpath adds the runtime-scoped dependencies as well. This is particularly useful if you develop and publish Java libraries with Gradle where the separation between `api` and `implementation` dependencies is reflected in the published scopes.
+
+[[rel4.5:visual_studio_single_solution]]
+=== [4.5] Visual Studio integration only supports a single solution file for all components of a build
+
+link:{groovyDslPath}/org.gradle.ide.visualstudio.VisualStudioExtension.html[VisualStudioExtension] no longer has a `solutions` property. Instead, you configure a single solution via link:{groovyDslPath}/org.gradle.ide.visualstudio.VisualStudioRootExtension.html[VisualStudioRootExtension] in the root project, like so:
+
+----
+model {
+    visualStudio {
+        solution {
+            solutionFile.location = "vs/${name}.sln"
+        }
+    }
+}
+----
+
+In addition, there are no longer individual tasks to generate the solution files for each component, but rather a single `visualStudio` task that generates a solution file that encompasses all components in the build.
+
+[[rel4.4:http_build_cache_no_follow_redirects]]
+=== [4.4] `HttpBuildCache` no longer follows redirects
+
+When connecting to an HTTP build cache backend via `HttpBuildCache`, Gradle does not follow redirects any more, treating them as errors instead. Getting a redirect from the build cache backend is mostly a configuration error — using an "http" URL instead of "https" for example — and has negative effects on performance.
+
+[[rel4.3:security_library_upgrades]]
+=== [4.3] Third-party dependency upgrades
+
+This version includes several upgrades of third-party dependencies:
+
+ * jackson: 2.6.6 -> 2.8.9
+ * plexus-utils: 2.0.6 -> 2.1
+ * xercesImpl: 2.9.1 -> 2.11.0
+ * bsh: 2.0b4 -> 2.0b6
+ * bouncycastle: 1.57 -> 1.58
+
+This fix the following security issues:
+
+ * http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525[CVE-2017-7525] (critical)
+ * SONATYPE-2017-0359 (critical)
+ * SONATYPE-2017-0355 (critical)
+ * SONATYPE-2017-0398 (critical)
+ * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-4002[CVE-2013-4002] (critical)
+ * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2510[CVE-2016-2510] (severe)
+ * SONATYPE-2016-0397 (severe)
+ * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-2625[CVE-2009-2625] (severe)
+ * SONATYPE-2017-0348 (severe)
+
+Gradle does not expose public APIs for these 3rd-party dependencies, but those who customize Gradle will want to be aware.
+

--- a/subprojects/docs/src/docs/userguide/upgrade_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrade_version_4.adoc
@@ -31,22 +31,30 @@ The most significant changes include the following:
  * A <<#upgrade_4.5,recommendation to enable the new and improved POM support>> in your builds.
  * A <<#rel4.5:annotation_processor_configuration,change to the way you add Java annotation processors to a project>>.
  * The <<custom_tasks.adoc#worker_api,Worker API>> for enabling units of work to execute in parallel.
+ * A new, <<feature_lifecycle#sec:incubating_state,incubating>> API for <<#rel4.8:lazy_task_creation,creating and configuring tasks lazily>> that can significantly improve your build's configuration time.
 
 There are many other changes that we list by Gradle version in the rest of the guide.
 
 [[upgrade_4.8]]
 == From 4.8
 
- * TBD
+ * <<#rel4.8:lazy_task_creation,Consider trying the lazy API for task creation and configuration>>
+
+=== Potential breaking changes
+
+ * `whenMerged {}` and `beforeMerged {}` blocks for link:{groovyDslPath}/org.gradle.plugins.ide.eclipse.model.EclipseProject.html[EclipseProject] are now executed by Buildship.
+ * You can no longer use GPath syntax with link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#withType-java.lang.Class-[tasks.withType()].
++
+Use http://docs.groovy-lang.org/latest/html/documentation/#_spread_operator[Groovy's spread operator] instead. For example, you would replace `tasks.withType(JavaCompile).name` with `tasks.withType(JavaCompile)*.name`.
 
 [[upgrade_4.7]]
 == From 4.7
 
  * <<#rel4.7:switch_to_publishing_plugins,Switch to the Maven Publish and Ivy Publish plugins>>
- * <<#rel4.7:switch_to_core_dependency_locking,Switch to the built-in dependency lock mechanism>>
  * <<#rel4.7:deferred_configuration,Use deferred configuration with the publishing plugins>>
  * <<#rel4.7:configure_internal_tasks,Configure existing `wrapper` and `init` tasks>> rather than defining your own
  * Use <<java_testing.adoc#test_filtering,test filtering>> rather than the <<java_testing.adoc#sec:single_test_execution_via_system_properties,old system properties>> like `-Dtest.single`
+ * Consider migrating to the built-in <<dependency_locking#dependency_locking,dependency locking mechanism>> if you are currently using a plugin or custom solution for this.
  * Use the `--debug-jvm` command-line option rather than `-Dtest.debug`
 
 === Deprecated classes, methods and properties
@@ -256,6 +264,13 @@ To override this behavior, you can explicitly declare the configuration to use i
 
 == Changes in detail
 
+[[rel4.8:lazy_task_creation]]
+=== [4.8] Consider trying the lazy API for task creation and configuration
+
+Gradle 4.9 introduced a new way to create and configure tasks that works lazily. When you use this approach for tasks that are expensive to configure, or when you have many, many tasks, your build configuration time can drop significantly when those tasks don't run.
+
+You can learn more about lazily creating tasks in the <<task_configuration_avoidance#task_configuration_avoidance,Task Configuration Avoidance>> chapter. You can also read about the background to this new feature in https://blog.gradle.org/preview-avoiding-task-configuration-time[this blog post].
+
 [[rel4.7:switch_to_publishing_plugins]]
 === [4.7] Switch to the Maven Publish and Ivy Publish Plugins
 
@@ -308,11 +323,6 @@ subprojects {
     }
 }
 ----
-
-[[rel4.7:switch_to_core_dependency_locking]]
-=== [4.7] Switch to the built-in dependency lock mechanism
-
-++[There is no migration information available right now]++
 
 [[rel4.7:configure_internal_tasks]]
 === [4.7] Configure existing `wrapper` and `init` tasks

--- a/subprojects/docs/src/docs/userguide/userguide_single.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide_single.adoc
@@ -33,6 +33,8 @@ include::overview.adoc[leveloffset=+2]
 
 include::installation.adoc[leveloffset=+2]
 
+include::upgrading_from_gradle4.adoc[leveloffset=+2]
+
 
 == Using Gradle Builds
 

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -74,6 +74,11 @@
             <li><a href="/userguide/userguide.html">User Manual Home</a></li>
             <li><a href="/release-notes.html">Release Notes</a></li>
             <li><a href="/userguide/installation.html">Installing Gradle</a></li>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle</a>
+                <ul id="upgrading-gradle">
+                    <li><a href="/userguide/upgrade_version_4.html">version 4.x to 5.0</a></li>
+                </ul>
+            </li>
             <li id="tutorials"><a href="https://guides.gradle.org/">Tutorials</a></li>
         </ul>
         <h3 id="reference">Reference</h3>

--- a/subprojects/docs/src/samples/plugins/dslWithBuildSrc/build.gradle
+++ b/subprojects/docs/src/samples/plugins/dslWithBuildSrc/build.gradle
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::use-plugin[]
+plugins {
+    id 'my-plugin'
+}
+// end::use-plugin[]
+
+

--- a/subprojects/docs/src/samples/plugins/dslWithBuildSrc/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/plugins/dslWithBuildSrc/buildSrc/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::main-block[]
+plugins {
+    id 'java'
+    id 'java-gradle-plugin'
+}
+
+gradlePlugin {
+    plugins {
+        myPlugins {
+            id = 'my-plugin'
+            implementationClass = 'my.MyPlugin'
+        }
+    }
+}
+
+dependencies {
+    compileOnly gradleApi()
+}
+// end::main-block[]

--- a/subprojects/docs/src/samples/plugins/dslWithBuildSrc/buildSrc/src/main/java/my/MyPlugin.java
+++ b/subprojects/docs/src/samples/plugins/dslWithBuildSrc/buildSrc/src/main/java/my/MyPlugin.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package my;
+
+import org.gradle.api.*;
+import org.gradle.api.plugins.BasePlugin;
+
+public class MyPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(BasePlugin.class);
+    }
+}

--- a/subprojects/docs/src/samples/plugins/dslWithBuildSrc/settings.gradle
+++ b/subprojects/docs/src/samples/plugins/dslWithBuildSrc/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'dsl'


### PR DESCRIPTION
This is a provisional chapter that will hopefully evolve. It covers everything I thought was appropriate from the various release notes.

A few question marks remain:

 * Whether to mention the dependency lock scheme, since there is still no migration guide from the Nebula plugin
 * The "From <version>" headings don't seem useful. I'm leaning towards just having headings containing the version number that the corresponding changes were introduced in. So instead of "From 4.3", we would have "4.4".

The nature of some of the content means that the guide needs reviewing and potentially updating every time a new version of Gradle is released until 5.0 comes out.