### PR TITLE
Make tests robust against additional root build operations

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.internal.execution.ExecuteTaskBuildOperationType
+import org.gradle.internal.operations.BuildOperationType
+import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.test.fixtures.file.TestFile
 /**
  * Tests for composite build.
@@ -71,19 +73,19 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
     protected void execute(BuildTestFile build, String[] tasks, Iterable<String> arguments = []) {
         prepare(build, arguments)
         succeeds(tasks)
-        assertSingleBuildOperationsTree()
+        assertSingleBuildOperationsTreeOfType(RunBuildBuildOperationType)
     }
 
     protected void execute(BuildTestFile build, String task, Iterable<String> arguments = []) {
         prepare(build, arguments)
         succeeds(task)
-        assertSingleBuildOperationsTree()
+        assertSingleBuildOperationsTreeOfType(RunBuildBuildOperationType)
     }
 
     protected void fails(BuildTestFile build, String task, Iterable<String> arguments = []) {
         prepare(build, arguments)
         fails(task)
-        assertSingleBuildOperationsTree()
+        assertSingleBuildOperationsTreeOfType(RunBuildBuildOperationType)
     }
 
     private void prepare(BuildTestFile build, Iterable<String> arguments) {
@@ -122,8 +124,8 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
         }
     }
 
-    void assertSingleBuildOperationsTree() {
-        assert operations.roots().size() == 1
+    private <T extends BuildOperationType<?, ?>> void assertSingleBuildOperationsTreeOfType(Class<T> type) {
+        assert operations.root(type) != null
     }
 
     TestFile getRootDir() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
-import org.gradle.util.CollectionUtils
+import org.gradle.launcher.exec.RunBuildBuildOperationType
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
@@ -56,7 +56,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         executed ":buildB:jar"
 
         and:
-        def root = CollectionUtils.single(operations.roots())
+        def root = operations.root(RunBuildBuildOperationType)
 
         def buildSrcOps = operations.all(BuildBuildSrcBuildOperationType)
         buildSrcOps.size() == 1
@@ -131,7 +131,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         executed ":buildB:jar"
 
         and:
-        def root = CollectionUtils.single(operations.roots())
+        def root = operations.root(RunBuildBuildOperationType)
 
         def buildSrcOps = operations.all(BuildBuildSrcBuildOperationType)
         buildSrcOps.size() == 2

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.internal.execution.ExecuteTaskBuildOperationType
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
-import org.gradle.util.CollectionUtils
+import org.gradle.launcher.exec.RunBuildBuildOperationType
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
@@ -76,7 +76,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         executed ":${buildName}:jar"
 
         and:
-        def root = CollectionUtils.single(operations.roots())
+        def root = operations.root(RunBuildBuildOperationType)
 
         def loadOps = operations.all(LoadBuildBuildOperationType)
         loadOps.size() == 2

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.execution.ExecuteTaskBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
-import org.gradle.util.CollectionUtils
+import org.gradle.launcher.exec.RunBuildBuildOperationType
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
@@ -39,7 +39,7 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         succeeds()
 
         then:
-        def root = CollectionUtils.single(ops.roots())
+        def root = ops.root(RunBuildBuildOperationType)
 
         def buildSrcOps = ops.all(BuildBuildSrcBuildOperationType)
         buildSrcOps.size() == 1

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.resource.transfer.ProgressLoggingExternalResourceAccessor
+import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.junit.Rule
@@ -295,7 +296,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         succeeds "t"
 
         List<BuildOperationRecord.Progress> output = []
-        operations.walk(operations.roots().first()) {
+        operations.walk(operations.root(RunBuildBuildOperationType)) {
             output.addAll(it.progress.findAll { it.hasDetailsOfType(LogEventBuildOperationProgressDetails) })
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -48,10 +48,14 @@ class BuildOperationsFixture {
     }
 
     @SuppressWarnings("GrUnnecessaryPublicModifier")
-    public <T extends BuildOperationType<?, ?>> List<BuildOperationRecord> roots() {
-        return operations.roots
+    public <T extends BuildOperationType<?, ?>> BuildOperationRecord root(Class<T> type, Spec<? super BuildOperationRecord> predicate = Specs.satisfyAll()) {
+        def detailsType = BuildOperationTypes.detailsType(type)
+        def roots = operations.roots.findAll {
+            it.detailsType && detailsType.isAssignableFrom(it.detailsType) && predicate.isSatisfiedBy(it)
+        }
+        assert roots.size() == 1
+        return roots[0]
     }
-
 
     @SuppressWarnings("GrUnnecessaryPublicModifier")
     public <T extends BuildOperationType<?, ?>> BuildOperationRecord first(Class<T> type, Spec<? super BuildOperationRecord> predicate = Specs.satisfyAll()) {

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
-import org.gradle.util.CollectionUtils
+import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
 import spock.lang.Unroll
@@ -68,7 +68,7 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
         succeeds("assemble")
 
         then:
-        def root = CollectionUtils.single(operations.roots())
+        def root = operations.root(RunBuildBuildOperationType)
 
         def resolve = operations.first(ResolveConfigurationDependenciesBuildOperationType) { r -> r.details.buildPath == ":" && r.details.projectPath == ":" && r.details.configurationName == "compileClasspath" }
         resolve


### PR DESCRIPTION
Prior to this PR, a lot of tests asserted that there's a single root build operation. This assertion was too strict and did not account for potential additional root build operations such as the recently introduced cache cleanup for the artifact and artifact transform caches. Now, `BuildOperationsFixture` provides a new `root()` method to get the root for the supplied `BuildOperationType`.
