### PR TITLE
Issue: #5949 - Dynamically renaming projects should not depend on renaming order.

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultProjectDescriptorRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultProjectDescriptorRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.initialization;
 
+import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.internal.project.DefaultProjectRegistry;
 import org.gradle.util.Path;
 
@@ -24,5 +25,12 @@ public class DefaultProjectDescriptorRegistry extends DefaultProjectRegistry<Def
         DefaultProjectDescriptor projectDescriptor = removeProject(oldPath.toString());
         projectDescriptor.setPath(newPath);
         addProject(projectDescriptor);
+        refreshSubProjectsDescriptorPaths(projectDescriptor);
+    }
+
+    private void refreshSubProjectsDescriptorPaths(DefaultProjectDescriptor projectDescriptor) {
+        for (ProjectDescriptor subProjectDescriptor: projectDescriptor.getChildren()) {
+            subProjectDescriptor.setName(subProjectDescriptor.getName());
+        }
     }
 }


### PR DESCRIPTION
When renaming a project's descriptor path, update all subprojects as well.

Signed-off-by: POST\toomas.laigna <toomas.laigna@omniva.ee>

### Context
Attempt to fix small issue of project's name change from groovy scripts not being propagated to subprojects.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
