### PR TITLE
Remove `TaskProvider` from task dependencies when the `Task` instance is provided

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
+    def "can remove a Task instance from task dependencies containing the Task instance"() {
+        given:
+        buildFile << '''
+            tasks.configureEach {
+                doLast {
+                    println "Executing $it"
+                }
+            }
+            task bar
+            task foo {
+                dependsOn bar
+            }
+
+            foo.dependsOn.remove(bar)
+        '''
+
+        when:
+        succeeds "foo"
+
+        then:
+        result.assertTasksExecuted(":foo")
+        result.assertTaskNotExecuted(":bar")
+    }
+
+    def "can remove a Task instance from task dependencies containing a Provider to the Task instance"() {
+        given:
+        buildFile << '''
+            tasks.configureEach {
+                doLast {
+                    println "Executing $it"
+                }
+            }
+            def provider = tasks.register("bar")
+            task foo {
+                dependsOn provider
+            }
+
+            foo.dependsOn.remove(provider.get())
+        '''
+
+        when:
+        executer.expectDeprecationWarning()
+        succeeds "foo"
+
+        then:
+        result.assertTasksExecuted(":foo")
+        result.assertTaskNotExecuted(":bar")
+    }
+
+    def "can remove a Provider instance from task dependencies containing the Provider"() {
+        given:
+        buildFile << '''
+            tasks.configureEach {
+                doLast {
+                    println "Executing $it"
+                }
+            }
+            def provider = tasks.register("bar")
+            task foo {
+                dependsOn provider
+            }
+
+            foo.dependsOn.remove(provider)
+        '''
+
+        when:
+        succeeds "foo"
+
+        then:
+        result.assertTasksExecuted(":foo")
+        result.assertTaskNotExecuted(":bar")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -25,6 +25,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import org.gradle.util.DeprecationLogger;
 
@@ -240,21 +241,21 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
 
             for (Iterator<Object> it = delegate.iterator(); it.hasNext();) {
                 Object obj = it.next();
-                if (obj instanceof ProviderInternal) {
-                    if (((ProviderInternal) obj).getType().isInstance(o)) {
-                        obj = ((ProviderInternal) obj).get();
-                    } else {
-                        continue;
-                    }
-                }
-
-                if (obj.equals(o)) {
+                if (isTaskProvider(obj) && o instanceof Task && isTaskProviderOfTask((TaskProvider) obj, (Task) o)) {
                     DeprecationLogger.nagUserOfDeprecatedBehaviour("Do not remove a Task instance from a task dependency set when it contains a Provider to the Task instance.");
                     it.remove();
                     return true;
                 }
             }
             return false;
+        }
+
+        private static boolean isTaskProvider(Object obj) {
+            return obj instanceof TaskProvider;
+        }
+
+        private static boolean isTaskProviderOfTask(TaskProvider provider, Task task) {
+            return provider instanceof ProviderInternal && ((ProviderInternal) provider).getType().isInstance(task) && provider.getName().equals(task.getName());
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
@@ -28,7 +28,7 @@ import java.util.concurrent.Callable
 
 import static org.gradle.util.WrapUtil.toSet
 
-public class DefaultTaskDependencyTest extends Specification {
+class DefaultTaskDependencyTest extends Specification {
     private final TaskResolver resolver = Mock(TaskResolver.class)
     private final DefaultTaskDependency dependency = new DefaultTaskDependency(resolver)
     private Task task
@@ -278,6 +278,45 @@ The following types/formats are supported:
 
         then:
         dependency.getDependencies(task) == toSet(otherTask)
+    }
+
+    def "can mutate dependency values by removing a Task instance from dependency"() {
+        given:
+        dependency.add(otherTask)
+
+        when:
+        dependency.mutableValues.remove(otherTask)
+
+        then:
+        dependency.getDependencies(task) == toSet()
+    }
+
+    def "can mutate dependency values by removing a Task instance from dependency containing a Provider to the Task instance"() {
+        given:
+        def provider = Mock(ProviderInternal)
+        provider.type >> otherTask.class
+        provider.get() >> otherTask
+        dependency.add(provider)
+
+        when:
+        dependency.mutableValues.remove(otherTask)
+
+        then:
+        dependency.getDependencies(task) == toSet()
+    }
+
+    def "can mutate dependency values by removing a Provider instance from dependency containing the Provider instance"() {
+        given:
+        def provider = Mock(ProviderInternal)
+        provider.type >> otherTask.class
+        provider.get() >> otherTask
+        dependency.add(provider)
+
+        when:
+        dependency.mutableValues.remove(provider)
+
+        then:
+        dependency.getDependencies(task) == toSet()
     }
 
     def "can nest iterables and maps and closures and callables"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Task
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.typeconversion.UnsupportedNotationException
 import org.gradle.util.TextUtil
 import spock.lang.Specification
@@ -293,9 +294,11 @@ The following types/formats are supported:
 
     def "can mutate dependency values by removing a Task instance from dependency containing a Provider to the Task instance"() {
         given:
-        def provider = Mock(ProviderInternal)
+        otherTask.name >> "otherTask"
+
+        def provider = Mock(TestTaskProvider)
         provider.type >> otherTask.class
-        provider.get() >> otherTask
+        provider.name >> otherTask.name
         dependency.add(provider)
 
         when:
@@ -307,9 +310,7 @@ The following types/formats are supported:
 
     def "can mutate dependency values by removing a Provider instance from dependency containing the Provider instance"() {
         given:
-        def provider = Mock(ProviderInternal)
-        provider.type >> otherTask.class
-        provider.get() >> otherTask
+        def provider = Mock(TestTaskProvider)
         dependency.add(provider)
 
         when:
@@ -342,5 +343,8 @@ The following types/formats are supported:
     }
 
     interface TestProvider extends ProviderInternal, TaskDependencyContainer {
+    }
+
+    interface TestTaskProvider extends ProviderInternal, TaskProvider {
     }
 }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
With the introduction of lazy task configuration, lots of plugins were
converted to add dependencies using `TaskProvider` instead of `Task`.
It wasn't a breaking change, but users are sometimes removing task
dependencies using the the `Task` instance. Because some dependencies
are now `TaskProvider`, it breaks the code of some users.

Fixes https://github.com/gradle/gradle-native/issues/738
Fixes https://github.com/gradle/gradle/issues/5730

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fissue-738)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
