### PR TITLE
Make UriNotationConverter faster on Windows

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -98,20 +98,19 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
                 result.converted(new File(uriDecode(notationString.substring(5))));
                 return;
             }
-            for (File file : File.listRoots()) {
-                String rootPath = file.getAbsolutePath();
-                String normalisedStr = notationString;
-                if (!fileSystem.isCaseSensitive()) {
-                    rootPath = rootPath.toLowerCase();
-                    normalisedStr = normalisedStr.toLowerCase();
-                }
-                if (normalisedStr.startsWith(rootPath) || normalisedStr.startsWith(rootPath.replace(File.separatorChar, '/'))) {
-                    result.converted(new File(notationString));
-                    return;
-                }
-            }
-            // Check if string starts with a URI scheme
             if (URI_SCHEME.matcher(notationString).matches()) {
+                for (File file : File.listRoots()) {
+                    String rootPath = file.getAbsolutePath();
+                    String normalisedStr = notationString;
+                    if (!fileSystem.isCaseSensitive()) {
+                        rootPath = rootPath.toLowerCase();
+                        normalisedStr = normalisedStr.toLowerCase();
+                    }
+                    if (normalisedStr.startsWith(rootPath) || normalisedStr.startsWith(rootPath.replace(File.separatorChar, '/'))) {
+                        result.converted(new File(notationString));
+                        return;
+                    }
+                }
                 try {
                     result.converted(new URI(notationString));
                     return;


### PR DESCRIPTION
Windows paths can look very much like a URI,
which is why we need to disambiguation between them
by looking at the file system.

However, this is only necessary if the notation starts
with what looks like a URI scheme. In the vast majority
of cases, the notation converter is called with relative
paths that don't have this problem. This change makes
that common case much faster.

Fixes #5951