### PR TITLE
Log info instead of warning on cleanup timeout

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -40,7 +40,7 @@ public abstract class AbstractCacheCleanup implements CleanupAction {
         int filesDeleted = 0;
         for (File file : findEligibleFiles(cleanableStore)) {
             if (timer.hasExpired()) {
-                LOGGER.warn("{} cleanup was aborted because timeout has expired", cleanableStore.getDisplayName());
+                LOGGER.debug("{} cleanup was aborted because timeout has expired", cleanableStore.getDisplayName());
                 break;
             }
             if (shouldDelete(file)) {
@@ -50,7 +50,7 @@ public abstract class AbstractCacheCleanup implements CleanupAction {
                 }
             }
         }
-        LOGGER.info("{} cleanup deleted {} files/directories.", cleanableStore.getDisplayName(), filesDeleted);
+        LOGGER.debug("{} cleanup deleted {} files/directories.", cleanableStore.getDisplayName(), filesDeleted);
     }
 
     protected int deleteEmptyParentDirectories(File baseDir, File dir) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -208,10 +208,13 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
             if (cleanupAction != null) {
                 CountdownTimer timer = Time.startCountdownTimer(DEFAULT_CLEANUP_TIMEOUT);
                 cleanupAction.clean(DefaultPersistentDirectoryStore.this, timer);
-                if (!timer.hasExpired()) {
+                if (timer.hasExpired()) {
+                    LOGGER.info("{} partially cleaned up in {}. Cleanup was aborted because it took too long to complete but will be resumed next time.",
+                        DefaultPersistentDirectoryStore.this, timer.getElapsed());
+                } else {
                     GFileUtils.touch(gcFile);
+                    LOGGER.info("{} fully cleaned up in {}.", DefaultPersistentDirectoryStore.this, timer.getElapsed());
                 }
-                LOGGER.info("{} cleaned up in {}.", DefaultPersistentDirectoryStore.this, timer.getElapsed());
             }
         }
     }


### PR DESCRIPTION
When the timeout for cache cleanup expires, there's no need to warn
users about it because it just will continue where it left off during
the next cleanup.