### PR TITLE
Add plugin extensions for more JVM plugins to replace convention objects

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -26,9 +26,9 @@ import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.antlr.internal.AntlrSourceVirtualDirectoryImpl;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -77,7 +77,7 @@ public class AntlrPlugin implements Plugin<Project> {
             }
         });
 
-        project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().all(
+        project.getExtensions().getByType(SourceSetContainer.class).all(
                 new Action<SourceSet>() {
                     public void execute(final SourceSet sourceSet) {
                         // for each source set we will:

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionMapping;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.resources.TextResource;
@@ -70,7 +71,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         conventionMappingOf(extension).map("targetJdk", new Callable<Object>() {
             @Override
             public Object call() {
-                return getDefaultTargetJdk(getJavaPluginConvention().getSourceCompatibility());
+                return getDefaultTargetJdk(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility());
             }
         });
         return extension;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.ReportingBasePlugin;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
 import org.gradle.api.reporting.ReportingExtension;
@@ -212,6 +213,10 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
 
     protected void withBasePlugin(Action<Plugin> action) {
         project.getPlugins().withType(getBasePlugin(), action);
+    }
+
+    protected JavaPluginConvention getJavaPluginConvention() {
+        return project.getConvention().getPlugin(JavaPluginConvention.class);
     }
 
     protected SourceSetContainer getSourceSets() {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.ReportingBasePlugin;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
 import org.gradle.api.reporting.ReportingExtension;
@@ -132,7 +131,7 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
                 extensionMapping.map("sourceSets", new Callable<SourceSetContainer>() {
                     @Override
                     public SourceSetContainer call() {
-                        return getJavaPluginConvention().getSourceSets();
+                        return getSourceSets();
                     }
                 });
             }
@@ -160,7 +159,7 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
         withBasePlugin(new Action<Plugin>() {
             @Override
             public void execute(Plugin plugin) {
-                configureForSourceSets(getJavaPluginConvention().getSourceSets());
+                configureForSourceSets(getSourceSets());
             }
         });
     }
@@ -215,7 +214,7 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
         project.getPlugins().withType(getBasePlugin(), action);
     }
 
-    protected JavaPluginConvention getJavaPluginConvention() {
-        return project.getConvention().getPlugin(JavaPluginConvention.class);
+    protected SourceSetContainer getSourceSets() {
+        return project.getExtensions().getByType(SourceSetContainer.class);
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPlugin.java
@@ -23,6 +23,8 @@ import org.gradle.api.reporting.dependencies.HtmlDependencyReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
 import org.gradle.api.tasks.diagnostics.PropertyReportTask;
 import org.gradle.api.tasks.diagnostics.TaskReportTask;
+import org.gradle.internal.Factory;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -38,9 +40,14 @@ public class ProjectReportsPlugin implements Plugin<Project> {
     public static final String PROJECT_REPORT = "projectReport";
 
     @Override
-    public void apply(Project project) {
+    public void apply(final Project project) {
         project.getPluginManager().apply(ReportingBasePlugin.class);
-        final ProjectReportsPluginConvention convention = new ProjectReportsPluginConvention(project);
+        final ProjectReportsPluginConvention convention = DeprecationLogger.whileDisabled(new Factory<ProjectReportsPluginConvention>() {
+            @Override
+            public ProjectReportsPluginConvention create() {
+                return new ProjectReportsPluginConvention(project);
+            }
+        });
         project.getConvention().getPlugins().put("projectReports", convention);
 
         TaskReportTask taskReportTask = project.getTasks().create(TASK_REPORT, TaskReportTask.class);

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPluginConvention.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPluginConvention.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins;
 
 import org.gradle.api.Project;
 import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.WrapUtil;
 
 import java.io.File;
@@ -30,7 +31,14 @@ public class ProjectReportsPluginConvention {
     private String projectReportDirName = "project";
     private final Project project;
 
+    /**
+     * Creates a {@link ProjectReportsPluginConvention} instance.
+     *
+     * @deprecated Creating instances of this class is deprecated. These should be created by the reporting base plugin only.
+     */
+    @Deprecated
     public ProjectReportsPluginConvention(Project project) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of ProjectReportsPluginConvention");
         this.project = project;
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -47,6 +47,22 @@ Instances of this class are intended to be created only by the `java-base` plugi
 
 Instances of this class are intended to be created only by the `application` plugin and should not be created directly. Creating instances using the constructor of `ApplicationPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `application` plugin.
 
+### Creating instances of WarPluginConvention
+
+Instances of this class are intended to be created only by the `war` plugin and should not be created directly. Creating instances using the constructor of `WarPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `war` plugin.
+
+### Creating instances of EarPluginConvention
+
+Instances of this class are intended to be created only by the `ear` plugin and should not be created directly. Creating instances using the constructor of `EarPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `ear` plugin.
+
+### Creating instances of BasePluginConvention
+
+Instances of this class are intended to be created only by the `base` plugin and should not be created directly. Creating instances using the constructor of `BasePluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `base` plugin.
+
+### Creating instances of ProjectReportsPluginConvention
+
+Instances of this class are intended to be created only by the `project-reports` plugin and should not be created directly. Creating instances using the constructor of `ProjectReportsPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `project-reports` plugin.
+
 ## Potential breaking changes
 
 ### Kotlin DSL breakages

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -12,9 +12,12 @@ Starting with this release, it is now possible to use SNAPSHOT plugin versions i
 
 ### Nested included builds
 
-TBD - Composite builds can be included by other builds. Some combinations are not supported yet:
-- `buildSrc` cannot include other builds.
-- No duplicate root project names.
+Composite builds is a feature that allows a Gradle build to 'include' another build and conveniently use its outputs locally rather than via a binary repository. This makes some common workflows more convenient, such as working on multiple source repositories at the same time to implement a cross-cutting feature. In previous releases, it was not possible for a Gradle build to include another build that also includes other builds, which limits the usefulness of this feature for these workflows. In this Gradle release, a build can now include another build that also includes other builds. In other words, composite builds can now be nested.
+
+There are a number of limitations to be aware of. These will be improved in later Gradle releases:
+
+- A `buildSrc` build cannot include other builds, such as a shared plugin build.
+- The root project of each build must have a unique name.
 
 ## Promoted features
 
@@ -26,10 +29,6 @@ The following are the features that have been promoted in this Gradle release.
 <!--
 ### Example promoted
 -->
-
-### Tooling API types and methods
-
-Many types and methods that were previously marked `@Incubating` are now considered stable. 
 
 ## Fixed issues
 
@@ -43,6 +42,10 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Creating instances of JavaPluginConvention
 
 Instances of this class are intended to be created only by the `java-base` plugin and should not be created directly. Creating instances using the constructor of `JavaPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `java-base` plugin.
+
+### Creating instances of ApplicationPluginConvention
+
+Instances of this class are intended to be created only by the `application` plugin and should not be created directly. Creating instances using the constructor of `ApplicationPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `application` plugin.
 
 ## Potential breaking changes
 

--- a/subprojects/docs/src/docs/userguide/compositeBuilds.adoc
+++ b/subprojects/docs/src/docs/userguide/compositeBuilds.adoc
@@ -97,12 +97,10 @@ More details tasks that depend on included build tasks below.
 [[included_builds]]
 ==== Restrictions on included builds
 
-Most builds can be included into a composite, however there are some limitations.
+Most builds can be included into a composite, including other composite builds. However there are some limitations.
 
 Every included build:
 
-* must have a `settings.gradle` file.
-* must not itself be a composite build.
 * must not have a `rootProject.name` the same as another included build.
 * must not have a `rootProject.name` the same as a top-level project of the composite build.
 * must not have a `rootProject.name` the same as the composite build `rootProject.name`.
@@ -219,5 +217,5 @@ Improvements we have planned for upcoming releases include:
 
 * Better detection of dependency substitution, for build that publish with custom coordinates, builds that produce multiple components, etc. This will reduce the cases where dependency substitution needs to be explicitly declared for an included build.
 * The ability to target a task or tasks in an included build directly from the command line. We are currently exploring syntax options for allowing this functionality, which will remove many cases where a delegating task is required in the composite.
+* Make the `plugins {}` block consider included builds when locating plugins and their dependencies.
 * Making the implicit `buildSrc` project an included build.
-* Supporting composite-of-composite builds.

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -33,7 +33,9 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.Factory;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
+import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -69,7 +71,12 @@ public class EarPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(BasePlugin.class);
 
-        final EarPluginConvention earPluginConvention = objectFactory.newInstance(EarPluginConvention.class, fileResolver, objectFactory);
+        EarPluginConvention earPluginConvention = DeprecationLogger.whileDisabled(new Factory<EarPluginConvention>() {
+            @Override
+            public EarPluginConvention create() {
+                return objectFactory.newInstance(EarPluginConvention.class, fileResolver, objectFactory);
+            }
+        });
         project.getConvention().getPlugins().put("ear", earPluginConvention);
         earPluginConvention.setLibDirName(DEFAULT_LIB_DIR_NAME);
         earPluginConvention.setAppDirName("src/main/application");

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
@@ -24,6 +24,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -41,9 +42,9 @@ public class EarPluginConvention {
     private String libDirName;
 
     /**
-     * Construct an EarPluginConvention using internal {@link Instantiator}.
+     * Construct an {@link EarPluginConvention} using internal {@link Instantiator}.
      *
-     * @deprecated Use public {@link ObjectFactory} constructor instead of this one using internal {@link Instantiator}.
+     * @deprecated Creating instances of this class is deprecated. These should be created by the EAR plugin only.
      */
     @Deprecated
     public EarPluginConvention(FileResolver fileResolver, Instantiator instantiator) {
@@ -51,12 +52,15 @@ public class EarPluginConvention {
     }
 
     /**
-     * Construct an EarPluginConvention using public {@link ObjectFactory}.
+     * Construct an {@link EarPluginConvention} using public {@link ObjectFactory}.
      *
      * @since 4.2
+     * @deprecated Creating instances of this class is deprecated. These should be created by the EAR plugin only.
      */
     @Inject
+    @Deprecated
     public EarPluginConvention(FileResolver fileResolver, ObjectFactory objectFactory) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of EarPluginConvention");
         this.fileResolver = fileResolver;
         this.objectFactory = objectFactory;
         deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class, fileResolver, objectFactory);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -36,7 +36,7 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.GroovyBasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -223,7 +223,7 @@ public class EclipsePlugin extends IdePlugin {
                 XmlTransformer xmlTransformer = new XmlTransformer();
                 xmlTransformer.setIndentation("\t");
                 model.getClasspath().setFile(new XmlFileContentMerger(xmlTransformer));
-                model.getClasspath().setSourceSets(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets());
+                model.getClasspath().setSourceSets(project.getExtensions().getByType(SourceSetContainer.class));
 
                 AfterEvaluateHelper.afterEvaluateOrExecute(project, new Action<Project>() {
                     @Override
@@ -251,7 +251,7 @@ public class EclipsePlugin extends IdePlugin {
                 ((IConventionAware) model.getClasspath()).getConventionMapping().map("classFolders", new Callable<List<File>>() {
                     @Override
                     public List<File> call() {
-                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                         return Lists.newArrayList(Iterables.concat(sourceSets.getByName("main").getOutput().getDirs(), sourceSets.getByName("test").getOutput().getDirs()));
                     }
                 });
@@ -259,7 +259,7 @@ public class EclipsePlugin extends IdePlugin {
                 task.configure(new Action<GenerateEclipseClasspath>() {
                     @Override
                     public void execute(GenerateEclipseClasspath task) {
-                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                         task.dependsOn(sourceSets.getByName("main").getOutput().getDirs());
                         task.dependsOn(sourceSets.getByName("test").getOutput().getDirs());
                     }
@@ -325,21 +325,21 @@ public class EclipsePlugin extends IdePlugin {
                 conventionMapping.map("sourceCompatibility", new Callable<JavaVersion>() {
                     @Override
                     public JavaVersion call() {
-                        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility();
+                        return project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility();
                     }
 
                 });
                 conventionMapping.map("targetCompatibility", new Callable<JavaVersion>() {
                     @Override
                     public JavaVersion call() {
-                        return project.getConvention().getPlugin(JavaPluginConvention.class).getTargetCompatibility();
+                        return project.getExtensions().getByType(JavaPluginExtension.class).getTargetCompatibility();
                     }
 
                 });
                 conventionMapping.map("javaRuntimeName", new Callable<String>() {
                     @Override
                     public String call() {
-                        return eclipseJavaRuntimeNameFor(project.getConvention().getPlugin(JavaPluginConvention.class).getTargetCompatibility());
+                        return eclipseJavaRuntimeNameFor(project.getExtensions().getByType(JavaPluginExtension.class).getTargetCompatibility());
                     }
 
                 });

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -23,9 +23,10 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.WarPluginConvention;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.internal.reflect.Instantiator;
@@ -281,7 +282,7 @@ public class EclipseWtpPlugin extends IdePlugin {
                         return Lists.newArrayList(
                             new Facet(Facet.FacetType.fixed, "jst.java", null),
                             new Facet(Facet.FacetType.installed, "jst.utility", "1.0"),
-                            new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility()))
+                            new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility()))
                         );
                     }
                 });
@@ -298,7 +299,7 @@ public class EclipseWtpPlugin extends IdePlugin {
                             new Facet(Facet.FacetType.fixed, "jst.java", null),
                             new Facet(Facet.FacetType.fixed, "jst.web", null),
                             new Facet(Facet.FacetType.installed, "jst.web", "2.4"),
-                            new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility()))
+                            new Facet(Facet.FacetType.installed, "jst.java", toJavaFacetVersion(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility()))
                         );
                     }
                 });
@@ -343,7 +344,7 @@ public class EclipseWtpPlugin extends IdePlugin {
     }
 
     private Set<File> getMainSourceDirs(Project project) {
-        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("main").getAllSource().getSrcDirs();
+        return project.getExtensions().getByType(SourceSetContainer.class).getByName("main").getAllSource().getSrcDirs();
     }
 
     private String toJavaFacetVersion(JavaVersion version) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/LinkedResourcesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/LinkedResourcesCreator.java
@@ -18,7 +18,6 @@ package org.gradle.plugins.ide.eclipse.internal;
 import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
@@ -32,7 +31,7 @@ import java.util.Set;
 
 public class LinkedResourcesCreator {
     public Set<Link> links(final Project project) {
-        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         EclipseClasspath classpath = project.getExtensions().getByType(EclipseModel.class).getClasspath();
         File defaultOutputDir = classpath == null ? project.file(EclipsePluginConstants.DEFAULT_PROJECT_OUTPUT_PATH) : classpath.getDefaultOutputDir();
         List<SourceFolder> sourceFolders = new SourceFoldersCreator().getBasicExternalSourceFolders(sourceSets, new Function<File, String>() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -36,7 +36,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -86,14 +86,14 @@ public class IdeaPlugin extends IdePlugin {
     };
     public static final Function<Project, JavaVersion> SOURCE_COMPATIBILITY = new Function<Project, JavaVersion>() {
         @Override
-        public JavaVersion apply(Project p) {
-            return p.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility();
+        public JavaVersion apply(Project project) {
+            return project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility();
         }
     };
     public static final Function<Project, JavaVersion> TARGET_COMPATIBILITY = new Function<Project, JavaVersion>() {
         @Override
-        public JavaVersion apply(Project p) {
-            return p.getConvention().getPlugin(JavaPluginConvention.class).getTargetCompatibility();
+        public JavaVersion apply(Project project) {
+            return project.getExtensions().getByType(JavaPluginExtension.class).getTargetCompatibility();
         }
     };
     private static final String IDEA_MODULE_TASK_NAME = "ideaModule";
@@ -357,7 +357,7 @@ public class IdeaPlugin extends IdePlugin {
                 ideaModule.dependsOn(new Callable<FileCollection>() {
                     @Override
                     public FileCollection call() {
-                        SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                         return sourceSets.getByName("main").getOutput().getDirs().plus(sourceSets.getByName("test").getOutput().getDirs());
                     }
 
@@ -374,35 +374,35 @@ public class IdeaPlugin extends IdePlugin {
         convention.map("sourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() {
-                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                 return sourceSets.getByName("main").getAllSource().getSrcDirs();
             }
         });
         convention.map("testSourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() {
-                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                 return sourceSets.getByName("test").getAllSource().getSrcDirs();
             }
         });
         convention.map("resourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() throws Exception {
-                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                 return sourceSets.getByName("main").getResources().getSrcDirs();
             }
         });
         convention.map("testResourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() throws Exception {
-                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                 return sourceSets.getByName("test").getResources().getSrcDirs();
             }
         });
         convention.map("singleEntryLibraries", new Callable<Map<String, FileCollection>>() {
             @Override
             public Map<String, FileCollection> call() {
-                SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
                 LinkedHashMap<String, FileCollection> map = new LinkedHashMap<String, FileCollection>(2);
                 map.put("RUNTIME", sourceSets.getByName("main").getOutput().getDirs());
                 map.put("TEST", sourceSets.getByName("test").getOutput().getDirs());
@@ -413,7 +413,7 @@ public class IdeaPlugin extends IdePlugin {
         convention.map("targetBytecodeVersion", new Callable<JavaVersion>() {
             @Override
             public JavaVersion call() {
-                JavaVersion moduleTargetBytecodeLevel = project.getConvention().getPlugin(JavaPluginConvention.class).getTargetCompatibility();
+                JavaVersion moduleTargetBytecodeLevel = project.getExtensions().getByType(JavaPluginExtension.class).getTargetCompatibility();
                 return includeModuleBytecodeLevelOverride(project.getRootProject(), moduleTargetBytecodeLevel) ? moduleTargetBytecodeLevel : null;
             }
 
@@ -421,7 +421,7 @@ public class IdeaPlugin extends IdePlugin {
         convention.map("languageLevel", new Callable<IdeaLanguageLevel>() {
             @Override
             public IdeaLanguageLevel call() {
-                IdeaLanguageLevel moduleLanguageLevel = new IdeaLanguageLevel(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceCompatibility());
+                IdeaLanguageLevel moduleLanguageLevel = new IdeaLanguageLevel(project.getExtensions().getByType(JavaPluginExtension.class).getSourceCompatibility());
                 return includeModuleLanguageLevelOverride(project.getRootProject(), moduleLanguageLevel) ? moduleLanguageLevel : null;
             }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -24,11 +24,11 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.ReportingBasePlugin;
 import org.gradle.api.reporting.ConfigurableReport;
 import org.gradle.api.reporting.Report;
 import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.jacoco.JacocoAgentJar;
 import org.gradle.internal.reflect.Instantiator;
@@ -234,7 +234,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
         reportTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
         reportTask.setDescription(String.format("Generates code coverage report for the %s task.", task.getName()));
         reportTask.executionData(task);
-        reportTask.sourceSets(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("main"));
+        reportTask.sourceSets(project.getExtensions().getByType(SourceSetContainer.class).getByName("main"));
         reportTask.getReports().all(new Action<ConfigurableReport>() {
             @Override
             public void execute(final ConfigurableReport report) {
@@ -262,6 +262,6 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
         coverageVerificationTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
         coverageVerificationTask.setDescription(String.format("Verifies code coverage metrics based on specified rules for the %s task.", task.getName()));
         coverageVerificationTask.executionData(task);
-        coverageVerificationTask.sourceSets(project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("main"));
+        coverageVerificationTask.sourceSets(project.getExtensions().getByType(SourceSetContainer.class).getByName("main"));
     }
 }

--- a/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPlugin.java
+++ b/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPlugin.java
@@ -25,6 +25,8 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.internal.Factory;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
@@ -35,7 +37,12 @@ public class OsgiPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaBasePlugin.class);
 
-        final OsgiPluginConvention osgiConvention = new OsgiPluginConvention((ProjectInternal) project);
+        final OsgiPluginConvention osgiConvention = DeprecationLogger.whileDisabled(new Factory<OsgiPluginConvention>() {
+            @Override
+            public OsgiPluginConvention create() {
+                return new OsgiPluginConvention((ProjectInternal) project);
+            }
+        });
         project.getConvention().getPlugins().put("osgi", osgiConvention);
 
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {

--- a/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPlugin.java
+++ b/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPlugin.java
@@ -22,7 +22,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.internal.Factory;
@@ -51,7 +51,7 @@ public class OsgiPlugin implements Plugin<Project> {
 
                 // When creating the OSGi manifest, we must have a single view of all of the classes included in the jar.
                 Sync prepareOsgiClasses = project.getTasks().create("osgiClasses", Sync.class);
-                FileCollection classes = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("main").getOutput().getClassesDirs();
+                FileCollection classes = project.getExtensions().getByType(SourceSetContainer.class).getByName("main").getOutput().getClassesDirs();
                 File singleClassesDirectory = new File(project.getBuildDir(), "osgi-classes");
                 prepareOsgiClasses.setDescription("Prepares a single classes directory required for OSGi analysis.");
                 prepareOsgiClasses.from(classes);

--- a/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPluginConvention.java
+++ b/subprojects/osgi/src/main/java/org/gradle/api/plugins/osgi/OsgiPluginConvention.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.internal.Actions;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.concurrent.Callable;
 
@@ -36,7 +37,14 @@ import static org.gradle.util.ConfigureUtil.configure;
 public class OsgiPluginConvention {
     private final ProjectInternal project;
 
+    /**
+     * Creates an {@link OsgiPluginConvention} instance.
+     *
+     * @deprecated Creating instances of this class is deprecated. These should be created by the OSGi plugin only.
+     */
+    @Deprecated
     public OsgiPluginConvention(ProjectInternal project) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of OsgiPluginConvention");
         this.project = project;
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -37,10 +37,10 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.ClasspathNormalizer;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
@@ -148,9 +148,9 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
     }
 
     private GradlePluginDevelopmentExtension createExtension(Project project) {
-        JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-        SourceSet defaultPluginSourceSet = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-        SourceSet defaultTestSourceSet = javaConvention.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        SourceSet defaultPluginSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        SourceSet defaultTestSourceSet = sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME);
         return project.getExtensions().create(EXTENSION_NAME, GradlePluginDevelopmentExtension.class, project, defaultPluginSourceSet, defaultTestSourceSet);
     }
 
@@ -251,7 +251,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
         validator.getOutputFile().set(project.getLayout().getBuildDirectory().file("reports/task-properties/report.txt"));
 
-        final SourceSet mainSourceSet = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        final SourceSet mainSourceSet = project.getExtensions().getByType(SourceSetContainer.class).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         validator.setClasses(mainSourceSet.getOutput().getClassesDirs());
         validator.setClasspath(mainSourceSet.getCompileClasspath());
         validator.dependsOn(mainSourceSet.getOutput());

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginConfigurationIntegrationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ScriptExecuter
+import org.gradle.util.TextUtil
+
+
+class ApplicationPluginConfigurationIntegrationTest extends AbstractIntegrationSpec {
+    def "can configure using project extension"() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+
+        file("src/main/java/test/Main.java") << """
+            package test;
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("all good");
+                }
+            }
+        """
+
+        buildFile << """
+            plugins { 
+                id("application") 
+            }
+            application {
+                mainClassName = "test.Main"
+            }
+        """
+
+        when:
+        run("installDist")
+
+        def out = new ByteArrayOutputStream()
+        def executer = new ScriptExecuter()
+        executer.workingDir = testDirectory
+        executer.standardOutput = out
+        executer.commandLine = "build/install/test/bin/test"
+
+        then:
+        executer.run().assertNormalExitValue()
+        out.toString() == TextUtil.toPlatformLineSeparators("all good\n")
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.plugins.DistributionPlugin;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
@@ -106,6 +107,7 @@ public class ApplicationPlugin implements Plugin<Project> {
         pluginConvention = new ApplicationPluginConvention(project);
         pluginConvention.setApplicationName(project.getName());
         project.getConvention().getPlugins().put("application", pluginConvention);
+        project.getExtensions().create(JavaApplication.class, "application", DefaultJavaApplication.class, pluginConvention);
     }
 
     private void addRunTask() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -32,6 +32,8 @@ import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.application.CreateStartScripts;
+import org.gradle.internal.Factory;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -60,7 +62,7 @@ public class ApplicationPlugin implements Plugin<Project> {
         project.getPluginManager().apply(JavaPlugin.class);
         project.getPluginManager().apply(DistributionPlugin.class);
 
-        addPluginConvention();
+        addExtensions();
         addRunTask();
         addCreateScriptsTask();
 
@@ -103,8 +105,13 @@ public class ApplicationPlugin implements Plugin<Project> {
         });
     }
 
-    private void addPluginConvention() {
-        pluginConvention = new ApplicationPluginConvention(project);
+    private void addExtensions() {
+        pluginConvention = DeprecationLogger.whileDisabled(new Factory<ApplicationPluginConvention>() {
+            @Override
+            public ApplicationPluginConvention create() {
+                return new ApplicationPluginConvention(project);
+            }
+        });
         pluginConvention.setApplicationName(project.getName());
         project.getConvention().getPlugins().put("application", pluginConvention);
         project.getExtensions().create(JavaApplication.class, "application", DefaultJavaApplication.class, pluginConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.application.CreateStartScripts;
 import org.gradle.internal.Factory;
@@ -122,8 +123,8 @@ public class ApplicationPlugin implements Plugin<Project> {
         run.setDescription("Runs this project as a JVM application");
         run.setGroup(APPLICATION_GROUP);
 
-        JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-        run.setClasspath(javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath());
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        run.setClasspath(sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath());
         run.getConventionMapping().map("main", new Callable<Object>() {
             @Override
             public Object call() throws Exception {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.ArrayList;
 
@@ -34,7 +35,14 @@ public class ApplicationPluginConvention {
 
     private final Project project;
 
+    /**
+     * Constructs an {@link ApplicationPluginConvention}.
+     *
+     * @deprecated Creating instances of this class is deprecated. These should be created by the application plugin only.
+     */
+    @Deprecated
     public ApplicationPluginConvention(Project project) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of ApplicationPluginConvention");
         this.project = project;
         applicationDistribution = project.copySpec();
     }
@@ -83,6 +91,7 @@ public class ApplicationPluginConvention {
 
     /**
      * Directory to place executables in
+     *
      * @since 4.5
      */
     @Incubating
@@ -92,6 +101,7 @@ public class ApplicationPluginConvention {
 
     /**
      * Directory to place executables in
+     *
      * @since 4.5
      */
     @Incubating

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -40,8 +40,10 @@ import org.gradle.api.tasks.Upload;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.internal.Describables;
+import org.gradle.internal.Factory;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -69,10 +71,15 @@ public class BasePlugin implements Plugin<Project> {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
     }
 
-    public void apply(Project project) {
+    public void apply(final Project project) {
         project.getPluginManager().apply(LifecycleBasePlugin.class);
 
-        BasePluginConvention convention = new BasePluginConvention(project);
+        BasePluginConvention convention = DeprecationLogger.whileDisabled(new Factory<BasePluginConvention>() {
+            @Override
+            public BasePluginConvention create() {
+                return new BasePluginConvention(project);
+            }
+        });
         project.getConvention().getPlugins().put("base", convention);
 
         configureBuildConfigurationRule(project);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePluginConvention.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins;
 import org.gradle.api.Project;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
@@ -39,7 +40,14 @@ public class BasePluginConvention {
 
     private String archivesBaseName;
 
+    /**
+     * Creates a {@link BasePluginConvention} instance.
+     *
+     * @deprecated Creating instances of this class is deprecated. These should be created by the base plugin only.
+     */
+    @Deprecated
     public BasePluginConvention(Project project) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of BasePluginConvention");
         this.project = (ProjectInternal) project;
         archivesBaseName = project.getName();
         distsDirName = "distributions";

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -34,6 +34,7 @@ import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.GroovyRuntime;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.javadoc.Groovydoc;
 
@@ -88,7 +89,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
     }
 
     private void configureSourceSetDefaults() {
-        project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().all(new Action<SourceSet>() {
+        project.getExtensions().getByType(SourceSetContainer.class).all(new Action<SourceSet>() {
             public void execute(final SourceSet sourceSet) {
                 final DefaultGroovySourceSet groovySourceSet = new DefaultGroovySourceSet("groovy", ((DefaultSourceSet) sourceSet).getDisplayName(), sourceDirectorySetFactory);
                 new DslObject(sourceSet).getConvention().getPlugins().put("groovy", groovySourceSet);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.tasks.GroovySourceSet;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.javadoc.Groovydoc;
 
 /**
@@ -44,8 +45,8 @@ public class GroovyPlugin implements Plugin<Project> {
                 groovyDoc.setDescription("Generates Groovydoc API documentation for the main source code.");
                 groovyDoc.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
 
-                JavaPluginConvention convention = project.getConvention().getPlugin(JavaPluginConvention.class);
-                SourceSet sourceSet = convention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+                SourceSet sourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
                 groovyDoc.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
 
                 GroovySourceSet groovySourceSet = new DslObject(sourceSet).getConvention().getPlugin(GroovySourceSet.class);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.file.CopySpec;
+
+/**
+ * Configuration for a Java application, defining how to assemble the application.
+ *
+ * <p>An instance of this type is added as a project extension by the Java application plugin.</p>
+ *
+ * @since 4.10
+ */
+@Incubating
+public interface JavaApplication {
+    /**
+     * The name of the application.
+     */
+    String getApplicationName();
+
+    /**
+     * The name of the application.
+     */
+    void setApplicationName(String applicationName);
+
+    /**
+     * The fully qualified name of the application's main class.
+     */
+    String getMainClassName();
+
+    /**
+     * The fully qualified name of the application's main class.
+     */
+    void setMainClassName(String mainClassName);
+
+    /**
+     * Array of string arguments to pass to the JVM when running the application
+     */
+    Iterable<String> getApplicationDefaultJvmArgs();
+
+    /**
+     * Array of string arguments to pass to the JVM when running the application
+     */
+    void setApplicationDefaultJvmArgs(Iterable<String> applicationDefaultJvmArgs);
+
+    /**
+     * Directory to place executables in
+     */
+    String getExecutableDir();
+
+    /**
+     * Directory to place executables in
+     */
+    void setExecutableDir(String executableDir);
+
+    /**
+     * <p>The specification of the contents of the distribution.</p>
+     * <p>
+     * Use this {@link org.gradle.api.file.CopySpec} to include extra files/resource in the application distribution.
+     * <pre class='autoTested'>
+     * apply plugin: 'application'
+     *
+     * applicationDistribution.from("some/dir") {
+     *   include "*.txt"
+     * }
+     * </pre>
+     * <p>
+     * Note that the application plugin pre configures this spec to; include the contents of "{@code src/dist}",
+     * copy the application start scripts into the "{@code bin}" directory, and copy the built jar and its dependencies
+     * into the "{@code lib}" directory.
+     */
+    CopySpec getApplicationDistribution();
+
+    void setApplicationDistribution(CopySpec applicationDistribution);
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -42,6 +42,7 @@ import org.gradle.api.plugins.internal.SourceSetUtil;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -92,7 +93,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
             }
         });
         project.getConvention().getPlugins().put("java", javaConvention);
-        project.getExtensions().add("sourceSets", javaConvention.getSourceSets());
+        project.getExtensions().add(SourceSetContainer.class, "sourceSets", javaConvention.getSourceSets());
         project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);
 
         configureSourceSetDefaults(javaConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -86,15 +86,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         project.getPluginManager().apply(BasePlugin.class);
         project.getPluginManager().apply(ReportingBasePlugin.class);
 
-        JavaPluginConvention javaConvention = DeprecationLogger.whileDisabled(new Factory<JavaPluginConvention>() {
-            @Override
-            public JavaPluginConvention create() {
-                return new JavaPluginConvention(project, instantiator);
-            }
-        });
-        project.getConvention().getPlugins().put("java", javaConvention);
-        project.getExtensions().add(SourceSetContainer.class, "sourceSets", javaConvention.getSourceSets());
-        project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);
+        JavaPluginConvention javaConvention = addExtensions(project);
 
         configureSourceSetDefaults(javaConvention);
         configureCompileDefaults(project, javaConvention);
@@ -105,6 +97,19 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         configureBuildDependents(project);
         configureSchema(project);
         bridgeToSoftwareModelIfNecessary(project);
+    }
+
+    private JavaPluginConvention addExtensions(final ProjectInternal project) {
+        JavaPluginConvention javaConvention = DeprecationLogger.whileDisabled(new Factory<JavaPluginConvention>() {
+            @Override
+            public JavaPluginConvention create() {
+                return new JavaPluginConvention(project, instantiator);
+            }
+        });
+        project.getConvention().getPlugins().put("java", javaConvention);
+        project.getExtensions().add(SourceSetContainer.class, "sourceSets", javaConvention.getSourceSets());
+        project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);
+        return javaConvention;
     }
 
     private void bridgeToSoftwareModelIfNecessary(ProjectInternal project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.tasks.SourceSetCompileClasspath;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.reflect.Instantiator;
@@ -71,8 +72,8 @@ class JavaBasePluginRules implements Plugin<Project> {
     public void apply(Project project) {
         project.getPluginManager().apply(LanguageBasePlugin.class);
         project.getPluginManager().apply(BinaryBasePlugin.class);
-        JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-        BridgedBinaries binaries = collectBinariesForSourceSets(project.getTasks(), javaConvention);
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        BridgedBinaries binaries = collectBinariesForSourceSets(project, project.getTasks(), sourceSets);
 
         modelRegistry.register(ModelRegistrations.bridgedInstance(ModelReference.of("bridgedBinaries", BridgedBinaries.class), binaries)
             .descriptor("JavaBasePlugin.apply()")
@@ -81,10 +82,9 @@ class JavaBasePluginRules implements Plugin<Project> {
 
     }
 
-    private BridgedBinaries collectBinariesForSourceSets(final TaskContainer tasks, final JavaPluginConvention pluginConvention) {
-        final Project project = pluginConvention.getProject();
+    private BridgedBinaries collectBinariesForSourceSets(final Project project, final TaskContainer tasks, final SourceSetContainer sourceSets) {
         final List<ClassDirectoryBinarySpecInternal> binaries = Lists.newArrayList();
-        pluginConvention.getSourceSets().all(new Action<SourceSet>() {
+        sourceSets.all(new Action<SourceSet>() {
             public void execute(final SourceSet sourceSet) {
 
                 Provider<ProcessResources> resourcesTask = tasks.withType(ProcessResources.class).named(sourceSet.getProcessResourcesTaskName());

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
 
 import javax.inject.Inject;
@@ -53,13 +54,13 @@ public class JavaLibraryPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPluginManager().apply(JavaPlugin.class);
 
-        JavaPluginConvention convention = (JavaPluginConvention) project.getConvention().getPlugins().get("java");
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         ConfigurationContainer configurations = project.getConfigurations();
-        addApiToMainSourceSet(project, convention, configurations);
+        addApiToMainSourceSet(project, sourceSets, configurations);
     }
 
-    private void addApiToMainSourceSet(Project project, JavaPluginConvention convention, ConfigurationContainer configurations) {
-        SourceSet sourceSet = convention.getSourceSets().getByName("main");
+    private void addApiToMainSourceSet(Project project, SourceSetContainer sourceSets, ConfigurationContainer configurations) {
+        SourceSet sourceSet = sourceSets.getByName("main");
 
         Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
         apiConfiguration.setVisible(false);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -31,6 +31,8 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
+import org.gradle.internal.Factory;
+import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -54,7 +56,12 @@ public class WarPlugin implements Plugin<Project> {
 
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaPlugin.class);
-        final WarPluginConvention pluginConvention = new WarPluginConvention(project);
+        final WarPluginConvention pluginConvention = DeprecationLogger.whileDisabled(new Factory<WarPluginConvention>() {
+            @Override
+            public WarPluginConvention create() {
+                return new WarPluginConvention(project);
+            }
+        });
         project.getConvention().getPlugins().put("war", pluginConvention);
 
         project.getTasks().withType(War.class).configureEach(new Action<War>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.java.WebApplication;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.internal.Factory;
@@ -73,14 +74,13 @@ public class WarPlugin implements Plugin<Project> {
                 });
                 task.dependsOn(new Callable() {
                     public Object call() throws Exception {
-                        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(
+                        return project.getExtensions().getByType(SourceSetContainer.class).getByName(
                                 SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
                     }
                 });
                 task.classpath(new Object[] {new Callable() {
                     public Object call() throws Exception {
-                        FileCollection runtimeClasspath = project.getConvention().getPlugin(JavaPluginConvention.class)
-                                .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
+                        FileCollection runtimeClasspath = project.getExtensions().getByType(SourceSetContainer.class).getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
                         Configuration providedRuntime = project.getConfigurations().getByName(
                                 PROVIDED_RUNTIME_CONFIGURATION_NAME);
                         return runtimeClasspath.minus(providedRuntime);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPluginConvention.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Project;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
@@ -27,7 +28,14 @@ public class WarPluginConvention {
     private String webAppDirName;
     private final Project project;
 
+    /**
+     * Creates a {@link WarPluginConvention}.
+     *
+     * @deprecated Creating instances of this class is deprecated. These should be created by the WAR plugin only.
+     */
+    @Deprecated
     public WarPluginConvention(Project project) {
+        DeprecationLogger.nagUserOfDeprecated("Creating instances of WarPluginConvention");
         this.project = project;
         webAppDirName = "src/main/webapp";
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaApplication.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.plugins.ApplicationPluginConvention;
+import org.gradle.api.plugins.JavaApplication;
+
+public class DefaultJavaApplication implements JavaApplication {
+    private final ApplicationPluginConvention convention;
+
+    public DefaultJavaApplication(ApplicationPluginConvention convention) {
+        this.convention = convention;
+    }
+
+    @Override
+    public String getApplicationName() {
+        return convention.getApplicationName();
+    }
+
+    @Override
+    public void setApplicationName(String applicationName) {
+        convention.setApplicationName(applicationName);
+    }
+
+    @Override
+    public String getMainClassName() {
+        return convention.getMainClassName();
+    }
+
+    @Override
+    public void setMainClassName(String mainClassName) {
+        convention.setMainClassName(mainClassName);
+    }
+
+    @Override
+    public Iterable<String> getApplicationDefaultJvmArgs() {
+        return convention.getApplicationDefaultJvmArgs();
+    }
+
+    @Override
+    public void setApplicationDefaultJvmArgs(Iterable<String> applicationDefaultJvmArgs) {
+        convention.setApplicationDefaultJvmArgs(applicationDefaultJvmArgs);
+    }
+
+    @Override
+    public String getExecutableDir() {
+        return convention.getExecutableDir();
+    }
+
+    @Override
+    public void setExecutableDir(String executableDir) {
+        convention.setExecutableDir(executableDir);
+    }
+
+    @Override
+    public CopySpec getApplicationDistribution() {
+        return convention.getApplicationDistribution();
+    }
+
+    @Override
+    public void setApplicationDistribution(CopySpec applicationDistribution) {
+        convention.setApplicationDistribution(applicationDistribution);
+    }
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/ApplicationPluginTest.groovy
@@ -34,11 +34,17 @@ class ApplicationPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         project.plugins.hasPlugin(JavaPlugin.class)
+
         project.convention.getPlugin(ApplicationPluginConvention.class) != null
         project.applicationName == project.name
         project.mainClassName == null
         project.applicationDefaultJvmArgs == []
         project.applicationDistribution instanceof CopySpec
+
+        def application = project.extensions.getByName('application')
+        application instanceof JavaApplication
+        application.applicationName == project.name
+        application.applicationDistribution.is(project.applicationDistribution)
     }
 
     def "adds run task to project"() {

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.ScalaRuntime;
 import org.gradle.api.tasks.ScalaSourceSet;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaCompile;
@@ -81,7 +82,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
     }
 
     private static void configureSourceSetDefaults(final Project project, final SourceDirectorySetFactory sourceDirectorySetFactory) {
-        project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().all(new Action<SourceSet>() {
+        project.getExtensions().getByType(SourceSetContainer.class).all(new Action<SourceSet>() {
             @Override
             public void execute(final SourceSet sourceSet) {
                 String displayName = (String) InvokerHelper.invokeMethod(sourceSet, "getDisplayName", null);

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
@@ -24,8 +24,8 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.scala.ScalaDoc;
 
 import java.util.concurrent.Callable;
@@ -50,7 +50,7 @@ public class ScalaPlugin implements Plugin<Project> {
         project.getTasks().withType(ScalaDoc.class).configureEach(new Action<ScalaDoc>() {
             @Override
             public void execute(ScalaDoc scalaDoc) {
-                final SourceSet main = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName("main");
+                final SourceSet main = project.getExtensions().getByType(SourceSetContainer.class).getByName("main");
                 scalaDoc.getConventionMapping().map("classpath", new Callable<FileCollection>() {
                     @Override
                     public FileCollection call() throws Exception {


### PR DESCRIPTION
### Context

The PR continues the migration for #5377 started with #5867 to change the `application` plugin to add an `application` extension.

This PR also deprecates the constructors of various public contention types, so that these can be made abstract types with internal implementations in Gradle 5.x and later retired in 6.x.

This PR also changes a bunch of plugins to use the Java base plugin extension instead of the convention object.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
