### PR TITLE
Clarify deprecation message for FileTrees as outputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1252,7 +1252,7 @@ task generate(type: TransformerTask) {
 
         then:
         skippedTasks.contains(':myTask')
-        output.contains('Adding file trees which are not directory trees as output files has been deprecated and is scheduled to be removed in Gradle 5.0')
+        output.contains('Adding file trees which are not directory based as output files has been deprecated and is scheduled to be removed in Gradle 5.0')
     }
 
     def "task with no actions is skipped even if it has inputs"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1252,7 +1252,7 @@ task generate(type: TransformerTask) {
 
         then:
         skippedTasks.contains(':myTask')
-        output.contains('Adding file trees which are not directory based as output files has been deprecated and is scheduled to be removed in Gradle 5.0')
+        output.contains('The ability to add non-directory-based file trees as declared outputs has been deprecated and is scheduled to be removed in Gradle 5.0')
     }
 
     def "task with no actions is skipped even if it has inputs"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
@@ -358,7 +358,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
 
             @Override
             public void visitTree(FileTreeInternal fileTree) {
-                DeprecationLogger.nagUserOfDeprecated("Adding file trees which are not directory trees as output files");
+                DeprecationLogger.nagUserOfDeprecated("Adding file trees which are not directory based as output files");
                 addAllPaths(fileTree, declaredOutputFilePaths, stringInterner);
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
@@ -358,7 +358,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
 
             @Override
             public void visitTree(FileTreeInternal fileTree) {
-                DeprecationLogger.nagUserOfDeprecated("Adding file trees which are not directory based as output files");
+                DeprecationLogger.nagUserOfDeprecated("The ability to add non-directory-based file trees as declared outputs");
                 addAllPaths(fileTree, declaredOutputFilePaths, stringInterner);
             }
 


### PR DESCRIPTION
The userguide does not say what a directory tree is.