### PR TITLE
Provide an API to supersede System.getenv

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/GradleSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/GradleSystem.java
@@ -22,18 +22,33 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
- * Gradle environmental variable collection.
+ * Gradle-managed environment variable collection. It's recommended to prefer this API over {@code java.lang.System.getnenv()}.
  *
  * @since 4.10
  */
 @Incubating
 public class GradleSystem {
+
+    /**
+     * Gets the value of the specified environment variable in current build.
+     *
+     * @param  name the name of the environment variable
+     * @return the string value of the variable, or <code>null</code>
+     *         if the variable is not defined in the system environment
+     * @see    #getenv()
+     */
     @Incubating
     @Nullable
-    public static String getenv(String env) {
-        return GradleProcessEnvironment.getenv(env);
+    public static String getenv(String name) {
+        return GradleProcessEnvironment.getenv(name);
     }
 
+    /**
+     *
+     * Returns an unmodifiable string map view of the current system environment in current build.
+     * @return the environment as a map of variable names to values
+     * @see    #getenv(String)
+     */
     @Incubating
     public static Map<String, String> getenv() {
         return GradleProcessEnvironment.getenv();

--- a/subprojects/base-services/src/main/java/org/gradle/api/GradleSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/GradleSystem.java
@@ -18,16 +18,18 @@ package org.gradle.api;
 
 import org.gradle.api.internal.GradleProcessEnvironment;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
- * Gradle environmental variable
+ * Gradle environmental variable collection.
  *
  * @since 4.10
  */
 @Incubating
 public class GradleSystem {
     @Incubating
+    @Nullable
     public static String getenv(String env) {
         return GradleProcessEnvironment.getenv(env);
     }

--- a/subprojects/base-services/src/main/java/org/gradle/api/GradleSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/GradleSystem.java
@@ -32,25 +32,25 @@ public class GradleSystem {
     /**
      * Gets the value of the specified environment variable in current build.
      *
-     * @param  name the name of the environment variable
+     * @param name the name of the environment variable
      * @return the string value of the variable, or <code>null</code>
-     *         if the variable is not defined in the system environment
-     * @see    #getenv()
+     * if the variable is not defined in the system environment
+     * @see #getenv()
      */
     @Incubating
     @Nullable
     public static String getenv(String name) {
-        return GradleProcessEnvironment.getenv(name);
+        return GradleProcessEnvironment.INSTANCE.getenv(name);
     }
 
     /**
-     *
      * Returns an unmodifiable string map view of the current system environment in current build.
+     *
      * @return the environment as a map of variable names to values
-     * @see    #getenv(String)
+     * @see #getenv(String)
      */
     @Incubating
     public static Map<String, String> getenv() {
-        return GradleProcessEnvironment.getenv();
+        return GradleProcessEnvironment.INSTANCE.getenv();
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/GradleProcessEnvironment.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/GradleProcessEnvironment.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GradleProcessEnvironment {
-    private static final Map<String, String> ENVS = new ConcurrentHashMap<String, String>();
+    private static final Map<String, String> ENVS = new ConcurrentHashMap<String, String>(System.getenv());
 
     public static Map<String, String> getenv() {
         return Collections.unmodifiableMap(ENVS);

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/GradleProcessEnvironment.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/GradleProcessEnvironment.java
@@ -16,11 +16,16 @@
 
 package org.gradle.api.internal;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GradleProcessEnvironment {
     private static final Map<String, String> ENVS = new ConcurrentHashMap<String, String>();
+
+    public static Map<String, String> getenv() {
+        return Collections.unmodifiableMap(ENVS);
+    }
 
     public static String getenv(String env) {
         return ENVS.get(env);

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/GradleProcessEnvironment.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/GradleProcessEnvironment.java
@@ -14,28 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.nativeintegration;
+package org.gradle.api.internal;
 
-/**
- * Encapsulates what happened when we tried to modify the environment.
- */
-public enum EnvironmentModificationResult {
-    SUCCESS(null),
-    ONLY_SET_GRADLE_ENV("Java 9 does not support modifying environment variables."),
-    UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-    private final String reason;
+public class GradleProcessEnvironment {
+    private static final Map<String, String> ENVS = new ConcurrentHashMap<String, String>();
 
-    EnvironmentModificationResult(String reason) {
-        this.reason = reason;
+    public static String getenv(String env) {
+        return ENVS.get(env);
     }
 
-    @Override
-    public String toString() {
-        return reason;
+    public static void unsetenv(String name) {
+        ENVS.remove(name);
     }
 
-    public boolean isSuccess() {
-        return this == SUCCESS;
+    public static void setenv(String name, String value) {
+        ENVS.put(name, value);
     }
 }
+

--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.os;
 
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
@@ -165,7 +166,7 @@ public abstract class OperatingSystem {
     }
 
     public List<File> getPath() {
-        String path = System.getenv(getPathVar());
+        String path = GradleSystem.getenv(getPathVar());
         if (path == null) {
             return Collections.emptyList();
         }

--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -17,6 +17,7 @@
 package org.gradle.util;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.UncheckedException;
 
 import java.io.InputStream;
@@ -70,7 +71,7 @@ public class GradleVersion implements Comparable<GradleVersion> {
             // to the version and need to test with various different version patterns.
             // We use an env variable because these are easy to set on daemon startup,
             // whereas system properties are scrubbed at daemon startup.
-            String overrideVersion = System.getenv(VERSION_OVERRIDE_VAR);
+            String overrideVersion = GradleSystem.getenv(VERSION_OVERRIDE_VAR);
             if (overrideVersion != null) {
                 version = overrideVersion;
             }

--- a/subprojects/core-api/src/main/java/org/gradle/api/GradleSystem.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/GradleSystem.java
@@ -14,28 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.nativeintegration;
+package org.gradle.api;
+
+import org.gradle.api.internal.GradleProcessEnvironment;
 
 /**
- * Encapsulates what happened when we tried to modify the environment.
+ * Gradle environmental variable
+ * @since 4.10
  */
-public enum EnvironmentModificationResult {
-    SUCCESS(null),
-    ONLY_SET_GRADLE_ENV("Java 9 does not support modifying environment variables."),
-    UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
-
-    private final String reason;
-
-    EnvironmentModificationResult(String reason) {
-        this.reason = reason;
-    }
-
-    @Override
-    public String toString() {
-        return reason;
-    }
-
-    public boolean isSuccess() {
-        return this == SUCCESS;
+@Incubating
+public class GradleSystem {
+    @Incubating
+    public static String getenv(String env) {
+        return GradleProcessEnvironment.getenv(env);
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/GradleSystem.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/GradleSystem.java
@@ -18,8 +18,11 @@ package org.gradle.api;
 
 import org.gradle.api.internal.GradleProcessEnvironment;
 
+import java.util.Map;
+
 /**
  * Gradle environmental variable
+ *
  * @since 4.10
  */
 @Incubating
@@ -27,5 +30,10 @@ public class GradleSystem {
     @Incubating
     public static String getenv(String env) {
         return GradleProcessEnvironment.getenv(env);
+    }
+
+    @Incubating
+    public static Map<String, String> getenv() {
+        return GradleProcessEnvironment.getenv();
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization;
 
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.deprecation.Deprecatable;
 import org.gradle.internal.deprecation.LoggingDeprecatable;
@@ -40,7 +41,7 @@ public class BuildLayoutParameters implements Deprecatable {
     public BuildLayoutParameters() {
         String gradleUserHome = System.getProperty(GRADLE_USER_HOME_PROPERTY_KEY);
         if (gradleUserHome == null) {
-            gradleUserHome = System.getenv("GRADLE_USER_HOME");
+            gradleUserHome = GradleSystem.getenv("GRADLE_USER_HOME");
             if (gradleUserHome == null) {
                 gradleUserHome = DEFAULT_GRADLE_USER_HOME.getAbsolutePath();
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/GradleSystemIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/GradleSystemIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GradleSystemIntegrationTest extends AbstractIntegrationSpec {
+    def 'can set env variables via GradleSystem and switch env variables between daemons'() {
+        given:
+        buildFile << '''
+            println GradleSystem.getenv('myEnv')
+        '''
+
+        when:
+        executer.withEnvironmentVars([myEnv: 'myValue1'])
+        succeeds('help')
+
+        then:
+        outputContains('myValue1')
+
+        when:
+        executer.withEnvironmentVars([myEnv: 'myValue2'])
+        succeeds('help')
+
+        then:
+        outputContains('myValue2')
+    }
+
+    def 'forked workers can read the env variables'() {
+        given:
+        buildFile << """ 
+            apply plugin: 'java'
+            
+            ${jcenterRepository()}
+
+            dependencies {
+                testCompile 'junit:junit:4.12'
+            }
+        """
+
+        file('src/test/java/EnvVariableReadTest.java') << '''
+            public class EnvVariableReadTest {
+                @org.junit.Test
+                public void readEnvVariable() {
+                    org.junit.Assert.assertEquals(System.getenv("myEnv"), "myValue");
+                }
+            }
+        '''
+        executer.withEnvironmentVars([myEnv: 'myValue'])
+
+        expect:
+        succeeds('test')
+    }
+
+    def 'forked Exec tasks can read the env variables'() {
+        given:
+        buildFile << '''
+            apply plugin: 'java'
+
+            task run(type: JavaExec) {
+                classpath(sourceSets.main.output.classesDirs)
+                main = 'Main'
+            }
+        '''
+
+        file('src/main/java/Main.java') << '''
+            public class Main {
+                public static void main(String[] args) {
+                    if(!"myValue".equals(System.getenv("myEnv"))) {
+                        throw new IllegalStateException();
+                    }
+                }
+            }
+        '''
+        executer.withEnvironmentVars([myEnv: 'myValue'])
+
+        expect:
+        succeeds 'run'
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/GradleSystemIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/GradleSystemIntegrationTest.groovy
@@ -22,22 +22,25 @@ class GradleSystemIntegrationTest extends AbstractIntegrationSpec {
     def 'can set env variables via GradleSystem and switch env variables between daemons'() {
         given:
         buildFile << '''
-            println GradleSystem.getenv('myEnv')
+            println "myEnv: ${GradleSystem.getenv('myEnv')}"
+            println "anotherEnv: ${GradleSystem.getenv('anotherEnv')}"
         '''
 
         when:
-        executer.withEnvironmentVars([myEnv: 'myValue1'])
+        executer.withEnvironmentVars([myEnv: 'myValue1', anotherEnv: 'anotherValue'])
         succeeds('help')
 
         then:
-        outputContains('myValue1')
+        outputContains('myEnv: myValue1')
+        outputContains('anotherEnv: anotherValue')
 
         when:
         executer.withEnvironmentVars([myEnv: 'myValue2'])
         succeeds('help')
 
         then:
-        outputContains('myValue2')
+        outputContains('myEnv: myValue2')
+        outputContains('anotherEnv: null')
     }
 
     def 'forked workers can read the env variables'() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/GradleSystemIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/GradleSystemIntegrationTest.groovy
@@ -43,6 +43,30 @@ class GradleSystemIntegrationTest extends AbstractIntegrationSpec {
         outputContains('anotherEnv: null')
     }
 
+    def 'can set system properties via ORG_GRADLE_PROJECT_ between daemons'() {
+        given:
+        buildFile << '''
+            println "myProperty: ${project.findProperty('myProperty')}"
+            println "anotherProperty: ${project.findProperty('anotherProperty')}"
+        '''
+
+        when:
+        executer.withEnvironmentVars([ORG_GRADLE_PROJECT_myProperty: 'myValue1', ORG_GRADLE_PROJECT_anotherProperty: 'anotherValue'])
+        succeeds('help')
+
+        then:
+        outputContains('myProperty: myValue1')
+        outputContains('anotherProperty: anotherValue')
+
+        when:
+        executer.withEnvironmentVars([ORG_GRADLE_PROJECT_myProperty: 'myValue2'])
+        succeeds('help')
+
+        then:
+        outputContains('myProperty: myValue2')
+        outputContains('anotherProperty: null')
+    }
+
     def 'forked workers can read the env variables'() {
         given:
         buildFile << """ 

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/RemoteProcess.java
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/RemoteProcess.java
@@ -18,6 +18,7 @@ package org.gradle.process.internal;
 
 import org.apache.tools.ant.Project;
 import org.gradle.api.Action;
+import org.gradle.api.GradleSystem;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 
 import java.io.Serializable;
@@ -29,7 +30,7 @@ public class RemoteProcess implements Action<WorkerProcessContext>, Serializable
     public void execute(WorkerProcessContext workerProcessContext) {
         // Check environment
         assertThat(System.getProperty("test.system.property"), equalTo("value"));
-        assertThat(System.getenv().get("TEST_ENV_VAR"), equalTo("value"));
+        assertThat(GradleSystem.getenv().get("TEST_ENV_VAR"), equalTo("value"));
 
         // Check ClassLoaders
         ClassLoader antClassLoader = Project.class.getClassLoader();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesLoader.java
@@ -16,6 +16,7 @@
 package org.gradle.initialization;
 
 import org.gradle.StartParameter;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.Project;
 import org.gradle.util.GUtil;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class DefaultGradlePropertiesLoader implements IGradlePropertiesLoader {
     }
 
     Map<String, String> getAllEnvProperties() {
-        return System.getenv();
+        return GradleSystem.getenv();
     }
 
     private void addGradleProperties(Map<String, String> target, File... files) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -18,6 +18,7 @@ package org.gradle.process.internal;
 
 import com.google.common.base.Joiner;
 import net.rubygrapefruit.platform.ProcessLauncher;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.initialization.BuildCancellationToken;
@@ -32,6 +33,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -163,7 +165,9 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     }
 
     public Map<String, String> getEnvironment() {
-        return Collections.unmodifiableMap(environment);
+        Map<String, String> currentProcessEnvironments = new HashMap<String, String>(GradleSystem.getenv());
+        currentProcessEnvironments.putAll(environment);
+        return Collections.unmodifiableMap(currentProcessEnvironments);
     }
 
     public ExecHandleState getState() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -18,7 +18,6 @@ package org.gradle.process.internal;
 
 import com.google.common.base.Joiner;
 import net.rubygrapefruit.platform.ProcessLauncher;
-import org.gradle.api.GradleSystem;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.initialization.BuildCancellationToken;
@@ -33,7 +32,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -165,9 +163,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     }
 
     public Map<String, String> getEnvironment() {
-        Map<String, String> currentProcessEnvironments = new HashMap<String, String>(GradleSystem.getenv());
-        currentProcessEnvironments.putAll(environment);
-        return Collections.unmodifiableMap(currentProcessEnvironments);
+        return Collections.unmodifiableMap(environment);
     }
 
     public ExecHandleState getState() {
@@ -245,7 +241,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
     public ExecHandle start() {
         LOGGER.info("Starting process '{}'. Working directory: {} Command: {}",
-                displayName, directory, command + ' ' + Joiner.on(' ').useForNull("null").join(arguments));
+            displayName, directory, command + ' ' + Joiner.on(' ').useForNull("null").join(arguments));
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Environment for process '{}': {}", displayName, environment);
         }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -16,6 +16,7 @@
 package org.gradle.process.internal;
 
 import com.google.common.collect.Maps;
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.ProcessForkOptions;
@@ -73,7 +74,7 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
 
     public Map<String, Object> getEnvironment() {
         if (environment == null) {
-            setEnvironment(Jvm.current().getInheritableEnvironmentVariables(System.getenv()));
+            setEnvironment(Jvm.current().getInheritableEnvironmentVariables(GradleSystem.getenv()));
         }
         return environment;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocator.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.mvnsettings;
 
 import org.apache.maven.settings.building.SettingsBuildingException;
+import org.gradle.api.GradleSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +107,7 @@ public class DefaultLocalMavenRepositoryLocator implements LocalMavenRepositoryL
 
         @Override
         public String getEnv(String name) {
-            return System.getenv(name);
+            return GradleSystem.getenv(name);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultMavenFileLocations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/mvnsettings/DefaultMavenFileLocations.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.mvnsettings;
 
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.SystemProperties;
 
 import javax.annotation.Nullable;
@@ -28,7 +29,7 @@ public class DefaultMavenFileLocations implements MavenFileLocations {
 
     @Nullable
     public File getGlobalMavenDir() {
-        String m2Home = System.getenv("M2_HOME");
+        String m2Home = GradleSystem.getenv("M2_HOME");
         if (m2Home == null) {
             return null;
         }

--- a/subprojects/docs/src/docs/userguide/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/build_environment.adoc
@@ -24,6 +24,7 @@ When configuring Gradle behavior you can use these methods, listed in order of h
 * <<sec:gradle_system_properties, System properties>> such as `systemProp.http.proxyHost=somehost.org` stored in a `gradle.properties` file.
 * <<sec:gradle_configuration_properties, Gradle properties>> such as `org.gradle.caching=true` that are typically stored in a `gradle.properties` file in a project root directory or `GRADLE_USER_HOME` environment variable.
 * <<sec:gradle_environment_variables, Environment variables>> such as `GRADLE_OPTS` sourced by the environment that executes Gradle.
+* <<sec:gradle_environment_variables_for_build, Environment variables for build>> such as `M2_HOME` that is used in your build.
 
 Aside from configuring the build environment, you can configure a given project build using <<sec:project_properties, Project properties>> such as `-PreleaseType=final`.
 
@@ -115,6 +116,27 @@ Specifies <<command_line_interface, command-line arguments>> to use when startin
 Specifies the Gradle user home directory (which defaults to `$USER_HOME/.gradle` if not set).
 `JAVA_HOME`::
 Specifies the JDK installation directory to use.
+
+[[sec:gradle_environment_variables_for_build]]
+=== Environment variables for build
+
+To leverage <<gradle_daemon,Gradle Daemon>>, Gradle has to reset environment variables of daemon process between builds. On Java 7/8, this kind of modification was done via
+reflection, which is severely restricted since Java 9. To overcome this restriction, Gradle 4.10 introduces api:org.gradle.api.GradleSystem#getenv()[] to make
+changed environment variables visible to the build. We recommend to use api:org.gradle.api.GradleSystem#getenv()[] instead of `System.getenv()` in your build logic.
+
+.Reading environment variables in the build
+====
+[source,groovy]
+----
+println GradleSystem.getenv('MY_ENV_VARIABLE')
+----
+====
+
+[NOTE]
+====
+On Java 9+, once daemon process starts up, its environment variables won't change any more. To make the changed environment variables visible to your build,
+you have to either disable Gradle daemon (not recommended) or use api:org.gradle.api.GradleSystem#getenv()[] (recommended, but only after Gradle 4.10).
+====
 
 [[sec:project_properties]]
 === Project properties

--- a/subprojects/docs/src/docs/userguide/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle_daemon.adoc
@@ -86,6 +86,12 @@ As mentioned, the Daemon is a background process. You needn’t worry about a bu
 
 This will terminate all Daemon processes that were started with the same version of Gradle used to execute the command. If you have the Java Development Kit (JDK) installed, you can easily verify that a Daemon has stopped by running the `jps` command. You’ll see any running Daemons listed with the name `GradleDaemon`.
 
+[[sec:set_env_variables_for_daemon]]
+=== Set environment variables for the Daemon
+
+In a JVM process, all environment variables are stored in an `UnmodifiableMap`, which can't be modified after the JVM starts up. To overcome this limitation, we recommend to use api:org.gradle.api.GradleSystem#getenv()[] instead of `java.lang.System.getenv()` in your build logic.
+
+
 [[daemon_faq]]
 === FAQ
 

--- a/subprojects/docs/src/docs/userguide/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle_daemon.adoc
@@ -89,8 +89,7 @@ This will terminate all Daemon processes that were started with the same version
 [[sec:set_env_variables_for_daemon]]
 === Set environment variables for the Daemon
 
-In a JVM process, all environment variables are stored in an `UnmodifiableMap`, which can't be modified after the JVM starts up. To overcome this limitation, we recommend to use api:org.gradle.api.GradleSystem#getenv()[] instead of `java.lang.System.getenv()` in your build logic.
-
+See <<gradle_environment_variables_for_build>> for more details.
 
 [[daemon_faq]]
 === FAQ

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.output.TeeOutputStream;
 import org.gradle.BuildResult;
 import org.gradle.StartParameter;
 import org.gradle.api.GradleException;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.Task;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.execution.TaskExecutionGraphListener;
@@ -233,7 +234,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         Properties originalSysProperties = new Properties();
         originalSysProperties.putAll(System.getProperties());
         File originalUserDir = new File(originalSysProperties.getProperty("user.dir")).getAbsoluteFile();
-        Map<String, String> originalEnv = new HashMap<String, String>(System.getenv());
+        Map<String, String> originalEnv = new HashMap<String, String>(GradleSystem.getenv());
 
         GradleInvocation invocation = buildInvocation();
         Set<String> changedEnvVars = new HashSet<String>(invocation.environmentVars.keySet());
@@ -335,7 +336,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
     private BuildActionParameters createBuildActionParameters(StartParameter startParameter) {
         return new DefaultBuildActionParameters(
             System.getProperties(),
-            System.getenv(),
+            GradleSystem.getenv(),
             SystemProperties.getInstance().getCurrentDir(),
             startParameter.getLogLevel(),
             false,

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -16,6 +16,7 @@
 package org.gradle.launcher.daemon.configuration;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.IdentityFileResolver;
 import org.gradle.initialization.BuildLayoutParameters;
@@ -68,7 +69,7 @@ public class DaemonParameters {
         }
         baseDir = new File(layout.getGradleUserHomeDir(), "daemon");
         gradleUserHomeDir = layout.getGradleUserHomeDir();
-        envVariables = new HashMap<String, String>(System.getenv());
+        envVariables = new HashMap<String, String>(GradleSystem.getenv());
     }
 
     public boolean isInteractive() {
@@ -163,7 +164,7 @@ public class DaemonParameters {
     }
 
     public void setEnvironmentVariables(Map<String, String> envVariables) {
-        this.envVariables = envVariables == null ? new HashMap<String, String>(System.getenv()) : envVariables;
+        this.envVariables = envVariables == null ? new HashMap<String, String>(GradleSystem.getenv()) : envVariables;
     }
 
     public void setDebug(boolean debug) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -71,7 +71,7 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
                 + System.getProperty("line.separator") + "  "
                 + "If the daemon was started with a significantly different environment from the client, and your build "
                 + System.getProperty("line.separator") + "  "
-                + "relies on environment variables, you may experience unexpected behavior.");
+                + "relies on environment variables, you may experience unexpected behavior. Consider using Gradle.getenv()");
         }
         processEnvironment.maybeSetProcessDir(build.getParameters().getCurrentDir());
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.launcher.daemon.server.exec;
 
+import org.gradle.api.GradleSystem;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.FileUtils;
@@ -45,7 +46,7 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
     protected void doBuild(DaemonCommandExecution execution, Build build) {
         Properties originalSystemProperties = new Properties();
         originalSystemProperties.putAll(System.getProperties());
-        Map<String, String> originalEnv = new HashMap<String, String>(System.getenv());
+        Map<String, String> originalEnv = new HashMap<String, String>(GradleSystem.getenv());
         File originalProcessDir = FileUtils.canonicalize(new File("."));
 
         for (Map.Entry<String, String> entry : build.getParameters().getSystemProperties().entrySet()) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/AnsiConsoleUtil.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/AnsiConsoleUtil.java
@@ -19,6 +19,7 @@ package org.gradle.internal.logging.sink;
 import org.fusesource.jansi.AnsiOutputStream;
 import org.fusesource.jansi.internal.Kernel32.*;
 import org.fusesource.jansi.internal.WindowsSupport;
+import org.gradle.api.GradleSystem;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -131,7 +132,7 @@ public final class AnsiConsoleUtil {
      * @see <a href="https://github.com/fusesource/jansi/blob/eeda18cb05122abe48b284dca969e2c060a0c009/jansi/src/main/java/org/fusesource/jansi/AnsiConsole.java#L121-L124">Method copied over from AnsiConsole.isXterm</a>
      */
     private static boolean isXterm() {
-        String term = System.getenv("TERM");
+        String term = GradleSystem.getenv("TERM");
         return term != null && term.startsWith("xterm");
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.remote.internal.inet;
 
+import org.gradle.api.GradleSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,9 +117,9 @@ public class InetAddressFactory {
 
 
     private InetAddress findOpenshiftAddresses() {
-        for (String key : System.getenv().keySet()) {
+        for (String key : GradleSystem.getenv().keySet()) {
             if (key.startsWith("OPENSHIFT_") && key.endsWith("_IP")) {
-                String ipAddress = System.getenv(key);
+                String ipAddress = GradleSystem.getenv(key);
                 logger.debug("OPENSHIFT IP environment variable {} detected. Using IP address {}.", key, ipAddress);
                 try {
                     return InetAddress.getByName(ipAddress);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/EnvVariableHandler.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/EnvVariableHandler.java
@@ -16,26 +16,11 @@
 
 package org.gradle.internal.nativeintegration;
 
-/**
- * Encapsulates what happened when we tried to modify the environment.
- */
-public enum EnvironmentModificationResult {
-    SUCCESS(null),
-    ONLY_SET_GRADLE_ENV("Java 9 does not support modifying environment variables."),
-    UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
+public interface EnvVariableHandler {
+    void unsetenv(String name);
 
-    private final String reason;
+    void setenv(String name, String value);
 
-    EnvironmentModificationResult(String reason) {
-        this.reason = reason;
-    }
+    EnvironmentModificationResult result();
 
-    @Override
-    public String toString() {
-        return reason;
-    }
-
-    public boolean isSuccess() {
-        return this == SUCCESS;
-    }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/GradleEnvVariableHandler.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/GradleEnvVariableHandler.java
@@ -16,26 +16,23 @@
 
 package org.gradle.internal.nativeintegration;
 
-/**
- * Encapsulates what happened when we tried to modify the environment.
- */
-public enum EnvironmentModificationResult {
-    SUCCESS(null),
-    ONLY_SET_GRADLE_ENV("Java 9 does not support modifying environment variables."),
-    UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
+import org.gradle.api.internal.GradleProcessEnvironment;
 
-    private final String reason;
+public enum GradleEnvVariableHandler implements EnvVariableHandler {
+    INSTANCE;
 
-    EnvironmentModificationResult(String reason) {
-        this.reason = reason;
+    @Override
+    public void unsetenv(String name) {
+        GradleProcessEnvironment.unsetenv(name);
     }
 
     @Override
-    public String toString() {
-        return reason;
+    public void setenv(String name, String value) {
+        GradleProcessEnvironment.setenv(name, value);
     }
 
-    public boolean isSuccess() {
-        return this == SUCCESS;
+    @Override
+    public EnvironmentModificationResult result() {
+        return EnvironmentModificationResult.ONLY_SET_GRADLE_ENV;
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/GradleEnvVariableHandler.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/GradleEnvVariableHandler.java
@@ -23,12 +23,12 @@ public enum GradleEnvVariableHandler implements EnvVariableHandler {
 
     @Override
     public void unsetenv(String name) {
-        GradleProcessEnvironment.unsetenv(name);
+        GradleProcessEnvironment.INSTANCE.unsetenv(name);
     }
 
     @Override
     public void setenv(String name, String value) {
-        GradleProcessEnvironment.setenv(name, value);
+        GradleProcessEnvironment.INSTANCE.setenv(name, value);
     }
 
     @Override

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/UnixReflectiveEnvVariableHandler.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/UnixReflectiveEnvVariableHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.nativeintegration;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class UnixReflectiveEnvVariableHandler implements EnvVariableHandler {
+    public static final UnixReflectiveEnvVariableHandler INSTANCE = new UnixReflectiveEnvVariableHandler();
+
+    @Override
+    public void unsetenv(String name) {
+        GradleEnvVariableHandler.INSTANCE.unsetenv(name);
+        getEnv().remove(name);
+    }
+
+    @Override
+    public void setenv(String name, String value) {
+        GradleEnvVariableHandler.INSTANCE.setenv(name, value);
+        getEnv().put(name, value);
+    }
+
+    @Override
+    public EnvironmentModificationResult result() {
+        return EnvironmentModificationResult.SUCCESS;
+    }
+
+    private Map<String, String> getEnv() {
+        try {
+            Map<String, String> theUnmodifiableEnvironment = System.getenv();
+            Class<?> cu = theUnmodifiableEnvironment.getClass();
+            Field m = cu.getDeclaredField("m");
+            m.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<String, String> result = (Map<String, String>) m.get(theUnmodifiableEnvironment);
+            return result;
+        } catch (Exception e) {
+            throw new NativeIntegrationException("Unable to get mutable environment map", e);
+        }
+    }
+}

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/WindowsReflectiveEnvVariableHandler.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/WindowsReflectiveEnvVariableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,32 +16,22 @@
 
 package org.gradle.internal.nativeintegration;
 
-import org.gradle.internal.os.OperatingSystem;
-
 import java.lang.reflect.Field;
 import java.util.Map;
 
-/**
- * Uses reflection to update private environment state
- */
-public class ReflectiveEnvironment {
+public class WindowsReflectiveEnvVariableHandler extends UnixReflectiveEnvVariableHandler {
+    public static final WindowsReflectiveEnvVariableHandler INSTANCE = new WindowsReflectiveEnvVariableHandler();
 
+    @Override
     public void unsetenv(String name) {
-        Map<String, String> map = getEnv();
-        map.remove(name);
-        if (OperatingSystem.current().isWindows()) {
-            Map<String, String> env2 = getWindowsEnv();
-            env2.remove(name);
-        }
+        super.unsetenv(name);
+        getWindowsEnv().remove(name);
     }
 
+    @Override
     public void setenv(String name, String value) {
-        Map<String, String> map = getEnv();
-        map.put(name, value);
-        if (OperatingSystem.current().isWindows()) {
-            Map<String, String> env2 = getWindowsEnv();
-            env2.put(name, value);
-        }
+        super.setenv(name, value);
+        getWindowsEnv().put(name, value);
     }
 
     /**
@@ -53,24 +43,10 @@ public class ReflectiveEnvironment {
             Field caseinsensitive = sc.getDeclaredField("theCaseInsensitiveEnvironment");
             caseinsensitive.setAccessible(true);
             @SuppressWarnings("unchecked")
-            Map<String, String> result = (Map<String, String>)caseinsensitive.get(null);
+            Map<String, String> result = (Map<String, String>) caseinsensitive.get(null);
             return result;
         } catch (Exception e) {
             throw new NativeIntegrationException("Unable to get mutable windows case insensitive environment map", e);
-        }
-    }
-
-    private Map<String, String> getEnv() {
-        try {
-            Map<String, String> theUnmodifiableEnvironment = System.getenv();
-            Class<?> cu = theUnmodifiableEnvironment.getClass();
-            Field m = cu.getDeclaredField("m");
-            m.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Map<String, String> result = (Map<String, String>)m.get(theUnmodifiableEnvironment);
-            return result;
-        } catch (Exception e) {
-            throw new NativeIntegrationException("Unable to get mutable environment map", e);
         }
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetector.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetector.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.nativeintegration.console;
 
 import net.rubygrapefruit.platform.Terminals;
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.os.OperatingSystem;
 
 import static net.rubygrapefruit.platform.Terminals.Output.Stderr;
@@ -33,7 +34,7 @@ public class NativePlatformConsoleDetector implements ConsoleDetector {
     public ConsoleMetaData getConsole() {
         // Dumb terminal doesn't support ANSI control codes.
         // TODO - remove this when we use Terminal rather than JAnsi to render to console
-        String term = System.getenv("TERM");
+        String term = GradleSystem.getenv("TERM");
         if ((term != null && term.equals("dumb")) || (OperatingSystem.current().isUnix() && term == null)) {
             return null;
         }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/UnixConsoleMetaData.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/UnixConsoleMetaData.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.nativeintegration.console;
 
+import org.gradle.api.GradleSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ public class UnixConsoleMetaData implements ConsoleMetaData {
 
     @Override
     public int getCols() {
-        final String columns = System.getenv("COLUMNS");
+        final String columns = GradleSystem.getenv("COLUMNS");
         if (columns != null) {
             try {
                 return Integer.parseInt(columns);
@@ -54,7 +55,7 @@ public class UnixConsoleMetaData implements ConsoleMetaData {
 
     @Override
     public int getRows() {
-        final String rows = System.getenv("LINES");
+        final String rows = GradleSystem.getenv("LINES");
         if (rows != null) {
             try {
                 return Integer.parseInt(rows);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
@@ -17,6 +17,7 @@ package org.gradle.internal.nativeintegration.processenvironment;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.JavaVersion;
 import org.gradle.internal.nativeintegration.NativeIntegrationException;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
@@ -47,7 +48,7 @@ public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
     @Override
     public EnvironmentModificationResult maybeSetEnvironment(Map<String, String> source) {
         // need to take copy to prevent ConcurrentModificationException
-        List<String> keysToRemove = Lists.newArrayList(Sets.difference(System.getenv().keySet(), source.keySet()));
+        List<String> keysToRemove = Lists.newArrayList(Sets.difference(GradleSystem.getenv().keySet(), source.keySet()));
         for (String key : keysToRemove) {
             removeEnvironmentVariable(key);
         }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
@@ -18,50 +18,58 @@ package org.gradle.internal.nativeintegration.processenvironment;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.JavaVersion;
-import org.gradle.internal.nativeintegration.EnvironmentModificationResult;
 import org.gradle.internal.nativeintegration.NativeIntegrationException;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
-import org.gradle.internal.nativeintegration.ReflectiveEnvironment;
+import org.gradle.internal.nativeintegration.EnvVariableHandler;
+import org.gradle.internal.nativeintegration.EnvironmentModificationResult;
+import org.gradle.internal.nativeintegration.GradleEnvVariableHandler;
+import org.gradle.internal.nativeintegration.UnixReflectiveEnvVariableHandler;
+import org.gradle.internal.nativeintegration.WindowsReflectiveEnvVariableHandler;
+import org.gradle.internal.os.OperatingSystem;
 
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
-    //for updates to private JDK caches of the environment state
-    private final ReflectiveEnvironment reflectiveEnvironment = new ReflectiveEnvironment();
+    private final EnvVariableHandler envVariableHandler = handler();
+
+    private EnvVariableHandler handler() {
+        if (JavaVersion.current().isJava9Compatible()) {
+            return GradleEnvVariableHandler.INSTANCE;
+        } else if (OperatingSystem.current().isWindows()) {
+            return WindowsReflectiveEnvVariableHandler.INSTANCE;
+        } else {
+            return UnixReflectiveEnvVariableHandler.INSTANCE;
+        }
+    }
 
     @Override
     public EnvironmentModificationResult maybeSetEnvironment(Map<String, String> source) {
-        if (JavaVersion.current().isJava9Compatible()) {
-            return EnvironmentModificationResult.JAVA_9_IMMUTABLE_ENVIRONMENT;
-        }
         // need to take copy to prevent ConcurrentModificationException
         List<String> keysToRemove = Lists.newArrayList(Sets.difference(System.getenv().keySet(), source.keySet()));
         for (String key : keysToRemove) {
             removeEnvironmentVariable(key);
         }
         for (Map.Entry<String, String> entry : source.entrySet()) {
-           setEnvironmentVariable(entry.getKey(), entry.getValue());
+            setEnvironmentVariable(entry.getKey(), entry.getValue());
         }
-        return EnvironmentModificationResult.SUCCESS;
+
+        return envVariableHandler.result();
     }
 
     @Override
     public void removeEnvironmentVariable(String name) throws NativeIntegrationException {
         removeNativeEnvironmentVariable(name);
-        reflectiveEnvironment.unsetenv(name);
+        envVariableHandler.unsetenv(name);
     }
 
     protected abstract void removeNativeEnvironmentVariable(String name);
 
     @Override
     public EnvironmentModificationResult maybeRemoveEnvironmentVariable(String name) {
-        if (JavaVersion.current().isJava9Compatible()) {
-            return EnvironmentModificationResult.JAVA_9_IMMUTABLE_ENVIRONMENT;
-        }
         removeEnvironmentVariable(name);
-        return EnvironmentModificationResult.SUCCESS;
+        return envVariableHandler.result();
     }
 
     @Override
@@ -72,18 +80,15 @@ public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
         }
 
         setNativeEnvironmentVariable(name, value);
-        reflectiveEnvironment.setenv(name, value);
+        envVariableHandler.setenv(name, value);
     }
 
     protected abstract void setNativeEnvironmentVariable(String name, String value);
 
     @Override
     public EnvironmentModificationResult maybeSetEnvironmentVariable(String name, String value) {
-        if (JavaVersion.current().isJava9Compatible()) {
-            return EnvironmentModificationResult.JAVA_9_IMMUTABLE_ENVIRONMENT;
-        }
         setEnvironmentVariable(name, value);
-        return EnvironmentModificationResult.SUCCESS;
+        return envVariableHandler.result();
     }
 
     @Override

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -26,6 +26,7 @@ import net.rubygrapefruit.platform.SystemInfo;
 import net.rubygrapefruit.platform.Terminals;
 import net.rubygrapefruit.platform.WindowsRegistry;
 import net.rubygrapefruit.platform.internal.DefaultProcessLauncher;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.JavaVersion;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
@@ -118,7 +119,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     }
 
     private static String getNativeDirOverride() {
-        return System.getProperty(NATIVE_DIR_OVERRIDE, System.getenv(NATIVE_DIR_OVERRIDE));
+        return System.getProperty(NATIVE_DIR_OVERRIDE, GradleSystem.getenv(NATIVE_DIR_OVERRIDE));
     }
 
     public static synchronized NativeServices getInstance() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultCommandLineToolInvocationWorker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultCommandLineToolInvocationWorker.java
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.toolchain.internal;
 
 import com.google.common.base.Joiner;
+import org.gradle.api.GradleSystem;
 import org.gradle.internal.io.StreamByteBuffer;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.os.OperatingSystem;
@@ -66,7 +67,7 @@ public class DefaultCommandLineToolInvocationWorker implements CommandLineToolIn
         if (!invocation.getPath().isEmpty()) {
             String pathVar = OperatingSystem.current().getPathVar();
             String toolPath = Joiner.on(File.pathSeparator).join(invocation.getPath());
-            toolPath = toolPath + File.pathSeparator + System.getenv(pathVar);
+            toolPath = toolPath + File.pathSeparator + GradleSystem.getenv(pathVar);
             toolExec.environment(pathVar, toolPath);
             if (OperatingSystem.current().isWindows() && toolExec.getEnvironment().containsKey(pathVar.toUpperCase())) {
                 toolExec.getEnvironment().remove(pathVar.toUpperCase());

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppPlatformToolProvider.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Transformer;
 import org.gradle.internal.Transformers;
@@ -205,7 +206,7 @@ class VisualCppPlatformToolProvider extends AbstractPlatformToolProvider {
 
     private void clearEnvironmentVars(MutableCommandLineToolContext invocation, String... names) {
         // TODO: This check should really be done in the compiler process
-        Map<String, ?> environmentVariables = Jvm.current().getInheritableEnvironmentVariables(System.getenv());
+        Map<String, ?> environmentVariables = Jvm.current().getInheritableEnvironmentVariables(GradleSystem.getenv());
         for (String name : names) {
             Object value = environmentVariables.get(name);
             if (value != null) {

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -19,6 +19,7 @@ package org.gradle.nativeplatform.fixtures;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.gradle.api.GradleSystem;
 import org.gradle.api.internal.file.TestFiles;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
@@ -327,7 +328,7 @@ public class AvailableToolChains {
             String compilerPath = Joiner.on(File.pathSeparator).join(pathEntries);
 
             if (compilerPath.length() > 0) {
-                originalPath = System.getenv(pathVarName);
+                originalPath = GradleSystem.getenv(pathVarName);
                 String path = compilerPath + File.pathSeparator + originalPath;
                 System.out.println(String.format("Using path %s", path));
                 PROCESS_ENVIRONMENT.setEnvironmentVariable(pathVarName, path);
@@ -367,7 +368,7 @@ public class AvailableToolChains {
                 return Collections.emptyList();
             }
 
-            String path = Joiner.on(File.pathSeparator).join(pathEntries) + File.pathSeparator + System.getenv(pathVarName);
+            String path = Joiner.on(File.pathSeparator).join(pathEntries) + File.pathSeparator + GradleSystem.getenv(pathVarName);
             return Collections.singletonList(pathVarName + "=" + path);
         }
 


### PR DESCRIPTION
### Context

JVM stores all environment variables in an internal `UnmodifiableMap` and doesn't allow us to modify it. Previously we did a hackery for Gradle daemon - reflectively modify these environment variables, which is more and more difficult after Java 9. Aiming at superseding `System.getenv`, this PR provides a new API to get environment variables on daemon side.

Basically, what this PR does is:

- Provides a new `GradleSystem` to fetch current "Gradle-managed" environment variables.
- When daemon resets environment variable, it also reset these values in `GradleSystem`.
- When a new process is forked by daemon, `GradleSystem`'s environment variables are also passed to the forked process.
