### PR TITLE
Improvements on ClassLoaderUtils

### DIFF
--- a/subprojects/base-services/src/integTest/groovy/org/gradle/internal/classloader/ClassLoaderUtilsIntegrationTest.groovy
+++ b/subprojects/base-services/src/integTest/groovy/org/gradle/internal/classloader/ClassLoaderUtilsIntegrationTest.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader
+
+import org.apache.commons.io.IOUtils
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Type
+import spock.lang.Unroll
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC
+import static org.objectweb.asm.Opcodes.ALOAD
+import static org.objectweb.asm.Opcodes.H_INVOKESPECIAL
+import static org.objectweb.asm.Opcodes.RETURN
+import static org.objectweb.asm.Opcodes.V1_5
+
+@Requires(TestPrecondition.JDK9_OR_LATER)
+class ClassLoaderUtilsIntegrationTest extends AbstractIntegrationSpec {
+    private String packageName = ClassLoaderUtils.getPackageName()
+
+    @Unroll
+    def 'have illegal access warning when trying to inject into #classLoader'() {
+        given:
+        buildFile << """ 
+            apply plugin:'java'
+            
+            ${jcenterRepository()}
+
+            dependencies {
+                testCompile gradleApi()
+                testCompile 'junit:junit:4.12'
+            }
+        """
+
+        file("src/test/java/${packageName.replace('.', '/')}/Test.java") << """
+            package ${packageName};
+            import java.nio.file.*;
+            
+            public class Test {
+                @org.junit.Test
+                public void test() throws Exception {
+                    Path path = Paths.get("${file('MyClass.class').absolutePath.replace('\\', '/')}");
+                    byte[] bytes = Files.readAllBytes(path);
+                    ClassLoaderUtils.define(${classLoader}, "MyClass", bytes);
+                }
+                
+                private static class MyClassLoader extends ClassLoader { }
+            }
+        """
+
+        createClassFile()
+
+        when:
+        succeeds('test')
+
+        then:
+        result.hasErrorOutput("Illegal reflective access using Lookup on ${ClassLoaderUtils.name}") == hasWarning
+
+        where:
+        classLoader                          | hasWarning
+        'ClassLoader.getSystemClassLoader()' | true
+        'new MyClassLoader()'                | false
+    }
+
+    void createClassFile() {
+        ClassWriter cw = new ClassWriter(0)
+        cw.visit(V1_5, ACC_PUBLIC, "MyClass", null, 'java/lang/Object', null)
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null)
+        mv.visitMaxs(2, 1)
+        mv.visitVarInsn(ALOAD, 0) // push `this` to the operand stack
+        mv.visitMethodInsn(H_INVOKESPECIAL, Type.getInternalName(Object.class), "<init>", "()V", false)
+        mv.visitInsn(RETURN)
+        mv.visitEnd()
+        cw.visitEnd()
+
+        IOUtils.write(cw.toByteArray(), new FileOutputStream(file('MyClass.class')))
+    }
+
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -55,7 +55,9 @@ public class LogContent {
      * Creates a new instance, from raw characters.
      */
     public static LogContent of(String chars) {
-        return new LogContent(toLines(stripJavaIllegalAccessWarnings(stripWorkInProgressArea(chars))), false, null);
+        String stripped = stripWorkInProgressArea(chars);
+        LogContent raw = new LogContent(toLines(stripped), false, null);
+        return new LogContent(toLines(stripJavaIllegalAccessWarnings(stripped)), false, raw);
     }
 
     private static ImmutableList<String> toLines(String chars) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -191,7 +191,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     @Override
     public boolean hasErrorOutput(String expectedOutput) {
-        return getError().contains(expectedOutput);
+        return getError().contains(expectedOutput) || getRawError().contains(expectedOutput);
     }
 
     @Override
@@ -211,6 +211,10 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     public String getError() {
         return error.withNormalizedEol();
+    }
+
+    public String getRawError() {
+        return errorContent.getRawContent().withNormalizedEol();
     }
 
     public List<String> getExecutedTasks() {

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGenerator.java
@@ -55,6 +55,6 @@ public class AsmClassGenerator {
     }
 
     public <T> Class<T> define(ClassLoader targetClassLoader) {
-       return ClassLoaderUtils.define(targetClassLoader, generatedTypeName, visitor.toByteArray());
+        return ClassLoaderUtils.defineDecorator(targetType, targetClassLoader, generatedTypeName, visitor.toByteArray());
     }
 }


### PR DESCRIPTION
### Context

After https://github.com/gradle/gradle/pull/5811 is merged, I was surprised that the illegal reflective access warnings still appear: 

> Illegal reflective access using Lookup on org.gradle.internal.classloader.ClassLoaderUtils

It turns out that a lookup object which is accessible to the target class class loader must be provided. For example, if we want to invoke `MyClassLoader.defineClass` via `Lookup`, we must provide a lookup object from `privateLookupIn(MyClassLoader.class)`, not `privateLookupIn(ClassLoader.class)`. Otherwise, we'll get the warning and potential failure in the future. This PR fixes this by 

```
try {
       return MethodHandles.privateLookupIn(classLoader.getClass(), baseLookup);
} catch (IllegalAccessException e) {
       // Fallback to ClassLoader's lookup
      return MethodHandles.privateLookupIn(ClassLoader.class, baseLookup);
}
```

See more information in the https://mydailyjava.blogspot.com/2018/04/jdk-11-and-proxies-in-world-past.html

Also, this PR does a tiny improvement: it uses `Lookup.defineClass` as much as possible. `Lookup.defineClass` is expected to replace `Unsafe.defineClass` by JDK team, but `Lookup.defineClass` has a limitation: it can only `defines a class to the same class loader and in the same runtime package and protection domain as this lookup's lookup class`. If we're decorating a class, this is gonna be fine and we use this API, otherwise we use `Lookup` to invoke `ClassLoader.defineClass` as a fallback.

Two integration tests are provided to make sure illegal reflective access warnings are eliminated.
