### PR TITLE
Update to build scan plugin 1.15.1

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -12,7 +12,7 @@ apply {
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.6")
     implementation("org.jsoup:jsoup:1.11.2")
-    implementation("com.gradle:build-scan-plugin:1.14")
+    implementation("com.gradle:build-scan-plugin:1.15.1")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedBuildScanPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedBuildScanPlugin.java
@@ -28,5 +28,5 @@ public interface AutoAppliedBuildScanPlugin {
     PluginId ID = new DefaultPluginId("com.gradle.build-scan");
     String GROUP = "com.gradle";
     String NAME = "build-scan-plugin";
-    String VERSION = "1.15";
+    String VERSION = "1.15.1";
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -45,7 +45,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "1.13.3",
         "1.13.4",
         "1.14",
-        "1.15"
+        "1.15.1"
     ]
 
     @Unroll


### PR DESCRIPTION
Build Scan plugin update to 1.15.1 

fixing VisitableURLClassLoader leaked caused by build scan threads

passing CI build: https://builds.gradle.org/viewLog.html?buildId=14056791&