### PR TITLE
Make DistributedPerformanceTest cacheable

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/GradleDistributionWithSamples.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/GradleDistributionWithSamples.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,40 +20,19 @@ import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
 @CompileStatic
-class GradleDistribution {
-    private ConfigurableFileTree libs
-    private ConfigurableFileTree plugins
+class GradleDistributionWithSamples extends GradleDistribution {
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    ConfigurableFileTree staticContent
+    ConfigurableFileTree samples
 
-    @Classpath
-    SortedSet<File> getCoreJars() {
-        libs.files as SortedSet
-    }
-
-    @Classpath
-    SortedSet<File> getPluginJars() {
-        plugins.files as SortedSet
-    }
-
-    GradleDistribution(Project project, DirectoryProperty gradleHomeDir) {
-        staticContent  = project.fileTree(gradleHomeDir)
-        staticContent.exclude 'lib/**'
-        staticContent.exclude 'samples/**'
-        staticContent.exclude 'src/**'
-        staticContent.exclude 'docs/**'
-        libs = project.fileTree(gradleHomeDir.dir('lib'))
-        libs.include('*.jar')
-        libs.exclude('plugins/**')
-        plugins = project.fileTree(gradleHomeDir.dir('lib/plugins'))
-        plugins.include('*.jar')
+    GradleDistributionWithSamples(Project project, DirectoryProperty gradleHomeDir) {
+        super(project, gradleHomeDir)
+        samples = project.fileTree(gradleHomeDir.dir('samples'))
     }
 }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -44,11 +44,11 @@ open class DistributionTest : Test() {
         "${OperatingSystem.current().name} ${System.getProperty("os.arch")}"
     }
 
-    @Internal
-    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project)
+    @get:Input
+    val binaryDistributions = BinaryDistributions(project.layout)
 
     @Internal
-    val binaryDistributions = BinaryDistributions(project.layout)
+    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project)
 
     @Internal
     val libsRepository = LibsRepositoryEnvironmentProvider(project.layout)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.testing.Test
 import org.gradle.build.GradleDistribution
+import org.gradle.build.GradleDistributionWithSamples
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.CommandLineArgumentProvider
 import java.util.concurrent.Callable
@@ -48,7 +49,7 @@ open class DistributionTest : Test() {
     val binaryDistributions = BinaryDistributions(project.layout)
 
     @Internal
-    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project)
+    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project, binaryDistributions.distributionsRequired)
 
     @Internal
     val libsRepository = LibsRepositoryEnvironmentProvider(project.layout)
@@ -81,7 +82,7 @@ class LibsRepositoryEnvironmentProvider(layout: ProjectLayout) : CommandLineArgu
 }
 
 
-class GradleInstallationForTestEnvironmentProvider(project: Project) : CommandLineArgumentProvider, Named {
+class GradleInstallationForTestEnvironmentProvider(project: Project, distributionsRequired: Boolean) : CommandLineArgumentProvider, Named {
 
     @Internal
     val gradleHomeDir = project.layout.directoryProperty()
@@ -100,7 +101,7 @@ class GradleInstallationForTestEnvironmentProvider(project: Project) : CommandLi
     val daemonRegistry = project.layout.directoryProperty()
 
     @Nested
-    val gradleDistribution = GradleDistribution(project, gradleHomeDir)
+    val gradleDistribution: GradleDistribution = if (distributionsRequired) GradleDistributionWithSamples(project, gradleHomeDir) else GradleDistribution(project, gradleHomeDir)
 
     override fun asArguments() =
         mapOf(

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -46,10 +46,10 @@ open class DistributionTest : Test() {
     }
 
     @Internal
-    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project, binaryDistributions.distributionsRequired)
+    val binaryDistributions = BinaryDistributions(project.layout)
 
     @Internal
-    val binaryDistributions = BinaryDistributions(project.layout)
+    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project, binaryDistributions.distributionsRequired)
 
     @Internal
     val libsRepository = LibsRepositoryEnvironmentProvider(project.layout)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -44,7 +44,7 @@ open class DistributionTest : Test() {
         "${OperatingSystem.current().name} ${System.getProperty("os.arch")}"
     }
 
-    @get:Input
+    @Internal
     val binaryDistributions = BinaryDistributions(project.layout)
 
     @Internal

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -46,10 +46,10 @@ open class DistributionTest : Test() {
     }
 
     @Internal
-    val binaryDistributions = BinaryDistributions(project.layout)
+    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project, binaryDistributions.distributionsRequired)
 
     @Internal
-    val gradleInstallationForTest = GradleInstallationForTestEnvironmentProvider(project, binaryDistributions.distributionsRequired)
+    val binaryDistributions = BinaryDistributions(project.layout)
 
     @Internal
     val libsRepository = LibsRepositoryEnvironmentProvider(project.layout)

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -94,6 +94,12 @@ class DistributedPerformanceTest extends PerformanceTest {
         this.cancellationToken = cancellationToken
     }
 
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    File getBinaryDistributionDir() {
+        new File(binaryDistributions.distsDir.asFile.get().absolutePath)
+    }
+
     @Override
     void addTestListener(TestListener listener) {
         testEventsGenerator.addTestListener(listener)

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -95,7 +95,7 @@ class DistributedPerformanceTest extends PerformanceTest {
         this.testEventsGenerator = new JUnitXmlTestEventsGenerator(listenerManager.createAnonymousBroadcaster(TestListener.class), listenerManager.createAnonymousBroadcaster(TestOutputListener.class))
         this.cancellationToken = cancellationToken
     }
-
+l
     @Override
     void addTestListener(TestListener listener) {
         testEventsGenerator.addTestListener(listener)
@@ -139,14 +139,10 @@ class DistributedPerformanceTest extends PerformanceTest {
 
         def scenarios = scenarioList.readLines()
             .collect { line ->
-                def parts = Splitter.on(';').split(line).toList()
-                new Scenario(id : parts[0], estimatedRuntime: Long.parseLong(parts[1]), templates: parts.subList(2, parts.size()))
-            }
-            .sort{ it.estimatedRuntime }
-
-        scenarios = scenarios[0..<1]
-
-        assert scenarios.size() == 1
+            def parts = Splitter.on(';').split(line).toList()
+            new Scenario(id : parts[0], estimatedRuntime: Long.parseLong(parts[1]), templates: parts.subList(2, parts.size()))
+        }
+        .sort{ -it.estimatedRuntime }
 
         createClient()
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -70,9 +70,11 @@ class DistributedPerformanceTest extends PerformanceTest {
     String teamCityPassword
 
     @OutputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     File scenarioList
 
     @OutputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     File scenarioReport
 
     private RESTClient client
@@ -92,12 +94,6 @@ class DistributedPerformanceTest extends PerformanceTest {
     DistributedPerformanceTest(BuildCancellationToken cancellationToken) {
         this.testEventsGenerator = new JUnitXmlTestEventsGenerator(listenerManager.createAnonymousBroadcaster(TestListener.class), listenerManager.createAnonymousBroadcaster(TestOutputListener.class))
         this.cancellationToken = cancellationToken
-    }
-
-    @InputDirectory
-    @PathSensitive(PathSensitivity.RELATIVE)
-    File getBinaryDistributionDir() {
-        new File(binaryDistributions.distsDir.asFile.get().absolutePath)
     }
 
     @Override

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -45,12 +45,13 @@ import java.util.zip.ZipInputStream
  * blocks until all the jobs have finished and aggregates their status.
  */
 @CompileStatic
+@CacheableTask
 class DistributedPerformanceTest extends PerformanceTest {
 
-    @Input @Optional
+    @Internal
     String coordinatorBuildId
 
-    @Input @Optional
+    @Internal
     String branchName
 
     @Input

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -95,7 +95,7 @@ class DistributedPerformanceTest extends PerformanceTest {
         this.testEventsGenerator = new JUnitXmlTestEventsGenerator(listenerManager.createAnonymousBroadcaster(TestListener.class), listenerManager.createAnonymousBroadcaster(TestOutputListener.class))
         this.cancellationToken = cancellationToken
     }
-l
+
     @Override
     void addTestListener(TestListener listener) {
         testEventsGenerator.addTestListener(listener)
@@ -139,10 +139,10 @@ l
 
         def scenarios = scenarioList.readLines()
             .collect { line ->
-            def parts = Splitter.on(';').split(line).toList()
-            new Scenario(id : parts[0], estimatedRuntime: Long.parseLong(parts[1]), templates: parts.subList(2, parts.size()))
-        }
-        .sort{ -it.estimatedRuntime }
+                def parts = Splitter.on(';').split(line).toList()
+                new Scenario(id: parts[0], estimatedRuntime: Long.parseLong(parts[1]), templates: parts.subList(2, parts.size()))
+            }
+            .sort { -it.estimatedRuntime }
 
         createClient()
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -146,7 +146,11 @@ class DistributedPerformanceTest extends PerformanceTest {
                 def parts = Splitter.on(';').split(line).toList()
                 new Scenario(id : parts[0], estimatedRuntime: Long.parseLong(parts[1]), templates: parts.subList(2, parts.size()))
             }
-            .sort{ -it.estimatedRuntime }
+            .sort{ it.estimatedRuntime }
+
+        scenarios = scenarios[0..<1]
+
+        assert scenarios.size() == 1
 
         createClient()
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.internal.IoActions
 import javax.inject.Inject
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipInputStream
+import javax.annotation.Nullable
 
 /**
  * Runs each performance test scenario in a dedicated TeamCity job.
@@ -94,6 +95,19 @@ class DistributedPerformanceTest extends PerformanceTest {
     DistributedPerformanceTest(BuildCancellationToken cancellationToken) {
         this.testEventsGenerator = new JUnitXmlTestEventsGenerator(listenerManager.createAnonymousBroadcaster(TestListener.class), listenerManager.createAnonymousBroadcaster(TestOutputListener.class))
         this.cancellationToken = cancellationToken
+    }
+
+    @Nullable
+    @Optional
+    @Input
+    String getBaselineCacheKey() {
+        List baselineList = baselines == null ? [] : baselines.split(',').collect { String it -> it.trim() }
+        if (baselineList.contains('last') || baselineList.contains('nightly')) {
+            // turn off cache if the baseline contains 'nightly' or 'last'
+            return UUID.randomUUID().toString()
+        } else {
+            return baselines
+        }
     }
 
     @Override

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -443,8 +443,8 @@ class PerformanceTestPlugin : Plugin<Project> {
     fun Project.configureForAnyDistributedPerformanceTestTask(task: DistributedPerformanceTest) {
         task.apply {
             val registerInputs: (Task) -> Unit = { prepareSampleTask ->
-                val workerTaskProperties = prepareSampleTask.inputs.properties.mapKeys { entry -> "${prepareSampleTask.name}_${entry.key}" }
-                task.inputs.properties(workerTaskProperties)
+                val prepareSampleTaskInputs = prepareSampleTask.inputs.properties.mapKeys { entry -> "${prepareSampleTask.name}_${entry.key}" }
+                task.inputs.properties(prepareSampleTaskInputs)
             }
             tasks.withType<ProjectGeneratorTask>().forEach(registerInputs)
             tasks.withType<RemoteProject>().forEach(registerInputs)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -321,6 +321,7 @@ class PerformanceTestPlugin : Plugin<Project> {
 
         val result = tasks.register(name, DistributedPerformanceTest::class.java) {
             configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask, performanceReportTask)
+            configureForAnyDistributedPerformanceTestTask(this)
             scenarioList = buildDir / Config.performanceTestScenarioListFileName
             scenarioReport = buildDir / Config.performanceTestScenarioReportFileName
             buildTypeId = stringPropertyOrNull(PropertyNames.buildTypeId)
@@ -435,6 +436,19 @@ class PerformanceTestPlugin : Plugin<Project> {
                     performanceReportTask.get().systemProperty(PropertyNames.channel, channel)
                 }
             }
+        }
+    }
+
+    private
+    fun Project.configureForAnyDistributedPerformanceTestTask(task: DistributedPerformanceTest) {
+        task.apply {
+            val registerInputs: (Task) -> Unit = { prepareSampleTask ->
+                val workerTaskProperties = prepareSampleTask.inputs.properties.mapKeys { entry -> "${prepareSampleTask.name}_${entry.key}" }
+                task.inputs.properties(workerTaskProperties)
+            }
+            tasks.withType<ProjectGeneratorTask>().forEach(registerInputs)
+            tasks.withType<RemoteProject>().forEach(registerInputs)
+            tasks.withType<JavaExecProjectGeneratorTask>().forEach(registerInputs)
         }
     }
 


### PR DESCRIPTION
### Context

Previously, `DistributedPerformanceTest` is non cacheable, which means, even though only a typo is fixed in documentation, the whole time-wasting PerformanceTestCoordinator stage will run for a few hours. This PR fixed this issue by:

- Change `DistributedPerformanceTest.coordinatorBuildId` from `@Input` to `@Internal`. In each build this value is new so the task will never be up-to-date.
- Change `DistributedPerformanceTest.branchName` from `@Input` to `@Internal`. If branch changes but the code doesn't change, it doesn't need to be rebuilt.
- Distinguish `GradleDistribution` and `GradleDistributionWithSamples`. Modifying samples shouldn't make the performance test out-of-date.
