### PR TITLE
Delete empty package directories

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -897,4 +897,28 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         succeeds "compileJava"
         output.contains "The CompileOptions.bootClasspath property has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the CompileOptions.bootstrapClasspath property instead."
     }
+
+    def "deletes empty packages dirs"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+        """
+        def a = file('src/main/java/com/foo/internal/A.java') << """
+            package com.foo.internal;
+            public class A {}
+        """
+        file('src/main/java/com/bar/B.java') << """
+            package com.bar;
+            public class B {}
+        """
+
+        succeeds "compileJava"
+        a.delete()
+
+        when:
+        succeeds "compileJava"
+
+        then:
+        ! file("build/classes/java/main/com/foo").exists()
+    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/SourceIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/SourceIncrementalJavaCompilationIntegrationTest.groovy
@@ -842,4 +842,25 @@ dependencies { compile 'net.sf.ehcache:ehcache:2.10.2' }
         then:
         failure.assertHasErrorOutput 'Runnable r = b;'
     }
+
+    def "deletes empty packages dirs"() {
+        given:
+        def a = file('src/main/java/com/foo/internal/A.java') << """
+            package com.foo.internal;
+            public class A {}
+        """
+        file('src/main/java/com/bar/B.java') << """
+            package com.bar;
+            public class B {}
+        """
+
+        succeeds "compileJava"
+        a.delete()
+
+        when:
+        succeeds "compileJava"
+
+        then:
+        ! file("build/classes/java/main/com/foo").exists()
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilationInitializer.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
+import org.gradle.language.base.internal.tasks.SimpleStaleClassCleaner;
 
 import java.io.File;
 import java.util.Collection;
@@ -78,12 +79,14 @@ class IncrementalCompilationInitializer {
         spec.setClasses(classesToProcess);
     }
 
-    private void deleteStaleFilesIn(PatternSet classesToDelete, File destinationDir) {
+    private void deleteStaleFilesIn(PatternSet filesToDelete, final File destinationDir) {
         if (destinationDir == null) {
             return;
         }
-        FileTree deleteMe = fileOperations.fileTree(destinationDir).matching(classesToDelete);
-        fileOperations.delete(deleteMe);
+        Set<File> toDelete = fileOperations.fileTree(destinationDir).matching(filesToDelete).getFiles();
+        SimpleStaleClassCleaner cleaner = new SimpleStaleClassCleaner(toDelete);
+        cleaner.addDirToClean(destinationDir);
+        cleaner.execute();
     }
 
     @VisibleForTesting

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/tasks/StaleClassCleaner.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/tasks/StaleClassCleaner.java
@@ -15,17 +15,10 @@
  */
 package org.gradle.language.base.internal.tasks;
 
-import com.google.common.collect.Sets;
-
 import java.io.File;
-import java.util.Set;
 
 public abstract class StaleClassCleaner {
-    protected Set<String> prefixes = Sets.newHashSet();
-
     public abstract void execute();
 
-    public void addDirToClean(File toClean) {
-        prefixes.add(toClean.getAbsolutePath() + File.separator);
-    }
+    public abstract void addDirToClean(File toClean);
 }


### PR DESCRIPTION
When all classes of a package have been removed,
the package directory in the output directory
will now be removed as well. This ensures that
the resulting JAR will be byte-for-byte equivalent
to a clean build.

Fixes https://github.com/gradle/gradle/issues/3405