### PR TITLE
Fix typo in userguide java plugin config image

### DIFF
--- a/subprojects/docs/src/docs/userguide/img/javaPluginConfigurations.dot
+++ b/subprojects/docs/src/docs/userguide/img/javaPluginConfigurations.dot
@@ -24,7 +24,7 @@ digraph javaPluginConfigurations {
     runtime -> compile
     runtimeClasspath -> {runtimeOnly runtime implementation}
     testCompile -> compile
-    testImplementaion -> {testCompile implementation}
+    testImplementation -> {testCompile implementation}
     testCompileClasspath -> {testCompile testCompileOnly testImplementation}
     testRuntime -> {runtime testCompile}
     testRuntimeOnly -> runtimeOnly


### PR DESCRIPTION

### Context
The dot file had a typo - a missing `t` in `testImplementation`, that created an extra node on the diagram, and caused confusion.
This has been documented in the issue #5681.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~~
- [ ] ~~Provide unit tests (under `<subproject>/src/test`) to verify logic~~
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
