### PR TITLE
Move :docs:userguideAsciidoc into sanityCheck

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ buildTypes {
     create("sanityCheck") {
         tasks(
             "classes", "doc:checkstyleApi", "codeQuality",
+            "docs:userguideAsciidoc", // This is in sanityCheck because we want to leverage build cache and avoid https://github.com/gradle/gradle-private/issues/1352
             "docs:check", "distribution:checkBinaryCompatibility", "javadocAll")
         projectProperties("ignoreIncomingBuildReceipt" to true)
     }


### PR DESCRIPTION
### Context

Previously, there're two issues on `docs:userguideAsciidoc`:

- https://github.com/gradle/gradle-private/issues/1352 because of the jruby usage
- `docs:userguideAsciidoc` were executed by multiple build agents simultaneously in `QuickFeedbackLinuxOnly` stage (e.g. [this one](https://e.grdev.net/s/bpfn42ohsta66/)), so all of them get cache-miss.

This PR moves `docs:userguideAsciidoc` into `sanityCheck`. Later, as a workaround of https://github.com/gradle/gradle-private/issues/1352, we make `sanityCheck` use
`--no-daemon`. 

@wolfs Do you think we should move the whole `binZip`/`srcZip`/`allZip` tasks into `sanityCheck` to leverage build-cache?