### PR TITLE
Recompile when module-info files change

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/compile/ApiMemberSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/compile/ApiMemberSelector.java
@@ -20,6 +20,7 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.ModuleVisitor;
 
 import java.util.Set;
 import java.util.SortedSet;
@@ -63,6 +64,11 @@ public class ApiMemberSelector extends ClassVisitor {
         super.visit(version, access, name, signature, superName, interfaces);
         classMember = new ClassMember(version, access, name, signature, superName, interfaces);
         isInnerClass = (access & ACC_SUPER) == ACC_SUPER;
+    }
+
+    @Override
+    public ModuleVisitor visitModule(String name, int access, String version) {
+        return apiMemberAdapter.visitModule(name, access, version);
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
@@ -16,10 +16,12 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.tasks.compile.CompileOptions;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -66,5 +68,19 @@ public class DefaultJavaCompileSpec extends DefaultJvmLanguageCompileSpec implem
     @Override
     public void setClasses(Set<String> classes) {
         this.classes = classes;
+    }
+
+    @Override
+    public List<File> getModulePath() {
+        int i = compileOptions.getCompilerArgs().indexOf("--module-path");
+        if (i < 0) {
+            return Collections.emptyList();
+        }
+        String[] modules = compileOptions.getCompilerArgs().get(i + 1).split(File.pathSeparator);
+        List<File> result = Lists.newArrayListWithCapacity(modules.length);
+        for (String module : modules) {
+            result.add(new File(module));
+        }
+        return result;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
@@ -42,4 +42,6 @@ public interface JavaCompileSpec extends JvmLanguageCompileSpec {
     void setClasses(Set<String> classes);
 
     Set<String> getClasses();
+
+    List<File> getModulePath();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalResultStoringCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile.incremental;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.JdkJavaCompilerResult;
 import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathSnapshotData;
@@ -58,7 +59,7 @@ class IncrementalResultStoringCompiler implements Compiler<JavaCompileSpec> {
     }
 
     private void storeResult(JavaCompileSpec spec, WorkResult result) {
-        ClasspathSnapshotData classpathSnapshot = classpathSnapshotProvider.getClasspathSnapshot(spec.getCompileClasspath()).getData();
+        ClasspathSnapshotData classpathSnapshot = classpathSnapshotProvider.getClasspathSnapshot(Iterables.concat(spec.getCompileClasspath(), spec.getModulePath())).getData();
         AnnotationProcessingData annotationProcessingData = getAnnotationProcessingResult(spec, result);
         PreviousCompilationData data = new PreviousCompilationData(spec.getDestinationDir(), annotationProcessingData, classpathSnapshot, spec.getAnnotationProcessorPath());
         stash.put(data);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
+import org.objectweb.asm.ModuleVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.TypePath;
@@ -99,6 +100,12 @@ public class ClassDependenciesVisitor extends ClassVisitor {
             maybeAddSuperType(interfaceType);
         }
 
+    }
+
+    @Override
+    public ModuleVisitor visitModule(String name, int access, String version) {
+        dependencyToAll = true;
+        return null;
     }
 
     // performs a fast analysis of classes referenced in bytecode (method bodies)

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CurrentCompilation.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CurrentCompilation.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.recomp;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathSnapshot;
@@ -39,7 +40,7 @@ public class CurrentCompilation {
     }
 
     public ClasspathSnapshot getClasspathSnapshot() {
-        return classpathSnapshotProvider.getClasspathSnapshot(spec.getCompileClasspath());
+        return classpathSnapshotProvider.getClasspathSnapshot(Iterables.concat(spec.getCompileClasspath(), spec.getModulePath()));
     }
 
     public Collection<File> getAnnotationProcessorPath() {


### PR DESCRIPTION
This uses a deliberatly simple strategy for now,
recompiling everything if a module file changes.
We could make this smarter by tracking changes
to exported packages and required modules and only
recompiling those who used them. But the gain is
questionable, as module files only rarely change.