### PR TITLE
Fix thread leak in worker API

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutor.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutor.java
@@ -37,4 +37,9 @@ public interface ManagedExecutor extends AsyncStoppable, ExecutorService {
      * Sets the fixed size of the thread pool for the executor.
      */
     void setFixedPoolSize(int numThreads);
+
+    /**
+     * Sets the keep alive time for the thread pool of the executor.
+     */
+    void setKeepAlive(int timeout, TimeUnit timeUnit);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutorImpl.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutorImpl.java
@@ -103,4 +103,13 @@ class ManagedExecutorImpl extends AbstractDelegatingExecutorService implements M
             throw new UnsupportedOperationException();
         }
     }
+
+    @Override
+    public void setKeepAlive(int timeout, TimeUnit timeUnit) {
+        if (executor instanceof ThreadPoolExecutor) {
+            ((ThreadPoolExecutor)executor).setKeepAliveTime(timeout, timeUnit);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -27,6 +27,7 @@ import org.gradle.internal.resources.ResourceLockState;
 
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -38,6 +39,7 @@ import static org.gradle.internal.resources.DefaultResourceLockCoordinationServi
 // TODO This class, DefaultBuildOperationQueue and TaskExecutionPlan have many of the same
 // behavior and concerns - we should look for a way to generalize this pattern.
 public class DefaultConditionalExecutionQueue<T> implements ConditionalExecutionQueue<T> {
+    public static final int KEEP_ALIVE_TIME_MS = 2000;
     private enum QueueState {
         Working, Stopped
     }
@@ -55,6 +57,8 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         this.maxWorkers = maxWorkers;
         this.executor = executorFactory.create(displayName);
         this.coordinationService = coordinationService;
+
+        executor.setKeepAlive(KEEP_ALIVE_TIME_MS, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -65,6 +69,7 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
 
         lock.lock();
         try {
+            // expand the thread pool until we hit max workers
             if (workerCount < maxWorkers) {
                 expand(true);
             }
@@ -81,9 +86,17 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         expand(false);
     }
 
+    /**
+     * Expanding the thread pool is necessary when work items submit other work.  We want to avoid a starvation scenario where
+     * the thread pool is full of work items that are waiting on other queued work items.  The queued work items cannot execute
+     * because the thread pool is already full with their parent work items.  We use expand() to allow the thread pool to temporarily
+     * expand when work items have to wait on other work.  The thread pool will shrink below max workers again once the queue is
+     * drained.
+     */
     private void expand(boolean force) {
         lock.lock();
         try {
+            // Only expand the thread pool if there is work in the queue or we know that work is about to be submitted (i.e. force == true)
             if (force || !queue.isEmpty()) {
                 executor.submit(new ExecutionRunner());
                 workerCount++;
@@ -105,6 +118,10 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         executor.stop();
     }
 
+    /**
+     * ExecutionRunners process items from the queue until there are no items left, at which point it will either wait for
+     * new items to arrive (if there are < max workers threads running) or exit, finishing the thread.
+     */
     private class ExecutionRunner implements Runnable {
         @Override
         public void run() {
@@ -118,7 +135,9 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         private ConditionalExecution waitForNextOperation() {
             lock.lock();
             try {
-                while (queueState == QueueState.Working && queue.isEmpty()) {
+                // Wait for work to be submitted if the queue is empty and our worker count is under max workers
+                // This attempts to keep up to max workers threads alive once they've been started.
+                while (queueState == QueueState.Working && queue.isEmpty() && (workerCount <= maxWorkers)) {
                     try {
                         workAvailable.await();
                     } catch (InterruptedException e) {
@@ -133,6 +152,9 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
             return getReadyExecution();
         }
 
+        /**
+         * Run executions until there are none ready to be executed.
+         */
         private void runBatch(final ConditionalExecution firstOperation) {
             ConditionalExecution operation = firstOperation;
             while (operation != null) {
@@ -142,7 +164,10 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         }
 
         /**
-         * Gets the next ConditionalExecution object that is ready to be executed.
+         * Gets the next ConditionalExecution object that is ready to be executed.  It does this by
+         * attempting to acquire the associated resource lock of each execution.  If successful, the
+         * execution is removed from the queue and returned.  If unsuccessful, it continues to iterate
+         * the queue looking for an execution that is ready to execute.
          */
         private ConditionalExecution getReadyExecution() {
             final MutableReference<ConditionalExecution> execution = MutableReference.empty();
@@ -179,6 +204,9 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
             return execution.get();
         }
 
+        /**
+         * Executes a conditional execution and then releases it's resource lock
+         */
         private void runExecution(ConditionalExecution execution) {
             try {
                 execution.getExecution().run();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -66,7 +66,7 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         lock.lock();
         try {
             if (workerCount < maxWorkers) {
-                expand();
+                expand(true);
             }
 
             queue.add(execution);
@@ -78,10 +78,16 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
 
     @Override
     public void expand() {
+        expand(false);
+    }
+
+    private void expand(boolean force) {
         lock.lock();
         try {
-            executor.submit(new ExecutionRunner());
-            workerCount++;
+            if (force || !queue.isEmpty()) {
+                executor.submit(new ExecutionRunner());
+                workerCount++;
+            }
         } finally {
             lock.unlock();
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -49,7 +49,7 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
     private final ReentrantLock lock = new ReentrantLock();
     private final Condition workAvailable = lock.newCondition();
     private QueueState queueState = QueueState.Working;
-    private int workerCount;
+    private volatile int workerCount;
 
     public DefaultConditionalExecutionQueue(String displayName, int maxWorkers, ExecutorFactory executorFactory, ResourceLockCoordinationService coordinationService) {
         this.maxWorkers = maxWorkers;

--- a/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
@@ -41,4 +41,9 @@ public interface AsyncWorkTracker {
      * @param releaseLocks - Whether or not project locks should be released while waiting on work
      */
     void waitForCompletion(BuildOperationRef operation, boolean releaseLocks);
+
+    /**
+     * Returns true if the given operation has work registered that has not completed.
+     */
+    boolean hasUncompletedWork(BuildOperationRef operation);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
@@ -92,6 +92,22 @@ public class DefaultAsyncWorkTracker implements AsyncWorkTracker {
         }
     }
 
+    @Override
+    public boolean hasUncompletedWork(BuildOperationRef operation) {
+        lock.lock();
+        try {
+            List<AsyncWorkCompletion> workItems = ImmutableList.copyOf(items.get(operation));
+            return CollectionUtils.any(workItems, new Spec<AsyncWorkCompletion>() {
+                @Override
+                public boolean isSatisfiedBy(AsyncWorkCompletion workCompletion) {
+                    return !workCompletion.isComplete();
+                }
+            });
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private void waitForItemsAndGatherFailures(Iterable<AsyncWorkCompletion> workItems) {
         final List<Throwable> failures = Lists.newArrayList();
         for (AsyncWorkCompletion item : workItems) {

--- a/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
@@ -96,13 +96,13 @@ public class DefaultAsyncWorkTracker implements AsyncWorkTracker {
     public boolean hasUncompletedWork(BuildOperationRef operation) {
         lock.lock();
         try {
-            List<AsyncWorkCompletion> workItems = ImmutableList.copyOf(items.get(operation));
-            return CollectionUtils.any(workItems, new Spec<AsyncWorkCompletion>() {
-                @Override
-                public boolean isSatisfiedBy(AsyncWorkCompletion workCompletion) {
-                    return !workCompletion.isComplete();
+            List<AsyncWorkCompletion> workItems = items.get(operation);
+            for (AsyncWorkCompletion workCompletion : workItems) {
+                if (!workCompletion.isComplete()) {
+                    return true;
                 }
-            });
+            }
+            return false;
         } finally {
             lock.unlock();
         }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/ConcurrentTestUtil.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/ConcurrentTestUtil.groovy
@@ -498,6 +498,11 @@ class ManagedExecutorStub extends AbstractExecutorService implements ManagedExec
     void setFixedPoolSize(int numThreads) {
         throw new UnsupportedOperationException()
     }
+
+    @Override
+    void setKeepAlive(int timeout, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException()
+    }
 }
 
 class AbstractAsyncAction {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/concurrent/TestManagedExecutor.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/concurrent/TestManagedExecutor.groovy
@@ -99,4 +99,9 @@ class TestManagedExecutor extends AbstractExecutorService implements ManagedExec
     void setFixedPoolSize(int numThreads) {
         throw new UnsupportedOperationException()
     }
+
+    @Override
+    void setKeepAlive(int timeout, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException()
+    }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -400,7 +400,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                     println "threads: \${threadGroup.activeCount()} groups: \${threadGroup.activeGroupCount()}"
                     def threads = new Thread[threadGroup.activeCount()]
                     threadGroup.enumerate(threads) 
-                    def executorThreads = threads.findAll { it.name.startsWith("${DefaultWorkerExecutor.QUEUE_DISPLAY_NAME}") } 
+                    def executorThreads = threads.findAll { it.name.startsWith("${WorkerExecutionQueueFactory.QUEUE_DISPLAY_NAME}") } 
                     threads.each { println it }
                     assert executorThreads.size() <= ${maxWorkers}
                 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -397,11 +397,13 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 }
                 doLast {
                     def threadGroup = Thread.currentThread().threadGroup
-                    println "threads: \${threadGroup.activeCount()} groups: \${threadGroup.activeGroupCount()}"
+                    println "\\nWorker Executor threads:"
                     def threads = new Thread[threadGroup.activeCount()]
                     threadGroup.enumerate(threads) 
                     def executorThreads = threads.findAll { it.name.startsWith("${WorkerExecutionQueueFactory.QUEUE_DISPLAY_NAME}") } 
-                    threads.each { println it }
+                    executorThreads.each { println it }
+                    
+                    // Ensure that we don't leave any threads lying around
                     assert executorThreads.size() <= ${maxWorkers}
                 }
             }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -21,7 +21,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.classloader.FilteringClassLoader;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.file.PathToFileResolver;
@@ -32,7 +31,6 @@ import org.gradle.internal.work.AbstractConditionalExecution;
 import org.gradle.internal.work.AsyncWorkCompletion;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.internal.work.ConditionalExecutionQueue;
-import org.gradle.internal.work.ConditionalExecutionQueueFactory;
 import org.gradle.internal.work.NoAvailableWorkerLeaseException;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
@@ -49,8 +47,7 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-public class DefaultWorkerExecutor implements WorkerExecutor, Stoppable {
-    public static final String QUEUE_DISPLAY_NAME = "WorkerExecutor Queue";
+public class DefaultWorkerExecutor implements WorkerExecutor {
     private final ConditionalExecutionQueue<DefaultWorkResult> executionQueue;
     private final WorkerFactory daemonWorkerFactory;
     private final WorkerFactory isolatedClassloaderWorkerFactory;
@@ -63,21 +60,16 @@ public class DefaultWorkerExecutor implements WorkerExecutor, Stoppable {
 
     public DefaultWorkerExecutor(WorkerFactory daemonWorkerFactory, WorkerFactory isolatedClassloaderWorkerFactory, WorkerFactory noIsolationWorkerFactory,
                                  PathToFileResolver fileResolver, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor,
-                                 AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
+                                 AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory workerExecutionQueueFactory) {
         this.daemonWorkerFactory = daemonWorkerFactory;
         this.isolatedClassloaderWorkerFactory = isolatedClassloaderWorkerFactory;
         this.noIsolationWorkerFactory = noIsolationWorkerFactory;
         this.fileResolver = fileResolver;
-        this.executionQueue = conditionalExecutionQueueFactory.create(QUEUE_DISPLAY_NAME, DefaultWorkResult.class);
+        this.executionQueue = workerExecutionQueueFactory.create();
         this.workerLeaseRegistry = workerLeaseRegistry;
         this.buildOperationExecutor = buildOperationExecutor;
         this.asyncWorkTracker = asyncWorkTracker;
         this.workerDirectoryProvider = workerDirectoryProvider;
-    }
-
-    @Override
-    public void stop() {
-        executionQueue.stop();
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -31,6 +31,7 @@ import org.gradle.internal.work.AbstractConditionalExecution;
 import org.gradle.internal.work.AsyncWorkCompletion;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.internal.work.ConditionalExecutionQueue;
+import org.gradle.internal.work.DefaultConditionalExecutionQueue;
 import org.gradle.internal.work.NoAvailableWorkerLeaseException;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
@@ -130,6 +131,12 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         }
     }
 
+    /**
+     * Wait for any outstanding work to complete.  Note that if there is uncompleted work associated
+     * with the current build operation, we'll also temporarily expand the thread pool of the execution queue.
+     * This is to avoid a thread starvation scenario (see {@link DefaultConditionalExecutionQueue#expand(boolean)}
+     * for further details).
+     */
     @Override
     public void await() throws WorkerExecutionException {
         BuildOperationRef currentOperation = buildOperationExecutor.getCurrentOperation();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerExecutionQueueFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerExecutionQueueFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.internal.Factory;
+import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.work.ConditionalExecutionQueue;
+import org.gradle.internal.work.ConditionalExecutionQueueFactory;
+
+import javax.annotation.Nullable;
+
+public class WorkerExecutionQueueFactory implements Factory<ConditionalExecutionQueue<DefaultWorkResult>>, Stoppable {
+    public static final String QUEUE_DISPLAY_NAME = "WorkerExecutor Queue";
+    private final ConditionalExecutionQueueFactory conditionalExecutionQueueFactory;
+    private ConditionalExecutionQueue<DefaultWorkResult> queue;
+
+    public WorkerExecutionQueueFactory(ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
+        this.conditionalExecutionQueueFactory = conditionalExecutionQueueFactory;
+    }
+
+    @Nullable
+    @Override
+    public ConditionalExecutionQueue<DefaultWorkResult> create() {
+        if (queue == null) {
+            queue = conditionalExecutionQueueFactory.create(QUEUE_DISPLAY_NAME, DefaultWorkResult.class);
+        }
+        return queue;
+    }
+
+    @Override
+    public void stop() {
+        if (queue != null) {
+            queue.stop();
+        }
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -87,9 +87,9 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     }
 
     private static class ProjectScopeServices {
-        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, PathToFileResolver fileResolver, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory wor) {
+        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, PathToFileResolver fileResolver, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory workerExecutionQueueFactory) {
             NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, asyncWorkTracker, instantiatorFactory);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorate().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, wor);
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorate().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory);
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -68,6 +68,13 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
             return new DefaultWorkerDirectoryProvider(gradleUserHomeDirProvider);
         }
 
+        ConditionalExecutionQueueFactory createConditionalExecutionQueueFactory(ExecutorFactory executorFactory, ParallelismConfiguration parallelismConfiguration, ResourceLockCoordinationService resourceLockCoordinationService) {
+            return new DefaultConditionalExecutionQueueFactory(parallelismConfiguration, executorFactory, resourceLockCoordinationService);
+        }
+
+        WorkerExecutionQueueFactory createWorkerExecutionQueueFactory(ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
+            return new WorkerExecutionQueueFactory(conditionalExecutionQueueFactory);
+        }
     }
 
     private static class GradleUserHomeServices {
@@ -80,14 +87,9 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     }
 
     private static class ProjectScopeServices {
-
-        ConditionalExecutionQueueFactory createConditionalExecutionQueueFactory(ExecutorFactory executorFactory, ParallelismConfiguration parallelismConfiguration, ResourceLockCoordinationService resourceLockCoordinationService) {
-            return new DefaultConditionalExecutionQueueFactory(parallelismConfiguration, executorFactory, resourceLockCoordinationService);
-        }
-
-        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, PathToFileResolver fileResolver, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
+        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, PathToFileResolver fileResolver, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory wor) {
             NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, asyncWorkTracker, instantiatorFactory);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorate().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, conditionalExecutionQueueFactory);
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorate().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, fileResolver, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, wor);
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.internal.file.PathToFileResolver
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
 import org.gradle.internal.work.ConditionalExecutionQueue
-import org.gradle.internal.work.ConditionalExecutionQueueFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
@@ -44,7 +43,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def fileResolver = Mock(PathToFileResolver)
     def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def instantiatorFactory = Mock(InstantiatorFactory)
-    def executionQueueFactory = Mock(ConditionalExecutionQueueFactory)
+    def executionQueueFactory = Mock(WorkerExecutionQueueFactory)
     def executionQueue = Mock(ConditionalExecutionQueue)
     ListenableFutureTask task
     DefaultWorkerExecutor workerExecutor
@@ -52,7 +51,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def setup() {
         _ * fileResolver.resolve(_ as File) >> { files -> files[0] }
         _ * fileResolver.resolve(_ as String) >> { files -> new File(files[0]) }
-        _ * executionQueueFactory.create(_, _) >> executionQueue
+        _ * executionQueueFactory.create() >> executionQueue
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, fileResolver, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory)
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
 import org.gradle.internal.work.ConditionalExecution
 import org.gradle.internal.work.ConditionalExecutionQueue
-import org.gradle.internal.work.ConditionalExecutionQueueFactory
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.util.RedirectStdOutAndErr
@@ -47,7 +46,7 @@ class DefaultWorkerExecutorTest extends Specification {
     def workerDirectoryProvider = Mock(WorkerDirectoryProvider)
     def runnable = Mock(Runnable)
     def instantiatorFactory = Mock(InstantiatorFactory)
-    def executionQueueFactory = Mock(ConditionalExecutionQueueFactory)
+    def executionQueueFactory = Mock(WorkerExecutionQueueFactory)
     def executionQueue = Mock(ConditionalExecutionQueue)
     def worker = Mock(Worker)
     ConditionalExecution task
@@ -56,7 +55,7 @@ class DefaultWorkerExecutorTest extends Specification {
     def setup() {
         _ * fileResolver.resolve(_ as File) >> { files -> files[0] }
         _ * fileResolver.resolve(_ as String) >> { files -> new File(files[0]) }
-        _ * executionQueueFactory.create(_, _) >> executionQueue
+        _ * executionQueueFactory.create() >> executionQueue
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, fileResolver, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory)
     }
 


### PR DESCRIPTION
This fixes an issue where worker API invocations could eagerly expand the thread pool way beyond what's necessary to process the work submitted.  This PR does two things:

1. Only expand the thread pool when there is incomplete work associated with this build operation (for instance, when nested work has been submitted) and there is work waiting to be processed.
1. Moves the work queue up to build session scope (from project scope) so that all projects use the same queue.