### PR TITLE
Trust missing components when resolution is trying a virtual platform

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -86,7 +86,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
 
         List<ComponentMetaDataResolveState> resolveStates = new ArrayList<ComponentMetaDataResolveState>();
         for (ModuleComponentRepository repository : repositories) {
-            resolveStates.add(new ComponentMetaDataResolveState(identifier, componentOverrideMetadata, repository, versionedComponentChooser));
+            resolveStates.add(new ComponentMetaDataResolveState(identifier, componentOverrideMetadata, repository, versionedComponentChooser, result.isRetryMissing()));
         }
 
         final RepositoryChainModuleResolution latestResolved = findBestMatch(resolveStates, errors);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -153,6 +153,11 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return metadata;
     }
 
+    ComponentResolveMetadata getMetadataWithoutRetryMissing() {
+        resolve(false);
+        return metadata;
+    }
+
     @Override
     public ComponentIdentifier getComponentId() {
         // Use the resolved component id if available: this ensures that Maven Snapshot ids are correctly reported
@@ -188,6 +193,10 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     public void resolve() {
+        resolve(true);
+    }
+
+    public void resolve(boolean retryMissing) {
         if (alreadyResolved()) {
             return;
         }
@@ -195,7 +204,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         // Any metadata overrides (e.g classifier/artifacts/client-module) will be taken from the first dependency that referenced this component
         ComponentOverrideMetadata componentOverrideMetadata = DefaultComponentOverrideMetadata.forDependency(firstSelectedBy.getDependencyMetadata());
 
-        DefaultBuildableComponentResolveResult result = new DefaultBuildableComponentResolveResult();
+        DefaultBuildableComponentResolveResult result = new DefaultBuildableComponentResolveResult(retryMissing);
         resolver.resolve(componentIdentifier, componentOverrideMetadata, result);
         if (result.getFailure() != null) {
             metadataResolveFailure = result.getFailure();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
@@ -50,11 +50,9 @@ class PotentialEdge {
         ComponentState version = resolveState.getModule(toSelector.getModuleIdentifier()).getVersion(toModuleVersionId, toComponent);
         SelectorState selector = edge.getSelector();
         version.selectedBy(selector);
-        // We need to check if the target version exists. For this,
-        // we have to try to get metadata for the aligned version. If it's there,
-        // it means we can align, otherwise, we must NOT add the edge, or resolution
-        // would fail
-        ComponentResolveMetadata metadata = version.getMetadata();
+        // We need to check if the target version exists. For this, we have to try to get metadata for the aligned version.
+        // If it's there, it means we can align, otherwise, we must NOT add the edge, or resolution would fail
+        ComponentResolveMetadata metadata = version.getMetadataWithoutRetryMissing();
         return new PotentialEdge(edge, toModuleVersionId, metadata, version);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentResolveResult.java
@@ -40,4 +40,11 @@ public interface BuildableComponentResolveResult extends ComponentResolveResult,
      * Replaces the meta-data in the result. Result must already be resolved.
      */
     void setMetadata(ComponentResolveMetadata metadata);
+
+    /**
+     * Returns true if we should retry to get the resource when it was missing. This should only
+     * be used if the result of resolution shouldn't be impacted by a missing module (that is to say,
+     * it doesn't fail if a module is missing).
+     */
+    boolean isRetryMissing();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
@@ -70,4 +70,5 @@ public interface BuildableModuleComponentMetaDataResolveResult extends ResourceA
     boolean isAuthoritative();
 
     void setAuthoritative(boolean authoritative);
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResult.java
@@ -25,8 +25,18 @@ import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 public class DefaultBuildableComponentResolveResult extends DefaultResourceAwareResolveResult implements BuildableComponentResolveResult {
+    private final boolean retryMissing;
+
     private ComponentResolveMetadata metadata;
     private ModuleVersionResolveException failure;
+
+    public DefaultBuildableComponentResolveResult() {
+        this(true);
+    }
+
+    public DefaultBuildableComponentResolveResult(boolean retryMissing) {
+        this.retryMissing = retryMissing;
+    }
 
     public DefaultBuildableComponentResolveResult failed(ModuleVersionResolveException failure) {
         metadata = null;
@@ -94,5 +104,9 @@ public class DefaultBuildableComponentResolveResult extends DefaultResourceAware
         if (metadata != null) {
             idResolve.resolved(metadata);
         }
+    }
+
+    public boolean isRetryMissing() {
+        return retryMissing;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResult.java
@@ -19,6 +19,7 @@ import org.gradle.internal.component.external.model.ModuleComponentResolveMetada
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 public class DefaultBuildableModuleComponentMetaDataResolveResult extends DefaultResourceAwareResolveResult implements BuildableModuleComponentMetaDataResolveResult {
+
     private State state = State.Unknown;
     private ModuleVersionResolveException failure;
     private ModuleComponentResolveMetadata metaData;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
@@ -84,6 +84,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo
             metaData
         }
+        1 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -111,6 +112,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo
             metaData
         }
+        1 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -140,6 +142,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo
             metaData
         }
+        1 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -162,6 +165,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.attempted("scheme:thing")
             result.missing()
         }
+        1 * result.isRetryMissing() >> true
         1 * result.attempted("scheme:thing")
         1 * result.notFound(moduleComponentId)
 
@@ -186,6 +190,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.missing()
         }
+        1 * result.isRetryMissing() >> true
         1 * result.notFound(moduleComponentId)
 
         and:
@@ -214,6 +219,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo1
             metaData
         }
+        3 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -246,6 +252,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -279,6 +286,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -312,6 +320,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -352,6 +361,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -387,6 +397,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -424,6 +435,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo1
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -455,6 +467,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -489,6 +502,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
+        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -518,6 +532,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.missing()
         }
+        2 * result.isRetryMissing() >> true
         1 * result.failed({ it.cause == failure })
 
         and:
@@ -546,6 +561,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.missing()
         }
+        2 * result.isRetryMissing() >> true
         1 * result.failed({ it.cause == failure })
 
         and:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MavenHttpModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/MavenHttpModule.groovy
@@ -94,6 +94,7 @@ class MavenHttpModule extends DelegatingMavenModule<MavenHttpModule> implements 
         server.allowGetOrHeadMissing(pomPath)
         server.allowGetOrHeadMissing(metaDataPath)
         server.allowGetOrHeadMissing(artifactPath)
+        getModuleMetadata().allowGetOrHead()
     }
 
     HttpResource getMetaData() {


### PR DESCRIPTION
## Context

This commit adds a special case in the resolution engine for missing modules.
The default behavior, when a module is missing, is to cache the result. However,
when there are multiple repositories, it is possible for a module to be found
in a subsequent repository, in which case the result is deemed authoritative,
and we wouldn't try again on the repositories which had "missing metadata". But,
for UX reasons, if a module is missing from _all_ repositories, we would always
try again on the next build, despite knowing that the module would be absent.

This was intended to solve the following use case:

-  `BuildA` attempts to resolve` org:module:1.1`, but the user forgot to publish this module version, so resolution fails
-  `BuildB` executes, publishing `org:module:1.1`
-  `BuildA` executes again, without using `--refresh-dependencies`. We prefer making additional network calls rather than failing the build again.

This behavior interferes with the "virtual platform" use case, where we need
to pre-emptively try to find a module, without knowing if it actually exists.

This commit adds a flag, `retryMissing`, which is by default `true`, but can be set
to false when we resolve a module. If so, then the engine will trust the cached missing
status. Virtual platforms (and edges) use this new method, bypassing the old path.

Fixes #5947