### PR TITLE
Fix distribution cleanup for pre 4.x releases

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -19,6 +19,8 @@ package org.gradle.cache.internal;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
@@ -33,11 +35,14 @@ import org.gradle.util.GradleVersion;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -48,6 +53,20 @@ public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
 
     @VisibleForTesting static final String WRAPPER_DISTRIBUTION_FILE_PATH = "wrapper/dists";
     private static final Logger LOGGER = Logging.getLogger(WrapperDistributionCleanupAction.class);
+
+    private static final ImmutableMap<String, Pattern> JAR_FILE_PATTERNS_BY_PREFIX;
+    static {
+        Set<String> prefixes = ImmutableSet.of(
+            "gradle-base-services", // 4.x
+            "gradle-version-info", // 2.x - 3.x
+            "gradle-core" // 1.x
+        );
+        ImmutableMap.Builder<String, Pattern> builder = ImmutableMap.builder();
+        for (String prefix : prefixes) {
+            builder.put(prefix, Pattern.compile('^' + Pattern.quote(prefix) + "-\\d.+.jar$"));
+        }
+        JAR_FILE_PATTERNS_BY_PREFIX = builder.build();
+    }
 
     private final File distsDir;
     private Multimap<GradleVersion, File> checksumDirsByVersion;
@@ -64,6 +83,7 @@ public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
     private void deleteDistributions(GradleVersion version) {
         Set<File> parentsOfDeletedDistributions = Sets.newLinkedHashSet();
         for (File checksumDir : getChecksumDirsByVersion().get(version)) {
+            LOGGER.debug("Deleting distribution at {}", checksumDir);
             if (FileUtils.deleteQuietly(checksumDir)) {
                 parentsOfDeletedDistributions.add(checksumDir.getParentFile());
             }
@@ -105,9 +125,20 @@ public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
 
     @VisibleForTesting
     protected GradleVersion determineGradleVersionFromDistribution(File distributionHomeDir) throws Exception {
-        List<File> jarFiles = listFiles(new File(distributionHomeDir, "lib"), new RegexFileFilter("^gradle-base-services-\\d.+.jar$"));
-        Preconditions.checkArgument(jarFiles.size() == 1, "A Gradle distribution must contain exactly one gradle-base-services-*.jar: %s", jarFiles);
-        return readGradleVersionFromJarFile(single(jarFiles));
+        List<File> checkedJarFiles = new ArrayList<File>();
+        for (Map.Entry<String, Pattern> entry : JAR_FILE_PATTERNS_BY_PREFIX.entrySet()) {
+            List<File> jarFiles = listFiles(new File(distributionHomeDir, "lib"), new RegexFileFilter(entry.getValue()));
+            if (!jarFiles.isEmpty()) {
+                Preconditions.checkArgument(jarFiles.size() == 1, "A Gradle distribution must contain at most one %s-*.jar: %s", entry.getKey(), jarFiles);
+                File jarFile = single(jarFiles);
+                GradleVersion gradleVersion = readGradleVersionFromJarFile(jarFile);
+                if (gradleVersion != null) {
+                    return gradleVersion;
+                }
+                checkedJarFiles.add(jarFile);
+            }
+        }
+        throw new IllegalArgumentException("No checked JAR file contained a build receipt: " + checkedJarFiles);
     }
 
     private GradleVersion readGradleVersionFromJarFile(File jarFile) throws Exception {
@@ -122,7 +153,9 @@ public class WrapperDistributionCleanupAction implements Action<GradleVersion> {
 
     private GradleVersion readGradleVersionFromBuildReceipt(ZipFile zipFile) throws Exception {
         ZipEntry zipEntry = zipFile.getEntry(StringUtils.removeStart(GradleVersion.RESOURCE_NAME, "/"));
-        Preconditions.checkArgument(zipEntry != null, "%s must contain " + GradleVersion.RESOURCE_NAME, zipFile.getName());
+        if (zipEntry == null) {
+            return null;
+        }
         InputStream in = zipFile.getInputStream(zipEntry);
         try {
             Properties properties = new Properties();

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture.groovy
@@ -28,20 +28,21 @@ trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture implements
     private static final BiAction<GradleVersion, File> DEFAULT_JAR_WRITER = { version, jarFile ->
         jarFile << JarUtils.jarWithContents((GradleVersion.RESOURCE_NAME.substring(1)): "${GradleVersion.VERSION_NUMBER_PROPERTY}: ${version.version}")
     }
+    static final String DEFAULT_JAR_PREFIX = 'gradle-base-services'
 
     @Override
     TestFile getCachesDir() {
         gradleUserHomeDir.file(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME)
     }
 
-    TestFile createDistributionChecksumDir(GradleVersion version) {
-        createCustomDistributionChecksumDir("gradle-${version.version}-all", version)
+    TestFile createDistributionChecksumDir(GradleVersion version, String jarPrefix = DEFAULT_JAR_PREFIX) {
+        createCustomDistributionChecksumDir("gradle-${version.version}-all", version, jarPrefix)
     }
 
-    TestFile createCustomDistributionChecksumDir(String parentDirName, GradleVersion version, BiAction<GradleVersion, File> jarWriter = DEFAULT_JAR_WRITER) {
+    TestFile createCustomDistributionChecksumDir(String parentDirName, GradleVersion version, String jarPrefix = DEFAULT_JAR_PREFIX, BiAction<GradleVersion, File> jarWriter = DEFAULT_JAR_WRITER) {
         def checksumDir = distsDir.file(parentDirName).createDir(UUID.randomUUID())
         def libDir = checksumDir.file("gradle-${version.baseVersion.version}", "lib").createDir()
-        def jarFile = libDir.file("gradle-base-services-${version.baseVersion.version}.jar")
+        def jarFile = libDir.file("$jarPrefix-${version.baseVersion.version}.jar")
         jarWriter.execute(version, jarFile)
         return checksumDir
     }


### PR DESCRIPTION
The build receipt properties file has only been part of
`gradle-base-services-*.jar` since 4.x. Gradle 1.x packaged it in
`gradle-core-1.x.jar`, Gradle 2.x and 3.x used
`gradle-version-info-*.jar`.

With the change in this commit, we now first attempt the current
location and use the old ones as fallbacks.

Issue: #5742