### PR TITLE
Remove leading slash when reading from JAR file

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionIntegrationTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
+
+class WrapperDistributionCleanupActionIntegrationTest extends AbstractIntegrationSpec {
+
+    def "reads Gradle version from actual distribution"() {
+        given:
+        def cleanupAction = new WrapperDistributionCleanupAction(executer.gradleUserHomeDir)
+
+        when:
+        def gradleVersion = cleanupAction.determineGradleVersionFromDistribution(executer.distribution.gradleHomeDir)
+
+        then:
+        gradleVersion == GradleVersion.current()
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
@@ -26,7 +26,7 @@ import static org.gradle.cache.internal.WrapperDistributionCleanupAction.WRAPPER
 trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture implements VersionSpecificCacheCleanupFixture {
 
     private static final BiAction<GradleVersion, File> DEFAULT_JAR_WRITER = { version, jarFile ->
-        jarFile << JarUtils.jarWithContents((GradleVersion.RESOURCE_NAME): "${GradleVersion.VERSION_NUMBER_PROPERTY}: ${version.version}")
+        jarFile << JarUtils.jarWithContents((GradleVersion.RESOURCE_NAME.substring(1)): "${GradleVersion.VERSION_NUMBER_PROPERTY}: ${version.version}")
     }
 
     @Override


### PR DESCRIPTION
This commit fixes reading the Gradle version from the build receipt in
the base-services JAR. ZIP entries must be read without a leading slash.
It adds an integration test to check that reading from an actual JAR
file in a distribution works.

Issue: #5742