### PR TITLE
Add support for nested included builds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
@@ -28,7 +28,9 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         includeBuild(buildC)
         buildA.buildFile << """
             assert gradle.includedBuild("buildB").name == "buildB"
+            assert gradle.includedBuild("buildB").projectDir == file('${buildB.toURI()}')
             assert gradle.includedBuild("buildC").name == "buildC"
+            assert gradle.includedBuild("buildC").projectDir == file('${buildC.toURI()}')
             assert gradle.includedBuilds.name == ["buildB", "buildC"]
             
             task broken {
@@ -46,16 +48,58 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         failure.assertHasCause("Included build 'unknown' not found in build 'buildA'.")
     }
 
-    def "other builds are not visible from included build"() {
+    def "root project name is used as build name"() {
+        given:
+        def buildB = singleProjectBuild("buildB") {
+            settingsFile << """
+                rootProject.name = 'b'
+            """
+        }
+        includeBuild(buildB)
+        def buildC = singleProjectBuild("buildC") {
+            settingsFile << """
+                rootProject.name = 'c'
+            """
+        }
+        includeBuild(buildC)
+        buildA.buildFile << """
+            assert gradle.includedBuild("b").name == "b"
+            assert gradle.includedBuild("b").projectDir == file('${buildB.toURI()}')
+            assert gradle.includedBuild("c").name == "c"
+            assert gradle.includedBuild("c").projectDir == file('${buildC.toURI()}')
+            assert gradle.includedBuilds.name == ["b", "c"]
+            
+            task broken {
+                doLast {
+                    assert gradle.includedBuilds.name == ["b", "c"]
+                    gradle.includedBuild("buildB")
+                }
+            }
+        """
+
+        when:
+        fails(buildA, "broken")
+
+        then:
+        failure.assertHasCause("Included build 'buildB' not found in build 'buildA'.")
+    }
+
+    def "parent and sibling builds are not visible from included build"() {
         given:
         def buildB = singleProjectBuild("buildB") {
             buildFile << """
                 assert gradle.includedBuilds.empty
             
-                task broken {
+                task broken1 {
                     doLast {
                         assert gradle.includedBuilds.empty
                         gradle.includedBuild("buildA")
+                    }
+                }
+                task broken2 {
+                    doLast {
+                        assert gradle.includedBuilds.empty
+                        gradle.includedBuild("buildC")
                     }
                 }
             """
@@ -68,14 +112,17 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
 
         buildA.buildFile << """
             task broken {
-                dependsOn gradle.includedBuild("buildB").task(":broken")
+                dependsOn gradle.includedBuild("buildB").task(":broken1")
+                dependsOn gradle.includedBuild("buildB").task(":broken2")
             }
         """
 
         when:
+        executer.withArgument("--continue")
         fails(buildA, "broken")
 
         then:
         failure.assertHasCause("Included build 'buildA' not found in build 'buildB'.")
+        failure.assertHasCause("Included build 'buildC' not found in build 'buildB'.")
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+
+class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    def "can query the included builds defined by the root build"() {
+        given:
+        def buildB = singleProjectBuild("buildB") {
+        }
+        includeBuild(buildB)
+        def buildC = singleProjectBuild("buildC") {
+        }
+        includeBuild(buildC)
+        buildA.buildFile << """
+            assert gradle.includedBuild("buildB").name == "buildB"
+            assert gradle.includedBuild("buildC").name == "buildC"
+            assert gradle.includedBuilds.name == ["buildB", "buildC"]
+            
+            task broken {
+                doLast {
+                    assert gradle.includedBuilds.name == ["buildB", "buildC"]
+                    gradle.includedBuild("unknown")
+                }
+            }
+        """
+
+        when:
+        fails(buildA, "broken")
+
+        then:
+        failure.assertHasCause("Included build 'unknown' not found in build 'buildA'.")
+    }
+
+    def "other builds are not visible from included build"() {
+        given:
+        def buildB = singleProjectBuild("buildB") {
+            buildFile << """
+                assert gradle.includedBuilds.empty
+            
+                task broken {
+                    doLast {
+                        assert gradle.includedBuilds.empty
+                        gradle.includedBuild("buildA")
+                    }
+                }
+            """
+        }
+        includeBuild(buildB)
+
+        def buildC = singleProjectBuild("buildC") {
+        }
+        includeBuild(buildC)
+
+        buildA.buildFile << """
+            task broken {
+                dependsOn gradle.includedBuild("buildB").task(":broken")
+            }
+        """
+
+        when:
+        fails(buildA, "broken")
+
+        then:
+        failure.assertHasCause("Included build 'buildA' not found in build 'buildB'.")
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestedBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestedBuildLookupIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+
+class CompositeBuildNestedBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    def "can query the included builds defined by an included build"() {
+        given:
+        def buildC = singleProjectBuild("buildC") {
+        }
+        def buildB = singleProjectBuild("buildB") {
+            settingsFile << """
+                includeBuild('${buildC.toURI()}')
+            """
+            buildFile << """
+                assert gradle.includedBuild("buildC").name == "buildC"
+                assert gradle.includedBuilds.name == ["buildC"]
+                
+                task broken {
+                    doLast {
+                        assert gradle.includedBuilds.name == ["buildC"]
+                        gradle.includedBuild("unknown")
+                    }
+                }
+            """
+        }
+        includeBuild(buildB)
+
+        buildA.buildFile << """
+            task broken {
+                dependsOn gradle.includedBuild("buildB").task(":broken")
+            }
+        """
+
+        when:
+        fails(buildA, "broken")
+
+        then:
+        failure.assertHasCause("Included build 'unknown' not found in build 'buildB'.")
+    }
+
+    def "other builds are not visible from included build"() {
+        given:
+        def buildC = singleProjectBuild("buildC") {
+            buildFile << """
+                assert gradle.includedBuilds.empty
+            
+                task broken {
+                    doLast {
+                        assert gradle.includedBuilds.empty
+                        gradle.includedBuild("buildA")
+                    }
+                }
+            """
+        }
+        def buildB = singleProjectBuild("buildB") {
+            settingsFile << """
+                includeBuild('${buildC.toURI()}')
+            """
+            buildFile << """
+                task broken {
+                    dependsOn gradle.includedBuild("buildC").task(":broken")
+                }
+            """
+        }
+        includeBuild(buildB)
+
+        buildA.buildFile << """
+            task broken {
+                dependsOn gradle.includedBuild("buildB").task(":broken")
+            }
+        """
+
+        when:
+        fails(buildA, "broken")
+
+        then:
+        failure.assertHasCause("Included build 'buildA' not found in build 'buildC'.")
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestingIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestingIntegrationTest.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+
+class CompositeBuildNestingIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    def "can nest included builds"() {
+        given:
+        dependency(buildA, "org.test:buildB:1.2")
+
+        def buildC = singleProjectBuild("buildC") {
+            buildFile << """
+                apply plugin: 'java'
+            """
+        }
+        def buildB = singleProjectBuild("buildB") {
+            settingsFile << """
+                includeBuild('${buildC.toURI()}')
+            """
+            buildFile << """
+                apply plugin: 'java'
+                dependencies { implementation 'org.test:buildC:1.2' }
+            """
+        }
+        includeBuild(buildB)
+
+        when:
+        execute(buildA, "assemble")
+
+        then:
+        result.assertTaskExecuted(":buildC:jar")
+        result.assertTaskExecuted(":buildB:jar")
+        result.assertTaskExecuted(":jar")
+    }
+
+    def "a nested included build is substituted into all other builds"() {
+        given:
+        dependency(buildA, "org.test:buildB:1.2")
+        dependency(buildA, "org.test:buildC:1.2")
+
+        def buildC = singleProjectBuild("buildC") {
+            buildFile << """
+                apply plugin: 'java'
+            """
+        }
+
+        def buildB = singleProjectBuild("buildB") {
+            settingsFile << """
+                includeBuild('${buildC.toURI()}')
+            """
+            buildFile << """
+                apply plugin: 'java'
+                dependencies { implementation 'org.test:buildD:1.2' }
+                dependencies { implementation 'org.test:buildC:1.2' }
+            """
+        }
+        includeBuild(buildB)
+
+        def buildD = singleProjectBuild("buildD") {
+            buildFile << """
+                apply plugin: 'java'
+                dependencies { implementation 'org.test:buildC:1.2' }
+            """
+        }
+        includeBuild(buildD)
+
+        when:
+        execute(buildA, "assemble")
+
+        then:
+        result.assertTaskExecuted(":buildC:jar")
+        result.assertTaskExecuted(":buildD:jar")
+        result.assertTaskExecuted(":buildB:jar")
+        result.assertTaskExecuted(":jar")
+    }
+
+    def "a build can be included by multiple other builds"() {
+        given:
+        dependency(buildA, "org.test:buildB:1.2")
+
+        def buildC = singleProjectBuild("buildC") {
+            buildFile << """
+                apply plugin: 'java'
+            """
+        }
+        includeBuild(buildC)
+        def buildB = singleProjectBuild("buildB") {
+            settingsFile << """
+                includeBuild('${buildC.toURI()}')
+            """
+            buildFile << """
+                apply plugin: 'java'
+                dependencies { implementation 'org.test:buildC:1.2' }
+            """
+        }
+        includeBuild(buildB)
+
+        when:
+        execute(buildA, "assemble")
+
+        then:
+        result.assertTaskExecuted(":buildC:jar")
+        result.assertTaskExecuted(":buildB:jar")
+        result.assertTaskExecuted(":jar")
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskDependencyIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskDependencyIntegrationTest.groovy
@@ -209,7 +209,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project 'buildA'.")
-        failure.assertHasCause("Included build 'does-not-exist' not found.")
+        failure.assertHasCause("Included build 'does-not-exist' not found in build 'buildA'.")
     }
 
     def "reports failure when task does not exist for included build"() {
@@ -283,7 +283,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project 'buildB'.")
-        failure.assertHasCause("Included build 'does-not-exist' not found.")
+        failure.assertHasCause("Included build 'does-not-exist' not found in build 'buildB'.")
     }
 
     @Unroll
@@ -310,7 +310,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
 
         and:
         failure.assertHasDescription("A problem occurred evaluating project ':buildC'.")
-        failure.assertHasCause("Included build '${buildName}' not found.")
+        failure.assertHasCause("Included build '${buildName}' not found in build 'buildC'.")
 
         where:
         scenario  | buildName

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -71,23 +71,6 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
         failure.assertHasDescription("Included build 'b1' must have a settings file.")
     }
 
-    def "reports failure when included build is itself a composite"() {
-        when:
-        def buildC = singleProjectBuild("buildC")
-        buildB.settingsFile << """
-            includeBuild('${buildC.toURI()}')
-"""
-
-        includedBuilds << buildB
-
-        then:
-        fails(buildA, "help")
-
-        and:
-        failure.assertHasCause("Included build 'buildB' cannot have included builds.")
-    }
-
-
     def "reports failure for duplicate included build name"() {
         given:
         def buildC = singleProjectBuild("buildC")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/IncludedBuildValidationIntegrationTest.groovy
@@ -81,7 +81,9 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
         fails(buildA, "help")
 
         then:
-        failure.assertHasDescription("Included build 'buildB' is not unique in composite.")
+        failure.assertHasDescription("""Multiple included builds have the same root project name 'buildB':
+  - Included build in ${buildB}
+  - Included build in ${buildC}""")
     }
 
     def "reports failure for included build name that conflicts with subproject name"() {
@@ -95,7 +97,7 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
         fails(buildA, "help")
 
         then:
-        failure.assertHasDescription("Included build 'buildB' collides with subproject of the same name.")
+        failure.assertHasDescription("Included build in ${buildB} has a root project whose name 'buildB' is the same as a project of the main build.")
     }
 
     def "reports failure for included build name that conflicts with root project name"() {
@@ -107,6 +109,6 @@ class IncludedBuildValidationIntegrationTest extends AbstractCompositeBuildInteg
         fails(buildA, "help")
 
         then:
-        failure.assertHasDescription("Included build 'buildA' collides with root project name.")
+        failure.assertHasDescription("Included build in ${buildC} has the same root project name 'buildA' as the main build.")
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -85,6 +85,11 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
     }
 
     @Override
+    public File getRootDirectory() {
+        return buildDefinition.getBuildRootDir();
+    }
+
+    @Override
     public Path getIdentityPath() {
         return identityPath;
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.GradleLauncher;
+import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.Pair;
@@ -126,6 +127,14 @@ public class DefaultIncludedBuild extends AbstractBuildState implements Included
     @Override
     public NestedBuildFactory getNestedBuildFactory() {
         return getGradleLauncher().getGradle().getServices().get(NestedBuildFactory.class);
+    }
+
+    @Override
+    public void assertCanAdd(IncludedBuildSpec includedBuildSpec) {
+        if (isImplicit) {
+            // Not yet supported for implicit included builds
+            super.assertCanAdd(includedBuildSpec);
+        }
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
@@ -42,7 +41,6 @@ import org.gradle.internal.text.TreeFormatter;
 import org.gradle.util.Path;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -136,13 +134,8 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         validateIncludedBuilds(settings);
 
         projectRegistry.registerProjects(rootBuild);
+
         Collection<IncludedBuildState> includedBuilds = getIncludedBuilds();
-        List<IncludedBuild> modelElements = new ArrayList<IncludedBuild>(includedBuilds.size());
-        for (IncludedBuildState includedBuild : includedBuilds) {
-            modelElements.add(includedBuild.getModel());
-        }
-        // Set the only visible included builds from the root build
-        settings.getGradle().setIncludedBuilds(modelElements);
         registerProjects(includedBuilds);
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -37,7 +37,6 @@ import org.gradle.util.Path;
 
 class DefaultRootBuildState extends AbstractBuildState implements RootBuildState, Stoppable {
     private final ListenerManager listenerManager;
-    private SettingsInternal settings;
     private GradleLauncher gradleLauncher;
 
     DefaultRootBuildState(BuildDefinition buildDefinition, BuildRequestContext requestContext, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager, ServiceRegistry parentServices) {
@@ -77,16 +76,9 @@ class DefaultRootBuildState extends AbstractBuildState implements RootBuildState
         }
     }
 
-    public void setSettings(SettingsInternal settings) {
-        this.settings = settings;
-    }
-
     @Override
     public SettingsInternal getLoadedSettings() {
-        if (settings == null) {
-            throw new IllegalStateException("Settings have not been attached to this build yet.");
-        }
-        return settings;
+        return gradleLauncher.getGradle().getSettings();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.initialization.BuildRequestContext;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.GradleLauncherFactory;
+import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.build.AbstractBuildState;
@@ -57,6 +58,10 @@ class DefaultRootBuildState extends AbstractBuildState implements RootBuildState
     @Override
     public boolean isImplicitBuild() {
         return false;
+    }
+
+    @Override
+    public void assertCanAdd(IncludedBuildSpec includedBuildSpec) {
     }
 
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -23,6 +23,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
+import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.Settings;
@@ -355,8 +356,9 @@ public interface Gradle extends PluginAware {
     /**
      * Returns the included build with the specified name for this build.
      *
+     * @throws UnknownDomainObjectException when there is no build with the given name
      * @since 3.1
      */
     @Incubating
-    IncludedBuild includedBuild(String name);
+    IncludedBuild includedBuild(String name) throws UnknownDomainObjectException;
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.buildsrc
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+
+class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
+    def "buildSrc cannot (yet) define any included builds"() {
+        file("buildSrc/settings.gradle") << """
+            includeBuild "child"
+        """
+        file("buildSrc/child/settings.gradle").createFile()
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasDescription("Cannot include build 'child' in build 'buildSrc'. This is not supported yet.")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.execution.TaskExecutionGraphInternal;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
@@ -45,6 +46,11 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
     GradleInternal getParent();
 
     GradleInternal getRoot();
+
+    /**
+     * Returns the {@link BuildState} that manages the state of this instance.
+     */
+    BuildState getOwner();
 
     /**
      * {@inheritDoc}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -73,7 +73,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
     private final BuildScopeServices buildServices;
     private final List<?> servicesToStop;
     private final IncludedBuildControllers includedBuildControllers;
-    private GradleInternal gradle;
+    private final GradleInternal gradle;
     private SettingsInternal settings;
     private Stage stage;
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -17,7 +17,6 @@ package org.gradle.initialization;
 
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.UnknownProjectException;
 import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.initialization.ProjectDescriptor;
@@ -273,12 +272,8 @@ public class DefaultSettings extends AbstractPluginAware implements SettingsInte
 
     @Override
     public void includeBuild(Object rootProject, Action<ConfigurableIncludedBuild> configuration) {
-        if (gradle.getParent() == null) {
-            File projectDir = getFileResolver().resolve(rootProject);
-            includedBuildSpecs.add(new IncludedBuildSpec(projectDir, configuration));
-        } else {
-            throw new InvalidUserDataException(String.format("Included build '%s' cannot have included builds.", getRootProject().getName()));
-        }
+        File projectDir = getFileResolver().resolve(rootProject);
+        includedBuildSpecs.add(new IncludedBuildSpec(projectDir, configuration));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -16,10 +16,9 @@
 
 package org.gradle.initialization;
 
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.internal.build.BuildStateRegistry;
+import org.gradle.internal.composite.ChildBuildRegisteringSettingsLoader;
 import org.gradle.internal.composite.CompositeBuildSettingsLoader;
 
 public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
@@ -52,19 +51,13 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
     }
 
     private SettingsLoader defaultSettingsLoader() {
-        final DefaultSettingsLoader delegate = new DefaultSettingsLoader(
-            settingsFinder,
-            settingsProcessor,
-            buildSourceBuilder
-        );
-        return new SettingsLoader() {
-            @Override
-            public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
-                SettingsInternal settings = delegate.findAndLoadSettings(gradle);
-                gradle.setSettings(settings);
-                return settings;
-            }
-        };
+        return new ChildBuildRegisteringSettingsLoader(
+            new SettingsAttachingSettingsLoader(
+                new DefaultSettingsLoader(
+                    settingsFinder,
+                    settingsProcessor,
+                    buildSourceBuilder
+                )),
+            buildRegistry);
     }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -19,6 +19,7 @@ package org.gradle.initialization;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.composite.ChildBuildRegisteringSettingsLoader;
+import org.gradle.internal.composite.CommandLineIncludedBuildSettingsLoader;
 import org.gradle.internal.composite.CompositeBuildSettingsLoader;
 
 public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
@@ -36,28 +37,29 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
 
     @Override
     public SettingsLoader forTopLevelBuild() {
-        return compositeBuildSettingsLoader();
+        return new CompositeBuildSettingsLoader(
+            new ChildBuildRegisteringSettingsLoader(
+                new CommandLineIncludedBuildSettingsLoader(
+                    defaultSettingsLoader()
+                ),
+                buildRegistry
+            ),
+            buildRegistry);
     }
 
     @Override
     public SettingsLoader forNestedBuild() {
-        return defaultSettingsLoader();
-    }
-
-    private SettingsLoader compositeBuildSettingsLoader() {
-        return new CompositeBuildSettingsLoader(
+        return new ChildBuildRegisteringSettingsLoader(
             defaultSettingsLoader(),
             buildRegistry);
     }
 
     private SettingsLoader defaultSettingsLoader() {
-        return new ChildBuildRegisteringSettingsLoader(
-            new SettingsAttachingSettingsLoader(
-                new DefaultSettingsLoader(
-                    settingsFinder,
-                    settingsProcessor,
-                    buildSourceBuilder
-                )),
-            buildRegistry);
+        return new SettingsAttachingSettingsLoader(
+            new DefaultSettingsLoader(
+                settingsFinder,
+                settingsProcessor,
+                buildSourceBuilder
+            ));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsAttachingSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsAttachingSettingsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,20 @@
 
 package org.gradle.initialization;
 
-public interface SettingsLoaderFactory {
-    /**
-     * Create a SettingsLoader for a top-level build.
-     */
-    SettingsLoader forTopLevelBuild();
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
 
-    /**
-     * Create a SettingsLoader for a nested build.
-     */
-    SettingsLoader forNestedBuild();
+class SettingsAttachingSettingsLoader implements SettingsLoader {
+    private final DefaultSettingsLoader delegate;
+
+    SettingsAttachingSettingsLoader(DefaultSettingsLoader delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
+        SettingsInternal settings = delegate.findAndLoadSettings(gradle);
+        gradle.setSettings(settings);
+        return settings;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -20,12 +20,18 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.initialization.DefaultProjectDescriptor;
+import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.util.Path;
 
 public abstract class AbstractBuildState implements BuildState {
     @Override
     public String toString() {
         return getBuildIdentifier().toString();
+    }
+
+    @Override
+    public void assertCanAdd(IncludedBuildSpec includedBuildSpec) {
+        throw new UnsupportedOperationException("Cannot include build '" + includedBuildSpec.rootDir.getName() + "' in " + getBuildIdentifier() + ". This is not supported yet.");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -19,6 +19,7 @@ package org.gradle.internal.build;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.util.Path;
 
@@ -69,4 +70,9 @@ public interface BuildState {
      * Calculates the identifier for a project in this build.
      */
     ProjectComponentIdentifier getIdentifierForProject(Path projectPath) throws IllegalStateException;
+
+    /**
+     * Asserts that the given build can be included by this build.
+     */
+    void assertCanAdd(IncludedBuildSpec includedBuildSpec);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -24,6 +24,7 @@ import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.Pair;
 
+import java.io.File;
 import java.util.Set;
 
 /**
@@ -31,6 +32,7 @@ import java.util.Set;
  */
 public interface IncludedBuildState extends NestedBuildState {
     String getName();
+    File getRootDirectory();
     ConfigurableIncludedBuild getModel();
     Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions();
     Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> getAvailableModules();

--- a/subprojects/core/src/main/java/org/gradle/internal/build/RootBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/RootBuildState.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.build;
 
 import org.gradle.api.Transformer;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.internal.invocation.BuildController;
 
 /**
@@ -28,9 +27,4 @@ public interface RootBuildState extends BuildState {
      * Runs a single invocation of this build, executing the given action and returning the result. Should be called once only for a given build instance.
      */
     <T> T run(Transformer<T, ? super BuildController> buildAction);
-
-    /**
-     * This method should not be here. Instead, this instance should manage the settings object itself.
-     */
-    void setSettings(SettingsInternal settings);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -26,9 +26,10 @@ import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.plugin.management.internal.DefaultPluginRequests;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
     private final SettingsLoader delegate;
@@ -46,7 +47,7 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
         // Add included builds defined in settings
         List<IncludedBuildSpec> includedBuilds = settings.getIncludedBuilds();
         if (!includedBuilds.isEmpty()) {
-            List<IncludedBuild> children = new ArrayList<IncludedBuild>(includedBuilds.size());
+            Set<IncludedBuild> children = new LinkedHashSet<IncludedBuild>(includedBuilds.size());
             for (IncludedBuildSpec includedBuildSpec : includedBuilds) {
                 // TODO: Allow builds to inject into explicitly included builds
                 BuildDefinition buildDefinition = BuildDefinition.fromStartParameterForBuild(gradle.getStartParameter(), includedBuildSpec.rootDir, DefaultPluginRequests.EMPTY);
@@ -56,9 +57,9 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
             }
 
             // Set the visible included builds
-            settings.getGradle().setIncludedBuilds(children);
+            gradle.setIncludedBuilds(children);
         } else {
-            settings.getGradle().setIncludedBuilds(Collections.<IncludedBuild>emptyList());
+            gradle.setIncludedBuilds(Collections.<IncludedBuild>emptyList());
         }
 
         return settings;

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/ChildBuildRegisteringSettingsLoader.java
@@ -49,7 +49,7 @@ public class ChildBuildRegisteringSettingsLoader implements SettingsLoader {
         if (!includedBuilds.isEmpty()) {
             Set<IncludedBuild> children = new LinkedHashSet<IncludedBuild>(includedBuilds.size());
             for (IncludedBuildSpec includedBuildSpec : includedBuilds) {
-                // TODO: Allow builds to inject into explicitly included builds
+                gradle.getOwner().assertCanAdd(includedBuildSpec);
                 BuildDefinition buildDefinition = BuildDefinition.fromStartParameterForBuild(gradle.getStartParameter(), includedBuildSpec.rootDir, DefaultPluginRequests.EMPTY);
                 IncludedBuildState includedBuild = buildRegistry.addIncludedBuild(buildDefinition);
                 includedBuildSpec.configurer.execute(includedBuild.getModel());

--- a/subprojects/core/src/main/java/org/gradle/internal/composite/CommandLineIncludedBuildSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/composite/CommandLineIncludedBuildSettingsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,24 @@ package org.gradle.internal.composite;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.SettingsLoader;
-import org.gradle.internal.build.BuildStateRegistry;
 
-public class CompositeBuildSettingsLoader implements SettingsLoader {
+import java.io.File;
+
+public class CommandLineIncludedBuildSettingsLoader implements SettingsLoader {
     private final SettingsLoader delegate;
-    private final BuildStateRegistry buildRegistry;
 
-    public CompositeBuildSettingsLoader(SettingsLoader delegate, BuildStateRegistry buildRegistry) {
+    public CommandLineIncludedBuildSettingsLoader(SettingsLoader delegate) {
         this.delegate = delegate;
-        this.buildRegistry = buildRegistry;
     }
 
     @Override
     public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
         SettingsInternal settings = delegate.findAndLoadSettings(gradle);
 
-        // Lock-in explicitly included builds
-        buildRegistry.registerRootBuild(settings);
+        // Add all included builds from the command-line
+        for (File rootDir : gradle.getStartParameter().getIncludedBuilds()) {
+            settings.includeBuild(rootDir);
+        }
 
         return settings;
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -43,6 +43,7 @@ import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.execution.TaskExecutionGraphInternal;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.internal.MutableActionSet;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.installation.CurrentGradleInstallation;
@@ -166,6 +167,11 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             root = root.getParent();
         }
         return root;
+    }
+
+    @Override
+    public BuildState getOwner() {
+        return getServices().get(BuildState.class);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -20,6 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.AsmBackedClassGenerator;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
@@ -64,6 +65,7 @@ import org.gradle.invocation.DefaultGradle;
 import org.gradle.util.Path;
 
 import java.io.File;
+import java.util.Collections;
 
 public class ProjectBuilderImpl {
     private static ServiceRegistry globalServices;
@@ -114,6 +116,7 @@ public class ProjectBuilderImpl {
         topLevelRegistry.add(BuildState.class, build);
 
         GradleInternal gradle = CLASS_GENERATOR.newInstance(DefaultGradle.class, null, startParameter, topLevelRegistry.get(ServiceRegistryFactory.class));
+        gradle.setIncludedBuilds(Collections.<IncludedBuild>emptyList());
 
         DefaultProjectDescriptor projectDescriptor = new DefaultProjectDescriptor(null, name, projectDir, new DefaultProjectDescriptorRegistry(),
             topLevelRegistry.get(FileResolver.class));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -95,7 +95,6 @@ import org.gradle.authentication.Authentication;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.internal.GeneratedGradleJarCache;
 import org.gradle.cache.internal.ProducerGuard;
-import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -389,8 +388,8 @@ class DependencyManagementBuildScopeServices {
         }
     }
 
-    VcsDependencyResolver createVcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, NestedBuildFactory nestedBuildFactory, VersionParser versionParser) {
-        return new VcsDependencyResolver(vcsWorkingDirectoryRoot, projectDependencyResolver, localComponentRegistry, vcsResolver, versionControlSystemFactory, versionSelectorScheme, versionComparator, buildRegistry, nestedBuildFactory, versionParser);
+    VcsDependencyResolver createVcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirectoryRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, VersionParser versionParser) {
+        return new VcsDependencyResolver(vcsWorkingDirectoryRoot, projectDependencyResolver, localComponentRegistry, vcsResolver, versionControlSystemFactory, versionSelectorScheme, versionComparator, buildRegistry, versionParser);
     }
 
     ResolverProviderFactory createVcsResolverProviderFactory(VcsDependencyResolver vcsDependencyResolver, ProjectDependencyResolver projectDependencyResolver, VcsResolver vcsResolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -31,11 +31,9 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.specs.Spec;
-import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.internal.Pair;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.IncludedBuildState;
-import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.hash.HashUtil;
@@ -70,12 +68,11 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
     private final VersionSelectorScheme versionSelectorScheme;
     private final VersionComparator versionComparator;
     private final BuildStateRegistry buildRegistry;
-    private final NestedBuildFactory nestedBuildFactory;
     private final File baseWorkingDir;
     private final Map<String, VersionRef> selectedVersionCache = new HashMap<String, VersionRef>();
     private final VersionParser versionParser;
 
-    public VcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, NestedBuildFactory nestedBuildFactory, VersionParser versionParser) {
+    public VcsDependencyResolver(VcsWorkingDirectoryRoot vcsWorkingDirRoot, ProjectDependencyResolver projectDependencyResolver, LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlSystemFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, VersionParser versionParser) {
         this.baseWorkingDir = vcsWorkingDirRoot.getDir();
         this.projectDependencyResolver = projectDependencyResolver;
         this.localComponentRegistry = localComponentRegistry;
@@ -84,7 +81,6 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
         this.versionSelectorScheme = versionSelectorScheme;
         this.versionComparator = versionComparator;
         this.buildRegistry = buildRegistry;
-        this.nestedBuildFactory = nestedBuildFactory;
         this.versionParser = versionParser;
     }
 
@@ -121,12 +117,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                     result.failed(new ModuleVersionResolveException(depSelector, spec.getDisplayName() + " did not contain a project publishing the specified dependency."));
                 } else {
                     LocalComponentMetadata componentMetaData = localComponentRegistry.getComponent(entry.right);
-
-                    if (componentMetaData == null) {
-                        result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(entry.right), spec.getDisplayName() + " could not be resolved into a usable project."));
-                    } else {
-                        result.resolved(componentMetaData);
-                    }
+                    result.resolved(componentMetaData);
                     return;
                 }
             }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,9 +6,11 @@ Here are the new features introduced in this Gradle release.
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
 
-<!--
-### Example new and noteworthy
--->
+### Nested included builds
+
+TBD - Composite builds can be included by other builds. Some combinations are not supported yet:
+- `buildSrc` cannot include other builds.
+- No duplicate root project names.
 
 ### Use SNAPSHOT plugin versions with the `plugins {}` block
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,16 +6,15 @@ Here are the new features introduced in this Gradle release.
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
 
+### Use SNAPSHOT plugin versions with the `plugins {}` block
+
+Starting with this release, it is now possible to use SNAPSHOT plugin versions in the `plugins {}` and `pluginManagement {}` blocks.
+
 ### Nested included builds
 
 TBD - Composite builds can be included by other builds. Some combinations are not supported yet:
 - `buildSrc` cannot include other builds.
 - No duplicate root project names.
-
-### Use SNAPSHOT plugin versions with the `plugins {}` block
-
-Starting with this release, it is now possible to use SNAPSHOT plugin versions in the `plugins {}` and `pluginManagement {}` blocks.
-
 
 ## Promoted features
 

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiBuildIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiBuildIntegrationTest.groovy
@@ -16,18 +16,23 @@
 
 package org.gradle.ide.visualstudio
 
+import org.gradle.ide.visualstudio.fixtures.ProjectFile
 import org.gradle.ide.visualstudio.fixtures.SolutionFile
 import org.gradle.plugins.ide.fixtures.AbstractMultiBuildIdeIntegrationTest
-import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
 import org.gradle.test.fixtures.file.TestFile
-
 
 class VisualStudioMultiBuildIntegrationTest extends AbstractMultiBuildIdeIntegrationTest {
     String pluginId = "visual-studio"
     String workspaceTask = "visualStudio"
+    String libraryPluginId = "cpp-library"
 
     @Override
-    IdeWorkspaceFixture workspace(TestFile workspaceDir) {
-        return new SolutionFile(workspaceDir.file(workspaceDir.name + ".sln"))
+    SolutionFile workspace(TestFile workspaceDir, String ideWorkspaceName) {
+        return new SolutionFile(workspaceDir.file(ideWorkspaceName + ".sln"))
+    }
+
+    @Override
+    ProjectFile project(TestFile projectDir, String ideProjectName) {
+        return new ProjectFile(projectDir.file(ideProjectName + "Dll.vcxproj"))
     }
 }

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XCodeMultiBuildIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XCodeMultiBuildIntegrationTest.groovy
@@ -16,18 +16,23 @@
 
 package org.gradle.ide.xcode
 
+import org.gradle.ide.xcode.fixtures.XcodeProjectPackage
 import org.gradle.ide.xcode.fixtures.XcodeWorkspacePackage
 import org.gradle.plugins.ide.fixtures.AbstractMultiBuildIdeIntegrationTest
-import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
 import org.gradle.test.fixtures.file.TestFile
-
 
 class XCodeMultiBuildIntegrationTest extends AbstractMultiBuildIdeIntegrationTest {
     String pluginId = "xcode"
     String workspaceTask = "xcode"
+    String libraryPluginId = "cpp-library"
 
     @Override
-    IdeWorkspaceFixture workspace(TestFile workspaceDir) {
-        return new XcodeWorkspacePackage(workspaceDir.file(workspaceDir.name + ".xcworkspace"))
+    XcodeWorkspacePackage workspace(TestFile workspaceDir, String ideWorkspaceName) {
+        return new XcodeWorkspacePackage(workspaceDir.file(ideWorkspaceName + ".xcworkspace"))
+    }
+
+    @Override
+    XcodeProjectPackage project(TestFile projectDir, String ideProjectName) {
+        return new XcodeProjectPackage(projectDir.file(ideProjectName + ".xcodeproj"))
     }
 }

--- a/subprojects/ide-native/src/testFixtures/groovy/org/gradle/ide/xcode/fixtures/WorkspaceFile.groovy
+++ b/subprojects/ide-native/src/testFixtures/groovy/org/gradle/ide/xcode/fixtures/WorkspaceFile.groovy
@@ -31,10 +31,13 @@ class WorkspaceFile {
     }
 
     void assertHasProjects(String... paths) {
-        def includedProjectPaths = paths.collect { path ->
-            file.parentFile.parentFile.file(path).absolutePath
+        assert contentXml.FileRef.size() == paths.length
+        paths.each { path ->
+            assertHasProject(file.parentFile.parentFile.file(path))
         }
-        assert contentXml.FileRef.size() == includedProjectPaths.size()
-        assert contentXml.FileRef*.@location*.replaceAll('absolute:', '').containsAll(includedProjectPaths)
+    }
+
+    void assertHasProject(File projectFile) {
+        assert contentXml.FileRef*.@location*.replaceAll('absolute:', '').contains(projectFile.absolutePath)
     }
 }

--- a/subprojects/ide-native/src/testFixtures/groovy/org/gradle/ide/xcode/fixtures/XcodeProjectPackage.groovy
+++ b/subprojects/ide-native/src/testFixtures/groovy/org/gradle/ide/xcode/fixtures/XcodeProjectPackage.groovy
@@ -16,9 +16,10 @@
 
 package org.gradle.ide.xcode.fixtures
 
+import org.gradle.plugins.ide.fixtures.IdeProjectFixture
 import org.gradle.test.fixtures.file.TestFile
 
-class XcodeProjectPackage {
+class XcodeProjectPackage extends IdeProjectFixture {
     final TestFile dir
     final TestFile workspaceSettingsFile
     final ProjectFile projectFile

--- a/subprojects/ide-native/src/testFixtures/groovy/org/gradle/ide/xcode/fixtures/XcodeWorkspacePackage.groovy
+++ b/subprojects/ide-native/src/testFixtures/groovy/org/gradle/ide/xcode/fixtures/XcodeWorkspacePackage.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.xcode.fixtures
 
+import org.gradle.plugins.ide.fixtures.IdeProjectFixture
 import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
 import org.gradle.test.fixtures.file.TestFile
 
@@ -24,13 +25,14 @@ class XcodeWorkspacePackage extends IdeWorkspaceFixture {
     final WorkspaceFile contentFile
 
     XcodeWorkspacePackage(TestFile xcodeWorkspacePackage) {
-        xcodeWorkspacePackage.assertIsDir()
         dir = xcodeWorkspacePackage
+        dir.assertIsDir()
         contentFile = new WorkspaceFile(xcodeWorkspacePackage.file("contents.xcworkspacedata"))
     }
 
     @Override
-    void assertExists() {
-        dir.assertIsDir()
+    void assertContains(IdeProjectFixture project) {
+        assert project instanceof XcodeProjectPackage
+        contentFile.assertHasProject(project.dir)
     }
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseMultiBuildIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseMultiBuildIntegrationTest.groovy
@@ -17,16 +17,20 @@
 package org.gradle.plugins.ide.eclipse
 
 import org.gradle.plugins.ide.fixtures.AbstractMultiBuildIdeIntegrationTest
-import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
 import org.gradle.test.fixtures.file.TestFile
-
 
 class EclipseMultiBuildIntegrationTest extends AbstractMultiBuildIdeIntegrationTest {
     String pluginId = "eclipse"
     String workspaceTask = "eclipse"
+    String libraryPluginId = "java-library"
 
     @Override
-    IdeWorkspaceFixture workspace(TestFile workspaceDir) {
+    EclipseWorkspaceFixture workspace(TestFile workspaceDir, String ideWorkspaceName) {
         return new EclipseWorkspaceFixture(workspaceDir)
+    }
+
+    @Override
+    EclipseProjectFixture project(TestFile projectDir, String ideProjectName) {
+        return EclipseProjectFixture.create(projectDir)
     }
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectFixture.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseProjectFixture.groovy
@@ -18,9 +18,10 @@ package org.gradle.plugins.ide.eclipse
 
 import groovy.xml.XmlUtil
 import org.custommonkey.xmlunit.XMLUnit
+import org.gradle.plugins.ide.fixtures.IdeProjectFixture
 import org.gradle.test.fixtures.file.TestFile
 
-class EclipseProjectFixture {
+class EclipseProjectFixture extends IdeProjectFixture {
     private final Node project
 
     private EclipseProjectFixture(Node project) {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaMultiBuildIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaMultiBuildIntegrationTest.groovy
@@ -17,16 +17,23 @@
 package org.gradle.plugins.ide.idea
 
 import org.gradle.plugins.ide.fixtures.AbstractMultiBuildIdeIntegrationTest
-import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
 import org.gradle.plugins.ide.fixtures.IdeaFixtures
+import org.gradle.plugins.ide.fixtures.IdeaModuleFixture
+import org.gradle.plugins.ide.fixtures.IdeaProjectFixture
 import org.gradle.test.fixtures.file.TestFile
 
 class IdeaMultiBuildIntegrationTest extends AbstractMultiBuildIdeIntegrationTest {
     String pluginId = "idea"
     String workspaceTask = "idea"
+    String libraryPluginId = "java-library"
 
     @Override
-    IdeWorkspaceFixture workspace(TestFile workspaceDir) {
-        return IdeaFixtures.parseIpr(workspaceDir.file(workspaceDir.name + ".ipr"))
+    IdeaProjectFixture workspace(TestFile workspaceDir, String ideWorkspaceName) {
+        return IdeaFixtures.parseIpr(workspaceDir.file(ideWorkspaceName + ".ipr"))
+    }
+
+    @Override
+    IdeaModuleFixture project(TestFile projectDir, String ideProjectName) {
+        return IdeaFixtures.parseIml(projectDir.file(ideProjectName + ".iml"))
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.ConventionMapping;
@@ -103,6 +104,20 @@ public class EclipsePlugin extends IdePlugin {
         configureEclipseClasspath(project, model);
 
         applyEclipseWtpPluginOnWebProjects(project);
+
+        configureRootProjectTask(project);
+    }
+
+    private void configureRootProjectTask(Project project) {
+        // The `eclipse` task in the root project should generate Eclipse projects for all Gradle projects
+        if (project.getGradle().getParent() == null && project.getParent() == null) {
+            getLifecycleTask().configure(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    task.dependsOn(artifactRegistry.getIdeProjectFiles(EclipseProjectMetadata.class));
+                }
+            });
+        }
     }
 
     // No one should be calling this.

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -53,8 +53,8 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         wtpPlugin.apply(project)
 
         then:
-        project.tasks.eclipse.dependsOn*.get().contains(project.eclipseWtp)
-        project.tasks.cleanEclipse.dependsOn*.get().contains(project.cleanEclipseWtp)
+        project.tasks.eclipse.taskDependencies.getDependencies(null).contains(project.eclipseWtp)
+        project.tasks.cleanEclipse.taskDependencies.getDependencies(null).contains(project.cleanEclipseWtp)
     }
 
     def applyToJavaProject_shouldHaveWebProjectAndClasspathTask() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
@@ -16,6 +16,11 @@
 
 package org.gradle.plugins.ide.internal.tooling
 
+
+import org.gradle.api.initialization.IncludedBuild
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.internal.build.IncludedBuildState
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
@@ -32,9 +37,12 @@ class GradleBuildBuilderTest extends Specification {
     @ClassRule
     public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
     def builder = new GradleBuildBuilder()
-    @Shared def project = TestUtil.builder(temporaryFolder).withName("root").build()
-    @Shared def child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
-    @Shared def child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
+    @Shared
+    def project = TestUtil.builder(temporaryFolder).withName("root").build()
+    @Shared
+    def child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
+    @Shared
+    def child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
 
     def "builds model"() {
         expect:
@@ -47,10 +55,79 @@ class GradleBuildBuilderTest extends Specification {
         model.rootProject.children.every { it.parent == model.rootProject }
         model.projects*.name == ["root", "child1", "child2"]
         model.projects*.path == [":", ":child1", ":child2"]
+        model.includedBuilds.empty
+        model.allBuilds.empty
 
         where:
         startProject | _
         project      | _
         child2       | _
+    }
+
+    def "builds model for included builds"() {
+        def rootProject = Mock(ProjectInternal)
+        def project1 = Mock(ProjectInternal)
+        def project2 = Mock(ProjectInternal)
+
+        def rootDir = temporaryFolder.createDir("root")
+        def dir1 = temporaryFolder.createDir("dir1")
+        def dir2 = temporaryFolder.createDir("dir2")
+
+        def rootBuild = Mock(GradleInternal)
+        def build1 = Mock(GradleInternal)
+        def build2 = Mock(GradleInternal)
+
+        def includedBuild1 = Mock(TestIncludedBuild)
+        def includedBuild2 = Mock(TestIncludedBuild)
+
+        rootProject.gradle >> rootBuild
+        rootProject.rootDir >> rootDir
+        rootProject.childProjects >> [:]
+        rootProject.allprojects >> [rootProject]
+
+        project1.rootDir >> dir1
+        project1.childProjects >> [:]
+        project1.allprojects >> [project1]
+
+        project2.rootDir >> dir2
+        project2.childProjects >> [:]
+        project2.allprojects >> [project2]
+
+        rootBuild.rootProject >> rootProject
+        rootBuild.includedBuilds >> [includedBuild1]
+
+        includedBuild1.configuredBuild >> build1
+
+        build1.includedBuilds >> [includedBuild2]
+        build1.rootProject >> project1
+        build1.parent >> rootBuild
+
+        includedBuild2.configuredBuild >> build2
+
+        build2.includedBuilds >> []
+        build2.rootProject >> project2
+        build2.parent >> rootBuild
+
+        expect:
+        def model = builder.buildAll("org.gradle.tooling.model.gradle.GradleBuild", rootProject)
+        model.includedBuilds.size() == 1
+
+        def model1 = model.includedBuilds[0]
+        model1.rootDir == dir1
+        model1.includedBuilds.size() == 1
+
+        def model2 = model1.includedBuilds[0]
+        model2.rootDir == dir2
+        model2.includedBuilds.empty
+
+        model.allBuilds.size() == 2
+        model.allBuilds[0] == model1
+        model.allBuilds[1] == model2
+
+        model1.allBuilds.empty
+        model2.allBuilds.empty
+    }
+
+    interface TestIncludedBuild extends IncludedBuild, IncludedBuildState {
     }
 }

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeProjectFixture.java
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeProjectFixture.java
@@ -14,23 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.plugins.ide.eclipse
+package org.gradle.plugins.ide.fixtures;
 
-import org.gradle.plugins.ide.fixtures.IdeProjectFixture
-import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
-import org.gradle.test.fixtures.file.TestFile
-
-
-class EclipseWorkspaceFixture extends IdeWorkspaceFixture {
-    final TestFile workspaceDir
-
-    EclipseWorkspaceFixture(TestFile workspaceDir) {
-        this.workspaceDir = workspaceDir
-        workspaceDir.file(".project").assertExists()
-    }
-
-    @Override
-    void assertContains(IdeProjectFixture project) {
-        // Doesn't really make sense
-    }
+public abstract class IdeProjectFixture {
 }

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeWorkspaceFixture.java
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeWorkspaceFixture.java
@@ -17,5 +17,5 @@
 package org.gradle.plugins.ide.fixtures;
 
 public abstract class IdeWorkspaceFixture {
-    public abstract void assertExists();
+    public abstract void assertContains(IdeProjectFixture project);
 }

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaFixtures.groovy
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaFixtures.groovy
@@ -16,18 +16,20 @@
 
 package org.gradle.plugins.ide.fixtures
 
+import org.gradle.test.fixtures.file.TestFile
+
 class IdeaFixtures {
-    static parseFile(File file) {
-        assert file.file
+    static parseFile(TestFile file) {
+        file.assertIsFile()
         new XmlSlurper().parse(file)
     }
 
-    static IdeaProjectFixture parseIpr(File projectFile) {
-        return new IdeaProjectFixture(parseFile(projectFile))
+    static IdeaProjectFixture parseIpr(TestFile projectFile) {
+        return new IdeaProjectFixture(projectFile, parseFile(projectFile))
     }
 
-    static IdeaModuleFixture parseIml(File moduleFile) {
-        return new IdeaModuleFixture(parseFile(moduleFile))
+    static IdeaModuleFixture parseIml(TestFile moduleFile) {
+        return new IdeaModuleFixture(moduleFile, parseFile(moduleFile))
     }
 
     private IdeaFixtures() {}

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaModuleFixture.groovy
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaModuleFixture.groovy
@@ -19,13 +19,16 @@ package org.gradle.plugins.ide.fixtures
 import groovy.transform.ToString
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.internal.Transformers
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.CollectionUtils
 
-class IdeaModuleFixture {
-    private GPathResult iml
+class IdeaModuleFixture extends IdeProjectFixture {
+    private final GPathResult iml
+    private final TestFile file
 
-    IdeaModuleFixture(GPathResult iml) {
+    IdeaModuleFixture(TestFile file, GPathResult iml) {
         this.iml = iml
+        this.file = file
     }
 
     String getLanguageLevel() {

--- a/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaProjectFixture.groovy
+++ b/subprojects/ide/src/testFixtures/groovy/org/gradle/plugins/ide/fixtures/IdeaProjectFixture.groovy
@@ -17,17 +17,15 @@
 package org.gradle.plugins.ide.fixtures
 
 import groovy.util.slurpersupport.GPathResult
+import org.gradle.test.fixtures.file.TestFile
 
 class IdeaProjectFixture extends IdeWorkspaceFixture {
-    private GPathResult ipr
+    private final GPathResult ipr
+    private final TestFile file
 
-    IdeaProjectFixture(GPathResult ipr) {
+    IdeaProjectFixture(TestFile file, GPathResult ipr) {
+        this.file = file
         this.ipr = ipr
-    }
-
-    @Override
-    void assertExists() {
-        // Already done
     }
 
     String getLanguageLevel() {
@@ -61,6 +59,12 @@ class IdeaProjectFixture extends IdeWorkspaceFixture {
         return new ProjectModules(moduleNames)
     }
 
+    @Override
+    void assertContains(IdeProjectFixture project) {
+        assert project instanceof IdeaModuleFixture
+        def path = project.file.relativizeFrom(file.parentFile).path
+        modules.modules.contains("\$PROJECT_DIR/$path")
+    }
 
     static class ProjectModules {
         List<String> modules
@@ -79,7 +83,7 @@ class IdeaProjectFixture extends IdeWorkspaceFixture {
 
         void assertHasModules(String... name) {
             List<String> modules = Arrays.asList(name)
-            assert modules.every { modules.contains(it) }
+            assert this.modules.every { modules.contains(it) }
         }
     }
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/ide/visualstudio/fixtures/ProjectFile.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/ide/visualstudio/fixtures/ProjectFile.groovy
@@ -18,22 +18,23 @@ package org.gradle.ide.visualstudio.fixtures
 
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.nativeplatform.fixtures.app.TestNativeComponent
+import org.gradle.plugins.ide.fixtures.IdeProjectFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.TextUtil
 
-class ProjectFile {
+class ProjectFile extends IdeProjectFixture {
     String name
     TestFile projectFile
     Node projectXml
 
     ProjectFile(TestFile projectFile) {
-        assert projectFile.exists()
+        projectFile.assertIsFile()
         this.projectFile = projectFile
         this.name = projectFile.name.replace(".vcxproj", "")
         this.projectXml = new XmlParser().parse(projectFile)
     }
 
-    public Map<String, Configuration> getProjectConfigurations() {
+    Map<String, Configuration> getProjectConfigurations() {
         def configs = itemGroup("ProjectConfigurations").collect {
             new Configuration(it.Configuration[0].text(), it.Platform[0].text())
         }
@@ -42,33 +43,33 @@ class ProjectFile {
         }
     }
 
-    public String getProjectGuid() {
+    String getProjectGuid() {
         return globals.ProjectGUID[0].text()
     }
 
-    public Node getGlobals() {
+    Node getGlobals() {
         return projectXml.PropertyGroup.find({it.'@Label' == 'Globals'}) as Node
     }
 
-    public String getToolsVersion() {
+    String getToolsVersion() {
         return projectXml.@ToolsVersion
     }
 
-    public String getWindowsTargetPlatformVersion() {
+    String getWindowsTargetPlatformVersion() {
         return globals.WindowsTargetPlatformVersion[0].text()
     }
 
-    public List<String> getSourceFiles() {
+    List<String> getSourceFiles() {
         def sources = itemGroup('Sources').ClCompile
         return normalise(sources*.'@Include')
     }
 
-    public List<String> getResourceFiles() {
+    List<String> getResourceFiles() {
         def sources = itemGroup('References').ResourceCompile
         return normalise(sources*.'@Include')
     }
 
-    public List<String> getHeaderFiles() {
+    List<String> getHeaderFiles() {
         def sources = itemGroup('Headers').ClInclude
         return normalise(sources*.'@Include')
     }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/ide/visualstudio/fixtures/SolutionFile.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/ide/visualstudio/fixtures/SolutionFile.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.visualstudio.fixtures
 
+import org.gradle.plugins.ide.fixtures.IdeProjectFixture
 import org.gradle.plugins.ide.fixtures.IdeWorkspaceFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.TextUtil
@@ -26,7 +27,7 @@ class SolutionFile extends IdeWorkspaceFixture {
     Map<String, ProjectReference> projects = [:]
 
     SolutionFile(TestFile solutionFile) {
-        assert solutionFile.exists()
+        solutionFile.assertIsFile()
         this.file = solutionFile
         assert TextUtil.convertLineSeparators(solutionFile.text, TextUtil.windowsLineSeparator) == solutionFile.text : "Solution file contains non-windows line separators"
 
@@ -38,8 +39,11 @@ class SolutionFile extends IdeWorkspaceFixture {
     }
 
     @Override
-    void assertExists() {
-        // Already done
+    void assertContains(IdeProjectFixture project) {
+        assert project instanceof ProjectFile
+        assert projects.keySet().contains(project.name)
+        def ref = projects[project.name]
+        assert ref.file == project.projectFile.absolutePath
     }
 
     def assertHasProjects(String... names) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/GradleBuildModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/GradleBuildModelCrossVersionSpec.groovy
@@ -28,23 +28,27 @@ class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
     @TargetGradleVersion(">=3.3")
     def "Included builds are present in the model"() {
         given:
-        singleProjectBuildInRootFolder("root") {
+        def rootDir = singleProjectBuildInRootFolder("root") {
             settingsFile << """
                 rootProject.name = 'root'
                 includeBuild 'includedBuild'
             """
         }
-        multiProjectBuildInSubFolder("includedBuild", ["a", "b", "c"])
+        def includedBuildDir = multiProjectBuildInSubFolder("includedBuild", ["a", "b", "c"])
 
         when:
         GradleBuild model = loadToolingModel(GradleBuild)
 
         then:
+        model.buildIdentifier.rootDir == rootDir
         model.rootProject.name == "root"
         model.includedBuilds.size() == 1
+
         def includedBuild = model.includedBuilds[0]
+        includedBuild.buildIdentifier.rootDir == includedBuildDir
         includedBuild.rootProject.name == "includedBuild"
         includedBuild.projects.size() == 4
+        includedBuild.includedBuilds.empty
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5167")
@@ -87,7 +91,7 @@ class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
         GradleBuild model = loadToolingModel(GradleBuild)
 
         then:
-        model.includedBuilds.size() == 0
+        model.includedBuilds.empty
     }
 
     def "No included builds for single root project"() {
@@ -96,6 +100,6 @@ class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
         GradleBuild model = loadToolingModel(GradleBuild)
 
         then:
-        model.includedBuilds.size() == 0
+        model.includedBuilds.empty
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r410/GradleBuildModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r410/GradleBuildModelCrossVersionSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling.r49
+package org.gradle.integtests.tooling.r410
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -24,7 +24,7 @@ import org.gradle.tooling.model.gradle.GradleBuild
 
 @ToolingApiVersion(">=3.3")
 class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
-    @TargetGradleVersion(">=4.9")
+    @TargetGradleVersion(">=4.10")
     def "nested included builds are present only in the model of the containing build"() {
         given:
         def rootDir = singleProjectBuildInRootFolder("root") {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r49/GradleBuildModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r49/GradleBuildModelCrossVersionSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r49
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.gradle.GradleBuild
+
+
+@ToolingApiVersion(">=3.3")
+class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
+    @TargetGradleVersion(">=4.9")
+    def "nested included builds are present only in the model of the containing build"() {
+        given:
+        def rootDir = singleProjectBuildInRootFolder("root") {
+            settingsFile << """
+                rootProject.name = 'root'
+                includeBuild 'buildB'
+            """
+        }
+        def buildBDir = multiProjectBuildInSubFolder("buildB", ["a", "b", "c"]) {
+            settingsFile << """
+                includeBuild '../buildC'
+            """
+        }
+        def buildCDir = singleProjectBuildInSubfolder("buildC")
+
+        when:
+        GradleBuild rootBuild = loadToolingModel(GradleBuild)
+
+        then:
+        rootBuild.buildIdentifier.rootDir == rootDir
+        rootBuild.rootProject.name == "root"
+        rootBuild.includedBuilds.size() == 1
+
+        def buildB = rootBuild.includedBuilds[0]
+        buildB.buildIdentifier.rootDir == buildBDir
+        buildB.rootProject.name == "buildB"
+        buildB.projects.size() == 4
+        buildB.includedBuilds.size() == 1
+
+        def buildC = buildB.includedBuilds[0]
+        buildC.buildIdentifier.rootDir == buildCDir
+        buildC.rootProject.name == "buildC"
+        buildC.projects.size() == 1
+        buildC.includedBuilds.empty
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/GradleBuildAdapterProducer.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/GradleBuildAdapterProducer.java
@@ -37,7 +37,7 @@ public class GradleBuildAdapterProducer implements ModelProducer {
     public <T> T produceModel(Class<T> type, ConsumerOperationParameters operationParameters) {
         if (type.equals(GradleBuild.class)) {
             GradleProject gradleProject = delegate.produceModel(GradleProject.class, operationParameters);
-            final DefaultGradleBuild convert = new GradleBuildConverter().convert(gradleProject);
+            DefaultGradleBuild convert = new GradleBuildConverter().convert(gradleProject);
             return mappingProvider.applyCompatibilityMapping(adapter.builder(type), operationParameters).build(convert);
         }
         return delegate.produceModel(type, operationParameters);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HasCompatibilityMapping.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HasCompatibilityMapping.java
@@ -48,7 +48,7 @@ public class HasCompatibilityMapping {
         viewBuilder.mixInTo(GradleTask.class, TaskDisplayNameMixin.class);
         viewBuilder.mixInTo(IdeaProject.class, IdeaProjectJavaLanguageSettingsMixin.class);
         viewBuilder.mixInTo(IdeaDependency.class, IdeaModuleDependencyTargetNameMixin.class);
-        viewBuilder.mixInTo(GradleBuild.class, new IncludedBuildsMixin());
+        viewBuilder.mixInTo(GradleBuild.class, IncludedBuildsMixin.class);
         return viewBuilder;
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/IncludedBuildsMixin.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/IncludedBuildsMixin.java
@@ -24,7 +24,17 @@ import java.io.Serializable;
 import java.util.Collections;
 
 public class IncludedBuildsMixin implements Serializable {
+    private final GradleBuild gradleBuild;
+
+    public IncludedBuildsMixin(GradleBuild gradleBuild) {
+        this.gradleBuild = gradleBuild;
+    }
+
     public DomainObjectSet<? extends GradleBuild> getIncludedBuilds() {
         return ImmutableDomainObjectSet.of(Collections.<GradleBuild>emptyList());
+    }
+
+    public DomainObjectSet<? extends GradleBuild> getAllBuilds() {
+        return gradleBuild.getIncludedBuilds();
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/versioning/ModelMapping.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/versioning/ModelMapping.java
@@ -111,15 +111,6 @@ public class ModelMapping {
     }
 
     @Nullable
-    public String getModelNameFromProtocolType(Class<?> protocolType) {
-        Class<?> modelType = MODEL_TO_PROTOCOL_MAP.inverse().get(protocolType);
-        if (modelType == null) {
-            return null;
-        }
-        return MODEL_NAME_MAP.get(modelType);
-    }
-
-    @Nullable
     public Class<?> getProtocolTypeFromModelName(String name) {
         Class<?> modelType = MODEL_NAME_MAP.inverse().get(name);
         if (modelType == null) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/gradle/DefaultGradleBuild.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/gradle/DefaultGradleBuild.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.gradle;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -26,6 +27,7 @@ public class DefaultGradleBuild implements Serializable, GradleBuildIdentity {
     private DefaultBuildIdentifier buildIdentifier;
     private Set<PartialBasicGradleProject> projects = new LinkedHashSet<PartialBasicGradleProject>();
     private Set<DefaultGradleBuild> includedBuilds = new LinkedHashSet<DefaultGradleBuild>();
+    private Set<DefaultGradleBuild> allBuilds = new LinkedHashSet<DefaultGradleBuild>();
 
     public PartialBasicGradleProject getRootProject() {
         return rootProject;
@@ -43,6 +45,14 @@ public class DefaultGradleBuild implements Serializable, GradleBuildIdentity {
 
     public void addProject(PartialBasicGradleProject project) {
         projects.add(project);
+    }
+
+    public Set<DefaultGradleBuild> getAllBuilds() {
+        return allBuilds;
+    }
+
+    public void addBuilds(Collection<DefaultGradleBuild> builds) {
+        allBuilds.addAll(builds);
     }
 
     public Set<DefaultGradleBuild> getIncludedBuilds() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.model.gradle;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.model.BuildIdentifier;
 import org.gradle.tooling.model.BuildModel;
 import org.gradle.tooling.model.DomainObjectSet;
@@ -49,9 +50,19 @@ public interface GradleBuild extends Model, BuildModel {
     DomainObjectSet<? extends BasicGradleProject> getProjects();
 
     /**
-     * Returns the builds that were included into this one.
+     * Returns the included builds that were referenced by this build.
      *
      * @since 3.3
      */
     DomainObjectSet<? extends GradleBuild> getIncludedBuilds();
+
+    /**
+     * Returns all builds contained in this build, and for which tooling models should be built when importing into an IDE. This is not necessarily the same as {@link #getIncludedBuilds()}, as an included build is not necessarily 'owned' by a build that includes it.
+     *
+     * <p>For the root build, this set contains all builds that participate in the composite build, including all nested included builds. For other builds, this set is empty.</p>
+     *
+     * @since 4.10
+     */
+    @Incubating
+    DomainObjectSet<? extends GradleBuild> getAllBuilds();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
@@ -59,7 +59,7 @@ public interface GradleBuild extends Model, BuildModel {
     /**
      * Returns all builds contained in this build, and for which tooling models should be built when importing into an IDE. This is not necessarily the same as {@link #getIncludedBuilds()}, as an included build is not necessarily 'owned' by a build that includes it.
      *
-     * <p>For the root build, this set contains all builds that participate in the composite build, including all nested included builds. For other builds, this set is empty.</p>
+     * <p>For the root build, this set contains all builds that participate in the composite build, including those from all nested included builds. For other builds, this set is empty.</p>
      *
      * @since 4.10
      */

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.vcs.fixtures.GitFileRepository
+import org.junit.Rule
+
+
+class SourceDependencyBuildLookupIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    GitFileRepository repo = new GitFileRepository('buildB', testDirectory)
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "root"
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:buildB") { details ->
+                        from(GitVersionControlSpec) {
+                            url = uri('$repo.url')
+                        }
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply plugin: 'java'
+            dependencies { implementation 'org.test:buildB:2.0' }
+        """
+
+        repo.file("settings.gradle") << """
+            rootProject.name = 'buildB'
+        """
+        repo.file("build.gradle") << """
+            apply plugin: 'java'
+            group = 'org.test'
+        """
+        repo.commit("version 2")
+        repo.createLightWeightTag("2.0")
+    }
+
+    def "source dependency builds are not visible to main build"() {
+        given:
+        buildFile << """
+            assert gradle.includedBuilds.empty
+
+            task broken {
+                dependsOn classes
+                doLast {
+                    assert gradle.includedBuilds.empty
+                    gradle.includedBuild("buildB")
+                }
+            }
+        """
+
+        when:
+        fails("broken")
+
+        then:
+        failure.assertHasCause("Included build 'buildB' not found in build 'root'.")
+        result.assertTaskExecuted(":buildB:jar")
+    }
+}

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIncludedBuildIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIncludedBuildIntegrationTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vcs.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.vcs.fixtures.GitFileRepository
+import org.junit.Rule
+
+
+class SourceDependencyIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    GitFileRepository repo = new GitFileRepository('buildB', temporaryFolder.getTestDirectory())
+
+    def "source dependency cannot (yet) define any included builds"() {
+        settingsFile << """
+            rootProject.name = 'buildA'
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:buildB") {
+                        from(GitVersionControlSpec) {
+                            url = uri("${repo.url}")
+                        }
+                    }
+                }
+            }
+        """
+        buildFile << """
+            apply plugin: 'java'
+            dependencies { implementation 'org.test:buildB:1.2' }
+        """
+
+        repo.file("settings.gradle") << """
+            includeBuild 'child'
+        """
+        repo.file("child/settings.gradle").createFile()
+        repo.commit("version 1.2")
+        repo.createLightWeightTag("1.2")
+
+        when:
+        fails("assemble")
+
+        then:
+        failure.assertHasDescription("Cannot include build 'child' in build 'buildB'. This is not supported yet.")
+    }
+}


### PR DESCRIPTION
### Context

This PR adds support for nested included builds (curtesy of some recent long haul flights).

Any build can now include a build that in turn includes other builds. There are some missing pieces, due to some complexity wiring this into these places:

- `buildSrc` cannot yet include any other builds (e.g. a shared plugin build).
- source dependency builds cannot yet include any other builds.

Later changes can improve this, particularly the second item.

This PR also changes the Eclipse plugin so that the `eclipse` task generates the Eclipse project files for all projects in all builds to produce a functional workspace, in a similar way that the IDEA, Visual Studio and XCode plugins do so.

This PR also adds a method to the `GradleBuild` tooling model to allow an IDE to query the builds that should be imported into the IDE rather than duplicating this logic.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
