### PR TITLE
Clean up custom distributions

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -48,6 +48,7 @@ public class GradleVersion implements Comparable<GradleVersion> {
 
     public static final String RESOURCE_NAME = "/org/gradle/build-receipt.properties";
     public static final String VERSION_OVERRIDE_VAR = "GRADLE_VERSION_OVERRIDE";
+    public static final String VERSION_NUMBER_PROPERTY = "versionNumber";
 
     static {
         URL resource = GradleVersion.class.getResource(RESOURCE_NAME);
@@ -63,7 +64,7 @@ public class GradleVersion implements Comparable<GradleVersion> {
             Properties properties = new Properties();
             properties.load(inputStream);
 
-            String version = properties.get("versionNumber").toString();
+            String version = properties.get(VERSION_NUMBER_PROPERTY).toString();
 
             // We allow the gradle version to be overridden for tests that are sensitive
             // to the version and need to test with various different version patterns.

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
@@ -30,22 +30,34 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest ex
         requireOwnGradleUserHomeDir() // because we delete caches and distributions
 
         and:
-        def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), USED_TODAY)
+        def oldButRecentlyUsedVersion = GradleVersion.version("1.4.5")
+        def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(oldButRecentlyUsedVersion, USED_TODAY)
+        def oldButRecentlyUsedDist = createDistributionChecksumDir(oldButRecentlyUsedVersion, "bin").parentFile
+        def oldButRecentlyUsedCustomDist = createCustomDistributionChecksumDir("my-dist-1", oldButRecentlyUsedVersion).parentFile
+
         def oldNotRecentlyUsedVersion = GradleVersion.version("2.3.4")
-        def oldCacheDir = createVersionSpecificCacheDir(oldNotRecentlyUsedVersion, NOT_USED_WITHIN_30_DAYS)
-        def oldDist = createDistributionDir(oldNotRecentlyUsedVersion, "bin")
+        def oldNotRecentlyUsedCacheDir = createVersionSpecificCacheDir(oldNotRecentlyUsedVersion, NOT_USED_WITHIN_30_DAYS)
+        def oldNotRecentlyUsedDist = createDistributionChecksumDir(oldNotRecentlyUsedVersion, "bin").parentFile
+        def oldNotRecentlyUsedCustomDist = createCustomDistributionChecksumDir("my-dist-2", oldNotRecentlyUsedVersion).parentFile
+
         def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_USED_WITHIN_30_DAYS)
-        def currentDist = createDistributionDir(GradleVersion.current(), "all")
+        def currentDist = createDistributionChecksumDir(GradleVersion.current(), "all").parentFile
 
         when:
         succeeds("tasks")
 
         then:
         oldButRecentlyUsedCacheDir.assertExists()
-        oldCacheDir.assertDoesNotExist()
-        oldDist.assertDoesNotExist()
+        oldButRecentlyUsedDist.assertExists()
+        oldButRecentlyUsedCustomDist.assertExists()
+
+        oldNotRecentlyUsedCacheDir.assertDoesNotExist()
+        oldNotRecentlyUsedDist.assertDoesNotExist()
+        oldNotRecentlyUsedCustomDist.assertDoesNotExist()
+
         currentCacheDir.assertExists()
         currentDist.assertExists()
+
         getGcFile(currentCacheDir).assertExists()
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest.groovy
@@ -32,16 +32,16 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceIntegrationTest ex
         and:
         def oldButRecentlyUsedVersion = GradleVersion.version("1.4.5")
         def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(oldButRecentlyUsedVersion, USED_TODAY)
-        def oldButRecentlyUsedDist = createDistributionChecksumDir(oldButRecentlyUsedVersion, "bin").parentFile
+        def oldButRecentlyUsedDist = createDistributionChecksumDir(oldButRecentlyUsedVersion).parentFile
         def oldButRecentlyUsedCustomDist = createCustomDistributionChecksumDir("my-dist-1", oldButRecentlyUsedVersion).parentFile
 
         def oldNotRecentlyUsedVersion = GradleVersion.version("2.3.4")
         def oldNotRecentlyUsedCacheDir = createVersionSpecificCacheDir(oldNotRecentlyUsedVersion, NOT_USED_WITHIN_30_DAYS)
-        def oldNotRecentlyUsedDist = createDistributionChecksumDir(oldNotRecentlyUsedVersion, "bin").parentFile
+        def oldNotRecentlyUsedDist = createDistributionChecksumDir(oldNotRecentlyUsedVersion).parentFile
         def oldNotRecentlyUsedCustomDist = createCustomDistributionChecksumDir("my-dist-2", oldNotRecentlyUsedVersion).parentFile
 
         def currentCacheDir = createVersionSpecificCacheDir(GradleVersion.current(), NOT_USED_WITHIN_30_DAYS)
-        def currentDist = createDistributionChecksumDir(GradleVersion.current(), "all").parentFile
+        def currentDist = createDistributionChecksumDir(GradleVersion.current()).parentFile
 
         when:
         succeeds("tasks")

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -35,8 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -46,7 +44,6 @@ import static org.gradle.util.CollectionUtils.single;
 public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
 
     @VisibleForTesting static final String WRAPPER_DISTRIBUTION_FILE_PATH = "wrapper/dists";
-    private static final Pattern DISTRIBUTION_PATTERN = Pattern.compile("^gradle-(\\d.+)-(?:(all)|(bin))$");
 
     private final File distsDir;
     private Multimap<GradleVersion, File> checksumDirsByVersion;
@@ -84,14 +81,6 @@ public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
     private Multimap<GradleVersion, File> determineChecksumDirsByVersion() {
         Multimap<GradleVersion, File> result = ArrayListMultimap.create();
         for (File dir : listDirs(distsDir)) {
-            Matcher matcher = DISTRIBUTION_PATTERN.matcher(dir.getName());
-            if (matcher.matches()) {
-                GradleVersion gradleVersion = tryParseGradleVersion(matcher.group(1));
-                if (gradleVersion != null) {
-                    result.putAll(gradleVersion, listDirs(dir));
-                    continue;
-                }
-            }
             for (File checksumDir : listDirs(dir)) {
                 GradleVersion gradleVersion = determineGradleVersionFromBuildReceipt(checksumDir);
                 if (gradleVersion != null) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -17,24 +17,39 @@
 package org.gradle.cache.internal;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.gradle.api.Action;
-import org.gradle.api.UncheckedIOException;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.util.GradleVersion;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.apache.commons.io.filefilter.FileFilterUtils.directoryFileFilter;
+import static org.gradle.util.CollectionUtils.single;
 
 public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
 
     @VisibleForTesting static final String WRAPPER_DISTRIBUTION_FILE_PATH = "wrapper/dists";
-    private static final Logger LOGGER = Logging.getLogger(WrapperDistributionCleanupAction.class);
-    private static final ImmutableList<String> DISTRIBUTION_TYPES = ImmutableList.of("bin", "all");
+    private static final Pattern DISTRIBUTION_PATTERN = Pattern.compile("^gradle-(\\d.+)-(?:(all)|(bin))$");
 
     private final File distsDir;
+    private Multimap<GradleVersion, File> checksumDirsByVersion;
 
     public WrapperDistributionCleanupAction(File gradleUserHomeDirectory) {
         this.distsDir = new File(gradleUserHomeDirectory, WRAPPER_DISTRIBUTION_FILE_PATH);
@@ -42,20 +57,105 @@ public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
 
     @Override
     public void execute(GradleVersion version) {
-        try {
-            deleteDistributions(version);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Error deleting distribution for " + version, e);
+        deleteDistributions(version);
+    }
+
+    private void deleteDistributions(GradleVersion version) {
+        Set<File> parentsOfDeletedDistributions = Sets.newLinkedHashSet();
+        for (File checksumDir : getChecksumDirsByVersion().get(version)) {
+            if (FileUtils.deleteQuietly(checksumDir)) {
+                parentsOfDeletedDistributions.add(checksumDir.getParentFile());
+            }
+        }
+        for (File parentDir : parentsOfDeletedDistributions) {
+            if (listFiles(parentDir).isEmpty()) {
+                parentDir.delete();
+            }
         }
     }
 
-    private void deleteDistributions(GradleVersion version) throws IOException {
-        for (String distributionType : DISTRIBUTION_TYPES) {
-            File dir = new File(distsDir, "gradle-" + version.getVersion() + "-" + distributionType);
-            if (dir.isDirectory()) {
-                LOGGER.debug("Deleting Gradle distribution at {}", dir);
-                FileUtils.deleteDirectory(dir);
+    private Multimap<GradleVersion, File> getChecksumDirsByVersion() {
+        if (checksumDirsByVersion == null) {
+            this.checksumDirsByVersion = determineChecksumDirsByVersion();
+        }
+        return checksumDirsByVersion;
+    }
+
+    private Multimap<GradleVersion, File> determineChecksumDirsByVersion() {
+        Multimap<GradleVersion, File> result = ArrayListMultimap.create();
+        for (File dir : listDirs(distsDir)) {
+            Matcher matcher = DISTRIBUTION_PATTERN.matcher(dir.getName());
+            if (matcher.matches()) {
+                GradleVersion gradleVersion = tryParseGradleVersion(matcher.group(1));
+                if (gradleVersion != null) {
+                    result.putAll(gradleVersion, listDirs(dir));
+                    continue;
+                }
             }
+            for (File checksumDir : listDirs(dir)) {
+                GradleVersion gradleVersion = determineGradleVersionFromBuildReceipt(checksumDir);
+                if (gradleVersion != null) {
+                    result.put(gradleVersion, checksumDir);
+                }
+            }
+        }
+        return result;
+    }
+
+    private GradleVersion determineGradleVersionFromBuildReceipt(File checksumDir) {
+        List<File> subDirs = listDirs(checksumDir);
+        if (subDirs.size() != 1) {
+            return null;
+        }
+        List<File> jarFiles = listFiles(new File(single(subDirs), "lib"), new RegexFileFilter("^gradle-base-services-\\d.+.jar$"));
+        return jarFiles.size() != 1 ? null : readGradleVersionFromJarFile(single(jarFiles));
+    }
+
+    private GradleVersion readGradleVersionFromJarFile(File jarFile) {
+        ZipFile zipFile = null;
+        try {
+            zipFile = new ZipFile(jarFile);
+            return readGradleVersionFromBuildReceipt(zipFile);
+        } catch (IOException ignore) {
+            return null;
+        } finally {
+            IOUtils.closeQuietly(zipFile);
+        }
+    }
+
+    private GradleVersion readGradleVersionFromBuildReceipt(ZipFile zipFile) throws IOException {
+        ZipEntry zipEntry = zipFile.getEntry(GradleVersion.RESOURCE_NAME);
+        if (zipEntry != null) {
+            InputStream in = zipFile.getInputStream(zipEntry);
+            try {
+                Properties properties = new Properties();
+                properties.load(in);
+                return tryParseGradleVersion(properties.getProperty(GradleVersion.VERSION_NUMBER_PROPERTY));
+            } finally {
+                in.close();
+            }
+        }
+        return null;
+    }
+
+    private List<File> listDirs(File baseDir) {
+        return listFiles(baseDir, directoryFileFilter());
+    }
+
+    private List<File> listFiles(File baseDir) {
+        return listFiles(baseDir, null);
+    }
+
+    private List<File> listFiles(File baseDir, FileFilter filter) {
+        File[] dirs = baseDir.listFiles(filter);
+        return dirs == null ? Collections.<File>emptyList() : Arrays.asList(dirs);
+    }
+
+    private GradleVersion tryParseGradleVersion(String versionString) {
+        try {
+            return GradleVersion.version(versionString);
+        } catch (Exception e) {
+            return null;
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
@@ -38,21 +38,17 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceTest extends Speci
         given:
         def oldVersion = GradleVersion.version("2.3.4")
         def oldCacheDir = createVersionSpecificCacheDir(oldVersion, NOT_USED_WITHIN_30_DAYS)
-        def oldAllDist = createDistributionChecksumDir(oldVersion, "all").parentFile
-        def oldBinDist = createDistributionChecksumDir(oldVersion, "bin").parentFile
-        def currentAllDist = createDistributionChecksumDir(currentVersion, "all").parentFile
-        def currentBinDist = createDistributionChecksumDir(currentVersion, "bin").parentFile
+        def oldDist = createDistributionChecksumDir(oldVersion).parentFile
+        def currentDist = createDistributionChecksumDir(currentVersion).parentFile
 
         when:
         cleanupService.stop()
 
         then:
         oldCacheDir.assertDoesNotExist()
-        oldAllDist.assertDoesNotExist()
-        oldBinDist.assertDoesNotExist()
+        oldDist.assertDoesNotExist()
         currentCacheDir.assertExists()
-        currentAllDist.assertExists()
-        currentBinDist.assertExists()
+        currentDist.assertExists()
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceTest.groovy
@@ -38,10 +38,10 @@ class VersionSpecificCacheAndWrapperDistributionCleanupServiceTest extends Speci
         given:
         def oldVersion = GradleVersion.version("2.3.4")
         def oldCacheDir = createVersionSpecificCacheDir(oldVersion, NOT_USED_WITHIN_30_DAYS)
-        def oldAllDist = createDistributionDir(oldVersion, "all")
-        def oldBinDist = createDistributionDir(oldVersion, "bin")
-        def currentAllDist = createDistributionDir(currentVersion, "all")
-        def currentBinDist = createDistributionDir(currentVersion, "bin")
+        def oldAllDist = createDistributionChecksumDir(oldVersion, "all").parentFile
+        def oldBinDist = createDistributionChecksumDir(oldVersion, "bin").parentFile
+        def currentAllDist = createDistributionChecksumDir(currentVersion, "all").parentFile
+        def currentBinDist = createDistributionChecksumDir(currentVersion, "bin").parentFile
 
         when:
         cleanupService.stop()

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.cache.internal
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
+import org.gradle.util.JarUtils
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
@@ -34,19 +35,102 @@ class WrapperDistributionCleanupActionTest extends Specification implements Vers
     def "deletes distributions for unused versions"() {
         given:
         def versionToCleanUp = GradleVersion.version("2.3.4")
-        def oldAllDist = createDistributionDir(versionToCleanUp, "all")
-        def oldBinDist = createDistributionDir(versionToCleanUp, "bin")
-        def currentAllDist = createDistributionDir(currentVersion, "all")
-        def currentBinDist = createDistributionDir(currentVersion, "bin")
+        def oldAllDist = createDistributionChecksumDir(versionToCleanUp, "all")
+        def oldBinDist = createDistributionChecksumDir(versionToCleanUp, "bin")
+        def currentAllDist = createDistributionChecksumDir(currentVersion, "all")
+        def currentBinDist = createDistributionChecksumDir(currentVersion, "bin")
 
         when:
         cleanupAction.execute(versionToCleanUp)
 
         then:
-        oldAllDist.assertDoesNotExist()
-        oldBinDist.assertDoesNotExist()
+        oldAllDist.parentFile.assertDoesNotExist()
+        oldBinDist.parentFile.assertDoesNotExist()
         currentAllDist.assertExists()
         currentBinDist.assertExists()
+    }
+
+    def "deletes custom distributions for unused versions"() {
+        given:
+        def versionToCleanUp = GradleVersion.version("2.3.4")
+        def oldAllDist = createCustomDistributionChecksumDir("my-all-dist-${versionToCleanUp.version}", versionToCleanUp)
+        def oldBinDist = createCustomDistributionChecksumDir("my-bin-dist-${versionToCleanUp.version}", versionToCleanUp)
+        def currentAllDist = createCustomDistributionChecksumDir("my-all-dist-${currentVersion.version}", currentVersion)
+        def currentBinDist = createCustomDistributionChecksumDir("my-bin-dist-${currentVersion.version}", currentVersion)
+
+        when:
+        cleanupAction.execute(versionToCleanUp)
+
+        then:
+        oldAllDist.parentFile.assertDoesNotExist()
+        oldBinDist.parentFile.assertDoesNotExist()
+        currentAllDist.assertExists()
+        currentBinDist.assertExists()
+    }
+
+    def "does not delete custom parent directories that are still in use"() {
+        given:
+        def versionToCleanUp = GradleVersion.version("2.3.4")
+        def oldDist = createCustomDistributionChecksumDir("my-dist", versionToCleanUp)
+        def currentDist = createCustomDistributionChecksumDir("my-dist", currentVersion)
+
+        when:
+        cleanupAction.execute(versionToCleanUp)
+
+        then:
+        oldDist.assertDoesNotExist()
+        currentDist.assertExists()
+    }
+
+    def "ignores custom distributions with multiple sub directories"() {
+        given:
+        def versionToCleanUp = GradleVersion.version("2.3.4")
+        def distributionWithMultipleSubDirectories = createCustomDistributionChecksumDir("my-dist", versionToCleanUp)
+        distributionWithMultipleSubDirectories.createDir("foo")
+
+        when:
+        cleanupAction.execute(versionToCleanUp)
+
+        then:
+        distributionWithMultipleSubDirectories.assertExists()
+    }
+
+    def "ignores custom distributions without gradle-base-services JAR"() {
+        given:
+        def versionToCleanUp = GradleVersion.version("2.3.4")
+        def distributionWithoutJar = createCustomDistributionChecksumDir("my-dist", versionToCleanUp, { version, jarFile -> })
+
+        when:
+        cleanupAction.execute(versionToCleanUp)
+
+        then:
+        distributionWithoutJar.assertExists()
+    }
+
+    def "ignores custom distributions without build receipt in gradle-base-services JAR"() {
+        given:
+        def versionToCleanUp = GradleVersion.version("2.3.4")
+        def distributionWithoutBuildReceiptInJar = createCustomDistributionChecksumDir("my-dist", versionToCleanUp) { version, jarFile ->
+            jarFile << JarUtils.jarWithContents(foo: "bar")
+        }
+
+        when:
+        cleanupAction.execute(versionToCleanUp)
+
+        then:
+        distributionWithoutBuildReceiptInJar.assertExists()
+    }
+
+    def "ignores distributions with invalid gradle version"() {
+        given:
+        def versionToCleanUp = GradleVersion.version("2.3.4")
+        def distributionWithInvalidVersionInDirName = createCustomDistributionChecksumDir("gradle-1-invalid-all", versionToCleanUp, { version, jarFile -> })
+
+        when:
+        cleanupAction.execute(versionToCleanUp)
+
+        then:
+        distributionWithInvalidVersionInDirName.assertExists()
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
@@ -35,19 +35,15 @@ class WrapperDistributionCleanupActionTest extends Specification implements Vers
     def "deletes distributions for unused versions"() {
         given:
         def versionToCleanUp = GradleVersion.version("2.3.4")
-        def oldAllDist = createDistributionChecksumDir(versionToCleanUp, "all")
-        def oldBinDist = createDistributionChecksumDir(versionToCleanUp, "bin")
-        def currentAllDist = createDistributionChecksumDir(currentVersion, "all")
-        def currentBinDist = createDistributionChecksumDir(currentVersion, "bin")
+        def oldDist = createDistributionChecksumDir(versionToCleanUp)
+        def currentDist = createDistributionChecksumDir(currentVersion)
 
         when:
         cleanupAction.execute(versionToCleanUp)
 
         then:
-        oldAllDist.parentFile.assertDoesNotExist()
-        oldBinDist.parentFile.assertDoesNotExist()
-        currentAllDist.assertExists()
-        currentBinDist.assertExists()
+        oldDist.parentFile.assertDoesNotExist()
+        currentDist.assertExists()
     }
 
     def "deletes custom distributions for unused versions"() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
@@ -34,8 +34,8 @@ trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture implements
         gradleUserHomeDir.file(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME)
     }
 
-    TestFile createDistributionChecksumDir(GradleVersion version, String distributionType) {
-        distsDir.file("gradle-${version.version}-$distributionType").createDir(UUID.randomUUID())
+    TestFile createDistributionChecksumDir(GradleVersion version) {
+        createCustomDistributionChecksumDir("gradle-${version.version}-all", version)
     }
 
     TestFile createCustomDistributionChecksumDir(String parentDirName, GradleVersion version, BiAction<GradleVersion, File> jarWriter = DEFAULT_JAR_WRITER) {


### PR DESCRIPTION
Custom distributions are now also deleted when a version has been
detected as unused as part of version-specific cache cleanup. In order
to determine the version of a custom distribution, the `versionNumber`
property is read from `build-receipt.properties` in
`lib/gradle-base-services-*.jar` of the distribution.

Resolves #5905.