### PR TITLE
Injecting a no-op RepositoryResourceAccessor for flat dir repos

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
@@ -127,7 +127,7 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
         return new ImplicitInputsCapturingInstantiator(registry, instantiatorFactory);
     }
 
-    private RepositoryResourceAccessor createRepositoryAccessor(RepositoryTransport transport, URI rootUri, FileStore<String> externalResourcesFileStore) {
+    protected RepositoryResourceAccessor createRepositoryAccessor(RepositoryTransport transport, URI rootUri, FileStore<String> externalResourcesFileStore) {
         return new ExternalRepositoryResourceAccessor(rootUri, transport.getResourceAccessor(), externalResourcesFileStore);
     }
 


### PR DESCRIPTION
This is required as there is otherwise no way to inject one in a project
 mixing ivy or maven repos with flat dir ones.
A follow-up improvement could be to have a real
RepositoryResourceAccessor for flat dir repos.