### PR TITLE
Add test for build cache overhead on up-to-date build

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/CurrentFileCollectionFingerprint.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/CurrentFileCollectionFingerprint.java
@@ -19,6 +19,8 @@ package org.gradle.internal.fingerprint;
 import org.gradle.api.internal.changedetection.state.mirror.PhysicalSnapshotVisitor;
 import org.gradle.internal.hash.HashCode;
 
+import javax.annotation.Nonnull;
+
 /**
  * A file collection fingerprint taken during this build.
  */
@@ -26,6 +28,7 @@ public interface CurrentFileCollectionFingerprint extends FileCollectionFingerpr
     /**
      * Returns the combined hash of the contents of this {@link CurrentFileCollectionFingerprint}.
      */
+    @Nonnull
     HashCode getHash();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/FileCollectionFingerprint.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/FileCollectionFingerprint.java
@@ -19,7 +19,9 @@ package org.gradle.internal.fingerprint;
 import org.gradle.api.internal.changedetection.rules.TaskStateChange;
 import org.gradle.api.internal.changedetection.rules.TaskStateChangeVisitor;
 import org.gradle.api.internal.changedetection.state.NormalizedFileSnapshot;
+import org.gradle.internal.hash.HashCode;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -38,6 +40,12 @@ public interface FileCollectionFingerprint {
      * The underlying snapshots.
      */
     Map<String, NormalizedFileSnapshot> getSnapshots();
+
+    /**
+     * The hash of the fingerprint, if available.
+     */
+    @Nullable
+    HashCode getHash();
 
     /**
      * Converts the {@link FileCollectionFingerprint} into a {@link HistoricalFileCollectionFingerprint} which can be serialized in the task history.

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -54,6 +54,9 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
 
     @Override
     public boolean visitChangesSince(FileCollectionFingerprint oldFingerprint, String title, boolean includeAdded, TaskStateChangeVisitor visitor) {
+        if (hash != null && hash.equals(oldFingerprint.getHash())) {
+            return true;
+        }
         return compareStrategy.visitChangesSince(visitor, getSnapshots(), oldFingerprint.getSnapshots(), title, includeAdded);
     }
 
@@ -84,6 +87,6 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
 
     @Override
     public HistoricalFileCollectionFingerprint archive() {
-        return new DefaultHistoricalFileCollectionFingerprint(snapshots, compareStrategy);
+        return new DefaultHistoricalFileCollectionFingerprint(snapshots, compareStrategy, hash);
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -16,7 +16,11 @@
 
 package org.gradle.performance.regression.java
 
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.fixture.BuildExperimentListenerAdapter
+import org.gradle.performance.fixture.BuildExperimentSpec
+import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
@@ -32,6 +36,43 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.tasksToRun = ['assemble']
         runner.targetVersions = ["4.10-20180712235924+0000"]
         runner.args += ["-Dorg.gradle.parallel=$parallel"]
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        where:
+        testProject                   | parallel
+        LARGE_MONOLITHIC_JAVA_PROJECT | false
+        LARGE_JAVA_MULTI_PROJECT      | true
+        LARGE_JAVA_MULTI_PROJECT      | false
+    }
+
+    @Unroll
+    def "up-to-date assemble on #testProject with local build cache enabled (parallel #parallel)"() {
+        given:
+        runner.testProject = testProject
+        runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
+        runner.tasksToRun = ['assemble']
+        runner.targetVersions = ["4.9-20180620235919+0000"]
+        runner.args += ["-Dorg.gradle.parallel=$parallel", "-D${StartParameterBuildOptions.BuildCacheOption.GRADLE_PROPERTY}=true"]
+        def cacheDir = temporaryFolder.file("local-cache")
+        runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
+            @Override
+            void beforeExperiment(BuildExperimentSpec experimentSpec, File projectDir) {
+                cacheDir.deleteDir().mkdirs()
+                def settingsFile = new TestFile(projectDir).file('settings.gradle')
+                settingsFile << """
+                    buildCache {
+                        local {
+                            directory = '${cacheDir.absoluteFile.toURI()}'
+                        }
+                    }
+                """.stripIndent()
+            }
+        })
 
         when:
         def result = runner.run()


### PR DESCRIPTION
We removed an optimization for the fully up-to-date case when the build cache is enabled. No performance test failed.

Therefore, this PR adds a performance test which checks that we do not become any slower in the fully up-to-date case when the build cache is enabled. Note that the same behaviour is in place when the build scan plugin is applied, so we pay the performance overhead of calculating the build cache key there, too.