### PR TITLE
Introduce some initial projects extensions for JVM plugins to replace convention objects

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -39,17 +39,18 @@ in the next major Gradle version (Gradle 5.0). See the User guide section on the
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
 
-<!--
-### Example deprecation
--->
+### Creating instances of JavaPluginConvention
+
+Instances of this class are intended to be created only by the `java-base` plugin and should not be created directly. Creating instances using the constructor of `JavaPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `java-base` plugin.
 
 ## Potential breaking changes
 
-<!--
-### Example breaking change
--->
+### Kotlin DSL breakages
+
+- `project.java.sourceSets` is now `project.sourceSets`
 
 ## External contributions
+
 
 We would like to thank the following community members for making contributions to this release of Gradle.
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BasePluginGoodBehaviourTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BasePluginGoodBehaviourTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.tasks;
 
-import org.gradle.api.NamedDomainObjectContainer;
+package org.gradle.api.plugins
 
-/**
- * A {@code SourceSetContainer} manages a set of {@link SourceSet} objects.
- */
-public interface SourceSetContainer extends NamedDomainObjectContainer<SourceSet> {
+import org.gradle.integtests.fixtures.WellBehavedPluginTest
+
+
+class BasePluginGoodBehaviourTest extends WellBehavedPluginTest {
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginGoodBehaviourTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginGoodBehaviourTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.tasks;
 
-import org.gradle.api.NamedDomainObjectContainer;
+package org.gradle.api.plugins
 
-/**
- * A {@code SourceSetContainer} manages a set of {@link SourceSet} objects.
- */
-public interface SourceSetContainer extends NamedDomainObjectContainer<SourceSet> {
+import org.gradle.integtests.fixtures.WellBehavedPluginTest
+
+
+class JavaBasePluginGoodBehaviourTest extends WellBehavedPluginTest {
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+
+class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
+    def "can define and build a source set with implementation dependencies"() {
+        settingsFile << """
+            include 'main', 'tests'
+        """
+        buildFile << """
+            project(':main') {
+                apply plugin: 'java'
+            }
+            project(':tests') {
+                apply plugin: 'java-base'
+                sourceSets {
+                    unitTest {
+                    }
+                }
+                dependencies {
+                    unitTestImplementation project(':main')
+                }
+            }
+        """
+        file("main/src/main/java/Main.java") << """public class Main { }"""
+        file("tests/src/unitTest/java/Test.java") << """public class Test { Main main = null; }"""
+
+        expect:
+        succeeds(":test:unitTestClasses")
+        file("main/build/classes/java/main").assertHasDescendants("Main.class")
+        file("tests/build/classes/java/unitTest").assertHasDescendants("Test.class")
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -16,7 +16,10 @@
 
 package org.gradle.api.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import spock.lang.IgnoreIf
 
 
 class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
@@ -46,5 +49,29 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
         succeeds(":test:unitTestClasses")
         file("main/build/classes/java/main").assertHasDescendants("Main.class")
         file("tests/build/classes/java/unitTest").assertHasDescendants("Test.class")
+    }
+
+    @IgnoreIf({ AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8) == null })
+    def "can configure source and target Java versions"() {
+        def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
+        buildFile << """
+            apply plugin: 'java-base'
+            java {
+                sourceCompatibility = JavaVersion.VERSION_1_7
+                targetCompatibility = JavaVersion.VERSION_1_8
+            }
+            sourceSets { 
+                unitTest { } 
+            }
+            compileUnitTestJava.options.forkOptions.javaHome = file('${jdk.javaHome}')
+            compileUnitTestJava.doFirst {
+                assert sourceCompatibility == "1.7"
+                assert targetCompatibility == "1.8"
+            }
+        """
+        file("src/unitTest/java/Test.java") << """public class Test { }"""
+
+        expect:
+        succeeds("unitTestClasses")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -63,7 +63,10 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
             sourceSets { 
                 unitTest { } 
             }
-            compileUnitTestJava.options.forkOptions.javaHome = file('${jdk.javaHome}')
+            compileUnitTestJava {
+                options.fork = true
+                options.forkOptions.javaHome = file('${jdk.javaHome.toURI()}')
+            }
             compileUnitTestJava.doFirst {
                 assert sourceCompatibility == "1.7"
                 assert targetCompatibility == "1.8"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginGoodBehaviourTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginGoodBehaviourTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.tasks;
 
-import org.gradle.api.NamedDomainObjectContainer;
+package org.gradle.api.plugins
 
-/**
- * A {@code SourceSetContainer} manages a set of {@link SourceSet} objects.
- */
-public interface SourceSetContainer extends NamedDomainObjectContainer<SourceSet> {
+import org.gradle.integtests.fixtures.WellBehavedPluginTest
+
+
+class JavaPluginGoodBehaviourTest extends WellBehavedPluginTest {
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -84,6 +84,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
 
         JavaPluginConvention javaConvention = new JavaPluginConvention(project, instantiator);
         project.getConvention().getPlugins().put("java", javaConvention);
+        project.getExtensions().add("sourceSets", javaConvention.getSourceSets());
 
         configureSourceSetDefaults(javaConvention);
         configureCompileDefaults(project, javaConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -46,10 +46,12 @@ import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.Factory;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.SingleMessageLogger;
 
 import javax.inject.Inject;
@@ -79,11 +81,16 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         this.objectFactory = objectFactory;
     }
 
-    public void apply(ProjectInternal project) {
+    public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(BasePlugin.class);
         project.getPluginManager().apply(ReportingBasePlugin.class);
 
-        JavaPluginConvention javaConvention = new JavaPluginConvention(project, instantiator);
+        JavaPluginConvention javaConvention = DeprecationLogger.whileDisabled(new Factory<JavaPluginConvention>() {
+            @Override
+            public JavaPluginConvention create() {
+                return new JavaPluginConvention(project, instantiator);
+            }
+        });
         project.getConvention().getPlugins().put("java", javaConvention);
         project.getExtensions().add("sourceSets", javaConvention.getSourceSets());
         project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.DefaultJavaPluginExtension;
 import org.gradle.api.plugins.internal.SourceSetUtil;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.ReportingExtension;
@@ -85,6 +86,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         JavaPluginConvention javaConvention = new JavaPluginConvention(project, instantiator);
         project.getConvention().getPlugins().put("java", javaConvention);
         project.getExtensions().add("sourceSets", javaConvention.getSourceSets());
+        project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);
 
         configureSourceSetDefaults(javaConvention);
         configureCompileDefaults(project, javaConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.internal.Actions;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testing.base.plugins.TestingBasePlugin;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
@@ -53,7 +54,14 @@ public class JavaPluginConvention {
     private JavaVersion srcCompat;
     private JavaVersion targetCompat;
 
+    /**
+     * Constructs a {@link JavaPluginConvention}.
+     *
+     * @deprecated Creating instances of this class is deprecated. These should be created by the Java base plugin only.
+     */
+    @Deprecated
     public JavaPluginConvention(ProjectInternal project, Instantiator instantiator) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of JavaPluginConvention");
         this.project = project;
         sourceSets = instantiator.newInstance(DefaultSourceSetContainer.class, project.getFileResolver(), project.getTasks(), instantiator,
             project.getServices().get(SourceDirectorySetFactory.class));

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.JavaVersion;
+
+/**
+ * Common configuration for Java based projects. This is added by the {@link JavaBasePlugin}.
+ *
+ * @since 4.10
+ */
+@Incubating
+public interface JavaPluginExtension {
+    /**
+     * Returns the source compatibility used for compiling Java sources.
+     */
+    JavaVersion getSourceCompatibility();
+
+    /**
+     * Sets the source compatibility used for compiling Java sources.
+     *
+     * @param value The value for the source compatibility
+     */
+    void setSourceCompatibility(JavaVersion value);
+
+    /**
+     * Returns the target compatibility used for compiling Java sources.
+     */
+    JavaVersion getTargetCompatibility();
+
+    /**
+     * Sets the target compatibility used for compiling Java sources.
+     *
+     * @param value The value for the target compatibility
+     */
+    void setTargetCompatibility(JavaVersion value);
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.tasks.SourceSetContainer;
 
 /**
  * Common configuration for Java based projects. This is added by the {@link JavaBasePlugin}.
@@ -49,4 +50,7 @@ public interface JavaPluginExtension {
      * @param value The value for the target compatibility
      */
     void setTargetCompatibility(JavaVersion value);
+
+    // TODO - this will be removed
+    SourceSetContainer getSourceSets();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.JavaVersion;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
+
+public class DefaultJavaPluginExtension implements JavaPluginExtension {
+    private final JavaPluginConvention convention;
+
+    public DefaultJavaPluginExtension(JavaPluginConvention convention) {
+        this.convention = convention;
+    }
+
+    @Override
+    public JavaVersion getSourceCompatibility() {
+        return convention.getSourceCompatibility();
+    }
+
+    @Override
+    public void setSourceCompatibility(JavaVersion value) {
+        convention.setSourceCompatibility(value);
+    }
+
+    @Override
+    public JavaVersion getTargetCompatibility() {
+        return convention.getTargetCompatibility();
+    }
+
+    @Override
+    public void setTargetCompatibility(JavaVersion value) {
+        convention.setTargetCompatibility(value);
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.internal;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.SourceSetContainer;
 
 public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final JavaPluginConvention convention;
@@ -45,5 +46,10 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     @Override
     public void setTargetCompatibility(JavaVersion value) {
         convention.setTargetCompatibility(value);
+    }
+
+    @Override
+    public SourceSetContainer getSourceSets() {
+        return convention.getSourceSets();
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -339,7 +339,7 @@ public interface SourceSet {
     String getRuntimeClasspathConfigurationName();
 
     /**
-     * Returns the name of the configuration containing elements that are stricly required
+     * Returns the name of the configuration containing elements that are strictly required
      * at runtime. Consumers of this configuration will get all the mandatory elements for
      * this component to execute at runtime.
      *

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -42,7 +42,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     @Rule
     public SetSystemProperties sysProperties = new SetSystemProperties()
 
-    void appliesBasePluginsAndAddsConventionObject() {
+    void appliesBasePluginsAndAddsConventionAndExtensions() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -50,6 +50,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.plugins.hasPlugin(ReportingBasePlugin)
         project.plugins.hasPlugin(BasePlugin)
         project.convention.plugins.java instanceof JavaPluginConvention
+        project.extensions.sourceSets.is(project.convention.plugins.java.sourceSets)
     }
 
     void "creates tasks and applies mappings for source set"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.JavaVersion
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
@@ -42,7 +43,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     @Rule
     public SetSystemProperties sysProperties = new SetSystemProperties()
 
-    void appliesBasePluginsAndAddsConventionAndExtensions() {
+    void "applies base plugins and adds convention and extensions"() {
         when:
         project.pluginManager.apply(JavaBasePlugin)
 
@@ -51,6 +52,55 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         project.plugins.hasPlugin(BasePlugin)
         project.convention.plugins.java instanceof JavaPluginConvention
         project.extensions.sourceSets.is(project.convention.plugins.java.sourceSets)
+        project.extensions.java instanceof JavaPluginExtension
+    }
+
+    void "properties on convention and extension are synchronized"() {
+        when:
+        project.pluginManager.apply(JavaBasePlugin)
+
+        then:
+        def ext = project.extensions.java
+        project.sourceCompatibility == JavaVersion.current()
+        project.targetCompatibility == JavaVersion.current()
+        ext.sourceCompatibility == JavaVersion.current()
+        ext.targetCompatibility == JavaVersion.current()
+
+        when:
+        project.sourceCompatibility = JavaVersion.VERSION_1_6
+
+        then:
+        project.sourceCompatibility == JavaVersion.VERSION_1_6
+        project.targetCompatibility == JavaVersion.VERSION_1_6
+        ext.sourceCompatibility == JavaVersion.VERSION_1_6
+        ext.targetCompatibility == JavaVersion.VERSION_1_6
+
+        when:
+        ext.sourceCompatibility = JavaVersion.VERSION_1_8
+
+        then:
+        project.sourceCompatibility == JavaVersion.VERSION_1_8
+        project.targetCompatibility == JavaVersion.VERSION_1_8
+        ext.sourceCompatibility == JavaVersion.VERSION_1_8
+        ext.targetCompatibility == JavaVersion.VERSION_1_8
+
+        when:
+        project.targetCompatibility = JavaVersion.VERSION_1_7
+
+        then:
+        project.sourceCompatibility == JavaVersion.VERSION_1_8
+        project.targetCompatibility == JavaVersion.VERSION_1_7
+        ext.sourceCompatibility == JavaVersion.VERSION_1_8
+        ext.targetCompatibility == JavaVersion.VERSION_1_7
+
+        when:
+        ext.targetCompatibility = JavaVersion.VERSION_1_6
+
+        then:
+        project.sourceCompatibility == JavaVersion.VERSION_1_8
+        project.targetCompatibility == JavaVersion.VERSION_1_6
+        ext.sourceCompatibility == JavaVersion.VERSION_1_8
+        ext.targetCompatibility == JavaVersion.VERSION_1_6
     }
 
     void "creates tasks and applies mappings for source set"() {


### PR DESCRIPTION
### Context

This is the first change to address https://github.com/gradle/gradle/issues/5377. It adds `java` and `sourceSets` extension objects to the project, intended to eventually replace the properties added using `JavaPluginConvention`.

This PR also deprecates the constructor of `JavaPluginConvention` and adds some missing test coverage.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
