### PR TITLE
Update the manual-maintained xml configurations to 2018.1

### DIFF
--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_FinalRelease.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_FinalRelease.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="44e9390f-e46c-457e-aa18-31b020aef4de" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="44e9390f-e46c-457e-aa18-31b020aef4de" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Release - Final</name>
   <description>Promotes the latest successful change on 'release' as a new release</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MasterNightlySnapshotManual.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MasterNightlySnapshotManual.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="9a55bec1-4e70-449b-8f45-400093505afb" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="9a55bec1-4e70-449b-8f45-400093505afb" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Master - Nightly Snapshot (from Quick Feedback)</name>
   <description>Promotes the latest change on 'master' that passed the 'Quick Feedback' stage as new nightly. This build configuration can be triggered manually if there are issues further down the pipeline we can ignore temporarily.</description>
   <settings>
@@ -10,7 +10,7 @@
       <option name="showDependenciesChanges" value="true" />
     </options>
     <parameters />
-    <build-runners order="RUNNER_9">
+    <build-runners>
       <runner id="RUNNER_9" name="Promote" type="gradle-runner">
         <parameters>
           <param name="org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration" value="GLOBAL" />

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MasterSanityCheck.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MasterSanityCheck.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="bf9b573a-6e5e-4db1-88b2-399e709026b5" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="bf9b573a-6e5e-4db1-88b2-399e709026b5" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Master - Sanity Check</name>
   <description>Compilation and test execution of buildSrc</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MilestoneMaster.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MilestoneMaster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="2ffb238a-08af-4f95-b863-9830d2bc3872" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="2ffb238a-08af-4f95-b863-9830d2bc3872" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Release - Milestone</name>
   <description>Promotes the latest successful change on 'release' as the new snapshot</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_ReleaseSnapshotFromQuickFeedback.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_ReleaseSnapshotFromQuickFeedback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="eeff4410-1e7d-4db6-b7b8-34c1f2754477" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="eeff4410-1e7d-4db6-b7b8-34c1f2754477" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Release - Snapshot (from Quick Feedback)</name>
   <description>Deploys the latest successful change on 'release' as a new snapshot</description>
   <settings>
@@ -8,7 +8,7 @@
       <option name="checkoutMode" value="ON_SERVER" />
     </options>
     <parameters />
-    <build-runners order="RUNNER_18">
+    <build-runners>
       <runner id="RUNNER_18" name="Promote" type="gradle-runner">
         <parameters>
           <param name="org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration" value="GLOBAL" />

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_StartReleaseCycle.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_StartReleaseCycle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="355487d7-45b9-4387-9fc5-713e7683e6d0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="355487d7-45b9-4387-9fc5-713e7683e6d0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Master - Start Release Cycle</name>
   <description>Promotes a successful build on master as the start of a new release cycle on the release branch</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/buildTypes/bt39.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt39.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="01432c63-861f-4d08-ae0a-7d127f63096e" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="01432c63-861f-4d08-ae0a-7d127f63096e" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Master - Nightly Snapshot</name>
   <description>Promotes the latest successful change on 'master' as the new nightly</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/buildTypes/bt60.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt60.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="5ed504bb-5ec3-46dc-a28a-e42a63ebbb31" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="5ed504bb-5ec3-46dc-a28a-e42a63ebbb31" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Release - Release Candidate</name>
   <description>Promotes the latest successful change on 'release' as a new release candidate</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="1f5ca7f8-b0f5-41f9-9ba7-6d518b2822f0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="1f5ca7f8-b0f5-41f9-9ba7-6d518b2822f0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Release - Snapshot</name>
   <description>Deploys the latest successful change on 'release' as a new snapshot</description>
   <settings>

--- a/.teamcity/Gradle_Promotion/pluginData/plugin-settings.xml
+++ b/.teamcity/Gradle_Promotion/pluginData/plugin-settings.xml
@@ -3,15 +3,15 @@
   <webhooks enabled="true">
     <webhook url="https://api.hipchat.com/v1/webhooks/teamcity/?auth_token=4422efda69d1e2193b770719a78e4f&amp;room_id=72960" enabled="true" format="nvpairs">
       <states>
-        <state type="buildInterrupted" enabled="true" />
         <state type="beforeBuildFinish" enabled="false" />
         <state type="buildFailed" enabled="false" />
-        <state type="buildBroken" enabled="false" />
-        <state type="buildStarted" enabled="false" />
-        <state type="buildFixed" enabled="false" />
         <state type="responsibilityChanged" enabled="true" />
         <state type="buildFinished" enabled="false" />
+        <state type="buildStarted" enabled="false" />
+        <state type="buildInterrupted" enabled="true" />
         <state type="buildSuccessful" enabled="false" />
+        <state type="buildFixed" enabled="false" />
+        <state type="buildBroken" enabled="false" />
       </states>
       <build-types enabled-for-all="true" enabled-for-subprojects="true" />
     </webhook>

--- a/.teamcity/Gradle_Promotion/project-config.xml
+++ b/.teamcity/Gradle_Promotion/project-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="Gradle" uuid="16c9f3e3-36a9-4596-a35c-70a3c7a2c5c8" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="Gradle" uuid="16c9f3e3-36a9-4596-a35c-70a3c7a2c5c8" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Promotion</name>
   <parameters>
     <param name="env.DOTCOM_DEV_DOCS_AWS_ACCESS_KEY" value="AKIAJFJBF5BXLBNI3E5A" />

--- a/.teamcity/Gradle_Promotion/vcsRoots/Gradle_Promotion_GradlePromotionBranches.xml
+++ b/.teamcity/Gradle_Promotion/vcsRoots/Gradle_Promotion_GradlePromotionBranches.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<vcs-root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="e4bc6ac6-ab3f-4459-b4c4-7d6ba6e2cbf6" type="jetbrains.git" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<vcs-root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="e4bc6ac6-ab3f-4459-b4c4-7d6ba6e2cbf6" type="jetbrains.git" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Gradle Promotion Branches</name>
   <param name="agentCleanFilesPolicy" value="ALL_UNTRACKED" />
   <param name="agentCleanPolicy" value="ON_BRANCH_CHANGE" />

--- a/.teamcity/Gradle_Promotion/vcsRoots/Gradle_Promotion__master_.xml
+++ b/.teamcity/Gradle_Promotion/vcsRoots/Gradle_Promotion__master_.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<vcs-root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="0974a0e7-3f2f-4c3f-a185-aded6ac045ff" type="jetbrains.git" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<vcs-root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="0974a0e7-3f2f-4c3f-a185-aded6ac045ff" type="jetbrains.git" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Gradle Promotion</name>
   <param name="agentCleanFilesPolicy" value="ALL_UNTRACKED" />
   <param name="agentCleanPolicy" value="ON_BRANCH_CHANGE" />

--- a/.teamcity/Gradle_Util/buildTypes/Gradle_Util_AdHocFunctionalTestLinux.xml
+++ b/.teamcity/Gradle_Util/buildTypes/Gradle_Util_AdHocFunctionalTestLinux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="5d59fee9-be42-4f6d-9e0b-fe103e0d2765" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="5d59fee9-be42-4f6d-9e0b-fe103e0d2765" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>AdHoc Functional Test - Linux</name>
   <description />
   <settings>
@@ -24,8 +24,8 @@
           <param name="teamcity.coverage.idea.includePatterns" value="*" />
           <param name="teamcity.coverage.jacoco.patterns" value="+:*" />
           <param name="teamcity.step.mode" value="default" />
-          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PmaxParallelForks=%maxParallelForks% -s --no-daemon --continue -I ./gradle/init-scripts/build-scan.init.gradle.kts -Djava7Home=%linux.jdk.for.gradle.compile%" />
+          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.gradle.tasks.names" value="clean %subproject%:%buildType%" />
           <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true" />
         </parameters>
@@ -52,8 +52,8 @@ fi]]></param>
           <param name="teamcity.coverage.idea.includePatterns" value="*" />
           <param name="teamcity.coverage.jacoco.patterns" value="+:*" />
           <param name="teamcity.step.mode" value="default" />
-          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PmaxParallelForks=%maxParallelForks% -s --no-daemon --continue -I ./gradle/init-scripts/build-scan.init.gradle.kts -Djava7Home=%linux.jdk.for.gradle.compile%" />
+          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.gradle.tasks.names" value="verifyTestFilesCleanup" />
           <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true" />
         </parameters>

--- a/.teamcity/Gradle_Util/buildTypes/Gradle_Util_AdHocFunctionalTestWindows.xml
+++ b/.teamcity/Gradle_Util/buildTypes/Gradle_Util_AdHocFunctionalTestWindows.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="944be583-446e-4ecc-b2f2-15f04dd0cfe9" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="944be583-446e-4ecc-b2f2-15f04dd0cfe9" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>AdHoc Functional Test - Windows</name>
   <description />
   <settings>
@@ -24,8 +24,8 @@
           <param name="teamcity.coverage.idea.includePatterns" value="*" />
           <param name="teamcity.coverage.jacoco.patterns" value="+:*" />
           <param name="teamcity.step.mode" value="default" />
-          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PmaxParallelForks=%maxParallelForks% -s --no-daemon --continue -I ./gradle/init-scripts/build-scan.init.gradle.kts &quot;-Djava7Home=%windows.java7.oracle.64bit%&quot;" />
+          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.gradle.tasks.names" value="clean %subproject%:%buildType%" />
           <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true" />
         </parameters>
@@ -48,8 +48,8 @@
           <param name="teamcity.coverage.idea.includePatterns" value="*" />
           <param name="teamcity.coverage.jacoco.patterns" value="+:*" />
           <param name="teamcity.step.mode" value="default" />
-          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PmaxParallelForks=%maxParallelForks% -s --no-daemon --continue -I ./gradle/init-scripts/build-scan.init.gradle.kts &quot;-Djava7Home=%windows.java7.oracle.64bit%&quot;" />
+          <param name="ui.gradleRunner.gradle.build.file" value="" />
           <param name="ui.gradleRunner.gradle.tasks.names" value="verifyTestFilesCleanup" />
           <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true" />
         </parameters>

--- a/.teamcity/Gradle_Util/project-config.xml
+++ b/.teamcity/Gradle_Util/project-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="Gradle" uuid="077cff89-d1d3-407b-acc0-88446a99dec7" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="Gradle" uuid="077cff89-d1d3-407b-acc0-88446a99dec7" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Util</name>
   <parameters />
   <project-extensions>

--- a/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_AdHocPerformanceScenarioLinux.xml
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_AdHocPerformanceScenarioLinux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="a3183d81-e07d-475c-8ef6-04ed60bf4053" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="a3183d81-e07d-475c-8ef6-04ed60bf4053" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>AdHoc Performance Scenario - Linux</name>
   <description />
   <settings>

--- a/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_PerformanceTestCoordinatorLinux.xml
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_PerformanceTestCoordinatorLinux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="a28ced77-77d1-41fd-bc3b-fe9c9016bf7b" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="a28ced77-77d1-41fd-bc3b-fe9c9016bf7b" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>AdHoc Performance Test Coordinator - Linux</name>
   <description />
   <settings>

--- a/.teamcity/Gradle_Util_Performance/project-config.xml
+++ b/.teamcity/Gradle_Util_Performance/project-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="Gradle_Util" uuid="fdc4f15a-e253-4744-a1b3-bcac37b18189" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2017.2/project-config.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" parent-id="Gradle_Util" uuid="fdc4f15a-e253-4744-a1b3-bcac37b18189" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
   <name>Performance</name>
   <parameters />
   <cleanup />


### PR DESCRIPTION
Resetting VCS synchronization on TeamCity results in some xmls updated.
These files should have been updated so here we partially revert the previous
85a4704ad4cd5f0493cc344b7feebbabd1dec94b commit.

@wolfs Seems it's just updating xsd definition and slightly reordering xml entries. I noticed there're lots of added xmls in `Gradle_Check` in this commit https://github.com/gradle/gradle/commit/84c4874bfac6e29b9d2f15319d8c118a913edff7. In my understanding, all xmls under `Gradle_Check` directory should be generated by DSL so I don't migrate that part.