### PR TITLE
Improve performance of nodes being queued

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
@@ -41,7 +41,7 @@ class DefaultPendingDependenciesHandler implements PendingDependenciesHandler {
             if (!isOptionalDependency) {
                 // Mark as not pending. If we saw pending dependencies before, mark them as no longer pending
                 PendingDependencies priorPendingDependencies = pendingDependencies.notPending(key);
-                if (priorPendingDependencies != null) {
+                if (priorPendingDependencies != null && priorPendingDependencies.isPending()) {
                     if (noLongerPending == null) {
                         noLongerPending = Lists.newLinkedList();
                     }


### PR DESCRIPTION
## Context

When fixing #5925 I have found that handing of nodes could be made faster by avoiding addition to a "queued" set, and avoiding restarting nodes which are already in a restart state. This was particularly visible when a node had several "pending" dependencies, and it could be added several times to the queue, or at least we tried to.