### PR TITLE
 Honor singleUse when creating GlobalScopeServices

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/environment/GradleBuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/environment/GradleBuildEnvironmentIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.environment
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class GradleBuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
+    @Unroll
+    def 'can know the current environment if daemon = #daemon'() {
+        given:
+        buildFile << """
+            import org.gradle.internal.environment.GradleBuildEnvironment
+            import javax.inject.Inject
+            class DaemonJudge extends DefaultTask {
+                GradleBuildEnvironment buildEnvironment
+
+                @Inject
+                DaemonJudge(GradleBuildEnvironment buildEnvironment) {
+                    this.buildEnvironment = buildEnvironment
+                }
+                
+                @TaskAction
+                void run() {
+                    assert buildEnvironment.isLongLivingProcess() == ${daemon}
+                } 
+            } 
+
+            task judge(type: DaemonJudge)
+        """
+        // Force to start a new JVM
+        file("gradle.properties") << "org.gradle.jvmargs=-Xmx32m"
+
+        expect:
+        succeeds('judge', arg)
+
+        where:
+        daemon | arg
+        true   | '--daemon'
+        false  | '--no-daemon'
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/environment/GradleBuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/environment/GradleBuildEnvironmentIntegrationTest.groovy
@@ -17,10 +17,14 @@
 package org.gradle.internal.environment
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.TestPrecondition
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 class GradleBuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
+    @IgnoreIf({ !GradleContextualExecuter.embedded })
     def 'can know the current environment if daemon = #daemon'() {
         given:
         buildFile << """

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
@@ -80,7 +80,7 @@ public class DaemonServices extends DefaultServiceRegistry {
         this.loggingManager = loggingManager;
 
         addProvider(new DaemonRegistryServices(configuration.getBaseDir()));
-        addProvider(new GlobalScopeServices(true, additionalModuleClassPath));
+        addProvider(new GlobalScopeServices(!configuration.isSingleUse(), additionalModuleClassPath));
     }
 
     protected DaemonContext createDaemonContext() {


### PR DESCRIPTION
### Context

Previously, `DaemonServerConfiguration.isSingleUse` is totally ignored
when creating `GlobalScopeServices`, which makes `GradleBuildEnvironment.isLongLivingProcess()`
always return true. This commit fixes this issue.

Fixes #2597