### PR TITLE
Cache jar snapshots for immutable files in user home

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
@@ -87,6 +87,7 @@ class TestProjectGenerator {
      */
     private addDummyBuildSrcProject(File projectDir) {
         file projectDir, "buildSrc/src/main/java/Thing.java", "public class Thing {}"
+        file projectDir, "buildSrc/build.gradle", "compileJava.options.incremental = true"
     }
 
     void file(File dir, String name, String content) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.tasks.compile.incremental;
 
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
-import org.gradle.api.internal.tasks.compile.incremental.cache.CompileCaches;
+import org.gradle.api.internal.tasks.compile.incremental.cache.TaskScopedCompileCaches;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
 import org.gradle.api.internal.tasks.compile.incremental.jar.JarClasspathSnapshotMaker;
@@ -35,7 +35,7 @@ public class IncrementalCompilerDecorator {
 
     private static final Logger LOG = Logging.getLogger(IncrementalCompilerDecorator.class);
     private final JarClasspathSnapshotMaker jarClasspathSnapshotMaker;
-    private final CompileCaches compileCaches;
+    private final TaskScopedCompileCaches compileCaches;
     private final CleaningJavaCompiler cleaningCompiler;
     private final String displayName;
     private final RecompilationSpecProvider staleClassDetecter;
@@ -44,7 +44,7 @@ public class IncrementalCompilerDecorator {
     private final Compiler<JavaCompileSpec> rebuildAllCompiler;
     private final IncrementalCompilationInitializer compilationInitializer;
 
-    public IncrementalCompilerDecorator(JarClasspathSnapshotMaker jarClasspathSnapshotMaker, CompileCaches compileCaches,
+    public IncrementalCompilerDecorator(JarClasspathSnapshotMaker jarClasspathSnapshotMaker, TaskScopedCompileCaches compileCaches,
                                         IncrementalCompilationInitializer compilationInitializer, CleaningJavaCompiler cleaningCompiler, String displayName,
                                         RecompilationSpecProvider staleClassDetecter, ClassSetAnalysisUpdater classSetAnalysisUpdater,
                                         CompilationSourceDirs sourceDirs, Compiler<JavaCompileSpec> rebuildAllCompiler) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/BuildScopedCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/BuildScopedCompileCaches.java
@@ -22,10 +22,14 @@ import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 import org.gradle.api.internal.tasks.compile.incremental.jar.LocalJarClasspathSnapshotStore;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 
-public interface CompileCaches {
+public interface BuildScopedCompileCaches {
     ClassAnalysisCache getClassAnalysisCache();
+
     JarSnapshotCache getJarSnapshotCache();
-    LocalJarClasspathSnapshotStore getLocalJarClasspathSnapshotStore();
-    LocalClassSetAnalysisStore getLocalClassSetAnalysisStore();
-    AnnotationProcessorPathStore getAnnotationProcessorPathStore();
+
+    LocalJarClasspathSnapshotStore createLocalJarClasspathSnapshotStore(String taskPath);
+
+    LocalClassSetAnalysisStore createLocalClassSetAnalysisStore(String taskPath);
+
+    AnnotationProcessorPathStore createAnnotationProcessorPathStore(String taskPath);
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/DefaultUserHomeScopedCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/DefaultUserHomeScopedCompileCaches.java
@@ -46,7 +46,6 @@ public class DefaultUserHomeScopedCompileCaches implements UserHomeScopedCompile
         PersistentIndexedCacheParameters<HashCode, JarSnapshotData> jarCacheParameters = new PersistentIndexedCacheParameters<HashCode, JarSnapshotData>("jarAnalysis", new HashCodeSerializer(), new JarSnapshotDataSerializer())
             .cacheDecorator(inMemoryCacheDecoratorFactory.decorator(20000, true));
         this.jarSnapshotCache = new DefaultJarSnapshotCache(fileHasher, cache.createCache(jarCacheParameters));
-
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/DefaultUserHomeScopedCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/DefaultUserHomeScopedCompileCaches.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.cache;
+
+import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
+import org.gradle.api.internal.tasks.compile.incremental.jar.DefaultJarSnapshotCache;
+import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
+import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotData;
+import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotDataSerializer;
+import org.gradle.cache.CacheRepository;
+import org.gradle.cache.FileLockManager;
+import org.gradle.cache.PersistentCache;
+import org.gradle.cache.PersistentIndexedCacheParameters;
+import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.serialize.HashCodeSerializer;
+
+import java.io.Closeable;
+
+import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
+
+public class DefaultUserHomeScopedCompileCaches implements UserHomeScopedCompileCaches, Closeable {
+    private final JarSnapshotCache jarSnapshotCache;
+    private final PersistentCache cache;
+
+    public DefaultUserHomeScopedCompileCaches(FileHasher fileHasher, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
+        cache = cacheRepository
+            .cache("javaCompile")
+            .withDisplayName("Java compile cache")
+            .withLockOptions(mode(FileLockManager.LockMode.None)) // Lock on demand
+            .open();
+        PersistentIndexedCacheParameters<HashCode, JarSnapshotData> jarCacheParameters = new PersistentIndexedCacheParameters<HashCode, JarSnapshotData>("jarAnalysis", new HashCodeSerializer(), new JarSnapshotDataSerializer())
+            .cacheDecorator(inMemoryCacheDecoratorFactory.decorator(20000, true));
+        this.jarSnapshotCache = new DefaultJarSnapshotCache(fileHasher, cache.createCache(jarCacheParameters));
+
+    }
+
+    @Override
+    public void close() {
+        cache.close();
+    }
+
+    @Override
+    public JarSnapshotCache getJarSnapshotCache() {
+        return jarSnapshotCache;
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/TaskScopedCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/TaskScopedCompileCaches.java
@@ -22,14 +22,10 @@ import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 import org.gradle.api.internal.tasks.compile.incremental.jar.LocalJarClasspathSnapshotStore;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorPathStore;
 
-public interface GeneralCompileCaches {
+public interface TaskScopedCompileCaches {
     ClassAnalysisCache getClassAnalysisCache();
-
     JarSnapshotCache getJarSnapshotCache();
-
-    LocalJarClasspathSnapshotStore createLocalJarClasspathSnapshotStore(String taskPath);
-
-    LocalClassSetAnalysisStore createLocalClassSetAnalysisStore(String taskPath);
-
-    AnnotationProcessorPathStore createAnnotationProcessorPathStore(String taskPath);
+    LocalJarClasspathSnapshotStore getLocalJarClasspathSnapshotStore();
+    LocalClassSetAnalysisStore getLocalClassSetAnalysisStore();
+    AnnotationProcessorPathStore getAnnotationProcessorPathStore();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/UserHomeScopedCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/UserHomeScopedCompileCaches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.compile.incremental.jar;
+package org.gradle.api.internal.tasks.compile.incremental.cache;
 
-import org.gradle.cache.internal.Cache;
-import org.gradle.internal.hash.HashCode;
+import org.gradle.api.internal.tasks.compile.incremental.jar.JarSnapshotCache;
 
-import java.io.File;
-import java.util.Map;
-
-public interface JarSnapshotCache extends Cache<File, JarSnapshot> {
-    Map<File, JarSnapshot> getJarSnapshots(Map<File, HashCode> jarHashes);
+public interface UserHomeScopedCompileCaches {
+    JarSnapshotCache getJarSnapshotCache();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/CachingJarSnapshotter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/CachingJarSnapshotter.java
@@ -37,7 +37,7 @@ public class CachingJarSnapshotter implements JarSnapshotter {
     @Override
     public JarSnapshot createSnapshot(final JarArchive jarArchive) {
         final HashCode hash = getHash(jarArchive);
-        return cache.get(hash, new Factory<JarSnapshot>() {
+        return cache.get(jarArchive.file, new Factory<JarSnapshot>() {
             public JarSnapshot create() {
                 return snapshotter.createSnapshot(hash, jarArchive);
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/DefaultJarSnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/DefaultJarSnapshotCache.java
@@ -20,15 +20,18 @@ import com.google.common.collect.Maps;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.MinimalPersistentCache;
 import org.gradle.internal.Factory;
+import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
 import java.util.Map;
 
 public class DefaultJarSnapshotCache implements JarSnapshotCache {
+    private final FileHasher fileHasher;
     private final MinimalPersistentCache<HashCode, JarSnapshotData> cache;
 
-    public DefaultJarSnapshotCache(PersistentIndexedCache<HashCode, JarSnapshotData> persistentCache) {
+    public DefaultJarSnapshotCache(FileHasher fileHasher, PersistentIndexedCache<HashCode, JarSnapshotData> persistentCache) {
+        this.fileHasher = fileHasher;
         cache = new MinimalPersistentCache<HashCode, JarSnapshotData>(persistentCache);
     }
 
@@ -47,8 +50,9 @@ public class DefaultJarSnapshotCache implements JarSnapshotCache {
     }
 
     @Override
-    public JarSnapshot get(HashCode key, final Factory<JarSnapshot> factory) {
-        return new JarSnapshot(cache.get(key, new Factory<JarSnapshotData>() {
+    public JarSnapshot get(File key, final Factory<JarSnapshot> factory) {
+        HashCode hash = fileHasher.hash(key);
+        return new JarSnapshot(cache.get(hash, new Factory<JarSnapshotData>() {
             public JarSnapshotData create() {
                 return factory.create().getData();
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarSnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/JarSnapshotCache.java
@@ -23,5 +23,8 @@ import java.io.File;
 import java.util.Map;
 
 public interface JarSnapshotCache extends Cache<File, JarSnapshot> {
+    /**
+     * Returns the jar snapshots for the given files. The resulting map has the same order as the input.
+     */
     Map<File, JarSnapshot> getJarSnapshots(Map<File, HashCode> jarHashes);
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/SplitJarSnapshotCache.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/jar/SplitJarSnapshotCache.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.jar;
+
+import com.google.common.collect.Maps;
+import org.gradle.api.internal.changedetection.state.WellKnownFileLocations;
+import org.gradle.internal.Factory;
+import org.gradle.internal.hash.HashCode;
+
+import java.io.File;
+import java.util.Map;
+
+public class SplitJarSnapshotCache implements JarSnapshotCache {
+    private final WellKnownFileLocations fileLocations;
+    private final JarSnapshotCache globalCache;
+    private final JarSnapshotCache localCache;
+
+    public SplitJarSnapshotCache(WellKnownFileLocations fileLocations, JarSnapshotCache globalCache, JarSnapshotCache localCache) {
+        this.fileLocations = fileLocations;
+        this.globalCache = globalCache;
+        this.localCache = localCache;
+    }
+
+    @Override
+    public Map<File, JarSnapshot> getJarSnapshots(Map<File, HashCode> jars) {
+        Map<File, HashCode> globalJars = Maps.newLinkedHashMap();
+        Map<File, HashCode> localJars = Maps.newLinkedHashMap();
+        for (Map.Entry<File, HashCode> entry : jars.entrySet()) {
+            if (fileLocations.isImmutable(entry.getKey().getPath())) {
+                globalJars.put(entry.getKey(), entry.getValue());
+            } else {
+                localJars.put(entry.getKey(), entry.getValue());
+            }
+        }
+        Map<File, JarSnapshot> globalSnapshots = globalCache.getJarSnapshots(globalJars);
+        Map<File, JarSnapshot> localSnapshots = localCache.getJarSnapshots(localJars);
+
+        Map<File, JarSnapshot> snapshots = Maps.newLinkedHashMap();
+        for (File jar : jars.keySet()) {
+            JarSnapshot snapshot = globalSnapshots.get(jar);
+            if (snapshot == null) {
+                snapshot = localSnapshots.get(jar);
+            }
+            snapshots.put(jar, snapshot);
+        }
+        return snapshots;
+    }
+
+    @Override
+    public JarSnapshot get(File jar, Factory<JarSnapshot> factory) {
+        if (fileLocations.isImmutable(jar.getPath())) {
+            return globalCache.get(jar, factory);
+        } else {
+            return localCache.get(jar, factory);
+        }
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.compile.incremental.IncrementalCompilerFactory;
-import org.gradle.api.internal.tasks.compile.incremental.cache.GeneralCompileCaches;
+import org.gradle.api.internal.tasks.compile.incremental.cache.BuildScopedCompileCaches;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorPathFactory;
 import org.gradle.api.logging.Logging;
@@ -63,7 +63,7 @@ public class JavaLanguagePluginServiceRegistry extends AbstractPluginServiceRegi
     }
 
     private static class JavaProjectScopeServices {
-        public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, GeneralCompileCaches compileCaches, BuildOperationExecutor buildOperationExecutor) {
+        public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, BuildScopedCompileCaches compileCaches, BuildOperationExecutor buildOperationExecutor) {
             return new IncrementalCompilerFactory(fileOperations, streamHasher, fileHasher, compileCaches, buildOperationExecutor);
         }
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -46,6 +46,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
             void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
                 runner.workingDir.eachDir {
                     GFileUtils.deleteDirectory(new File(it, '.gradle'))
+                    GFileUtils.deleteDirectory(new File(it, 'buildSrc/.gradle'))
                     GFileUtils.deleteDirectory(new File(it, 'gradle-user-home'))
                 }
             }
@@ -77,6 +78,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
             void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
                 runner.workingDir.eachDir {
                     GFileUtils.deleteDirectory(new File(it, '.gradle'))
+                    GFileUtils.deleteDirectory(new File(it, 'buildSrc/.gradle'))
                 }
             }
         })


### PR DESCRIPTION
The jar analysis for incremental compilation can be costly.
Up until now it was always kept in the project directory,
which is lost on clean checkouts on CI.
For immutable files (e.g. external dependencies, gradleApi()),
it is now kept in the user home where reuse is more likely.

This fixes https://github.com/gradle/gradle/issues/4447