### PR TITLE
Add displayName and description to PluginDeclaration

### DIFF
--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
@@ -85,8 +85,8 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
 
     def "Publishes one Ivy marker for every plugin"() {
         given:
-        plugin('foo', 'com.example.foo')
-        plugin('bar', 'com.example.bar')
+        plugin('foo', 'com.example.foo', 'The Foo Plugin', 'The greatest Foo plugin of all time.')
+        plugin('bar', 'com.example.bar', 'The Bar Plugin', 'The greatest Bar plugin of all time.')
         publishToIvy()
 
         when:
@@ -99,12 +99,14 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
             marker.assertPublished()
             assert marker.parsedIvy.dependencies['com.example:plugins:1.0']
         }
+        fooMarker.parsedIvy.description.text() == 'The greatest Foo plugin of all time.'
+        barMarker.parsedIvy.description.text() == 'The greatest Bar plugin of all time.'
     }
 
     def "Publishes one Maven marker for every plugin"() {
         given:
-        plugin('foo', 'com.example.foo')
-        plugin('bar', 'com.example.bar')
+        plugin('foo', 'com.example.foo', 'The Foo Plugin', 'The greatest Foo plugin of all time.')
+        plugin('bar', 'com.example.bar', 'The Bar Plugin', 'The greatest Bar plugin of all time.')
         publishToMaven()
 
         when:
@@ -116,6 +118,14 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
         [fooMarker, barMarker].each { marker ->
             marker.assertPublished()
             assert marker.parsedPom.scopes['runtime'].expectDependency('com.example:plugins:1.0')
+        }
+        with(fooMarker.parsedPom) {
+            it.name == 'The Foo Plugin'
+            it.description == 'The greatest Foo plugin of all time.'
+        }
+        with(barMarker.parsedPom) {
+            it.name == 'The Bar Plugin'
+            it.description == 'The greatest Bar plugin of all time.'
         }
     }
 
@@ -226,7 +236,7 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
         """
     }
 
-    def plugin(String name, String pluginId) {
+    def plugin(String name, String pluginId, String displayName = null, String description = null) {
         String implementationClass = name.capitalize();
 
         file("src/main/java/com/xxx/${implementationClass}.java") << """
@@ -243,6 +253,8 @@ public class ${implementationClass} implements Plugin<Project> {
                     ${name} {
                         id = '${pluginId}'
                         implementationClass = '${implementationClass}'
+                        ${displayName ? "displayName = '$displayName'" : ""}
+                        ${description ? "description = '$description'" : ""}
                     }
                 }
             }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
@@ -20,11 +20,11 @@ import com.google.common.base.Objects;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 
 
 //TODO version - could be different from main artifact's version
-//TODO description - could be put in the Pom/Ivy file for clarity
 /**
  * Describes a Gradle plugin under development.
  *
@@ -36,6 +36,8 @@ public class PluginDeclaration implements Named, Serializable {
     private final String name;
     private String id;
     private String implementationClass;
+    private String displayName;
+    private String description;
 
     public PluginDeclaration(String name) {
         this.name = name;
@@ -60,6 +62,56 @@ public class PluginDeclaration implements Named, Serializable {
 
     public void setImplementationClass(String implementationClass) {
         this.implementationClass = implementationClass;
+    }
+
+    /**
+     * Returns the display name for this plugin declaration.
+     *
+     * <p>The display name is used when publishing this plugin to repositories
+     * that support human-readable artifact names.
+     *
+     * @since 4.10
+     */
+    @Nullable
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Sets the display name for this plugin declaration.
+     *
+     * <p>The display name is used when publishing this plugin to repositories
+     * that support human-readable artifact names.
+     *
+     * @since 4.10
+     */
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Returns the description for this plugin declaration.
+     *
+     * <p>The description is used when publishing this plugin to repositories
+     * that support providing descriptions for artifacts.
+     *
+     * @since 4.10
+     */
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description for this plugin declaration.
+     *
+     * <p>The description is used when publishing this plugin to repositories
+     * that support providing descriptions for artifacts.
+     *
+     * @since 4.10
+     */
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/IvyPluginPublishingPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.ivy.IvyModuleDescriptorDescription;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorSpec;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.ivy.internal.publication.IvyPublicationInternal;
@@ -87,7 +88,7 @@ class IvyPluginPublishingPlugin implements Plugin<Project> {
         }
     }
 
-    private void createIvyMarkerPublication(PluginDeclaration declaration, final IvyPublication mainPublication, PublicationContainer publications) {
+    private void createIvyMarkerPublication(final PluginDeclaration declaration, final IvyPublication mainPublication, PublicationContainer publications) {
         String pluginId = declaration.getId();
         IvyPublicationInternal publication = (IvyPublicationInternal) publications.create(declaration.getName() + "PluginMarkerIvy", IvyPublication.class);
         publication.setAlias(true);
@@ -96,6 +97,12 @@ class IvyPluginPublishingPlugin implements Plugin<Project> {
         publication.descriptor(new Action<IvyModuleDescriptorSpec>() {
             @Override
             public void execute(IvyModuleDescriptorSpec descriptor) {
+                descriptor.description(new Action<IvyModuleDescriptorDescription>() {
+                    @Override
+                    public void execute(IvyModuleDescriptorDescription description) {
+                        description.getText().set(declaration.getDescription());
+                    }
+                });
                 descriptor.withXml(new Action<XmlProvider>() {
                     @Override
                     public void execute(XmlProvider xmlProvider) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -106,5 +106,7 @@ class MavenPluginPublishPlugin implements Plugin<Project> {
                 version.setTextContent(coordinates.getVersion());
             }
         });
+        publication.getPom().getName().set(declaration.getDisplayName());
+        publication.getPom().getDescription().set(declaration.getDescription());
     }
 }


### PR DESCRIPTION
Both attributes are used when generating the marker Ivy descriptor/POM and will be consumed by the `plugin-publish` plugin for publishing to the Plugin Portal.

Plain `String` properties are used to ensure the new attributes can be consumed by the `plugin-publish` plugin in a subsequent step.

Resolves #5985.