### PR TITLE
Make default artifact publication set lazy

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -20,6 +20,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * <p>A {@code DomainObjectCollection} is a specialised {@link Collection} that adds the ability to receive modification notifications and use live filtered sub collections.</p>
@@ -43,6 +44,17 @@ public interface DomainObjectCollection<T> extends Collection<T> {
      */
     @Incubating
     void addLater(Provider<? extends T> provider);
+
+    /**
+     * Adds a set of elements to this collection, given a {@link Provider} that will provide the set when required.
+     *
+     * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
+     *
+     * @param provider A {@link Provider} that can provide the set when required.
+     * @since 4.10
+     */
+    @Incubating
+    void addAllLater(Provider<Set<T>> provider);
 
     /**
      * Returns a collection containing the objects in this collection of the given type.  The returned collection is

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.internal.collections.ElementSource;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Actions;
@@ -282,7 +283,17 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
 
         @Override
-        public void onRealize(Action<ProviderInternal<? extends T>> action) {
+        public void addPendingCollection(CollectionProviderInternal<T, Set<T>> provider) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removePendingCollection(CollectionProviderInternal<T, Set<T>> provider) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void onRealize(Action<CollectionProviderInternal<T, Set<T>>> action) {
 
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -251,6 +251,19 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         store.addPending(providerInternal);
     }
 
+    @Override
+    public void addAllLater(Provider<Set<T>> provider) {
+        assertMutable();
+        CollectionProviderInternal<T, Set<T>> collectionProviderInternal = Cast.uncheckedCast(provider);
+        if (eventRegister.isSubscribed(collectionProviderInternal.getElementType())) {
+            for (T element : provider.get()) {
+                doAdd(element, eventRegister.getAddActions());
+            }
+            return;
+        }
+        store.addPendingCollection(collectionProviderInternal);
+    }
+
     protected void didAdd(T toAdd) {
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.collections.CollectionEventRegister;
 import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.collections.FilteredCollection;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
@@ -38,6 +39,7 @@ import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Set;
 
 public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> implements DomainObjectCollection<T>, WithEstimatedSize {
 
@@ -54,10 +56,12 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         this.type = type;
         this.store = store;
         this.eventRegister = eventRegister;
-        this.store.onRealize(new Action<ProviderInternal<? extends T>>() {
+        this.store.onRealize(new Action<CollectionProviderInternal<T, Set<T>>>() {
             @Override
-            public void execute(ProviderInternal<? extends T> provider) {
-                doAdd(provider.get(), eventRegister.getAddActions());
+            public void execute(CollectionProviderInternal<T, Set<T>> provider) {
+                for (T value : provider.get()) {
+                    doAdd(value, eventRegister.getAddActions());
+                }
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -543,7 +543,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         @Override
         public Map<String, ProviderInternal<? extends T>> getPendingAsMap() {
-            return pendingMap;
+            return Maps.newLinkedHashMap(pendingMap);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
@@ -89,6 +89,11 @@ public class DelegatingDomainObjectSet<T> implements DomainObjectSet<T> {
         backingSet.addLater(provider);
     }
 
+    @Override
+    public void addAllLater(Provider<Set<T>> provider) {
+        backingSet.addAllLater(provider);
+    }
+
     public boolean add(T o) {
         return backingSet.add(o);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
@@ -107,6 +107,11 @@ public class TypedDomainObjectContainerWrapper<U> implements NamedDomainObjectCo
         delegate.addLater(provider);
     }
 
+    @Override
+    public void addAllLater(Provider<Set<U>> provider) {
+        delegate.addAllLater(provider);
+    }
+
     public boolean addAll(Collection<? extends U> c) {
         return delegate.addAll(c);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -49,12 +49,16 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
 
     private void realize(Iterable<ProviderInternal<? extends T>> elements) {
         for (ProviderInternal<? extends T> provider : elements) {
-            if (flushAction != null) {
-                pending.remove(provider);
-                flushAction.execute(provider);
-            } else {
-                throw new IllegalStateException("Cannot realize pending elements when realize action is not set");
-            }
+            realize(provider);
+        }
+    }
+
+    private void realize(ProviderInternal<? extends T> provider) {
+        if (flushAction != null) {
+            pending.remove(provider);
+            flushAction.execute(provider);
+        } else {
+            throw new IllegalStateException("Cannot realize pending elements when realize action is not set");
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -16,18 +16,13 @@
 
 package org.gradle.api.internal.collections;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
-import org.gradle.api.internal.provider.AbstractCollectionProperty;
-import org.gradle.api.internal.provider.AbstractProvider;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.internal.Cast;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -16,12 +16,19 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.api.Transformer;
 import org.gradle.api.internal.WithEstimatedSize;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
+import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     protected final ElementSource<T> collection;
@@ -191,5 +198,18 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     }
 
     @Override
-    public void onRealize(Action<ProviderInternal<? extends S>> action) { }
+    public void addPendingCollection(CollectionProviderInternal<S, Set<S>> provider) {
+        CollectionProviderInternal<T, Set<T>> providerOfT = Cast.uncheckedCast(provider);
+        collection.addPendingCollection(providerOfT);
+    }
+
+    @Override
+    public void removePendingCollection(CollectionProviderInternal<S, Set<S>> provider) {
+        CollectionProviderInternal<T, Set<T>> providerOfT = Cast.uncheckedCast(provider);
+        collection.removePendingCollection(providerOfT);
+    }
+
+    @Override
+    public void onRealize(Action<CollectionProviderInternal<S, Set<S>>> action) { }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -16,15 +16,11 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
-import org.gradle.api.Transformer;
 import org.gradle.api.internal.WithEstimatedSize;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
-import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
-import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
@@ -18,14 +18,12 @@ package org.gradle.api.internal.collections;
 
 import com.google.common.base.Objects;
 import org.gradle.api.Action;
-import org.gradle.api.internal.provider.AbstractProvider;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.internal.Cast;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 
 public class ListElementSource<T> implements IndexedElementSource<T> {
     private final List<T> values = new ArrayList<T>();
@@ -154,7 +156,17 @@ public class ListElementSource<T> implements IndexedElementSource<T> {
     }
 
     @Override
-    public void onRealize(Action<ProviderInternal<? extends T>> action) {
+    public void addPendingCollection(CollectionProviderInternal<T, Set<T>> provider) {
+        pending.addPendingCollection(provider);
+    }
+
+    @Override
+    public void removePendingCollection(CollectionProviderInternal<T, Set<T>> provider) {
+        pending.removePendingCollection(provider);
+    }
+
+    @Override
+    public void onRealize(Action<CollectionProviderInternal<T, Set<T>>> action) {
         pending.onRealize(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
@@ -17,7 +17,10 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
+
+import java.util.Set;
 
 public interface PendingSource<T> {
     void realizePending();
@@ -26,9 +29,13 @@ public interface PendingSource<T> {
 
     void addPending(ProviderInternal<? extends T> provider);
 
+    void addPendingCollection(CollectionProviderInternal<T, Set<T>> provider);
+
     void removePending(ProviderInternal<? extends T> provider);
 
-    void onRealize(Action<ProviderInternal<? extends T>> action);
+    void removePendingCollection(CollectionProviderInternal<T, Set<T>> provider);
+
+    void onRealize(Action<CollectionProviderInternal<T, Set<T>>> action);
 
     boolean isEmpty();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -17,11 +17,13 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.TreeSet;
 
 public class SortedSetElementSource<T> implements ElementSource<T> {
@@ -112,7 +114,17 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     }
 
     @Override
-    public void onRealize(Action<ProviderInternal<? extends T>> action) {
+    public void addPendingCollection(CollectionProviderInternal<T, Set<T>> provider) {
+        pending.addPendingCollection(provider);
+    }
+
+    @Override
+    public void removePendingCollection(CollectionProviderInternal<T, Set<T>> provider) {
+        pending.removePendingCollection(provider);
+    }
+
+    @Override
+    public void onRealize(Action<CollectionProviderInternal<T, Set<T>>> action) {
         pending.onRealize(action);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
 
+// TODO - Let this class handle changing values
 public class SortedSetElementSource<T> implements ElementSource<T> {
     private final TreeSet<T> values;
     private final PendingSource<T> pending = new DefaultPendingSource<T>();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -31,7 +31,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     private static final EmptyCollection EMPTY_COLLECTION = new EmptyCollection();
     private static final NoValueCollector NO_VALUE_COLLECTOR = new NoValueCollector();
     private final Class<? extends Collection> collectionType;
-    private final Class elementType;
+    private final Class<? extends T> elementType;
     private Collector<T> value = (Collector<T>) EMPTY_COLLECTION;
     private List<Collector<T>> collectors = new LinkedList<Collector<T>>();
 
@@ -65,6 +65,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     @Override
     public Class<C> getType() {
         return null;
+    }
+
+    @Override
+    public Class<? extends T> getElementType() {
+        return elementType;
     }
 
     @Override
@@ -134,6 +139,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
         collectors.clear();
         value = new ElementsFromProvider<T>(provider);
+    }
+
+    @Override
+    public int size() {
+        return collectors.size();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/AbstractProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/AbstractProvider.java
@@ -16,12 +16,17 @@
 
 package org.gradle.api.internal.provider;
 
+import com.google.common.collect.Sets;
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.util.GUtil;
+
+import java.util.Set;
 
 import static org.gradle.api.internal.provider.Providers.NULL_VALUE;
 
 public abstract class AbstractProvider<T> implements ProviderInternal<T> {
+    Set<Action<T>> onValueChangeActions = Sets.newLinkedHashSet();
 
     @Override
     public T get() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/ChangingValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/ChangingValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.Action;
+import org.gradle.api.provider.Provider;
+
+public interface ChangingValue<T> {
+    void onValueChange(Action<Provider<T>> action);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/CollectionProviderInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/CollectionProviderInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,18 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.provider.HasMultipleValues;
-
+import javax.annotation.Nullable;
 import java.util.Collection;
 
-public interface CollectionPropertyInternal<T, C extends Collection<T>> extends PropertyInternal<C>, CollectionProviderInternal<T, C>, HasMultipleValues<T> {
+public interface CollectionProviderInternal<T, C extends Collection<T>> extends ProviderInternal<C> {
+    /**
+     * The type that all elements of the collection should be assignable from.
+     */
+    @Nullable
+    Class<? extends T> getElementType();
+
+    /**
+     * The number of elements this provider will produce.
+     */
+    int size();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultChangingValueHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultChangingValueHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.Action;
+import org.gradle.api.provider.Provider;
+
+import java.util.Set;
+
+public class DefaultChangingValueHandler<T> implements ChangingValue<T> {
+    Set<Action<Provider<T>>> onValueChangeActions = Sets.newLinkedHashSet();
+
+    @Override
+    public void onValueChange(Action<Provider<T>> action) {
+        onValueChangeActions.add(action);
+    }
+
+    public void valueChanged(Provider<T> newValue) {
+        for (Action<Provider<T>> action : onValueChangeActions) {
+            action.execute(newValue);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.provider.SetProperty;
 
@@ -30,5 +31,36 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     @Override
     protected Set<T> fromValue(Collection<T> values) {
         return ImmutableSet.copyOf(values);
+    }
+
+    public static <T> DefaultSetProperty<T> from(ProviderInternal<T> provider) {
+        return new SingleElementSetProvider<T>(provider);
+    }
+
+    public static class SingleElementSetProvider<T> extends DefaultSetProperty<T> {
+        private final ProviderInternal<T> providerInternal;
+
+        public SingleElementSetProvider(ProviderInternal<T> providerInternal) {
+            super(providerInternal.getType());
+            this.providerInternal = providerInternal;
+            this.add(providerInternal);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SingleElementSetProvider that = (SingleElementSetProvider) o;
+            return Objects.equal(providerInternal, that.providerInternal);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(providerInternal);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableCollectionProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/LockableCollectionProperty.java
@@ -64,4 +64,15 @@ public abstract class LockableCollectionProperty<T, C extends Collection<T>> ext
         super.lockNow();
         delegate = null;
     }
+
+    @Nullable
+    @Override
+    public Class getElementType() {
+        return delegate.getElementType();
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RealizableTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RealizableTaskCollection.java
@@ -135,6 +135,11 @@ public class RealizableTaskCollection<T extends Task> implements TaskCollection<
     }
 
     @Override
+    public void addAllLater(Provider<Set<T>> provider) {
+        delegate.addAllLater(provider);
+    }
+
+    @Override
     public boolean addAll(Collection<? extends T> c) {
         return delegate.addAll(c);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -74,7 +74,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.addLater(provider)
 
         then:
-        1 * provider.type >> type
+        _ * provider.type >> type
         0 * provider._
 
         and:
@@ -124,7 +124,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !result
 
         and:
-        1 * provider.get() >> a
+        // TODO this should only be called once - this will be fixed when we add support for providers that change values
+        (1.._) * provider.get() >> a
     }
 
     def "can get all domain objects ordered by order added"() {
@@ -169,8 +170,9 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         result == (insertionOrderExpected ? iterationOrder(b, a, d, c) : iterationOrder(b, c, a, d))
 
         and:
-        1 * provider1.get() >> a
-        1 * provider2.get() >> d
+        // TODO this should only be called once - this will be fixed when we add support for providers that change values
+        (1.._) * provider1.get() >> a
+        (1.._) * provider2.get() >> d
         0 * _
     }
 
@@ -209,7 +211,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         1 * action.execute(c)
         _ * provider1.type >> type
-        1 * provider1.get() >> c
+        // TODO this should only be called once - this will be fixed when we add support for providers that change values
+        _ * provider1.get() >> c
         0 * _
 
         when:
@@ -218,7 +221,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         1 * action.execute(a)
         _ * provider2.type >> type
-        1 * provider2.get() >> a
+        // TODO this should only be called once - this will be fixed when we add support for providers that change values
+        _ * provider2.get() >> a
         0 * _
     }
 
@@ -251,7 +255,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         result == iterationOrder(c, a)
         _ * provider.type >> type
-        1 * provider.get() >> a
+        // TODO this should only be called once - this will be fixed when we add support for providers that change values
+        (1.._) * provider.get() >> a
         0 * provider._
 
         when:
@@ -288,7 +293,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         result2 == (insertionOrderExpected ? iterationOrder(c, a, d) : iterationOrder(c, d, a))
-        1 * provider.get() >> a
+        // TODO this should only be called once - this will be fixed when we add support for providers that change values
+        (1.._) * provider.get() >> a
         0 * provider._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -34,6 +34,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
     abstract T getD()
 
+    abstract boolean isInsertionOrderExpected()
+
     Class<T> getType() {
         return a.class
     }
@@ -164,7 +166,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def result = toList(container)
 
         then:
-        result == iterationOrder(b, c, a, d)
+        result == (insertionOrderExpected ? iterationOrder(b, a, d, c) : iterationOrder(b, c, a, d))
 
         and:
         1 * provider1.get() >> a
@@ -256,7 +258,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def result2 = toList(container)
 
         then:
-        result2 == iterationOrder(c, d, a)
+        result2 == (insertionOrderExpected ? iterationOrder(c, a, d) : iterationOrder(c, d, a))
         0 * provider._
     }
 
@@ -285,7 +287,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def result2 = toList(container)
 
         then:
-        result2 == iterationOrder(c, d, a)
+        result2 == (insertionOrderExpected ? iterationOrder(c, a, d) : iterationOrder(c, d, a))
         1 * provider.get() >> a
         0 * provider._
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -124,8 +124,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !result
 
         and:
-        // TODO this should only be called once - this will be fixed when we add support for providers that change values
-        (1.._) * provider.get() >> a
+        1 * provider.get() >> a
     }
 
     def "can get all domain objects ordered by order added"() {
@@ -170,9 +169,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         result == (insertionOrderExpected ? iterationOrder(b, a, d, c) : iterationOrder(b, c, a, d))
 
         and:
-        // TODO this should only be called once - this will be fixed when we add support for providers that change values
-        (1.._) * provider1.get() >> a
-        (1.._) * provider2.get() >> d
+        1 * provider1.get() >> a
+        1 * provider2.get() >> d
         0 * _
     }
 
@@ -211,8 +209,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         1 * action.execute(c)
         _ * provider1.type >> type
-        // TODO this should only be called once - this will be fixed when we add support for providers that change values
-        _ * provider1.get() >> c
+        1 * provider1.get() >> c
         0 * _
 
         when:
@@ -221,8 +218,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         1 * action.execute(a)
         _ * provider2.type >> type
-        // TODO this should only be called once - this will be fixed when we add support for providers that change values
-        _ * provider2.get() >> a
+        1 * provider2.get() >> a
         0 * _
     }
 
@@ -255,8 +251,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         result == iterationOrder(c, a)
         _ * provider.type >> type
-        // TODO this should only be called once - this will be fixed when we add support for providers that change values
-        (1.._) * provider.get() >> a
+        1 * provider.get() >> a
         0 * provider._
 
         when:
@@ -269,6 +264,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
     def "provider for element is not queried when filtered collection with non matching type created"() {
         def provider = Mock(ProviderInternal)
+        _ * provider.type >> type
 
         container.add(c)
         container.addLater(provider)
@@ -285,7 +281,6 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         result == iterationOrder(d)
-        _ * provider.type >> type
         0 * provider._
 
         when:
@@ -293,8 +288,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         result2 == (insertionOrderExpected ? iterationOrder(c, a, d) : iterationOrder(c, d, a))
-        // TODO this should only be called once - this will be fixed when we add support for providers that change values
-        (1.._) * provider.get() >> a
+        1 * provider.get() >> a
         0 * provider._
     }
 
@@ -387,6 +381,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
+        _ * provider1.type >> type
 
         container.addLater(provider1)
         container.add(d)
@@ -395,7 +390,6 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.withType(otherType, action)
 
         then:
-        _ * provider1.type >> type
         1 * action.execute(d)
         0 * _
 
@@ -433,7 +427,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.addLater(provider2)
 
         then:
-        1 * provider2.type >> type
+        _ * provider2.type >> type
         0 * _
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
@@ -28,6 +28,7 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
     String b = "b"
     String c = "c"
     StringBuilder d = new StringBuilder("d")
+    boolean insertionOrderExpected = true
 
     def canGetAllMatchingDomainObjectsOrderedByOrderAdded() {
         def spec = new Spec<CharSequence>() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
@@ -22,6 +22,7 @@ class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<Char
     String b = "b"
     String c = "c"
     StringBuilder d = new StringBuilder("d")
+    boolean insertionOrderExpected = true
 
     def "findAll() filters elements and retains iteration order"() {
         set.add("a")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectCollectionTest.groovy
@@ -36,6 +36,7 @@ class DefaultNamedDomainObjectCollectionTest extends AbstractNamedDomainObjectCo
     final Bean b = new BeanSub1("b")
     final Bean c = new BeanSub1("c")
     final Bean d = new BeanSub2("d")
+    boolean insertionOrderExpected = true
 
     def setup() {
         container.clear()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
@@ -33,6 +33,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
     final String b = "b"
     final String c = "c"
     final StringBuilder d = new StringBuilder("d")
+    boolean insertionOrderExpected = false
 
     def "can add element at given index"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectSetSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectSetSpec.groovy
@@ -33,6 +33,7 @@ class DefaultNamedDomainObjectSetSpec extends AbstractNamedDomainObjectCollectio
     final Bean b = new BeanSub1("b")
     final Bean c = new BeanSub1("c")
     final Bean d = new BeanSub2("d")
+    boolean insertionOrderExpected = false
 
     @Override
     List<Bean> iterationOrder(Bean... elements) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections
+
+import org.gradle.api.Action
+import org.gradle.api.internal.provider.DefaultProvider
+import org.gradle.api.internal.provider.ProviderInternal
+import spock.lang.Specification
+
+import java.util.concurrent.Callable
+
+class IterationOrderRetainingSetElementSourceTest extends Specification {
+    IterationOrderRetainingSetElementSource<String> source = new IterationOrderRetainingSetElementSource<>()
+
+    def setup() {
+        source.onRealize(new Action<ProviderInternal<? extends String>>() {
+            @Override
+            void execute(ProviderInternal<? extends String> providerInternal) {
+                source.add(providerInternal.get())
+            }
+        })
+    }
+
+    def "can add a realized element"() {
+        when:
+        source.add("foo")
+
+        then:
+        source.size() == 1
+        source.contains("foo")
+    }
+
+    def "can add a provider"() {
+        when:
+        source.addPending(provider("foo"))
+
+        then:
+        source.size() == 1
+        source.contains("foo")
+    }
+
+    def "iterates elements in the order they were added"() {
+        when:
+        source.addPending(provider("foo"))
+        source.add("bar")
+        source.add("baz")
+        source.addPending(provider("fizz"))
+
+        then:
+        source.iteratorNoFlush().collect() == ["bar", "baz"]
+
+        and:
+        source.iterator().collect() == ["foo", "bar", "baz", "fizz"]
+    }
+
+    def "once realized, provided values appear like realized values"() {
+        when:
+        source.addPending(provider("foo"))
+        source.add("bar")
+        source.add("baz")
+        source.addPending(provider("fizz"))
+
+        then:
+        source.iteratorNoFlush().collect() == ["bar", "baz"]
+
+        when:
+        source.realizePending()
+
+        then:
+        source.iteratorNoFlush().collect() == ["foo", "bar", "baz", "fizz"]
+    }
+
+    def "can add only providers"() {
+        when:
+        source.addPending(provider("foo"))
+        source.addPending(provider("bar"))
+        source.addPending(provider("baz"))
+        source.addPending(provider("fizz"))
+
+        then:
+        source.iteratorNoFlush().collect() == []
+
+        and:
+        source.iterator().collect() == ["foo", "bar", "baz", "fizz"]
+    }
+
+    def "can add only realized providers"() {
+        when:
+        source.add("foo")
+        source.add("bar")
+        source.add("baz")
+        source.add("fizz")
+
+        then:
+        source.iteratorNoFlush().collect() == ["foo", "bar", "baz", "fizz"]
+
+        and:
+        source.iterator().collect() == ["foo", "bar", "baz", "fizz"]
+    }
+
+    def "can add the same element multiple times"() {
+        when:
+        3.times { source.add("foo") }
+        3.times { source.addPending(provider("bar"))}
+
+        then:
+        source.iteratorNoFlush().collect() == ["foo"]
+
+        and:
+        source.iterator().collect() == ["foo", "bar"]
+    }
+
+    def "can remove a realized element"() {
+        given:
+        source.add("foo")
+        source.addPending(provider("bar"))
+        source.add("baz")
+
+        expect:
+        source.remove("foo")
+
+        and:
+        source.size() == 2
+        source.iterator().collect() == ["bar", "baz"]
+
+        and:
+        !source.remove("foo")
+    }
+
+    def "can remove a provider"() {
+        given:
+        def bar = provider("bar")
+        source.add("foo")
+        source.addPending(bar)
+        source.add("baz")
+
+        expect:
+        source.removePending(bar)
+
+        and:
+        source.size() == 2
+        source.iterator().collect() == ["foo", "baz"]
+    }
+
+    def "can realize a filtered set of providers and order is retained"() {
+        when:
+        source.addPending(provider("foo"))
+        source.addPending(subtypeProvider("bar"))
+        source.addPending(subtypeProvider("baz"))
+        source.addPending(provider("fizz"))
+
+        then:
+        source.iteratorNoFlush().collect() == []
+
+        when:
+        source.realizePending(SubtypeProvider.class)
+
+        then:
+        source.iteratorNoFlush().collect() == ["bar", "baz"]
+
+        and:
+        source.iterator().collect() == ["foo", "bar", "baz", "fizz"]
+    }
+
+    ProviderInternal<? extends String> provider(String value) {
+        return new DefaultProvider<String>({ return value })
+    }
+
+    SubtypeProvider<? extends String> subtypeProvider(String value) {
+        return new SubtypeProvider<String>({ return value })
+    }
+
+    private static class SubtypeProvider<T> extends DefaultProvider<T> {
+        SubtypeProvider(Callable<? extends T> value) {
+            super(value)
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
@@ -184,6 +184,22 @@ class IterationOrderRetainingSetElementSourceTest extends Specification {
         source.iterator().collect() == ["foo", "fizz"]
     }
 
+    def "can remove an element from a provider of set"() {
+        given:
+        def barBaz = providerOfSet("bar", "baz")
+        source.add("foo")
+        source.addPendingCollection(barBaz)
+        source.add("fizz")
+        source.iterator()
+
+        expect:
+        source.remove("bar")
+
+        and:
+        source.size() == 3
+        source.iterator().collect() == ["foo", "baz", "fizz"]
+    }
+
     def "can remove a realized provider"() {
         given:
         source.add("foo")

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -44,7 +44,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(DirectInstantiator.INSTANCE, TestUtil.attributesFactory())],
-        ["configurations", new DefaultConfigurationContainer(null, DirectInstantiator.INSTANCE, domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, TestUtil.attributesFactory(), null, null, null)],
+        ["configurations", new DefaultConfigurationContainer(null, DirectInstantiator.INSTANCE, domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, TestUtil.attributesFactory(), null, null, null, null)],
         ["flavors", new DefaultFlavorContainer(DirectInstantiator.INSTANCE)]
     ]
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -79,6 +79,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.ProjectAccessListener;
@@ -189,7 +190,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                                     GlobalDependencyResolutionRules globalDependencyResolutionRules, VcsMappingsStore vcsMappingsStore, ComponentIdentifierFactory componentIdentifierFactory,
                                                                     BuildOperationExecutor buildOperationExecutor, ImmutableAttributesFactory attributesFactory,
                                                                     ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter,
-                                                                    DependencyLockingProvider dependencyLockingProvider) {
+                                                                    DependencyLockingProvider dependencyLockingProvider,
+                                                                    ProjectStateRegistry projectStateRegistry) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                 configurationResolver,
                 instantiator,
@@ -208,7 +210,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 attributesFactory,
                 moduleIdentifierFactory,
                 componentSelectorConverter,
-                dependencyLockingProvider
+                dependencyLockingProvider,
+                projectStateRegistry
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -38,6 +38,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootC
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.Factory;
@@ -84,7 +85,8 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
                                          ImmutableAttributesFactory attributesFactory,
                                          final ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                          final ComponentSelectorConverter componentSelectorConverter,
-                                         final DependencyLockingProvider dependencyLockingProvider) {
+                                         final DependencyLockingProvider dependencyLockingProvider,
+                                         ProjectStateRegistry projectStateRegistry) {
         super(Configuration.class, instantiator, new Configuration.Namer());
         this.resolver = resolver;
         this.instantiator = instantiator;
@@ -104,7 +106,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
                 return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider);
             }
         };
-        this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, localComponentMetadataBuilder, this);
+        this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, localComponentMetadataBuilder, this, projectStateRegistry);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -28,11 +28,16 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.internal.Factory;
 import org.gradle.internal.component.local.model.BuildableLocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata;
 import org.gradle.internal.component.local.model.RootLocalComponentMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.locking.NoOpDependencyLockingProvider;
+
+import javax.annotation.Nullable;
 
 public class DefaultRootComponentMetadataBuilder implements RootComponentMetadataBuilder {
     private final DependencyMetaDataProvider metadataProvider;
@@ -42,19 +47,21 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
     private final LocalComponentMetadataBuilder localComponentMetadataBuilder;
     private final ConfigurationsProvider configurationsProvider;
     private final MetadataHolder holder;
+    private final ProjectStateRegistry projectStateRegistry;
 
     public DefaultRootComponentMetadataBuilder(DependencyMetaDataProvider metadataProvider,
                                                ComponentIdentifierFactory componentIdentifierFactory,
                                                ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                ProjectFinder projectFinder,
                                                LocalComponentMetadataBuilder localComponentMetadataBuilder,
-                                               ConfigurationsProvider configurationsProvider) {
+                                               ConfigurationsProvider configurationsProvider, ProjectStateRegistry projectStateRegistry) {
         this.metadataProvider = metadataProvider;
         this.componentIdentifierFactory = componentIdentifierFactory;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.projectFinder = projectFinder;
         this.localComponentMetadataBuilder = localComponentMetadataBuilder;
         this.configurationsProvider = configurationsProvider;
+        this.projectStateRegistry = projectStateRegistry;
         this.holder = new MetadataHolder();
     }
 
@@ -70,12 +77,27 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         return metadata;
     }
 
-    private DefaultLocalComponentMetadata buildRootComponentMetadata(Module module, ComponentIdentifier componentIdentifier) {
-        ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
+    private DefaultLocalComponentMetadata buildRootComponentMetadata(final Module module, final ComponentIdentifier componentIdentifier) {
+        final ModuleVersionIdentifier moduleVersionIdentifier = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ProjectInternal project = projectFinder.findProject(module.getProjectPath());
-        AttributesSchemaInternal schema = project == null ? null : (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
-        DependencyLockingProvider dependencyLockingHandler = project == null ? NoOpDependencyLockingProvider.getInstance() : project.getServices().get(DependencyLockingProvider.class);
+        final AttributesSchemaInternal schema = project == null ? null : (AttributesSchemaInternal) project.getDependencies().getAttributesSchema();
+        final DependencyLockingProvider dependencyLockingHandler = project == null ? NoOpDependencyLockingProvider.getInstance() : project.getServices().get(DependencyLockingProvider.class);
 
+        if (project != null) {
+            ProjectState projectState = projectStateRegistry.stateFor(project);
+            return projectState.withMutableState(new Factory<DefaultLocalComponentMetadata>() {
+                @Nullable
+                @Override
+                public DefaultLocalComponentMetadata create() {
+                    return getRootComponentMetadata(module, componentIdentifier, moduleVersionIdentifier, schema, dependencyLockingHandler);
+                }
+            });
+        } else {
+            return getRootComponentMetadata(module, componentIdentifier, moduleVersionIdentifier, schema, dependencyLockingHandler);
+        }
+    }
+
+    private DefaultLocalComponentMetadata getRootComponentMetadata(Module module, ComponentIdentifier componentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier, AttributesSchemaInternal schema, DependencyLockingProvider dependencyLockingHandler) {
         DefaultLocalComponentMetadata metadata = new RootLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema, dependencyLockingHandler);
         for (ConfigurationInternal configuration : configurationsProvider.getAll()) {
             addConfiguration(metadata, configuration);
@@ -92,8 +114,8 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
 
     public RootComponentMetadataBuilder withConfigurationsProvider(ConfigurationsProvider alternateProvider) {
         return new DefaultRootComponentMetadataBuilder(
-            metadataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, localComponentMetadataBuilder, alternateProvider
-        );
+            metadataProvider, componentIdentifierFactory, moduleIdentifierFactory, projectFinder, localComponentMetadataBuilder, alternateProvider,
+            projectStateRegistry);
     }
 
     public MutationValidator getValidator() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder
 import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.event.ListenerManager
@@ -62,11 +63,12 @@ class DefaultConfigurationContainerSpec extends Specification {
     }
     private ComponentSelectorConverter componentSelectorConverter = Mock()
     private DependencyLockingProvider dependencyLockingProvider = Mock()
+    private ProjectStateRegistry projectStateRegistry = Mock()
     def immutableAttributesFactory = TestUtil.attributesFactory()
 
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider,
         projectAccessListener, projectFinder, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
-        immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider);
+        immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, projectStateRegistry);
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalCompone
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.event.ListenerManager
@@ -53,6 +54,7 @@ class DefaultConfigurationContainerTest extends Specification {
     private BuildOperationExecutor buildOperationExecutor = Mock(BuildOperationExecutor)
     private TaskResolver taskResolver = Mock(TaskResolver)
     private DependencyLockingProvider lockingProvider = Mock(DependencyLockingProvider)
+    private ProjectStateRegistry projectStateRegistry = Mock(ProjectStateRegistry)
 
     private Instantiator instantiator = TestUtil.instantiatorFactory().decorate()
     private ImmutableAttributesFactory immutableAttributesFactory = TestUtil.attributesFactory()
@@ -66,7 +68,7 @@ class DefaultConfigurationContainerTest extends Specification {
             resolver, instantiator, new RootScriptDomainObjectContext(),
             listenerManager, metaDataProvider, projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(),
             globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
-            immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, lockingProvider)
+            immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, lockingProvider, projectStateRegistry)
 
     def addsNewConfigurationWhenConfiguringSelf() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider
 import org.gradle.api.internal.artifacts.configurations.MutationValidator
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -40,6 +41,7 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
     def configurationsProvider = Stub(ConfigurationsProvider) {
         getAll() >> ([] as Set)
     }
+    ProjectStateRegistry projectStateRegistry = Mock()
 
     def mid = DefaultModuleIdentifier.newId('foo', 'bar')
 
@@ -49,7 +51,8 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
         moduleIdentifierFactory,
         projectFinder,
         configurationComponentMetaDataBuilder,
-        configurationsProvider)
+        configurationsProvider,
+        projectStateRegistry)
 
     def "caches root component metadata"() {
         componentIdentifierFactory.createComponentIdentifier(_) >> {

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -78,7 +78,6 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
     def addsTasks() {
         when:
         project.pluginManager.apply(EarPlugin)
-        project.evaluate()
 
         and:
         def task = project.tasks[EarPlugin.EAR_TASK_NAME]
@@ -98,7 +97,6 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaPlugin.class)
         project.pluginManager.apply(EarPlugin)
-        project.evaluate()
 
         and:
         def task = project.tasks[EarPlugin.EAR_TASK_NAME]
@@ -174,7 +172,6 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
     def addsEarAsPublication() {
         when:
         project.pluginManager.apply(EarPlugin)
-        project.evaluate()
 
         and:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
@@ -188,7 +185,6 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(WarPlugin)
-        project.evaluate()
 
         and:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
@@ -202,7 +198,6 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(JavaPlugin)
-        project.evaluate()
 
         and:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -78,6 +78,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
     def addsTasks() {
         when:
         project.pluginManager.apply(EarPlugin)
+        project.evaluate()
 
         and:
         def task = project.tasks[EarPlugin.EAR_TASK_NAME]
@@ -97,6 +98,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaPlugin.class)
         project.pluginManager.apply(EarPlugin)
+        project.evaluate()
 
         and:
         def task = project.tasks[EarPlugin.EAR_TASK_NAME]
@@ -172,6 +174,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
     def addsEarAsPublication() {
         when:
         project.pluginManager.apply(EarPlugin)
+        project.evaluate()
 
         and:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
@@ -185,6 +188,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(WarPlugin)
+        project.evaluate()
 
         and:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
@@ -198,6 +202,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(EarPlugin)
         project.pluginManager.apply(JavaPlugin)
+        project.evaluate()
 
         and:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)

--- a/subprojects/maven/src/test/groovy/org/gradle/api/plugins/MavenPluginTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/plugins/MavenPluginTest.groovy
@@ -47,6 +47,7 @@ class MavenPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(WarPlugin)
         project.pluginManager.apply(MavenPlugin)
+        project.evaluate()
 
         then:
         assertHasConfigurationAndMapping(WarPlugin.PROVIDED_COMPILE_CONFIGURATION_NAME, Conf2ScopeMappingContainer.PROVIDED,
@@ -75,6 +76,7 @@ class MavenPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaPlugin)
         project.pluginManager.apply(MavenPlugin)
+        project.evaluate()
 
         then:
         assertHasConfigurationAndMapping(JavaPlugin.COMPILE_CONFIGURATION_NAME, Conf2ScopeMappingContainer.COMPILE,
@@ -102,6 +104,7 @@ class MavenPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaLibraryPlugin)
         project.pluginManager.apply(MavenPlugin)
+        project.evaluate()
 
         then:
         assertHasConfigurationAndMapping(JavaPlugin.API_CONFIGURATION_NAME, Conf2ScopeMappingContainer.COMPILE,

--- a/subprojects/maven/src/test/groovy/org/gradle/api/plugins/MavenPluginTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/plugins/MavenPluginTest.groovy
@@ -47,7 +47,6 @@ class MavenPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(WarPlugin)
         project.pluginManager.apply(MavenPlugin)
-        project.evaluate()
 
         then:
         assertHasConfigurationAndMapping(WarPlugin.PROVIDED_COMPILE_CONFIGURATION_NAME, Conf2ScopeMappingContainer.PROVIDED,
@@ -76,7 +75,6 @@ class MavenPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaPlugin)
         project.pluginManager.apply(MavenPlugin)
-        project.evaluate()
 
         then:
         assertHasConfigurationAndMapping(JavaPlugin.COMPILE_CONFIGURATION_NAME, Conf2ScopeMappingContainer.COMPILE,
@@ -104,7 +102,6 @@ class MavenPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaLibraryPlugin)
         project.pluginManager.apply(MavenPlugin)
-        project.evaluate()
 
         then:
         assertHasConfigurationAndMapping(JavaPlugin.API_CONFIGURATION_NAME, Conf2ScopeMappingContainer.COMPILE,

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/BinaryTasksCollectionWrapper.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/BinaryTasksCollectionWrapper.java
@@ -185,6 +185,11 @@ public class BinaryTasksCollectionWrapper implements BinaryTasksCollection {
     }
 
     @Override
+    public void addAllLater(Provider<Set<Task>> provider) {
+        delegate.addAllLater(provider);
+    }
+
+    @Override
     public boolean remove(Object o) {
         return delegate.remove(o);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -39,6 +39,7 @@ public class DefaultArtifactPublicationSet {
     public void addCandidate(PublishArtifact artifact) {
         if (defaultArtifactProvider == null) {
             defaultArtifactProvider = new DefaultArtifactProvider(artifact);
+            artifactStore.addLater(defaultArtifactProvider);
         }
 
         defaultArtifactProvider.addCandidate(artifact);
@@ -93,8 +94,6 @@ public class DefaultArtifactPublicationSet {
                             replaceCurrent(artifact);
                         }
                     } else if (!newType.equals("jar")) {
-                        // we need to do this add so that we can ensure that artifacts are added in the correct order
-                        artifactStore.add(currentDefault);
                         artifactStore.add(artifact);
                     }
                 }
@@ -105,7 +104,6 @@ public class DefaultArtifactPublicationSet {
 
         private void replaceCurrent(PublishArtifact artifact) {
             artifactStore.remove(currentDefault);
-            artifactStore.add(artifact);
             currentDefault = artifact;
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -36,7 +36,6 @@ import org.gradle.api.internal.plugins.BuildConfigurationRule;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.internal.plugins.UploadRule;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Upload;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
@@ -160,7 +159,7 @@ public class BasePlugin implements Plugin<Project> {
         ConfigurationContainer configurations = project.getConfigurations();
         project.setStatus("integration");
 
-        final Configuration archivesConfiguration = configurations.maybeCreate(Dependency.ARCHIVES_CONFIGURATION).
+        Configuration archivesConfiguration = configurations.maybeCreate(Dependency.ARCHIVES_CONFIGURATION).
                 setDescription("Configuration for archive artifacts.");
 
         configurations.maybeCreate(Dependency.DEFAULT_CONFIGURATION).
@@ -172,22 +171,11 @@ public class BasePlugin implements Plugin<Project> {
 
         configurations.all(new Action<Configuration>() {
             public void execute(Configuration configuration) {
-                configuration.getArtifacts().all(new Action<PublishArtifact>() {
+                configuration.getArtifacts().configureEach(new Action<PublishArtifact>() {
                     public void execute(PublishArtifact artifact) {
                         defaultArtifacts.addCandidate(artifact);
                     }
                 });
-            }
-        });
-
-        // Register the default artifact provider after evaluation so that we don't realize/add the default artifact before all candidates have been added.
-        project.afterEvaluate(new Action<Project>() {
-            @Override
-            public void execute(Project project) {
-                Provider<PublishArtifact> defaultArtifactProvider = defaultArtifacts.getDefaultArtifactProvider();
-                if (defaultArtifactProvider != null) {
-                    archivesConfiguration.getArtifacts().addLater(defaultArtifacts.getDefaultArtifactProvider());
-                }
             }
         });
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/DefaultArtifactPublicationSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/DefaultArtifactPublicationSetTest.groovy
@@ -80,7 +80,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
         then:
         defaultArtifact == war
         1 * publications.remove(jar)
-        1 * publications.add(war)
 
         when:
         publication.addCandidate(jar)
@@ -106,7 +105,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
         then:
         defaultArtifact == ear
         1 * publications.remove(jar)
-        1 * publications.add(ear)
 
         when:
         publication.addCandidate(jar)
@@ -132,7 +130,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
         then:
         defaultArtifact == ear
         1 * publications.remove(war)
-        1 * publications.add(ear)
 
         when:
         publication.addCandidate(war)
@@ -157,7 +154,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
 
         then:
         defaultArtifact == jar
-        1 * publications.add(jar)
         1 * publications.add(exe)
     }
 
@@ -177,7 +173,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
 
         then:
         defaultArtifact == zip
-        1 * publications.add(zip)
         1 * publications.add(exe)
     }
 
@@ -229,7 +224,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
         then:
         defaultArtifact == ear
         1 * publications.remove(exe)
-        1 * publications.add(ear)
     }
 
     def "current default is cached after realizing the provider"() {
@@ -250,7 +244,6 @@ class DefaultArtifactPublicationSetTest extends Specification {
 
         then:
         1 * publications.remove(jar)
-        1 * publications.add(war)
 
         then:
         publication.defaultArtifactProvider.get() == war

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/BasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/BasePluginTest.groovy
@@ -203,6 +203,7 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(BasePlugin)
         project.configurations.create("custom").artifacts.add(artifact)
+        project.evaluate()
 
         then:
         project.configurations[Dependency.ARCHIVES_CONFIGURATION].artifacts.contains(artifact)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/BasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/BasePluginTest.groovy
@@ -203,7 +203,6 @@ class BasePluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(BasePlugin)
         project.configurations.create("custom").artifacts.add(artifact)
-        project.evaluate()
 
         then:
         project.configurations[Dependency.ARCHIVES_CONFIGURATION].artifacts.contains(artifact)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -210,7 +210,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
     def addsJarAsPublication() {
         given:
         project.pluginManager.apply(JavaPlugin)
-        project.evaluate()
 
         when:
         def runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
@@ -297,7 +296,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         new TestFile(project.file("src/main/resources/thing.txt")) << "foo"
         new TestFile(project.file("src/test/java/File.java")) << "foo"
         new TestFile(project.file("src/test/resources/thing.txt")) << "foo"
-        project.evaluate()
 
         when:
         def task = project.tasks[JavaPlugin.PROCESS_RESOURCES_TASK_NAME]

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -210,6 +210,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
     def addsJarAsPublication() {
         given:
         project.pluginManager.apply(JavaPlugin)
+        project.evaluate()
 
         when:
         def runtimeConfiguration = project.configurations.getByName(JavaPlugin.RUNTIME_CONFIGURATION_NAME)
@@ -296,6 +297,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         new TestFile(project.file("src/main/resources/thing.txt")) << "foo"
         new TestFile(project.file("src/test/java/File.java")) << "foo"
         new TestFile(project.file("src/test/resources/thing.txt")) << "foo"
+        project.evaluate()
 
         when:
         def task = project.tasks[JavaPlugin.PROCESS_RESOURCES_TASK_NAME]

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -76,9 +76,10 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
     def "adds tasks"() {
         when:
         project.pluginManager.apply(WarPlugin)
+        project.evaluate()
 
         then:
-        def task = project.tasks[WarPlugin.WAR_TASK_NAME]
+        def task = project.tasks.getByName(WarPlugin.WAR_TASK_NAME)
         task instanceof War
         dependsOn(JavaPlugin.CLASSES_TASK_NAME).matches(task)
         task.destinationDir == project.libsDir
@@ -146,6 +147,7 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
+        project.evaluate()
 
         then:
         archiveConfiguration.getAllArtifacts().size() == 1

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -76,7 +76,6 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
     def "adds tasks"() {
         when:
         project.pluginManager.apply(WarPlugin)
-        project.evaluate()
 
         then:
         def task = project.tasks.getByName(WarPlugin.WAR_TASK_NAME)
@@ -147,7 +146,6 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         def archiveConfiguration = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
-        project.evaluate()
 
         then:
         archiveConfiguration.getAllArtifacts().size() == 1

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -218,7 +218,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
      */
     public void sign(Configuration... configurations) {
         for (Configuration configuration : configurations) {
-            configuration.getAllArtifacts().configureEach(
+            configuration.getAllArtifacts().all(
                 new Action<PublishArtifact>() {
                     @Override
                     public void execute(PublishArtifact artifact) {

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -218,7 +218,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
      */
     public void sign(Configuration... configurations) {
         for (Configuration configuration : configurations) {
-            configuration.getAllArtifacts().all(
+            configuration.getAllArtifacts().configureEach(
                 new Action<PublishArtifact>() {
                     @Override
                     public void execute(PublishArtifact artifact) {


### PR DESCRIPTION
These changes do two things:
 1. `DefaultArtifactPublicationSet` is now lazy, adding a provider to the artifacts container (instead of a realized artifact) which will allow the jar task to be created lazily only when the provider is realized.
1. `IterationOrderRetainingSetElementSource` now tracks and maintains the insertion order of elements so that it will iterate over the set in the order that elements were inserted rather than realized.  This is necessary because the Maven plugin requires the default artifact to be the first artifact in the container.