### PR TITLE
Intern more paths/path segments for file snapshots

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultClasspathSnapshotter.java
@@ -28,10 +28,12 @@ import static org.gradle.api.internal.changedetection.state.mirror.logical.Class
 
 public class DefaultClasspathSnapshotter extends AbstractFileCollectionSnapshotter implements ClasspathSnapshotter {
     private final ResourceSnapshotterCacheService cacheService;
+    private final StringInterner stringInterner;
 
     public DefaultClasspathSnapshotter(ResourceSnapshotterCacheService cacheService, DirectoryFileTreeFactory directoryFileTreeFactory, FileSystemSnapshotter fileSystemSnapshotter, StringInterner stringInterner) {
         super(stringInterner, directoryFileTreeFactory, fileSystemSnapshotter);
         this.cacheService = cacheService;
+        this.stringInterner = stringInterner;
     }
 
     @Override
@@ -42,6 +44,6 @@ public class DefaultClasspathSnapshotter extends AbstractFileCollectionSnapshott
     @Override
     public FileCollectionSnapshot snapshot(FileCollection files, PathNormalizationStrategy pathNormalizationStrategy, InputNormalizationStrategy inputNormalizationStrategy) {
         ResourceHasher classpathResourceHasher = inputNormalizationStrategy.getRuntimeClasspathNormalizationStrategy().getRuntimeClasspathResourceHasher();
-        return super.snapshot(files, new ClasspathFingerprintingStrategy(USE_FILE_HASH, classpathResourceHasher, cacheService));
+        return super.snapshot(files, new ClasspathFingerprintingStrategy(USE_FILE_HASH, classpathResourceHasher, cacheService, stringInterner));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultCompileClasspathSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultCompileClasspathSnapshotter.java
@@ -29,18 +29,20 @@ import static org.gradle.api.internal.changedetection.state.mirror.logical.Class
 public class DefaultCompileClasspathSnapshotter extends AbstractFileCollectionSnapshotter implements CompileClasspathSnapshotter {
     private final ResourceHasher classpathResourceHasher;
     private final ResourceSnapshotterCacheService cacheService;
+    private final StringInterner stringInterner;
 
     public DefaultCompileClasspathSnapshotter(ResourceSnapshotterCacheService cacheService, DirectoryFileTreeFactory directoryFileTreeFactory, FileSystemSnapshotter fileSystemSnapshotter, StringInterner stringInterner) {
         super(stringInterner, directoryFileTreeFactory, fileSystemSnapshotter);
         this.cacheService = cacheService;
         this.classpathResourceHasher = new CachingResourceHasher(new AbiExtractingClasspathResourceHasher(), cacheService);
+        this.stringInterner = stringInterner;
     }
 
     @Override
     public FileCollectionSnapshot snapshot(FileCollection files, PathNormalizationStrategy pathNormalizationStrategy, InputNormalizationStrategy inputNormalizationStrategy) {
         return super.snapshot(
             files,
-            new ClasspathFingerprintingStrategy(IGNORE, classpathResourceHasher, cacheService));
+            new ClasspathFingerprintingStrategy(IGNORE, classpathResourceHasher, cacheService, stringInterner));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultGenericFileCollectionSnapshotter.java
@@ -29,8 +29,11 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.normalization.internal.InputNormalizationStrategy;
 
 public class DefaultGenericFileCollectionSnapshotter extends AbstractFileCollectionSnapshotter implements GenericFileCollectionSnapshotter {
+    private final StringInterner stringInterner;
+
     public DefaultGenericFileCollectionSnapshotter(StringInterner stringInterner, DirectoryFileTreeFactory directoryFileTreeFactory, FileSystemSnapshotter fileSystemSnapshotter) {
         super(stringInterner, directoryFileTreeFactory, fileSystemSnapshotter);
+        this.stringInterner = stringInterner;
     }
 
     @Override
@@ -51,7 +54,7 @@ public class DefaultGenericFileCollectionSnapshotter extends AbstractFileCollect
             case OUTPUT:
                 return new AbsolutePathFingerprintingStrategy(false);
             case RELATIVE:
-                return new RelativePathFingerprintingStrategy();
+                return new RelativePathFingerprintingStrategy(stringInterner);
             case NAME_ONLY:
                 return new NameOnlyFingerprintingStrategy();
             case NONE:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SnapshotMapSerializer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SnapshotMapSerializer.java
@@ -62,7 +62,7 @@ public class SnapshotMapSerializer extends AbstractSerializer<Map<String, Normal
                 return new NonNormalizedFileSnapshot(absolutePath, snapshot);
             case DEFAULT_NORMALIZATION:
                 String normalizedPath = decoder.readString();
-                return new DefaultNormalizedFileSnapshot(normalizedPath, snapshot);
+                return new DefaultNormalizedFileSnapshot(stringInterner.intern(normalizedPath), snapshot);
             case IGNORED_PATH_NORMALIZATION:
                 return snapshot;
             default:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/MirrorUpdatingDirectoryWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/MirrorUpdatingDirectoryWalker.java
@@ -91,7 +91,7 @@ public class MirrorUpdatingDirectoryWalker {
 
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-                    String name = dir.getFileName().toString();
+                    String name = stringInterner.intern(dir.getFileName().toString());
                     if (relativePath.isRoot() || isAllowed(dir, name, true, attrs, relativePath)) {
                         relativePath.enter(name);
                         levelHolder.addLast(new ArrayList<PhysicalSnapshot>());
@@ -103,7 +103,7 @@ public class MirrorUpdatingDirectoryWalker {
 
                 @Override
                 public FileVisitResult visitFile(Path file, @Nullable BasicFileAttributes attrs) {
-                    String name = file.getFileName().toString();
+                    String name = stringInterner.intern(file.getFileName().toString());
                     if (isAllowed(file, name, false, attrs, relativePath)) {
                         if (attrs == null) {
                             throw new GradleException(String.format("Cannot read file '%s': not authorized.", file));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/logical/ClasspathFingerprintingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/logical/ClasspathFingerprintingStrategy.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.changedetection.state.mirror.logical;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultNormalizedFileSnapshot;
 import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
 import org.gradle.api.internal.changedetection.state.FileHashSnapshot;
@@ -45,13 +46,15 @@ public class ClasspathFingerprintingStrategy implements FingerprintingStrategy {
     private final ResourceSnapshotterCacheService cacheService;
     private final ResourceHasher classpathResourceHasher;
     private final JarHasher jarHasher;
+    private final StringInterner stringInterner;
     private final HashCode jarHasherConfigurationHash;
 
-    public ClasspathFingerprintingStrategy(NonJarFingerprintingStrategy nonJarFingerprintingStrategy, ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService) {
+    public ClasspathFingerprintingStrategy(NonJarFingerprintingStrategy nonJarFingerprintingStrategy, ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, StringInterner stringInterner) {
         this.nonJarFingerprintingStrategy = nonJarFingerprintingStrategy;
         this.cacheService = cacheService;
         this.classpathResourceHasher = classpathResourceHasher;
         this.jarHasher = new JarHasher(classpathResourceHasher);
+        this.stringInterner = stringInterner;
         DefaultBuildCacheHasher hasher = new DefaultBuildCacheHasher();
         jarHasher.appendConfigurationToHasher(hasher);
         this.jarHasherConfigurationHash = hasher.hash();
@@ -84,7 +87,7 @@ public class ClasspathFingerprintingStrategy implements FingerprintingStrategy {
 
                 private NormalizedFileSnapshot createNormalizedSnapshot(String name, FileContentSnapshot content) {
                     relativePathHolder.enter(name);
-                    NormalizedFileSnapshot normalizedFileSnapshot = new DefaultNormalizedFileSnapshot(relativePathHolder.getRelativePathString(), content);
+                    NormalizedFileSnapshot normalizedFileSnapshot = new DefaultNormalizedFileSnapshot(stringInterner.intern(relativePathHolder.getRelativePathString()), content);
                     relativePathHolder.leave();
                     return normalizedFileSnapshot;
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/logical/RelativePathFingerprintingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/mirror/logical/RelativePathFingerprintingStrategy.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.changedetection.state.mirror.logical;
 
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultNormalizedFileSnapshot;
 import org.gradle.api.internal.changedetection.state.DirContentSnapshot;
 import org.gradle.api.internal.changedetection.state.FileContentSnapshot;
@@ -29,6 +30,11 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class RelativePathFingerprintingStrategy implements FingerprintingStrategy {
+    private final StringInterner stringInterner;
+
+    public RelativePathFingerprintingStrategy(StringInterner stringInterner) {
+        this.stringInterner = stringInterner;
+    }
 
     @Override
     public Map<String, NormalizedFileSnapshot> collectSnapshots(Iterable<PhysicalSnapshot> roots) {
@@ -43,7 +49,7 @@ public class RelativePathFingerprintingStrategy implements FingerprintingStrateg
                     boolean isRoot = relativePathHolder.isRoot();
                     relativePathHolder.enter(name);
                     if (processedEntries.add(absolutePath)) {
-                        NormalizedFileSnapshot snapshot = isRoot ? DirContentSnapshot.INSTANCE : new DefaultNormalizedFileSnapshot(relativePathHolder.getRelativePathString(), DirContentSnapshot.INSTANCE);
+                        NormalizedFileSnapshot snapshot = isRoot ? DirContentSnapshot.INSTANCE : new DefaultNormalizedFileSnapshot(stringInterner.intern(relativePathHolder.getRelativePathString()), DirContentSnapshot.INSTANCE);
                         builder.put(absolutePath, snapshot);
                     }
                     return true;
@@ -62,7 +68,7 @@ public class RelativePathFingerprintingStrategy implements FingerprintingStrateg
 
                 private NormalizedFileSnapshot createNormalizedFileSnapshot(String name, FileContentSnapshot content) {
                     relativePathHolder.enter(name);
-                    NormalizedFileSnapshot normalizedFileSnapshot = new DefaultNormalizedFileSnapshot(relativePathHolder.getRelativePathString(), content);
+                    NormalizedFileSnapshot normalizedFileSnapshot = new DefaultNormalizedFileSnapshot(stringInterner.intern(relativePathHolder.getRelativePathString()), content);
                     relativePathHolder.leave();
                     return normalizedFileSnapshot;
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/mirror/logical/PathNormalizationStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/mirror/logical/PathNormalizationStrategyTest.groovy
@@ -28,6 +28,8 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.test.fixtures.file.TestFile
 
 class PathNormalizationStrategyTest extends AbstractProjectBuilderSpec {
+    private StringInterner stringInterner = new StringInterner()
+
     public static final String IGNORED = "IGNORED"
     List<PhysicalSnapshot> roots
     TestFile jarFile1
@@ -94,7 +96,7 @@ class PathNormalizationStrategyTest extends AbstractProjectBuilderSpec {
     }
 
     def "sensitivity RELATIVE"() {
-        def snapshots = collectSnapshots(new RelativePathFingerprintingStrategy())
+        def snapshots = collectSnapshots(new RelativePathFingerprintingStrategy(stringInterner))
         expect:
         snapshots[jarFile1]                      == jarFile1.name
         snapshots[jarFile2]                      == jarFile2.name


### PR DESCRIPTION
It seems like https://github.com/gradle/gradle/commit/f781104015885c7d42495dace0935ad00b555a3c caused quite an increase on memory usage for multi project builds. We observed this in an increased Garbage collection time when building `sanityCheck` on Gradle itself (10s -> 2minutes).

This PR reduces the memory footprint by interning path segments and relative paths in file collection snapshots.