### PR TITLE
Avoid reinitializing DefaultPersistentDirectoryStores

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.caching.local.internal
 
-import org.gradle.cache.internal.DefaultPersistentDirectoryCache
+import org.gradle.cache.internal.DefaultPersistentDirectoryStore
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
@@ -128,7 +128,7 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
 
         // checkInterval-1 hours is not enough to trigger
         when:
-        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS - 1))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryStore.CLEANUP_INTERVAL_IN_HOURS - 1))
         lastCleanupCheck = gcFile().lastModified()
         run()
         then:
@@ -136,14 +136,14 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
 
         // checkInterval hours is enough to trigger
         when:
-        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryStore.CLEANUP_INTERVAL_IN_HOURS))
         run()
         then:
         assertCacheWasCleanedUpSince(lastCleanupCheck)
 
         // More than checkInterval hours is enough to trigger
         when:
-        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryCache.CLEANUP_INTERVAL_IN_HOURS * 10))
+        gcFile().setLastModified(originalCheckTime - TimeUnit.HOURS.toMillis(DefaultPersistentDirectoryStore.CLEANUP_INTERVAL_IN_HOURS * 10))
         run()
         then:
         assertCacheWasCleanedUpSince(lastCleanupCheck)

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -84,10 +84,10 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         DirCacheReference dirCacheReference = dirCaches.get(canonicalDir);
         if (dirCacheReference == null) {
             ReferencablePersistentCache cache;
-            if (!properties.isEmpty() || validator != null || initializer != null || cleanup != null) {
+            if (!properties.isEmpty() || validator != null || initializer != null) {
                 cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, validator, properties, lockTarget, lockOptions, initializer, cleanup, lockManager, executorFactory);
             } else {
-                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, lockManager, executorFactory);
+                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cleanup, lockManager, executorFactory);
             }
             cache.open();
             dirCacheReference = new DirCacheReference(cache, properties, lockTarget, lockOptions);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -17,6 +17,7 @@ package org.gradle.cache.internal;
 
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheOpenException;
+import org.gradle.cache.CleanupAction;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
@@ -25,27 +26,45 @@ import org.gradle.cache.PersistentIndexedCacheParameters;
 import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.time.CountdownTimer;
+import org.gradle.internal.time.Time;
 import org.gradle.util.GFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 public class DefaultPersistentDirectoryStore implements ReferencablePersistentCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPersistentDirectoryStore.class);
+
+    public static final int CLEANUP_INTERVAL_IN_HOURS = 24;
+
+    // Cleanup is performed while the file lock is being held. Using a timeout
+    // well below the limit used by another process to wait for the lock avoids
+    // those from timing out while waiting to acquire the file lock. Cleanup is
+    // usually much faster than this timeout.
+    private static final int DEFAULT_CLEANUP_TIMEOUT = DefaultFileLockManager.DEFAULT_LOCK_TIMEOUT / 3;
+
     private final File dir;
     private final CacheBuilder.LockTarget lockTarget;
     private final LockOptions lockOptions;
+    private final CleanupAction cleanupAction;
     private final FileLockManager lockManager;
     private final ExecutorFactory executorFactory;
     private final String displayName;
     protected final File propertiesFile;
-    protected final File gcFile;
+    private final File gcFile;
     private CacheCoordinator cacheAccess;
 
-    public DefaultPersistentDirectoryStore(File dir, String displayName, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, FileLockManager fileLockManager, ExecutorFactory executorFactory) {
+    public DefaultPersistentDirectoryStore(File dir, String displayName, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, CleanupAction cleanupAction, FileLockManager fileLockManager, ExecutorFactory executorFactory) {
         this.dir = dir;
         this.lockTarget = lockTarget;
         this.lockOptions = lockOptions;
+        this.cleanupAction = cleanupAction;
         this.lockManager = fileLockManager;
         this.executorFactory = executorFactory;
         this.propertiesFile = new File(dir, "cache.properties");
@@ -95,17 +114,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     }
 
     protected CacheCleanupAction getCleanupAction() {
-        return new CacheCleanupAction() {
-            @Override
-            public boolean requiresCleanup() {
-                return false;
-            }
-
-            @Override
-            public void cleanup() {
-                throw new UnsupportedOperationException();
-            }
-        };
+        return new Cleanup();
     }
 
     @Override
@@ -176,6 +185,35 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     @Override
     public void useCache(Runnable action) {
         cacheAccess.useCache(action);
+    }
+
+    private class Cleanup implements CacheCleanupAction {
+        @Override
+        public boolean requiresCleanup() {
+            if (cleanupAction != null) {
+                if (!gcFile.exists()) {
+                    GFileUtils.touch(gcFile);
+                } else {
+                    long duration = System.currentTimeMillis() - gcFile.lastModified();
+                    long timeInHours = TimeUnit.MILLISECONDS.toHours(duration);
+                    LOGGER.debug("{} has last been fully cleaned up {} hours ago", DefaultPersistentDirectoryStore.this, timeInHours);
+                    return timeInHours >= CLEANUP_INTERVAL_IN_HOURS;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void cleanup() {
+            if (cleanupAction != null) {
+                CountdownTimer timer = Time.startCountdownTimer(DEFAULT_CLEANUP_TIMEOUT);
+                cleanupAction.clean(DefaultPersistentDirectoryStore.this, timer);
+                if (!timer.hasExpired()) {
+                    GFileUtils.touch(gcFile);
+                }
+                LOGGER.info("{} cleaned up in {}.", DefaultPersistentDirectoryStore.this, timer.getElapsed());
+            }
+        }
     }
 
 }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
@@ -39,7 +39,7 @@ class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
 
     @Issue("GRADLE-3206")
     def "can create new caches and access them in parallel"() {
-        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), lockManager, executorFactory)
+        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, executorFactory)
         store.open()
 
         when:


### PR DESCRIPTION
Prior to this commit, adding a `CleanupAction` when building a
`PersistentCache` using `CacheBuilder.withCleanup()` caused the used
implementation class to be changed from
`DefaultPersistentDirectoryStore` to `DefaultPersistentDirectoryCache`.
The latter adds initialization logic and has a very strict check in
place that verifies whether the lock file has been unlocked cleanly. If
not, it will delete all files in the cache in order to reinitialize it.
Since the mere addition of a cleanup action should not change such a
fundamental behavior, this commit moves the cleanup logic to the
`DefaultPersistentDirectoryStore` class and instantiates it when a
cleanup action is configured but no initialization related properties.