### PR TITLE
Support definition of "containing" platforms

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -74,4 +74,13 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      */
     void allVariants(Action<? super VariantMetadata> action);
 
+    /**
+     * Declares that this component belongs to a platform, which should be
+     * considered during dependency resolution.
+     * @param notation the coordinates of the owner
+     *
+     * @since 4.10
+     */
+    void belongsTo(Object notation);
+
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.alignment
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+
+    def "should align leaves to the same version"() {
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'xml:1.1 -> core:1.1'
+            path 'json:1.1 -> core:1.1'
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org:json:1.1'
+            }
+        """
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        repositoryInteractions {
+            'org:core:1.0' {
+                expectGetMetadata()
+            }
+            'org:xml:1.0' {
+                expectGetMetadata()
+            }
+            'org:core:1.1' {
+                expectResolve()
+            }
+            'org:json:1.1' {
+                expectResolve()
+            }
+            'org:xml:1.1' {
+                expectResolve()
+            }
+            'org:platform:1.0' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+            'org:platform:1.1' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xml:1.0", "org:xml:1.1") {
+                    module('org:core:1.1')
+                }
+                module("org:json:1.1") {
+                    module('org:core:1.1')
+                }
+            }
+        }
+    }
+
+    def "should align leaf with core"() {
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'xml:1.1 -> core:1.1'
+            path 'json:1.1 -> core:1.1'
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org:json:1.0'
+                conf 'org:core:1.1'
+            }
+        """
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        repositoryInteractions {
+            'org:xml:1.0' {
+                expectGetMetadata()
+            }
+            'org:json:1.0' {
+                expectGetMetadata()
+            }
+            'org:core:1.1' {
+                expectResolve()
+            }
+            'org:json:1.1' {
+                expectResolve()
+            }
+            'org:xml:1.1' {
+                expectResolve()
+            }
+            'org:platform:1.0' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+            'org:platform:1.1' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xml:1.0", "org:xml:1.1") {
+                    module('org:core:1.1')
+                }
+                edge("org:json:1.0", "org:json:1.1") {
+                    module('org:core:1.1')
+                }
+                module('org:core:1.1')
+            }
+        }
+    }
+
+    def "shouldn't fail if target alignment version doesn't exist"() {
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'json:1.1 -> core:1.1'
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org:json:1.1'
+            }
+        """
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        repositoryInteractions {
+            'org:core:1.0' {
+                expectGetMetadata()
+            }
+            'org:xml:1.0' {
+                expectResolve()
+            }
+            'org:core:1.1' {
+                expectResolve()
+            }
+            'org:json:1.1' {
+                expectResolve()
+            }
+            'org:xml:1.1' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+            'org:platform:1.0' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+            'org:platform:1.1' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:xml:1.0") {
+                    edge('org:core:1.0', 'org:core:1.1').byConflictResolution("between versions 1.0 and 1.1")
+                }
+                module("org:json:1.1") {
+                    module('org:core:1.1')
+                }
+            }
+        }
+    }
+
+    def "should align leaves to the same version when core has lower version"() {
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'xml:1.1 -> core:1.0' // patch releases
+            path 'json:1.1 -> core:1.0' // patch releases
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org:json:1.1'
+            }
+        """
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        repositoryInteractions {
+            'org:xml:1.0' {
+                expectGetMetadata()
+            }
+            'org:core:1.0' {
+                expectResolve()
+            }
+            'org:core:1.1' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+            'org:json:1.1' {
+                expectResolve()
+            }
+            'org:xml:1.1' {
+                expectResolve()
+            }
+            'org:platform:1.0' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+            'org:platform:1.1' {
+                expectGetMetadataMissing()
+                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                    expectHeadArtifactMissing()
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xml:1.0", "org:xml:1.1") {
+                    module('org:core:1.0')
+                }
+                module("org:json:1.1") {
+                    module('org:core:1.0')
+                }
+            }
+        }
+    }
+
+    private void "a rule which infers module set from group and version"() {
+        buildFile << """
+            dependencies {
+                components.all(InferModuleSetFromGroupAndVersion)
+            }
+            
+            class InferModuleSetFromGroupAndVersion implements ComponentMetadataRule {
+                void execute(ComponentMetadataContext ctx) {
+                    ctx.details.with {
+                        belongsTo("\${id.group}:platform:\${id.version}")
+                    }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -59,18 +59,8 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:xml:1.1' {
                 expectResolve()
             }
-            'org:platform:1.0' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:1.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:platform:1.0'(virtualPlatform)
+            'org:platform:1.1'(virtualPlatform)
         }
         run ':checkDeps'
 
@@ -83,6 +73,73 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
                 }
                 module("org:json:1.1") {
                     module('org:core:1.1')
+                }
+            }
+        }
+    }
+
+    def "should not align modules outside of platform"() {
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'xml:1.1 -> core:1.1'
+            path 'json:1.1 -> core:1.1'
+            path 'outside:module:1.0 -> core:1.0'
+            path 'outside:module:1.1 -> core:1.0'
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org:json:1.1'
+                conf 'outside:module:1.0'
+            }
+        """
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        repositoryInteractions {
+            'org:core:1.0' {
+                expectGetMetadata()
+            }
+            'org:xml:1.0' {
+                expectGetMetadata()
+            }
+            'org:core:1.1' {
+                expectResolve()
+            }
+            'org:json:1.1' {
+                expectResolve()
+            }
+            'org:xml:1.1' {
+                expectResolve()
+            }
+            'org:platform:1.0'(virtualPlatform)
+            'org:platform:1.1'(virtualPlatform)
+
+            'outside:module:1.0' {
+                // this will NOT upgrade to 1.1, despite core being 1.1, because this module
+                // does not belong to the same platform
+                expectResolve()
+            }
+            'outside:platform:1.0'(virtualPlatform)
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xml:1.0", "org:xml:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
+                    module('org:core:1.1')
+                }
+                module("org:json:1.1") {
+                    module('org:core:1.1')
+                }
+                module("outside:module:1.0") {
+                    edge('org:core:1.0', 'org:core:1.1').byConflictResolution("between versions 1.0 and 1.1")
                 }
             }
         }
@@ -124,18 +181,8 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:xml:1.1' {
                 expectResolve()
             }
-            'org:platform:1.0' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:1.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:platform:1.0'(virtualPlatform)
+            'org:platform:1.1'(virtualPlatform)
         }
         run ':checkDeps'
 
@@ -186,24 +233,9 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:json:1.1' {
                 expectResolve()
             }
-            'org:xml:1.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:1.0' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:1.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:xml:1.1'(virtualPlatform)
+            'org:platform:1.0'(virtualPlatform)
+            'org:platform:1.1'(virtualPlatform)
         }
         run ':checkDeps'
 
@@ -248,30 +280,15 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:core:1.0' {
                 expectResolve()
             }
-            'org:core:1.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:core:1.1'(virtualPlatform)
             'org:json:1.1' {
                 expectResolve()
             }
             'org:xml:1.1' {
                 expectResolve()
             }
-            'org:platform:1.0' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:1.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:platform:1.0'(virtualPlatform)
+            'org:platform:1.1'(virtualPlatform)
         }
         run ':checkDeps'
 
@@ -328,54 +345,19 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:kt:2.9.4.1' {
                 expectResolve()
             }
-            'org:core:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:databind:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:annotations:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:core:2.9.4.1'(virtualPlatform)
+            'org:databind:2.9.4.1'(virtualPlatform)
+            'org:annotations:2.9.4.1'(virtualPlatform)
             'org:databind:2.9.4' {
                 expectResolve()
             }
             'org:annotations:2.9.4' {
                 expectResolve()
             }
-            'org:platform:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:2.9.4' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:2.9.0' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:2.7.9' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:platform:2.9.4.1'(virtualPlatform)
+            'org:platform:2.9.4'(virtualPlatform)
+            'org:platform:2.9.0'(virtualPlatform)
+            'org:platform:2.7.9'(virtualPlatform)
             'org:annotations:2.7.9' {
                 expectGetMetadata()
             }
@@ -437,54 +419,19 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:kt:2.9.4.1' {
                 expectResolve()
             }
-            'org:core:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:databind:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:annotations:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:core:2.9.4.1'(virtualPlatform)
+            'org:databind:2.9.4.1'(virtualPlatform)
+            'org:annotations:2.9.4.1'(virtualPlatform)
             'org:databind:2.9.4' {
                 expectResolve()
             }
             'org:annotations:2.9.4' {
                 expectResolve()
             }
-            'org:platform:2.9.4.1' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:2.9.4' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:2.9.0' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
-            'org:platform:2.7.9' {
-                expectGetMetadataMissing()
-                if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    expectHeadArtifactMissing()
-                }
-            }
+            'org:platform:2.9.4.1'(virtualPlatform)
+            'org:platform:2.9.4'(virtualPlatform)
+            'org:platform:2.9.0'(virtualPlatform)
+            'org:platform:2.7.9'(virtualPlatform)
             'org:annotations:2.9.0' {
                 expectGetMetadata()
             }
@@ -508,7 +455,7 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
     }
 
     @RequiredFeatures([
-        @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     ])
     def "can align thanks to a published platform"() {
         repository {
@@ -619,6 +566,161 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     }
 
+    def "can align 2 different platforms"() {
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'xml:1.1 -> core:1.1'
+            path 'json:1.1 -> core:1.1'
+
+            path 'org2:xml:1.0 -> org2:core:1.0'
+            path 'org2:json:1.0 -> org2:core:1.0'
+            path 'org2:xml:1.1 -> org2:core:1.1'
+            path 'org2:json:1.1 -> org2:core:1.1'
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org:json:1.1'
+
+                conf 'org2:xml:1.0'
+                conf 'org2:json:1.1'
+            }
+        """
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        repositoryInteractions {
+            ['org', 'org2'].each { group ->
+                "$group:core:1.0" {
+                    expectGetMetadata()
+                }
+                "$group:xml:1.0" {
+                    expectGetMetadata()
+                }
+                "$group:core:1.1" {
+                    expectResolve()
+                }
+                "$group:json:1.1" {
+                    expectResolve()
+                }
+                "$group:xml:1.1" {
+                    expectResolve()
+                }
+                "$group:platform:1.0" {
+                    expectGetMetadataMissing()
+                    if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                        expectHeadArtifactMissing()
+                    }
+                }
+                "$group:platform:1.1" {
+                    expectGetMetadataMissing()
+                    if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                        expectHeadArtifactMissing()
+                    }
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:xml:1.0", "org:xml:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
+                    module('org:core:1.1')
+                }
+                module("org:json:1.1") {
+                    module('org:core:1.1')
+                }
+
+                edge("org2:xml:1.0", "org2:xml:1.1") {
+                    byConstraint("belongs to platform org2:platform:1.1")
+                    module('org2:core:1.1')
+                }
+                module("org2:json:1.1") {
+                    module('org2:core:1.1')
+                }
+            }
+        }
+    }
+
+    def "doesn't align on evicted edge"() {
+        given:
+        repository {
+            path 'xml -> core'
+            path 'json -> core'
+            path 'xml:1.1 -> core:1.1'
+            path 'json:1.1 -> core:1.1'
+
+            path 'org2:foo:1.0 -> org4:a:1.0 -> org:json:1.1'
+            path 'org3:bar:1.0 -> org4:b:1.1 -> org4:a:1.1'
+        }
+
+        buildFile << """
+            dependencies {
+                conf 'org:xml:1.0'
+                conf 'org2:foo:1.0'
+                conf 'org3:bar:1.0'
+            }
+        """
+
+        and:
+        "align the 'org' group only"()
+
+        when:
+        repositoryInteractions {
+            'org:xml:1.0' {
+                expectResolve()
+            }
+            'org:core:1.0' {
+                expectResolve()
+            }
+            'org2:foo:1.0' {
+                expectResolve()
+            }
+            'org3:bar:1.0' {
+                expectResolve()
+            }
+            'org4:a:1.0' {
+                expectGetMetadata()
+            }
+            'org4:a:1.1' {
+                expectResolve()
+            }
+            'org4:b:1.1' {
+                expectResolve()
+            }
+            'org:json:1.1' {
+                expectGetMetadata()
+            }
+            'org:platform:1.0'(virtualPlatform)
+
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:xml:1.0') {
+                    module('org:core:1.0')
+                }
+                module('org2:foo:1.0') {
+                    edge('org4:a:1.0', 'org4:a:1.1') {
+                        byConflictResolution("between versions 1.0 and 1.1")
+                    }
+                }
+                module('org3:bar:1.0') {
+                    module('org4:b:1.1') {
+                        module('org4:a:1.1')
+                    }
+                }
+            }
+        }
+    }
 
     private void "a rule which infers module set from group and version"() {
         buildFile << """
@@ -634,5 +736,30 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
                 }
             }
         """
+    }
+
+    private void "align the 'org' group only"() {
+        buildFile << """
+            dependencies {
+                components.all(AlignOrgGroup)
+            }
+            
+            class AlignOrgGroup implements ComponentMetadataRule {
+                void execute(ComponentMetadataContext ctx) {
+                    ctx.details.with {
+                        if ('org' == id.group) {
+                           belongsTo("\${id.group}:platform:\${id.version}")
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    final Closure<Void> virtualPlatform = {
+        expectGetMetadataMissing()
+        if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+            expectHeadArtifactMissing()
+        }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -78,6 +78,7 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
                 module("org:json:1.1") {
@@ -142,9 +143,11 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
                 edge("org:json:1.0", "org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
                 module('org:core:1.1')
@@ -208,7 +211,9 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:xml:1.0") {
-                    edge('org:core:1.0', 'org:core:1.1').byConflictResolution("between versions 1.0 and 1.1")
+                    edge('org:core:1.0', 'org:core:1.1')
+                        .byConflictResolution("between versions 1.0 and 1.1")
+                        .byConstraint("belongs to platform org:platform:1.1")
                 }
                 module("org:json:1.1") {
                     module('org:core:1.1')
@@ -275,6 +280,7 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     module('org:core:1.0')
+                    byConstraint("belongs to platform org:platform:1.1")
                 }
                 module("org:json:1.1") {
                     module('org:core:1.0')
@@ -383,11 +389,11 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:core:2.9.4')
-                edge('org:databind:2.7.9', 'org:databind:2.9.4')
+                edge('org:databind:2.7.9', 'org:databind:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
                 module('org:kt:2.9.4.1') {
                     module('org:databind:2.9.4') {
-                        module('org:core:2.9.4')
-                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4')
+                        module('org:core:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
                     }
                 }
             }
@@ -488,12 +494,12 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org:core:2.9.4')
-                edge('org:databind:2.7.9', 'org:databind:2.9.4')
+                module('org:core:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                edge('org:databind:2.7.9', 'org:databind:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
                 module('org:kt:2.9.4.1') {
                     module('org:databind:2.9.4') {
-                        module('org:core:2.9.4')
-                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4')
+                        module('org:core:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.alignment
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.publish.RemoteRepositorySpec
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -43,24 +44,10 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:core:1.0' {
-                expectGetMetadata()
-            }
-            'org:xml:1.0' {
-                expectGetMetadata()
-            }
-            'org:core:1.1' {
-                expectResolve()
-            }
-            'org:json:1.1' {
-                expectResolve()
-            }
-            'org:xml:1.1' {
-                expectResolve()
-            }
-            'org:platform:1.0'(virtualPlatform)
-            'org:platform:1.1'(virtualPlatform)
+        expectAlignment {
+            module('core') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('json') alignsTo('1.1') byVirtualPlatform()
         }
         run ':checkDeps'
 
@@ -100,31 +87,14 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:core:1.0' {
-                expectGetMetadata()
-            }
-            'org:xml:1.0' {
-                expectGetMetadata()
-            }
-            'org:core:1.1' {
-                expectResolve()
-            }
-            'org:json:1.1' {
-                expectResolve()
-            }
-            'org:xml:1.1' {
-                expectResolve()
-            }
-            'org:platform:1.0'(virtualPlatform)
-            'org:platform:1.1'(virtualPlatform)
+        expectAlignment {
+            module('core') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('json') alignsTo('1.1') byVirtualPlatform()
 
-            'outside:module:1.0' {
-                // this will NOT upgrade to 1.1, despite core being 1.1, because this module
-                // does not belong to the same platform
-                expectResolve()
-            }
-            'outside:platform:1.0'(virtualPlatform)
+            // the following will NOT upgrade to 1.1, despite core being 1.1, because this module
+            // does not belong to the same platform
+            module('module') group('outside') alignsTo('1.0') byVirtualPlatform('outside', 'platform')
         }
         run ':checkDeps'
 
@@ -165,24 +135,10 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:xml:1.0' {
-                expectGetMetadata()
-            }
-            'org:json:1.0' {
-                expectGetMetadata()
-            }
-            'org:core:1.1' {
-                expectResolve()
-            }
-            'org:json:1.1' {
-                expectResolve()
-            }
-            'org:xml:1.1' {
-                expectResolve()
-            }
-            'org:platform:1.0'(virtualPlatform)
-            'org:platform:1.1'(virtualPlatform)
+        expectAlignment {
+            module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('json') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('core') alignsTo('1.1') byVirtualPlatform()
         }
         run ':checkDeps'
 
@@ -220,22 +176,10 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:core:1.0' {
-                expectGetMetadata()
-            }
-            'org:xml:1.0' {
-                expectResolve()
-            }
-            'org:core:1.1' {
-                expectResolve()
-            }
-            'org:json:1.1' {
-                expectResolve()
-            }
-            'org:xml:1.1'(virtualPlatform)
-            'org:platform:1.0'(virtualPlatform)
-            'org:platform:1.1'(virtualPlatform)
+        expectAlignment {
+            module('xml') misses('1.1') alignsTo('1.0') byVirtualPlatform()
+            module('core') tries('1.0') alignsTo('1.1')
+            module('json') alignsTo('1.1') byVirtualPlatform()
         }
         run ':checkDeps'
 
@@ -273,22 +217,10 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:xml:1.0' {
-                expectGetMetadata()
-            }
-            'org:core:1.0' {
-                expectResolve()
-            }
-            'org:core:1.1'(virtualPlatform)
-            'org:json:1.1' {
-                expectResolve()
-            }
-            'org:xml:1.1' {
-                expectResolve()
-            }
-            'org:platform:1.0'(virtualPlatform)
-            'org:platform:1.1'(virtualPlatform)
+        expectAlignment {
+            module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('core') misses('1.1') alignsTo('1.0')
+            module('json') alignsTo('1.1') byVirtualPlatform()
         }
         run ':checkDeps'
 
@@ -335,35 +267,11 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:core:2.9.4' {
-                expectResolve()
-            }
-            'org:databind:2.7.9' {
-                expectGetMetadata()
-            }
-            'org:kt:2.9.4.1' {
-                expectResolve()
-            }
-            'org:core:2.9.4.1'(virtualPlatform)
-            'org:databind:2.9.4.1'(virtualPlatform)
-            'org:annotations:2.9.4.1'(virtualPlatform)
-            'org:databind:2.9.4' {
-                expectResolve()
-            }
-            'org:annotations:2.9.4' {
-                expectResolve()
-            }
-            'org:platform:2.9.4.1'(virtualPlatform)
-            'org:platform:2.9.4'(virtualPlatform)
-            'org:platform:2.9.0'(virtualPlatform)
-            'org:platform:2.7.9'(virtualPlatform)
-            'org:annotations:2.7.9' {
-                expectGetMetadata()
-            }
-            'org:annotations:2.9.0' {
-                expectGetMetadata()
-            }
+        expectAlignment {
+            module('core') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('databind') tries('2.7.9') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('annotations') tries('2.7.9', '2.9.0') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('kt') alignsTo('2.9.4.1') byVirtualPlatform()
         }
         run ':checkDeps'
 
@@ -409,32 +317,11 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
-            'org:core:2.9.4' {
-                expectResolve()
-            }
-            'org:databind:2.7.9' {
-                expectGetMetadata()
-            }
-            'org:kt:2.9.4.1' {
-                expectResolve()
-            }
-            'org:core:2.9.4.1'(virtualPlatform)
-            'org:databind:2.9.4.1'(virtualPlatform)
-            'org:annotations:2.9.4.1'(virtualPlatform)
-            'org:databind:2.9.4' {
-                expectResolve()
-            }
-            'org:annotations:2.9.4' {
-                expectResolve()
-            }
-            'org:platform:2.9.4.1'(virtualPlatform)
-            'org:platform:2.9.4'(virtualPlatform)
-            'org:platform:2.9.0'(virtualPlatform)
-            'org:platform:2.7.9'(virtualPlatform)
-            'org:annotations:2.9.0' {
-                expectGetMetadata()
-            }
+        expectAlignment {
+            module('core') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('databind') tries('2.7.9') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('annotations') tries('2.9.0') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('kt') alignsTo('2.9.4.1') byVirtualPlatform()
         }
         run ':checkDeps'
 
@@ -516,37 +403,13 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
 
 
         when:
-        repositoryInteractions {
-            'org:core:2.9.4' {
-                expectResolve()
-            }
-            'org:databind:2.7.9' {
-                expectGetMetadata()
-            }
-            'org:kt:2.9.4.1' {
-                expectResolve()
-            }
-            'org:databind:2.9.4' {
-                expectResolve()
-            }
-            'org:annotations:2.9.4' {
-                expectResolve()
-            }
-            'org:platform:2.7.9' {
-                expectGetMetadata()
-            }
-            'org:platform:2.9.4.1' {
-                expectGetMetadata()
-            }
-            'org:platform:2.9.4' {
-                expectGetMetadata()
-            }
-            'org:annotations:2.7.9' {
-                expectGetMetadata()
-            }
-            'org:annotations:2.9.0' {
-                expectGetMetadata()
-            }
+        expectAlignment {
+            module('core') alignsTo('2.9.4') byPublishedPlatform()
+            module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') tries('2.7.9', '2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
+
+            doesNotGetPlatform("org", "platform", "2.9.0") // because of conflict resolution
         }
         run ':checkDeps'
 
@@ -593,35 +456,11 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "a rule which infers module set from group and version"()
 
         when:
-        repositoryInteractions {
+        expectAlignment {
             ['org', 'org2'].each { group ->
-                "$group:core:1.0" {
-                    expectGetMetadata()
-                }
-                "$group:xml:1.0" {
-                    expectGetMetadata()
-                }
-                "$group:core:1.1" {
-                    expectResolve()
-                }
-                "$group:json:1.1" {
-                    expectResolve()
-                }
-                "$group:xml:1.1" {
-                    expectResolve()
-                }
-                "$group:platform:1.0" {
-                    expectGetMetadataMissing()
-                    if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                        expectHeadArtifactMissing()
-                    }
-                }
-                "$group:platform:1.1" {
-                    expectGetMetadataMissing()
-                    if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                        expectHeadArtifactMissing()
-                    }
-                }
+                module('core') group(group) tries('1.0') alignsTo('1.1') byVirtualPlatform(group)
+                module('xml') group(group) tries('1.0') alignsTo('1.1') byVirtualPlatform(group)
+                module('json') group(group) alignsTo('1.1') byVirtualPlatform(group)
             }
         }
         run ':checkDeps'
@@ -672,33 +511,14 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         "align the 'org' group only"()
 
         when:
-        repositoryInteractions {
-            'org:xml:1.0' {
-                expectResolve()
-            }
-            'org:core:1.0' {
-                expectResolve()
-            }
-            'org2:foo:1.0' {
-                expectResolve()
-            }
-            'org3:bar:1.0' {
-                expectResolve()
-            }
-            'org4:a:1.0' {
-                expectGetMetadata()
-            }
-            'org4:a:1.1' {
-                expectResolve()
-            }
-            'org4:b:1.1' {
-                expectResolve()
-            }
-            'org:json:1.1' {
-                expectGetMetadata()
-            }
-            'org:platform:1.0'(virtualPlatform)
-
+        expectAlignment {
+            module('xml') alignsTo('1.0') byVirtualPlatform()
+            module('core') alignsTo('1.0')
+            module('json') tries('1.1')
+            module('foo') group('org2') alignsTo('1.0')
+            module('bar') group('org3') alignsTo('1.0')
+            module('a') group('org4') tries('1.0') alignsTo('1.1')
+            module('b') group('org4') alignsTo('1.1')
         }
         run ':checkDeps'
 
@@ -767,8 +587,8 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
             'org:json:1.1' {
                 expectResolve()
             }
-            'org:platform:1.0'(virtualPlatform)
-            'org:platform:1.1'(virtualPlatform)
+            'org:platform:1.0'(VIRTUAL_PLATFORM)
+            'org:platform:1.1'(VIRTUAL_PLATFORM)
         }
         run ':checkDeps'
 
@@ -823,10 +643,148 @@ class AlignmentIntegrationTest extends AbstractModuleDependencyResolveTest {
         """
     }
 
-    final Closure<Void> virtualPlatform = {
+    final static Closure<Void> VIRTUAL_PLATFORM = {
         expectGetMetadataMissing()
         if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
             expectHeadArtifactMissing()
+        }
+    }
+
+    void expectAlignment(@DelegatesTo(value = AlignmentSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def align = new AlignmentSpec()
+        spec.delegate = align
+        spec.resolveStrategy = Closure.DELEGATE_FIRST
+        spec()
+        repositoryInteractions {
+            align.applyTo(repoSpec)
+        }
+    }
+
+    static class AlignmentSpec {
+        final List<ModuleAlignmentSpec> specs = []
+        final Set<String> skipsPlatformMetadata = []
+
+        ModuleAlignmentSpec module(String name) {
+            def spec = new ModuleAlignmentSpec(name: name)
+            specs << spec
+            spec
+        }
+
+        void doesNotGetPlatform(String group='org', String name='platform', String version='1.0') {
+            skipsPlatformMetadata << "$group:$name:$version"
+        }
+
+        void applyTo(RemoteRepositorySpec spec) {
+            Set<String> virtualPlatforms = [] as Set
+            Set<String> publishedPlatforms = [] as Set
+            Set<String> resolvesToVirtual = [] as Set
+
+            specs.each {
+                it.applyTo(spec)
+                if (it.virtualPlatform) {
+                    it.seenVersions.each { v ->
+                        virtualPlatforms << "${it.virtualPlatform}:$v"
+                    }
+                    resolvesToVirtual << "${it.virtualPlatform}:$it.alignsTo"
+                } else if (it.publishedPlatform) {
+                    // for published platforms, we know there's no artifacts, so it's actually easier
+                    it.seenVersions.each { v ->
+                        publishedPlatforms << "${it.publishedPlatform}:$v"
+                    }
+                    publishedPlatforms << "${it.publishedPlatform}:$it.alignsTo"
+                }
+            }
+            virtualPlatforms.remove(resolvesToVirtual)
+            virtualPlatforms.removeAll(skipsPlatformMetadata)
+            resolvesToVirtual.removeAll(skipsPlatformMetadata)
+            publishedPlatforms.removeAll(skipsPlatformMetadata)
+            virtualPlatforms.each { p ->
+                spec."$p"(VIRTUAL_PLATFORM)
+            }
+            publishedPlatforms.each { p ->
+                spec."$p" {
+                    expectGetMetadata()
+                }
+            }
+            resolvesToVirtual.each {
+                spec."$it"(VIRTUAL_PLATFORM)
+            }
+        }
+
+    }
+
+    static class ModuleAlignmentSpec {
+        String group = 'org'
+        String name
+        List<String> seenVersions = []
+        List<String> misses = []
+        String alignsTo
+        String virtualPlatform
+        String publishedPlatform
+
+        ModuleAlignmentSpec group(String group) {
+            this.group = group
+            this
+        }
+
+        ModuleAlignmentSpec name(String name) {
+            this.name = name
+            this
+        }
+
+        ModuleAlignmentSpec tries(String... versions) {
+            Collections.addAll(seenVersions, versions)
+            this
+        }
+
+        ModuleAlignmentSpec misses(String... versions) {
+            Collections.addAll(misses, versions)
+            this
+        }
+
+        ModuleAlignmentSpec alignsTo(String version) {
+            this.alignsTo = version
+            this
+        }
+
+        ModuleAlignmentSpec byVirtualPlatform(String group='org', String name='platform') {
+            virtualPlatform = "${group}:${name}"
+            this
+        }
+
+        ModuleAlignmentSpec byPublishedPlatform(String group='org', String name='platform') {
+            publishedPlatform = "${group}:${name}"
+            this
+        }
+
+        void applyTo(RemoteRepositorySpec spec) {
+            def moduleName = name
+            def alignedTo = alignsTo
+            def otherVersions = seenVersions
+            otherVersions.remove(alignedTo)
+            def missedVersions = misses
+            spec.group(group) {
+                module(moduleName) {
+                    if (alignedTo) {
+                        version(alignedTo) {
+                            expectResolve()
+                        }
+                    }
+                    otherVersions.each {
+                        version(it) {
+                            expectGetMetadata()
+                        }
+                    }
+                    missedVersions.each {
+                        version(it) {
+                            expectGetMetadataMissing()
+                            if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
+                                expectHeadArtifactMissing()
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
@@ -36,6 +37,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstra
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory;
+import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser;
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter;
 import org.gradle.api.specs.Spec;
@@ -70,6 +72,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     private final NotationParser<Object, ModuleIdentifier> moduleIdentifierNotationParser;
     private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+    private final NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser;
     private final ImmutableAttributesFactory attributesFactory;
     private final IsolatableFactory isolatableFactory;
     private final ComponentMetadataRuleExecutor ruleExecutor;
@@ -90,6 +93,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
         this.ruleExecutor = ruleExecutor;
         this.dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl.class, stringInterner);
         this.dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl.class, stringInterner);
+        this.componentIdentifierNotationParser = new ComponentIdentifierParserFactory().create();
         this.attributesFactory = attributesFactory;
         this.isolatableFactory = isolatableFactory;
     }
@@ -196,7 +200,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
 
     @Override
     public ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext) {
-        return new DefaultComponentMetadataProcessor(rules, classBasedRules, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, attributesFactory, ruleExecutor, resolutionContext);
+        return new DefaultComponentMetadataProcessor(rules, classBasedRules, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, attributesFactory, ruleExecutor, resolutionContext);
     }
 
     static class ComponentMetadataDetailsMatchingSpec implements Spec<ComponentMetadataDetails> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VariantMetadata;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
@@ -114,6 +115,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+    private final NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser;
     private final ImmutableAttributesFactory attributesFactory;
     private final ComponentMetadataRuleExecutor ruleExecutor;
     private final MetadataResolutionContext metadataResolutionContext;
@@ -125,6 +127,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
                                              Instantiator instantiator,
                                              NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
                                              NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
+                                             NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser,
                                              ImmutableAttributesFactory attributesFactory,
                                              ComponentMetadataRuleExecutor ruleExecutor,
                                              MetadataResolutionContext resolutionContext) {
@@ -133,6 +136,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
+        this.componentIdentifierNotationParser = componentIdentifierNotationParser;
         this.attributesFactory = attributesFactory;
         this.ruleExecutor = ruleExecutor;
         this.metadataResolutionContext = resolutionContext;
@@ -147,7 +151,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
             updatedMetadata = processClassRuleWithCaching(metadata, metadataResolutionContext);
         } else {
             MutableModuleComponentResolveMetadata mutableMetadata = metadata.asMutable();
-            ComponentMetadataDetails details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+            ComponentMetadataDetails details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser);
             processAllRules(metadata, details, metadata.getModuleVersionId());
             updatedMetadata = mutableMetadata.asImmutable();
         }
@@ -164,7 +168,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         if (rules.isEmpty() && classBasedRules.isEmpty()) {
             updatedMetadata = metadata;
         } else {
-            ShallowComponentMetadataAdapter details = new ShallowComponentMetadataAdapter(metadata, attributesFactory);
+            ShallowComponentMetadataAdapter details = new ShallowComponentMetadataAdapter(componentIdentifierNotationParser, metadata, attributesFactory);
             processAllRules(null, details, metadata.getId());
             updatedMetadata = details.asImmutable();
         }
@@ -201,7 +205,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
                 new Transformer<WrappingComponentMetadataContext, ModuleComponentResolveMetadata>() {
                     @Override
                     public WrappingComponentMetadataContext transform(ModuleComponentResolveMetadata moduleVersionIdentifier) {
-                        return new WrappingComponentMetadataContext(metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+                        return new WrappingComponentMetadataContext(metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser);
                     }
                 }, metadataResolutionContext.getCachePolicy());
         } catch (InvalidUserCodeException e) {
@@ -265,16 +269,20 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
     }
 
     static class ShallowComponentMetadataAdapter implements ComponentMetadataDetails {
+        private final NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser;
         private final ModuleVersionIdentifier id;
         private boolean changing;
         private List<String> statusScheme;
         private AttributeContainerInternal attributes;
+        private final List<ComponentIdentifier> owners;
 
-        public ShallowComponentMetadataAdapter(ComponentMetadata source, ImmutableAttributesFactory attributesFactory) {
+        public ShallowComponentMetadataAdapter(NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser, ComponentMetadata source, ImmutableAttributesFactory attributesFactory) {
+            this.componentIdentifierNotationParser = componentIdentifierNotationParser;
             id = source.getId();
             changing = source.isChanging();
             statusScheme = source.getStatusScheme();
             attributes = attributesFactory.mutable((AttributeContainerInternal) source.getAttributes());
+            owners = Lists.newArrayListWithExpectedSize(1);
         }
 
         @Override
@@ -300,6 +308,11 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         @Override
         public void allVariants(Action<? super VariantMetadata> action) {
 
+        }
+
+        @Override
+        public void belongsTo(Object notation) {
+            owners.add(componentIdentifierNotationParser.parseNotation(notation));
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
@@ -36,17 +37,20 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
+    private final NotationParser<Object, ComponentIdentifier> componentIdentifierParser;
 
     private MutableModuleComponentResolveMetadata mutableMetadata;
     private ComponentMetadataDetails details;
 
     public WrappingComponentMetadataContext(ModuleComponentResolveMetadata metadata, Instantiator instantiator,
                                             NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
-                                            NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser) {
+                                            NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
+                                            NotationParser<Object, ComponentIdentifier> componentIdentifierParser) {
         this.metadata = metadata;
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
+        this.componentIdentifierParser = componentIdentifierParser;
     }
 
     @Override
@@ -64,7 +68,7 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
     public ComponentMetadataDetails getDetails() {
         createMutableMetadataIfNeeded();
         if (details == null) {
-            details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser);
+            details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierParser);
 
         }
         return details;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -174,6 +174,11 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
+        public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+            return ImmutableList.of();
+        }
+
+        @Override
         public AttributeContainer getAttributes() {
             return delegate.getAttributes();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
@@ -25,7 +25,7 @@ import org.gradle.internal.typeconversion.TypedNotationConverter;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import org.gradle.util.GUtil;
 
-import static org.gradle.api.internal.notations.ModuleIdentifierNotationConverter.validate;
+import static org.gradle.api.internal.notations.ModuleNotationValidation.*;
 
 class ModuleSelectorStringNotationConverter extends TypedNotationConverter<String, ComponentSelector> {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -130,7 +130,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
 
         DependencySubstitutionApplicator applicator = createDependencySubstitutionApplicator(resolutionStrategy);
         VersionSelectorScheme versionSelectorScheme = createVersionSelectorScheme(resolutionStrategy.isDependencyLockingEnabled());
-        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, capabilitiesConflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, globalRules.getModuleMetadataProcessor().getModuleReplacements(), applicator, componentSelectorConverter, attributesFactory, versionSelectorScheme);
+        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, capabilitiesConflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, globalRules.getModuleMetadataProcessor().getModuleReplacements(), applicator, componentSelectorConverter, attributesFactory, versionSelectorScheme, versionComparator.asVersionComparator(), versionParser);
     }
 
     private VersionSelectorScheme createVersionSelectorScheme(boolean dependencyLockingEnabled) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -27,6 +27,8 @@ import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -75,6 +78,8 @@ public class DependencyGraphBuilder {
     private final ImmutableAttributesFactory attributesFactory;
     private final CapabilitiesConflictHandler capabilitiesConflictHandler;
     private final VersionSelectorScheme versionSelectorScheme;
+    private final Comparator<Version> versionComparator;
+    private final VersionParser versionParser;
 
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver,
                                   ComponentMetaDataResolver componentMetaDataResolver,
@@ -89,7 +94,9 @@ public class DependencyGraphBuilder {
                                   DependencySubstitutionApplicator dependencySubstitutionApplicator,
                                   ComponentSelectorConverter componentSelectorConverter,
                                   ImmutableAttributesFactory attributesFactory,
-                                  VersionSelectorScheme versionSelectorScheme) {
+                                  VersionSelectorScheme versionSelectorScheme,
+                                  Comparator<Version> versionComparator,
+                                  VersionParser versionParser) {
         this.idResolver = componentIdResolver;
         this.metaDataResolver = componentMetaDataResolver;
         this.moduleResolver = resolveContextToComponentResolver;
@@ -104,6 +111,8 @@ public class DependencyGraphBuilder {
         this.attributesFactory = attributesFactory;
         this.capabilitiesConflictHandler = capabilitiesConflictHandler;
         this.versionSelectorScheme = versionSelectorScheme;
+        this.versionComparator = versionComparator;
+        this.versionParser = versionParser;
     }
 
     public void resolve(final ResolveContext resolveContext, final DependencyGraphVisitor modelVisitor) {
@@ -112,7 +121,7 @@ public class DependencyGraphBuilder {
         DefaultBuildableComponentResolveResult rootModule = new DefaultBuildableComponentResolveResult();
         moduleResolver.resolve(resolveContext, rootModule);
 
-        final ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleExclusions, moduleReplacementsData, componentSelectorConverter, attributesFactory, dependencySubstitutionApplicator, versionSelectorScheme);
+        final ResolveState resolveState = new ResolveState(idGenerator, rootModule, resolveContext.getName(), idResolver, metaDataResolver, edgeFilter, attributesSchema, moduleExclusions, moduleReplacementsData, componentSelectorConverter, attributesFactory, dependencySubstitutionApplicator, versionSelectorScheme, versionComparator, versionParser);
 
         traverseGraph(resolveState);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CandidateModule;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
@@ -33,6 +35,7 @@ import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,17 +54,27 @@ class ModuleResolveState implements CandidateModule {
     private final List<SelectorState> selectors = Lists.newArrayListWithExpectedSize(4);
     private final VariantNameBuilder variantNameBuilder;
     private final ImmutableAttributesFactory attributesFactory;
+    private final Comparator<Version> versionComparator;
+    private final VersionParser versionParser;
     private ComponentState selected;
     private ImmutableAttributes mergedAttributes = ImmutableAttributes.EMPTY;
     private AttributeMergingException attributeMergingError;
     private VirtualPlatformState platformState;
 
-    ModuleResolveState(IdGenerator<Long> idGenerator, ModuleIdentifier id, ComponentMetaDataResolver metaDataResolver, VariantNameBuilder variantNameBuilder, ImmutableAttributesFactory attributesFactory) {
+    ModuleResolveState(IdGenerator<Long> idGenerator,
+                       ModuleIdentifier id,
+                       ComponentMetaDataResolver metaDataResolver,
+                       VariantNameBuilder variantNameBuilder,
+                       ImmutableAttributesFactory attributesFactory,
+                       Comparator<Version> versionComparator,
+                       VersionParser versionParser) {
         this.idGenerator = idGenerator;
         this.id = id;
         this.metaDataResolver = metaDataResolver;
         this.variantNameBuilder = variantNameBuilder;
         this.attributesFactory = attributesFactory;
+        this.versionComparator = versionComparator;
+        this.versionParser = versionParser;
     }
 
     @Override
@@ -274,7 +287,7 @@ class ModuleResolveState implements CandidateModule {
 
     VirtualPlatformState getPlatformState() {
         if (platformState == null) {
-            platformState = new VirtualPlatformState(id);
+            platformState = new VirtualPlatformState(versionComparator, versionParser, this);
         }
         return platformState;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -54,6 +54,7 @@ class ModuleResolveState implements CandidateModule {
     private ComponentState selected;
     private ImmutableAttributes mergedAttributes = ImmutableAttributes.EMPTY;
     private AttributeMergingException attributeMergingError;
+    private VirtualPlatformState platformState;
 
     ModuleResolveState(IdGenerator<Long> idGenerator, ModuleIdentifier id, ComponentMetaDataResolver metaDataResolver, VariantNameBuilder variantNameBuilder, ImmutableAttributesFactory attributesFactory) {
         this.idGenerator = idGenerator;
@@ -271,4 +272,10 @@ class ModuleResolveState implements CandidateModule {
         return incoming;
     }
 
+    VirtualPlatformState getPlatformState() {
+        if (platformState == null) {
+            platformState = new VirtualPlatformState(id);
+        }
+        return platformState;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -54,6 +54,7 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.hash.HashValue;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -482,7 +483,8 @@ class NodeState implements DependencyGraphNode {
                 LenientPlatformResolveMetadata platformMetadata = (LenientPlatformResolveMetadata) targetComponent;
                 return Collections.<ConfigurationMetadata>singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.getPlatformState()));
             }
-            return Collections.emptyList();
+            // the target component exists, so we need to fallback to the traditional selection process
+            return new LocalComponentDependencyMetadata(platformId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -16,25 +16,52 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.component.external.model.ComponentVariant;
+import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.hash.HashValue;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -63,6 +90,8 @@ class NodeState implements DependencyGraphNode {
     private final ResolveState resolveState;
     private final boolean isTransitive;
     private ModuleExclusion previousTraversalExclusions;
+    // In opposite to outgoing edges, virtual edges are for now pretty rare, so they are created lazily
+    private List<EdgeState> virtualEdges;
 
     NodeState(Long resultId, ResolvedConfigurationIdentifier id, ComponentState component, ResolveState resolveState, ConfigurationMetadata md) {
         this.resultId = resultId;
@@ -138,6 +167,7 @@ class NodeState implements DependencyGraphNode {
     /**
      * Visits all of the dependencies that originate on this node, adding them as outgoing edges.
      * The {@link #outgoingEdges} collection is populated, as is the `discoveredEdges` parameter.
+     *
      * @param discoveredEdges A collector for visited edges.
      * @param pendingDependenciesHandler Handler for pending dependencies.
      */
@@ -190,6 +220,7 @@ class NodeState implements DependencyGraphNode {
         }
 
         visitDependencies(resolutionFilter, pendingDependenciesHandler, discoveredEdges);
+        visitOwners(discoveredEdges);
     }
 
     /**
@@ -197,7 +228,7 @@ class NodeState implements DependencyGraphNode {
      * or adding them to the `discoveredEdges` collection (and `this.outgoingEdges`)
      */
     private void visitDependencies(ModuleExclusion resolutionFilter, PendingDependenciesHandler pendingDependenciesHandler, Collection<EdgeState> discoveredEdges) {
-        PendingDependenciesHandler.Visitor pendingDepsVisitor =  pendingDependenciesHandler.start();
+        PendingDependenciesHandler.Visitor pendingDepsVisitor = pendingDependenciesHandler.start();
         try {
             for (DependencyMetadata dependency : metaData.getDependencies()) {
                 DependencyState dependencyState = new DependencyState(dependency, resolveState.getComponentSelectorConverter());
@@ -220,6 +251,66 @@ class NodeState implements DependencyGraphNode {
             pendingDepsVisitor.complete();
         }
     }
+
+    /**
+     * If a component declares that it belongs to a platform, we add an edge to the platform.
+     *
+     * @param discoveredEdges the collection of edges for this component
+     */
+    private void visitOwners(Collection<EdgeState> discoveredEdges) {
+        ImmutableList<? extends ComponentIdentifier> owners = component.getMetadata().getPlatformOwners();
+        if (!owners.isEmpty()) {
+            for (ComponentIdentifier owner : owners) {
+                if (owner instanceof ModuleComponentIdentifier) {
+                    ModuleComponentIdentifier platformId = (ModuleComponentIdentifier) owner;
+                    final ModuleComponentSelector cs = DefaultModuleComponentSelector.newSelector(platformId.getModuleIdentifier(), platformId.getVersion());
+
+                    // There are 2 possibilities here:
+                    // 1. the "platform" referenced is a real module, in which case we directly add it to the graph
+                    // 2. the "platform" is a virtual, constructed thing, in which case we add virtual edges to the graph
+                    addPlatformEdges(discoveredEdges, platformId, cs);
+                }
+            }
+        }
+    }
+
+    private PotentialEdge potentialEdgeTo(ModuleComponentIdentifier toComponent, ModuleComponentSelector toSelector) {
+        DependencyState dependencyState = new DependencyState(new LenientPlatformDependencyMetadata(toSelector, toComponent), resolveState.getComponentSelectorConverter());
+        EdgeState edge = new TransientEdge(dependencyState);
+        ModuleVersionIdentifier toModuleVersionId = DefaultModuleVersionIdentifier.newId(toSelector.getModuleIdentifier(), toSelector.getVersion());
+        ComponentState version = resolveState.getModule(toSelector.getModuleIdentifier()).getVersion(toModuleVersionId, toComponent);
+        SelectorState selector = edge.getSelector();
+        version.selectedBy(selector);
+        // We need to check if the target version exists. For this,
+        // we have to try to get metadata for the aligned version. If it's there,
+        // it means we can align, otherwise, we must NOT add the edge, or resolution
+        // would fail
+        ComponentResolveMetadata metadata = version.getMetadata();
+        return new PotentialEdge(edge, toModuleVersionId, metadata, version);
+    }
+
+    private void addPlatformEdges(Collection<EdgeState> discoveredEdges, ModuleComponentIdentifier platformComponentIdentifier, ModuleComponentSelector platformSelector) {
+        PotentialEdge potentialEdge = potentialEdgeTo(platformComponentIdentifier, platformSelector);
+        ComponentResolveMetadata metadata = potentialEdge.metadata;
+        VirtualPlatformState virtualPlatformState = null;
+        if (metadata == null || metadata instanceof LenientPlatformResolveMetadata) {
+            virtualPlatformState = potentialEdge.component.getModule().getPlatformState();
+            virtualPlatformState.participatingComponent(component);
+        }
+        if (metadata == null) {
+            // the platform doesn't exist, so we're building a lenient one
+            metadata = new LenientPlatformResolveMetadata(platformComponentIdentifier, potentialEdge.toModuleVersionId, virtualPlatformState.getParticipatingComponents());
+            potentialEdge.component.setMetadata(metadata);
+        }
+        if (virtualEdges == null) {
+            virtualEdges = Lists.newArrayList();
+        }
+        EdgeState edge = potentialEdge.edge;
+        virtualEdges.add(edge);
+        discoveredEdges.add(edge);
+        edge.getSelector().use();
+    }
+
 
     /**
      * Execute any dependency substitution rules that apply to this dependency.
@@ -311,6 +402,13 @@ class NodeState implements DependencyGraphNode {
             }
         }
         outgoingEdges.clear();
+        if (virtualEdges != null) {
+            for (EdgeState outgoingDependency : virtualEdges) {
+                outgoingDependency.removeFromTargetConfigurations();
+                outgoingDependency.getSelector().release();
+            }
+        }
+        virtualEdges = null;
         previousTraversalExclusions = null;
     }
 
@@ -346,10 +444,265 @@ class NodeState implements DependencyGraphNode {
     void resetSelectionState() {
         previousTraversalExclusions = null;
         outgoingEdges.clear();
+        virtualEdges = null;
         resolveState.onMoreSelected(this);
     }
 
     public ImmutableAttributesFactory getAttributesFactory() {
         return resolveState.getAttributesFactory();
+    }
+
+    private class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata {
+        private final ModuleComponentSelector cs;
+        private final ModuleComponentIdentifier platformId;
+
+        LenientPlatformDependencyMetadata(ModuleComponentSelector cs, ModuleComponentIdentifier platformId) {
+            this.cs = cs;
+            this.platformId = platformId;
+        }
+
+        @Override
+        public ModuleComponentSelector getSelector() {
+            return cs;
+        }
+
+        @Override
+        public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
+            return this;
+        }
+
+        @Override
+        public ModuleDependencyMetadata withReason(String reason) {
+            return this;
+        }
+
+        @Override
+        public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+            if (targetComponent instanceof LenientPlatformResolveMetadata) {
+                LenientPlatformResolveMetadata platformMetadata = (LenientPlatformResolveMetadata) targetComponent;
+                return Collections.<ConfigurationMetadata>singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.moduleVersionIdentifier.getVersion(), platformMetadata.getParticipatingComponents()));
+            }
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<ExcludeMetadata> getExcludes() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<IvyArtifactName> getArtifacts() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public DependencyMetadata withTarget(ComponentSelector target) {
+            return this;
+        }
+
+        @Override
+        public boolean isChanging() {
+            return false;
+        }
+
+        @Override
+        public boolean isTransitive() {
+            return true;
+        }
+
+        @Override
+        public boolean isPending() {
+            return true;
+        }
+
+        @Override
+        public String getReason() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "virtual metadata for " + platformId;
+        }
+
+        private class LenientPlatformConfigurationMetadata extends DefaultConfigurationMetadata {
+
+            private final String targetVersion;
+            private final Set<ComponentState> participatingComponents;
+
+            LenientPlatformConfigurationMetadata(String targetVersion, Set<ComponentState> participatingComponents) {
+                super(platformId, "default", true, false, ImmutableList.of("default"), ImmutableList.<ModuleComponentArtifactMetadata>of(), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
+                this.targetVersion = targetVersion;
+                this.participatingComponents = participatingComponents;
+            }
+
+            @Override
+            public List<? extends DependencyMetadata> getDependencies() {
+                List<DependencyMetadata> result = null;
+                for (ComponentState componentState : participatingComponents) {
+                    if (componentState.isSelected() && !componentState.getId().getVersion().equals(targetVersion)) {
+                        ModuleComponentIdentifier leafId = DefaultModuleComponentIdentifier.newId(componentState.getModule().getId(), targetVersion);
+                        ModuleComponentSelector leafSelector = DefaultModuleComponentSelector.newSelector(componentState.getModule().getId(), targetVersion);
+                        // We will only add dependencies to the leaves if there is such a published module
+                        PotentialEdge potentialEdge = potentialEdgeTo(leafId, leafSelector);
+                        if (potentialEdge.metadata != null) {
+                            if (result == null) {
+                                result = Lists.newArrayListWithExpectedSize(participatingComponents.size());
+                            }
+                            result.add(new LenientPlatformDependencyMetadata(
+                                leafSelector,
+                                leafId
+                            ));
+                        }
+                    }
+                }
+                return result == null ? Collections.<DependencyMetadata>emptyList() : result;
+            }
+        }
+    }
+
+    private static class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
+
+        private final ModuleComponentIdentifier moduleComponentIdentifier;
+        private final ModuleVersionIdentifier moduleVersionIdentifier;
+        private final Set<ComponentState> participatingComponents;
+
+        private LenientPlatformResolveMetadata(ModuleComponentIdentifier moduleComponentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier, Set<ComponentState> participatingComponents) {
+            this.moduleComponentIdentifier = moduleComponentIdentifier;
+            this.moduleVersionIdentifier = moduleVersionIdentifier;
+            this.participatingComponents = participatingComponents;
+        }
+
+        @Override
+        public ModuleComponentIdentifier getId() {
+            return moduleComponentIdentifier;
+        }
+
+        @Override
+        public ModuleVersionIdentifier getModuleVersionId() {
+            return moduleVersionIdentifier;
+        }
+
+        @Override
+        public ModuleSource getSource() {
+            return null;
+        }
+
+        @Override
+        public AttributesSchemaInternal getAttributesSchema() {
+            return null;
+        }
+
+        @Override
+        public ModuleComponentResolveMetadata withSource(ModuleSource source) {
+            return this;
+        }
+
+        @Override
+        public Set<String> getConfigurationNames() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public ConfigurationMetadata getConfiguration(String name) {
+            return null;
+        }
+
+        @Override
+        public Optional<ImmutableList<? extends ConfigurationMetadata>> getVariantsForGraphTraversal() {
+            return Optional.absent();
+        }
+
+        @Override
+        public boolean isMissing() {
+            return false;
+        }
+
+        @Override
+        public boolean isChanging() {
+            return false;
+        }
+
+        @Override
+        public String getStatus() {
+            return null;
+        }
+
+        @Override
+        public List<String> getStatusScheme() {
+            return null;
+        }
+
+        @Override
+        public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public MutableModuleComponentResolveMetadata asMutable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HashValue getContentHash() {
+            return null;
+        }
+
+        @Override
+        public ImmutableList<? extends ComponentVariant> getVariants() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public ImmutableAttributesFactory getAttributesFactory() {
+            return null;
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return ImmutableAttributes.EMPTY;
+        }
+
+        Set<ComponentState> getParticipatingComponents() {
+            return participatingComponents;
+        }
+    }
+
+    /**
+     * Represents an edge in the graph which is added only as an implementation detail. This
+     * is used for backlinks, from a component to its owner.
+     */
+    private class TransientEdge extends EdgeState {
+        TransientEdge(DependencyState dependencyState) {
+            super(NodeState.this, dependencyState, NodeState.this.previousTraversalExclusions, NodeState.this.resolveState);
+        }
+    }
+
+    /**
+     * This class wraps knowledge about a potential edge to a component. It's called potential,
+     * because when the edge is created we don't know if the target component exists, and, since
+     * the edge is created internally by the engine, we don't want to fail if the target component
+     * doesn't exist. This means that the edge would effectively be added if, and only if, the
+     * target component exists. Checking if it does exist is currently done by fetching metadata,
+     * but we could have a cheaper strategy (HEAD request, ...).
+     */
+    private static class PotentialEdge {
+        private final EdgeState edge;
+        private final ModuleVersionIdentifier toModuleVersionId;
+        private final ComponentResolveMetadata metadata;
+        private final ComponentState component;
+
+        PotentialEdge(EdgeState edge, ModuleVersionIdentifier toModuleVersionId, ComponentResolveMetadata metadata, ComponentState component) {
+            this.edge = edge;
+            this.toModuleVersionId = toModuleVersionId;
+            this.metadata = metadata;
+            this.component = component;
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -678,7 +678,7 @@ class NodeState implements DependencyGraphNode {
         }
 
         @Override
-        public HashValue getContentHash() {
+        public HashValue getOriginalContentHash() {
             return null;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 
@@ -67,7 +68,15 @@ public class VirtualPlatformState {
         return sorted;
     }
 
-    public Set<ModuleResolveState> getParticipatingModules() {
+    Set<ModuleResolveState> getParticipatingModules() {
         return participatingModules;
+    }
+
+    ComponentIdentifier getSelectedPlatformId() {
+        ComponentState selected = platformModule.getSelected();
+        if (selected != null) {
+            return selected.getComponentId();
+        }
+        return null;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.ModuleIdentifier;
+
+import java.util.Set;
+
+public class VirtualPlatformState {
+    private final ModuleIdentifier platformModuleIdentifier;
+    private final Set<ComponentState> participatingComponents = Sets.newHashSet();
+
+    public VirtualPlatformState(ModuleIdentifier platformModuleIdentifier) {
+        this.platformModuleIdentifier = platformModuleIdentifier;
+    }
+
+    void participatingComponent(ComponentState state) {
+        participatingComponents.add(state);
+    }
+
+    Set<ComponentState> getParticipatingComponents() {
+        return participatingComponents;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VariantMetadata;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
@@ -37,14 +38,17 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser;
+    private final NotationParser<Object, ComponentIdentifier> componentIdentifierParser;
 
     public ComponentMetadataDetailsAdapter(MutableModuleComponentResolveMetadata metadata, Instantiator instantiator,
                                            NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser,
-                                           NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser) {
+                                           NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser,
+                                           NotationParser<Object, ComponentIdentifier> dependencyNotationParser) {
         this.metadata = metadata;
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
+        this.componentIdentifierParser = dependencyNotationParser;
     }
 
     @Override
@@ -89,6 +93,11 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     @Override
     public void allVariants(Action<? super VariantMetadata> action) {
         action.execute(instantiator.newInstance(VariantMetadataAdapter.class, Specs.satisfyAll(), metadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser));
+    }
+
+    @Override
+    public void belongsTo(Object notation) {
+        metadata.belongsTo(componentIdentifierParser.parseNotation(notation));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.notations;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.internal.Factory;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.typeconversion.MapKey;
+import org.gradle.internal.typeconversion.MapNotationConverter;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
+import org.gradle.internal.typeconversion.TypedNotationConverter;
+
+import javax.annotation.Nullable;
+
+public class ComponentIdentifierParserFactory implements Factory<NotationParser<Object, ComponentIdentifier>> {
+
+    @Nullable
+    @Override
+    public NotationParser<Object, ComponentIdentifier> create() {
+        return NotationParserBuilder.toType(ComponentIdentifier.class)
+            .fromCharSequence(new StringNotationConverter())
+            .converter(new ComponentIdentifierMapNotationConverter())
+            .toComposite();
+    }
+
+    static class ComponentIdentifierMapNotationConverter extends MapNotationConverter<ModuleComponentIdentifier> {
+        protected ModuleComponentIdentifier parseMap(
+            @MapKey("group") String group,
+            @MapKey("name") String name,
+            @MapKey("version") String version) {
+
+            return DefaultModuleComponentIdentifier.newId(
+                DefaultModuleIdentifier.newId(group, name),
+                version
+            );
+        }
+    }
+
+    static class StringNotationConverter extends TypedNotationConverter<String, ModuleComponentIdentifier> {
+
+        StringNotationConverter() {
+            super(String.class);
+        }
+
+        @Override
+        protected ModuleComponentIdentifier parseType(String notation) {
+            String[] parts = notation.split(":");
+            if (parts.length != 3) {
+                throw new InvalidUserDataException("Invalid module component notation");
+            }
+            return DefaultModuleComponentIdentifier.newId(
+                DefaultModuleIdentifier.newId(parts[0], parts[1]),
+                parts[2]
+            );
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
@@ -29,6 +29,8 @@ import org.gradle.internal.typeconversion.TypedNotationConverter;
 
 import javax.annotation.Nullable;
 
+import static org.gradle.api.internal.notations.ModuleNotationValidation.validate;
+
 public class ComponentIdentifierParserFactory implements Factory<NotationParser<Object, ComponentIdentifier>> {
 
     @Nullable
@@ -47,8 +49,8 @@ public class ComponentIdentifierParserFactory implements Factory<NotationParser<
             @MapKey("version") String version) {
 
             return DefaultModuleComponentIdentifier.newId(
-                DefaultModuleIdentifier.newId(group, name),
-                version
+                DefaultModuleIdentifier.newId(validate(group.trim()), validate(name.trim())),
+                validate(version.trim())
             );
         }
     }
@@ -63,11 +65,11 @@ public class ComponentIdentifierParserFactory implements Factory<NotationParser<
         protected ModuleComponentIdentifier parseType(String notation) {
             String[] parts = notation.split(":");
             if (parts.length != 3) {
-                throw new InvalidUserDataException("Invalid module component notation");
+                throw new InvalidUserDataException("Invalid module component notation: " + notation + " : must be a valid 3 part identifier, eg.: org.gradle:gradle:1.0");
             }
             return DefaultModuleComponentIdentifier.newId(
-                DefaultModuleIdentifier.newId(parts[0], parts[1]),
-                parts[2]
+                DefaultModuleIdentifier.newId(validate(parts[0].trim(), notation), validate(parts[1].trim(), notation)),
+                validate(parts[2].trim(), notation)
             );
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleIdentifierNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleIdentifierNotationConverter.java
@@ -16,18 +16,15 @@
 
 package org.gradle.api.internal.notations;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.TypedNotationConverter;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
-import org.gradle.util.GUtil;
 
-import java.util.List;
+import static org.gradle.api.internal.notations.ModuleNotationValidation.validate;
 
 public class ModuleIdentifierNotationConverter extends TypedNotationConverter<String, ModuleIdentifier> {
-    private final static List<Character> INVALID_SPEC_CHARS = Lists.newArrayList('*', '[', ']', '(', ')', ',');
 
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 
@@ -48,18 +45,6 @@ public class ModuleIdentifierNotationConverter extends TypedNotationConverter<St
         String group = validate(split[0].trim(), notation);
         String name = validate(split[1].trim(), notation);
         return moduleIdentifierFactory.module(group, name);
-    }
-
-    public static String validate(String part, String notation) {
-        if (!GUtil.isTrue(part)) {
-            throw new UnsupportedNotationException(notation);
-        }
-        for (char c : INVALID_SPEC_CHARS) {
-            if (part.indexOf(c) != -1) {
-                throw new UnsupportedNotationException(notation);
-            }
-        }
-        return part;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleNotationValidation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ModuleNotationValidation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.notations;
+
+import com.google.common.collect.Lists;
+import org.gradle.internal.typeconversion.UnsupportedNotationException;
+import org.gradle.util.GUtil;
+
+import java.util.List;
+
+public abstract class ModuleNotationValidation {
+    private final static List<Character> INVALID_SPEC_CHARS = Lists.newArrayList('*', '[', ']', '(', ')', ',');
+
+    public static String validate(String part, String notation) {
+        if (!GUtil.isTrue(part)) {
+            throw new UnsupportedNotationException(notation);
+        }
+        for (char c : INVALID_SPEC_CHARS) {
+            if (part.indexOf(c) != -1) {
+                throw new UnsupportedNotationException(notation);
+            }
+        }
+        return part;
+    }
+
+    public static String validate(String part) {
+        return validate(part, part);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -54,7 +54,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue originalContentHash;
     private final ImmutableAttributes attributes;
-    private final ImmutableList<? extends ComponentIdentifier> plaftormOwners;
+    private final ImmutableList<? extends ComponentIdentifier> platformOwners;
 
     public AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
         this.componentIdentifier = metadata.getId();
@@ -67,7 +67,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.getContentHash();
         attributes = extractAttributes(metadata);
         variants = metadata.getVariants();
-        plaftormOwners = metadata.getPlatformOwners() == null ? ImmutableList.<ComponentIdentifier>of() : ImmutableList.copyOf(metadata.getPlatformOwners());
+        platformOwners = metadata.getPlatformOwners() == null ? ImmutableList.<ComponentIdentifier>of() : ImmutableList.copyOf(metadata.getPlatformOwners());
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants) {
@@ -81,6 +81,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.getOriginalContentHash();
         attributes = metadata.getAttributes();
         this.variants = variants;
+        this.platformOwners = metadata.getPlatformOwners();
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata) {
@@ -94,7 +95,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.originalContentHash;
         attributes = metadata.attributes;
         variants = metadata.variants;
-        plaftormOwners = metadata.plaftormOwners;
+        platformOwners = metadata.platformOwners;
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ModuleSource source) {
@@ -107,7 +108,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.originalContentHash;
         attributes = metadata.attributes;
         variants = metadata.variants;
-
+        platformOwners = metadata.platformOwners;
         moduleSource = source;
     }
 
@@ -193,7 +194,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
 
     @Override
     public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
-        return plaftormOwners;
+        return platformOwners;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -53,6 +54,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue originalContentHash;
     private final ImmutableAttributes attributes;
+    private final ImmutableList<? extends ComponentIdentifier> plaftormOwners;
 
     public AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
         this.componentIdentifier = metadata.getId();
@@ -65,6 +67,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.getContentHash();
         attributes = extractAttributes(metadata);
         variants = metadata.getVariants();
+        plaftormOwners = metadata.getPlatformOwners() == null ? ImmutableList.<ComponentIdentifier>of() : ImmutableList.copyOf(metadata.getPlatformOwners());
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants) {
@@ -91,6 +94,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.originalContentHash;
         attributes = metadata.attributes;
         variants = metadata.variants;
+        plaftormOwners = metadata.plaftormOwners;
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ModuleSource source) {
@@ -185,6 +189,11 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
      */
     protected Optional<ImmutableList<? extends ConfigurationMetadata>> maybeDeriveVariants() {
         return Optional.absent();
+    }
+
+    @Override
+    public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+        return plaftormOwners;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
@@ -67,6 +68,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
 
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
+    private List<ComponentIdentifier> owners;
 
     protected AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId, ModuleComponentIdentifier componentIdentifier) {
         this.attributesFactory = attributesFactory;
@@ -259,6 +261,18 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         return attributesFactory;
     }
 
+    @Override
+    public void belongsTo(ComponentIdentifier platform) {
+        if (owners == null) {
+            owners = Lists.newArrayListWithExpectedSize(1);
+        }
+        owners.add(platform);
+    }
+
+    @Override
+    public List<? extends ComponentIdentifier> getPlatformOwners() {
+        return owners;
+    }
 
     protected static class MutableVariantImpl implements MutableComponentVariant {
         private final String name;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -95,4 +96,13 @@ public interface MutableModuleComponentResolveMetadata {
      * Returns the metadata rules container for this module
      */
     VariantMetadataRules getVariantMetadataRules();
+
+    /**
+     * Declares that this component belongs to a platform.
+     * @param platform the identifer of the platform
+     */
+    void belongsTo(ComponentIdentifier platform);
+
+    @Nullable
+    List<? extends ComponentIdentifier> getPlatformOwners();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -212,6 +212,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
+    public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+        return ImmutableList.of();
+    }
+
+    @Override
     public Set<String> getConfigurationNames() {
         return allConfigurations.keySet();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -93,4 +93,6 @@ public interface ComponentResolveMetadata extends HasAttributes {
 
     List<String> getStatusScheme();
 
+    ImmutableList<? extends ComponentIdentifier> getPlatformOwners();
+
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstra
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
+import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.api.internal.notations.ModuleIdentifierNotationConverter
 import org.gradle.cache.CacheRepository
@@ -59,6 +60,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     def dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl, stringInterner)
     def dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl, stringInterner)
     def moduleIdentifierNotationParser = NotationParserBuilder.toType(ModuleIdentifier).converter(new ModuleIdentifierNotationConverter(new DefaultImmutableModuleIdentifierFactory())).toComposite();
+    def componentIdentifierNotationParser = new ComponentIdentifierParserFactory().create()
 
     def 'setup'() {
         TestComponentMetadataRule.instanceCount = 0
@@ -67,7 +69,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     def "does nothing when no rules registered"() {
-        def processor = new DefaultComponentMetadataProcessor([] as Set, [] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, TestUtil.attributesFactory(), executor, context)
         def metadata = ivyMetadata().asImmutable()
 
         expect:
@@ -78,7 +80,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         given:
         context.injectingInstantiator >> instantiator
         String notation = "${GROUP}:${MODULE}"
-        def processor = new DefaultComponentMetadataProcessor([] as Set, [ruleForModule(notation)] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [ruleForModule(notation)] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, TestUtil.attributesFactory(), executor, context)
 
 
         when:
@@ -92,7 +94,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         given:
         context.injectingInstantiator >> instantiator
         String notation = "${GROUP}:${MODULE}"
-        def processor = new DefaultComponentMetadataProcessor([] as Set, [ruleForModuleWithParams(notation, "foo", 42L)] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [ruleForModuleWithParams(notation, "foo", 42L)] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, TestUtil.attributesFactory(), executor, context)
 
         when:
         processor.processMetadata(ivyMetadata().asImmutable())
@@ -103,7 +105,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     def "processing fails when status is not present in status scheme"() {
-        def processor = new DefaultComponentMetadataProcessor([] as Set, [] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, TestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor([] as Set, [] as Set, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, TestUtil.attributesFactory(), executor, context)
         def metadata = ivyMetadata()
         metadata.status = "green"
         metadata.statusScheme = ["alpha", "beta"]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphPathResolver
@@ -118,7 +119,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.path >> 'root'
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme)
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -569,7 +570,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme)
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleM
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -45,6 +46,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     private instantiator = DirectInstantiator.INSTANCE
     private dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl.class, SimpleMapInterner.notThreadSafe())
     private dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl.class, SimpleMapInterner.notThreadSafe())
+    private componentIdentifierNotationParser = new ComponentIdentifierParserFactory().create()
 
     def versionIdentifier = DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "producer"), "1.0")
     def componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
@@ -55,9 +57,9 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     def gradleMetadata
-    def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
-    def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
-    def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser)
+    def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)
+    def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)
+    def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)
 
     private ivyComponentMetadata() {
         ivyMetadataFactory.create(componentIdentifier, [], [new Configuration("configurationDefinedInIvyMetadata", true, true, [])], [], [])

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ComponentIdentifierParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ComponentIdentifierParserTest.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.internal.typeconversion.NotationParser
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class ComponentIdentifierParserTest extends Specification {
+
+    @Subject
+    NotationParser<Object, ComponentIdentifier> parser = new ComponentIdentifierParserFactory().create()
+
+    @Unroll("Parses #notation")
+    def "can parse a module component identifier"() {
+        when:
+        def id = parser.parseNotation(notation)
+
+        then:
+        id instanceof ModuleComponentIdentifier
+        id.moduleIdentifier.group == expectedGroup
+        id.moduleIdentifier.name == expectedName
+        id.version == expectedVersion
+
+        where:
+        notation                                                  | expectedGroup | expectedName | expectedVersion
+        'g:a:v'                                                   | 'g'           | 'a'          | 'v'
+        'group:name:1.0'                                          | 'group'       | 'name'       | '1.0'
+        'group  :name  :1.0  '                                    | 'group'       | 'name'       | '1.0'
+        "${-> 'group'}:name:1.1"                                  | 'group'       | 'name'       | '1.1'
+        [group: 'group', name: 'foo', version: '1.4-beta-1']      | 'group'       | 'foo'        | '1.4-beta-1'
+        [group: ' group ', name: 'foo ', version: '  1.4-beta-1'] | 'group'       | 'foo'        | '1.4-beta-1'
+    }
+
+    @Unroll("Fails to parse #notation")
+    def "fails if string doesn't have 3 parts"() {
+        when:
+        parser.parseNotation(notation)
+
+        then:
+        InvalidUserDataException ex = thrown()
+        ex.message == "Invalid module component notation: $notation : must be a valid 3 part identifier, eg.: org.gradle:gradle:1.0"
+
+        where:
+        notation << ["foo", "foo:", "foo:bar", "foo:bar:", "foo:bar:baz:qux"]
+    }
+
+    @Unroll("Fails to parse #notation")
+    def "fails to parse map notation which doesn't pass validation"() {
+        when:
+        parser.parseNotation(notation)
+
+        then:
+        Exception ex = thrown()
+        ex.message.startsWith(error)
+
+        where:
+        notation                                    | error
+        [:]                                         | "Required keys [group, name, version] are missing from map {}."
+        [group: 'foo']                              | "Required keys [name, version] are missing from map {group=foo}."
+        [name: 'foo']                               | "Required keys [group, version] are missing from map {name=foo}."
+        [version: 'foo']                            | "Required keys [group, name] are missing from map {version=foo}."
+        [group: 'foo', name: 'module']              | "Required keys [version] are missing from map {group=foo, name=module}."
+        [group: 'foo', version: '1.0']              | "Required keys [name] are missing from map {group=foo, version=1.0}."
+        [name: 'foo', version: '1.0']               | "Required keys [group] are missing from map {name=foo, version=1.0}."
+        [group: '()', name: 'foo', version: '1.0']  | "Cannot convert the provided notation to an object of type ComponentIdentifier: ()."
+        [group: 'name', name: '*', version: '1.0']  | "Cannot convert the provided notation to an object of type ComponentIdentifier: *."
+        [group: 'name', name: 'name', version: '['] | "Cannot convert the provided notation to an object of type ComponentIdentifier: [."
+
+    }
+}

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/RemoteRepositorySpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/RemoteRepositorySpec.groovy
@@ -54,12 +54,17 @@ class RemoteRepositorySpec {
         def pathElements = (pathSpec.split("\\s?->\\s?") as List<String>).reverse()
         def last = null
         pathElements.each { String spec ->
-            if (!spec.contains(':')) {
-                spec += ':1.0'
+            def gav = spec.split(':') as List<String>
+            if (gav.size()==1) {
+                // name only
+                gav = ["org", gav[0], "1.0"]
+            } else if (gav.size() == 2) {
+                // name, version
+                gav = ["org", *gav]
             }
-            def (name, v) = spec.split(':')
-            group('org') {
-                module(name) {
+            def (g, a, v) = gav
+            group(g) {
+                module(a) {
                     version(v) {
                         if (last) {
                             dependsOn(last)
@@ -67,7 +72,7 @@ class RemoteRepositorySpec {
                     }
                 }
             }
-            last = "org:$spec"
+            last = "$g:$a:$v"
         }
     }
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependencyResolutionTest {
     ResolveTestFixture resolve
 
-    private final RemoteRepositorySpec repoSpec = new RemoteRepositorySpec()
+    protected final RemoteRepositorySpec repoSpec = new RemoteRepositorySpec()
 
     boolean useIvy() {
         GradleMetadataResolveRunner.useIvy()


### PR DESCRIPTION
### Context

This PR implements support for declaring to which platforms a component belongs to. By declaring an owner, it becomes possible to get reasonable rules for upgrading versions which belong to the same platform, and, as a consequence, provide proper alignment rules.

Let's take this example: the Groovy project provides `groovy-core`, `groovy-json` and `groovy-xml` (among others). It is possible, then, to ask for 2 different versions of the leaves:

```
dependencies {
    implementation 'org:groovy-xml:1.0'
    implementation 'org:groovy-json:1.1'
}
```

which would resolve `groovy:1.1`, `groovy-json:1.1`, but the leaf `groovy-xml` wouldn't be bumped to `1.1` because it doesn't conflict with anything else. Therefore, we get inconsistent versions of the groovy libraries on classpath: 2 of them have version `1.1`, while the 3rd one has `1.0`. This PR provides a mechanism to explain that those 3 libraries "belong to" the same platform, the "Groovy platform". By doing so, the dependency engine will try to match the dependency versions for modules that belong to the same platform. As a consequence, it will realize that `groovy-xml` needs to be bumped.

Currently, declaring the platform can _only_ be done using a component metadata rule. Here's, for example, how one would declare a rule to "align" all versions of the Jackson library:

```
dependencies {
    implementation("com.fasterxml.jackson.core:jackson-core:2.9.4")
    implementation("com.fasterxml.jackson.core:jackson-databind:2.7.9")
    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.4.1")
    // the following line will declare that all jackson modules belong to the same platform
    components.all(AlignJackson::class.java)
}

open class AlignJackson: ComponentMetadataRule {
   override fun execute(ctx: ComponentMetadataContext) {
      ctx.details.run {
         if (id.group.startsWith("com.fasterxml.jackson")) {
            belongsTo("com.fasterxml.jackson:jackson-platform:${id.version}")
         }
      }
   }
}
```

There are, then, 2 possible outcomes:

1. the "platform" is a published module, for example a BOM. In this case, this BOM is used as the _reference_, and will be added transparently as a dependency. The consequence is that the platform BOM is expected to tell how versions are going to be aligned, by declaring _in extenso_ all modules which belong to the platform. This is the simplest use case.
2. there is no such module, like in the Groovy and Jackson cases above. In this case, the dependency engine generates a _synthetic module_ for the platform, and will try to align versions of all the components dynamically, based on the actual versions found in the graph.

Because it's possible for leaves to be published in different versions than the nodes, in the 2d case, the engine implements _inference of versions_. For example. say that we have 3 modules:

- `core`, published in versions `1.0` and `1.1`
- `leaf1`, published in versions `1.0`, `1.1` and `1.1.1` 
- `leaf2`, published in versions `1.0`, `1.0.1` and `1.1`

And that the requested dependencies are: `core:1.1`, `leaf1:1.1.1` and `leaf2:1.0`, the engine will resolve to:

- `core:1.1`
- `leaf1:1.1.1`
- `leaf2:1.1`

Because the `1.1.1` version only exists for `leaf1`. It tries to find the corresponding versions for `core` and `leaf2`, but because they don't exist, it ignores them. On the other hand, we see `core:1.1`, and there is a `leaf2` version `1.1`, so we can bump `leaf2` to `1.1`. The consequence is additional network requests to figure out the best match (and of course, to try to find the platform, if it is published).