### PR TITLE
Intern type names in incremental compile caches

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzer.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile.incremental.analyzer;
 
 import com.google.common.io.ByteStreams;
 import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.tasks.compile.incremental.asm.ClassDependenciesVisitor;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
 import org.gradle.internal.hash.HashCode;
@@ -28,10 +29,16 @@ import java.io.InputStream;
 
 public class DefaultClassDependenciesAnalyzer implements ClassDependenciesAnalyzer {
 
+    private final StringInterner interner;
+
+    public DefaultClassDependenciesAnalyzer(StringInterner interner) {
+        this.interner = interner;
+    }
+
     public ClassAnalysis getClassAnalysis(InputStream input) throws IOException {
         ClassReader reader = new ClassReader(ByteStreams.toByteArray(input));
         String className = reader.getClassName().replace("/", ".");
-        return ClassDependenciesVisitor.analyze(className, reader);
+        return ClassDependenciesVisitor.analyze(className, reader, interner);
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
@@ -16,6 +16,7 @@
 
 package org.gradle.language.java.internal;
 
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -63,8 +64,8 @@ public class JavaLanguagePluginServiceRegistry extends AbstractPluginServiceRegi
     }
 
     private static class JavaProjectScopeServices {
-        public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, GeneralCompileCaches compileCaches, BuildOperationExecutor buildOperationExecutor) {
-            return new IncrementalCompilerFactory(fileOperations, streamHasher, fileHasher, compileCaches, buildOperationExecutor);
+        public IncrementalCompilerFactory createIncrementalCompilerFactory(FileOperations fileOperations, StreamHasher streamHasher, FileHasher fileHasher, GeneralCompileCaches compileCaches, BuildOperationExecutor buildOperationExecutor, StringInterner interner) {
+            return new IncrementalCompilerFactory(fileOperations, streamHasher, fileHasher, compileCaches, buildOperationExecutor, interner);
         }
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/analyzer/DefaultClassDependenciesAnalyzerTest.groovy
@@ -17,6 +17,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.analyzer
 
+import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.annotations.SomeClassAnnotation
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.annotations.SomeRuntimeAnnotation
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.annotations.SomeSourceAnnotation
@@ -38,7 +39,7 @@ import spock.lang.Subject
 class DefaultClassDependenciesAnalyzerTest extends Specification {
 
     @Subject
-    analyzer = new DefaultClassDependenciesAnalyzer()
+    analyzer = new DefaultClassDependenciesAnalyzer(new StringInterner())
 
     private ClassAnalysis analyze(Class foo) {
         analyzer.getClassAnalysis(classStream(foo))


### PR DESCRIPTION
Many types will appear again and again as a dependency
to another one. Each of those appearances would result
in an additional String until now. After this fix, each
class name will appear exactly once in the cache.