### PR TITLE
Update mockito-kotlin to 1.6.0

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
     api("org.gradle:gradle-kotlin-dsl:0.18.4")
     testImplementation("junit:junit:4.12")
-    testImplementation("com.nhaarman:mockito-kotlin:1.5.0")
+    testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
 }

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("org.ow2.asm:asm-commons:6.0")
     implementation("com.google.code.gson:gson:2.7")
     testImplementation("junit:junit:4.12")
-    testImplementation("com.nhaarman:mockito-kotlin:1.5.0")
+    testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
 }
 
 gradlePlugin {


### PR DESCRIPTION
### Context

Update mockito-kotlin to 1.6.0 to support building `gradle/gradle` on Java 10.