### PR TITLE
Defer parsing of substitutions to runtime

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -110,7 +110,7 @@ open class CapabilityRule @Inject constructor(
 
 class CapabilitySpec {
     lateinit var name: String
-    lateinit var providedBy: List<String>
+    lateinit var providedBy: Set<String>
     lateinit var selected: String
     var upgrade: String? = null
 
@@ -153,10 +153,10 @@ class CapabilitySpec {
     private
     fun ConfigurationContainer.forceUpgrade(to: String, version: String) = all {
         resolutionStrategy.dependencySubstitution {
-            providedBy.forEach { source ->
-                substitute(module(source))
-                    .because("Forceful upgrade of capability $name")
-                    .with(module("$to:$version"))
+            all {
+                if (providedBy.contains(requested.toString())) {
+                    useTarget("$to:$version", "Forceful upgrade of capability $name")
+                }
             }
         }
     }


### PR DESCRIPTION
We create a large amount of substitution rules
and many of them are never used, either because
the Configuration is not resolved or the dependency
in question does not appear.

We now only parse the rules when one of the dependencies
in questions is actually resolved.

Ideally these parsers would be less expensive/cached so that users
don't need to make such optimizations in their own builds.