### PR TITLE
Mention `Task` dependencies/ordering can take a `Provider`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.LoggingManager;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskDependency;
@@ -95,15 +96,21 @@ import java.util.Set;
  *
  * <li>A {@link TaskDependency} object.</li>
  *
+ * <li>A {@link org.gradle.api.tasks.TaskReference} object.</li>
+ *
  * <li>A {@link Buildable} object.</li>
  *
  * <li>A {@link org.gradle.api.file.RegularFileProperty} or {@link org.gradle.api.file.DirectoryProperty}.</li>
+ *
+ * <li>A {@link Provider} object. May contain any of the types listed here.</li>
  *
  * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
  * iterable/collection/map/array are recursively converted to tasks.</li>
  *
  * <li>A {@code Callable}. The {@code call()} method may return any of the types listed here. Its return value is
  * recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
+ *
+ * <li>Anything else is treated as a failure.</li>
  *
  * </ul>
  *
@@ -236,32 +243,7 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * <p>Adds the given dependencies to this task. See <a href="#dependencies">here</a> for a description of the types
      * of objects which can be used as task dependencies.</p>
      *
-     * @param paths The dependencies to add to this task. The path can be defined by:
-     * <ul>
-     * <li>A {@code String}, {@code CharSequence} or {@code groovy.lang.GString} task path or name. A relative path is interpreted relative to the task's {@link Project}. This
-     * allows you to refer to tasks in other projects.</li>
-     *
-     * <li>A {@link Task}.</li>
-     *
-     * <li>A closure. The closure may take a {@code Task} as parameter. It may return any of the types listed here. Its
-     * return value is recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
-     *
-     * <li>A {@link TaskDependency} object.</li>
-     *
-     * <li>A {@link org.gradle.api.tasks.TaskReference} object.</li>
-     *
-     * <li>A {@link Buildable} object.</li>
-     *
-     * <li>A {@link org.gradle.api.file.RegularFileProperty} or {@link org.gradle.api.file.DirectoryProperty}.</li>
-     *
-     * <li>A {@code Iterable}, {@code Collection}, {@code Map} or array. May contain any of the types listed here. The elements of the
-     * iterable/collection/map/array are recursively converted to tasks.</li>
-     *
-     * <li>A {@code Callable}. The {@code call()} method may return any of the types listed here. Its return value is
-     * recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
-     *
-     * <li>Anything else is treated as a failure.</li>
-     * </ul>
+     * @param paths The dependencies to add to this task.
      *
      * @return the task object this method is applied to
      */


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Fixes https://github.com/gradle/gradle/issues/5676

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazytask%2Ftask-javadoc)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
