### PR TITLE
Avoid caching "patchExternalModules"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -274,6 +274,7 @@ tasks.register<PatchExternalModules>("patchExternalModules") {
     coreModules = coreRuntime
     modulesToPatch = this@Build_gradle.externalModules
     destination = patchedExternalModulesDir
+    outputs.doNotCacheIf("Not running on CI") { !System.getenv().containsKey("CI") }
 }
 
 evaluationDependsOn(":distributions")


### PR DESCRIPTION
### Context

On slower internet connections like mine (5mbit/s), it takes less time to re-execute the task than downloading the outputs from the cache. Ideally, this should be inferred at some point.

