### PR TITLE
Make CiReportingPlugin cheaper

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/CiReportingPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/CiReportingPlugin.kt
@@ -52,10 +52,10 @@ open class CiReportingPlugin : Plugin<Project> {
     }
 
     private
-    fun failedTasks(projects: Set<Project>) = projects.flatMap { it.tasks.matching { it.state.failure != null } }
+    fun failedTasks(projects: Set<Project>) = projects.flatMap { it.gradle.taskGraph.allTasks.filter { it.state.failure != null } }
 
     private
-    fun executedTasks(projects: Set<Project>) = projects.flatMap { it.tasks.matching { it.state.executed } }
+    fun executedTasks(projects: Set<Project>) = projects.flatMap { it.gradle.taskGraph.allTasks.filter { it.state.executed } }
 
     private
     fun Task.failedTaskGenericHtmlReports() = when (this) {


### PR DESCRIPTION
This plugin was negating any benefit from lazy task configuration
because it realized all tasks. This was unnecessary, as we are only
interested in tasks that got executed. We now only look at those.