### PR TITLE
Deprecation progress events are enriched to allow better visualisation

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -70,10 +70,9 @@ public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
             @Override
             public Directory call() {
                 if (usesSubprojectCheckstyleConfiguration()) {
-                    DeprecationLogger.nagUserOfDeprecated("Setting the Checkstyle configuration file under 'config/checkstyle' of a sub project", "Use the root project's 'config/checkstyle' directory instead.");
+                    DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("Setting the Checkstyle configuration file under 'config/checkstyle' of a sub project", "Use the root project's 'config/checkstyle' directory instead.");
                     return project.getLayout().getProjectDirectory().dir(CONFIG_DIR_NAME);
                 }
-
                 return project.getRootProject().getLayout().getProjectDirectory().dir(CONFIG_DIR_NAME);
             }
         });

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
@@ -73,7 +73,7 @@ abstract class CheckstyleInvoker {
                 def userProvidedConfigLoc = configProperties[CONFIG_LOC_PROPERTY]
 
                 if (userProvidedConfigLoc) {
-                    SingleMessageLogger.nagUserOfDeprecated("Adding 'config_loc' to checkstyle.configProperties", "Use checkstyle.configDir instead as this will behave better with up-to-date checks.")
+                    SingleMessageLogger.nagUserWithDeprecatedIndirectUserCodeCause("Adding 'config_loc' to checkstyle.configProperties", "Use checkstyle.configDir instead as this will behave better with up-to-date checks.")
                 } else if (configDir) {
                     // Use configDir for config_loc
                     property(key: CONFIG_LOC_PROPERTY, value: configDir.toString())

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
@@ -40,7 +40,7 @@ public class LoggingDeprecatable implements Deprecatable {
     public void checkDeprecation() {
         String suffix = LoggingDeprecatedFeatureHandler.getRemovalDetails();
         for (String deprecation : deprecations) {
-            DeprecationLogger.nagUserWith(String.format("%s has been deprecated.", deprecation), String.format("This %s", suffix), null);
+            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(String.format("%s has been deprecated.", deprecation), String.format("This %s", suffix));
         }
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
@@ -40,7 +40,7 @@ public class LoggingDeprecatable implements Deprecatable {
     public void checkDeprecation() {
         String suffix = LoggingDeprecatedFeatureHandler.getRemovalDetails();
         for (String deprecation : deprecations) {
-            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(String.format("%s has been deprecated.", deprecation), String.format("This %s", suffix));
+            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(deprecation, String.format("This %s", suffix));
         }
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/LoggingDeprecatable.java
@@ -40,7 +40,7 @@ public class LoggingDeprecatable implements Deprecatable {
     public void checkDeprecation() {
         String suffix = LoggingDeprecatedFeatureHandler.getRemovalDetails();
         for (String deprecation : deprecations) {
-            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(deprecation, String.format("This %s", suffix));
+            DeprecationLogger.nagUserWithDeprecatedBuildInvocationFeature(deprecation, String.format("This %s", suffix));
         }
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -138,6 +138,6 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds "help"
-        output.contains "The AbstractFileCollection.getBuildDependencies() method has been deprecated. This is scheduled to be removed in Gradle 5.0. CustomFileCollection extends AbstractFileCollection. Don't do that, use Project.files() instead."
+        output.contains "The AbstractFileCollection.getBuildDependencies() method has been deprecated. This is scheduled to be removed in Gradle 5.0. CustomFileCollection extends AbstractFileCollection. Do not extend AbstractFileCollection. Use Project.files() instead."
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -131,7 +131,7 @@ task work {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds("work")
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':work'.
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':work'.
  - File '$link' specified for property '\$1' does not exist."""
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -131,7 +131,7 @@ task work {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds("work")
-        output.contains """A problem was found with the configuration of task ':work'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. 
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':work'.
  - File '$link' specified for property '\$1' does not exist."""
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -502,7 +502,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
  - No value has been specified for property 'input'."""
     }
 
@@ -528,7 +528,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
  - No value has been specified for property 'input'."""
 
         where:
@@ -561,7 +561,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
  - No value has been specified for property 'output'."""
 
         where:
@@ -595,7 +595,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        def expectedString = """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
+        def expectedString = """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
  - $type '${file("missing")}' specified for property 'input' does not exist."""
         output.contains expectedString
 
@@ -619,7 +619,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
  - ${type.capitalize()} '${file(path)}' specified for property 'input' is not a $type."""
 
         where:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -502,7 +502,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """A problem was found with the configuration of task ':test'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. 
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
  - No value has been specified for property 'input'."""
     }
 
@@ -528,7 +528,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """A problem was found with the configuration of task ':test'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. 
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
  - No value has been specified for property 'input'."""
 
         where:
@@ -561,7 +561,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """A problem was found with the configuration of task ':test'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. 
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
  - No value has been specified for property 'output'."""
 
         where:
@@ -595,8 +595,9 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """A problem was found with the configuration of task ':test'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. 
+        def expectedString = """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
  - $type '${file("missing")}' specified for property 'input' does not exist."""
+        output.contains expectedString
 
         where:
         method | type
@@ -618,7 +619,7 @@ task someTask(type: SomeTask) {
         expect:
         executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
         succeeds "test"
-        output.contains """A problem was found with the configuration of task ':test'. Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. 
+        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. A problem was found with the configuration of task ':test'.
  - ${type.capitalize()} '${file(path)}' specified for property 'input' is not a $type."""
 
         where:

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GradleUtilDefaultImportDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GradleUtilDefaultImportDeprecationIntegrationTest.groovy
@@ -58,7 +58,8 @@ task noop{
         succeeds('noop')
 
         then:
-        outputContains("build.gradle' is using GradleVersion from the private org.gradle.util package without an explicit import. The support for implicit import of internal classes is deprecated and will be removed in Gradle 5.0. Please either stop using these internal classes (recommended) or import them explicitly at the top of your build file.")
+        outputContains("The support for implicit import of internal classes has been deprecated. This is scheduled to be removed in Gradle 5.0.")
+        outputContains("build.gradle' is using GradleVersion from the private org.gradle.util package. Please either stop using internal classes (recommended) or import them explicitly at the top of your build file.")
     }
 
     def "deprecation warning points to the offending file"() {
@@ -75,7 +76,8 @@ task noop{
         succeeds('noop')
 
         then:
-        outputContains("foo.gradle' is using GradleVersion from the private org.gradle.util package without an explicit import. The support for implicit import of internal classes is deprecated and will be removed in Gradle 5.0. Please either stop using these internal classes (recommended) or import them explicitly at the top of your build file.")
+        outputContains("The support for implicit import of internal classes has been deprecated. This is scheduled to be removed in Gradle 5.0.")
+        outputContains("foo.gradle' is using GradleVersion from the private org.gradle.util package. Please either stop using internal classes (recommended) or import them explicitly at the top of your build file.")
     }
 
     def "multiple implicit imports will only be warned once"() {
@@ -92,6 +94,7 @@ task noop{
         succeeds('noop')
 
         then:
-        outputContains("build.gradle' is using CollectionUtils and GradleVersion from the private org.gradle.util package without an explicit import. The support for implicit import of internal classes is deprecated and will be removed in Gradle 5.0. Please either stop using these internal classes (recommended) or import them explicitly at the top of your build file.")
+        outputContains('The support for implicit import of internal classes has been deprecated. This is scheduled to be removed in Gradle 5.0. Build file')
+        outputContains("build.gradle' is using CollectionUtils and GradleVersion from the private org.gradle.util package. Please either stop using internal classes (recommended) or import them explicitly at the top of your build file.")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CacheBackedTaskHistoryRepository.java
@@ -358,7 +358,7 @@ public class CacheBackedTaskHistoryRepository implements TaskHistoryRepository {
 
             @Override
             public void visitTree(FileTreeInternal fileTree) {
-                DeprecationLogger.nagUserOfDeprecated("The ability to add non-directory-based file trees as declared outputs");
+                DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("The ability to add non-directory-based file trees as declared outputs");
                 addAllPaths(fileTree, declaredOutputFilePaths, stringInterner);
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -206,7 +206,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public TaskDependency getBuildDependencies() {
-        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()", getClass().getName() + " extends AbstractFileCollection. Don't do that, use Project.files() instead.");
+        DeprecationLogger.nagUserOfDiscontinuedMethod("AbstractFileCollection.getBuildDependencies()", "Do not extend AbstractFileCollection. Use Project.files() instead.", getClass().getName() + " extends AbstractFileCollection.");
         return TaskDependencies.EMPTY;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -221,7 +221,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
                 try {
                     validator.validate(propertyName, value, context, severity);
                 } catch (UnsupportedNotationException ex) {
-                    DeprecationLogger.nagUserOfDeprecated("Using TaskInputs." + method + "() with something that doesn't resolve to a File object", "Use TaskInputs.files() instead.");
+                    DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("Using TaskInputs." + method + "() with something that doesn't resolve to a File object", "Use TaskInputs.files() instead.");
                 }
             }
         };

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
@@ -26,17 +26,19 @@ import org.gradle.util.DeprecationLogger;
 import java.util.List;
 
 public interface TaskValidationContext {
+
+    String DEPRECATION_SUMMARY = "Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated.";
+
     enum Severity {
         WARNING() {
             @Override
             public boolean report(Task task, List<String> messages, TaskStateInternal state) {
-                String deprecationMessage = String.format("%s Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated.", getMainMessage(task, messages));
-                StringBuilder builder = new StringBuilder();
+                StringBuilder contextualAdviceBuilder = new StringBuilder(getMainMessage(task, messages));
                 for (String message : messages) {
-                    builder.append("\n - ");
-                    builder.append(message);
+                    contextualAdviceBuilder.append("\n - ");
+                    contextualAdviceBuilder.append(message);
                 }
-                DeprecationLogger.nagUserWith(deprecationMessage, builder.toString());
+                DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(DEPRECATION_SUMMARY, null, null, contextualAdviceBuilder.toString());
                 return true;
             }
         },

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public interface TaskValidationContext {
 
-    String DEPRECATION_SUMMARY = "Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated.";
+    String DEPRECATION_SUMMARY = "Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods";
 
     enum Severity {
         WARNING() {
@@ -38,7 +38,7 @@ public interface TaskValidationContext {
                     contextualAdviceBuilder.append("\n - ");
                     contextualAdviceBuilder.append(message);
                 }
-                DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(DEPRECATION_SUMMARY, null, null, contextualAdviceBuilder.toString());
+                DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(DEPRECATION_SUMMARY, null, contextualAdviceBuilder.toString());
                 return true;
             }
         },

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
@@ -117,7 +117,7 @@ public class OptionReader {
             } else {
                 org.gradle.api.internal.tasks.options.Option internalOption = findOption(field, org.gradle.api.internal.tasks.options.Option.class);
                 if (internalOption != null) {
-                    SingleMessageLogger.nagUserOfDeprecated("org.gradle.api.internal.tasks.options.Option", "Use org.gradle.api.tasks.options.Option instead.");
+                    SingleMessageLogger.nagUserWithDeprecatedIndirectUserCodeCause("org.gradle.api.internal.tasks.options.Option", "Use org.gradle.api.tasks.options.Option instead.");
                     fieldOptionElements.add(FieldOptionElement.create(internalOption, field, optionValueNotationParserFactory));
                 }
             }
@@ -147,7 +147,7 @@ public class OptionReader {
             }  else {
                 org.gradle.api.internal.tasks.options.Option internalOption = findOption(method, org.gradle.api.internal.tasks.options.Option.class);
                 if (internalOption != null) {
-                    SingleMessageLogger.nagUserOfDeprecated("org.gradle.api.internal.tasks.options.Option", "Use org.gradle.api.tasks.options.Option instead.");
+                    SingleMessageLogger.nagUserWithDeprecatedIndirectUserCodeCause("org.gradle.api.internal.tasks.options.Option", "Use org.gradle.api.tasks.options.Option instead.");
                     methodOptionElements.add(MethodOptionElement.create(internalOption, method, optionValueNotationParserFactory));
                 }
             }
@@ -176,7 +176,7 @@ public class OptionReader {
                 } else {
                     optionValuesMethod = getAsOptionValuesMethod(type, method, org.gradle.api.internal.tasks.options.OptionValues.class);
                     if (optionValuesMethod != null) {
-                        SingleMessageLogger.nagUserOfDeprecated("org.gradle.api.internal.tasks.options.OptionValues", "Use org.gradle.api.tasks.options.OptionValues instead.");
+                        SingleMessageLogger.nagUserWithDeprecatedIndirectUserCodeCause("org.gradle.api.internal.tasks.options.OptionValues", "Use org.gradle.api.tasks.options.OptionValues instead.");
                         methods.add(optionValuesMethod);
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -295,10 +295,9 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
                     if (phase == Phases.CANONICALIZATION) {
                         Set<String> deprecatedImports = resolveVisitor.getDeprecatedImports();
                         if (!deprecatedImports.isEmpty()) {
-                            DeprecationLogger.nagUserWith("The support for implicit import of internal classes is deprecated.",
-                                "The support for implicit import of internal classes is deprecated and will be removed in Gradle 5.0.",
-                                "Please either stop using these internal classes (recommended) or import them explicitly at the top of your build file.",
-                                StringUtils.capitalize(script.getDisplayName()) + " is using " + Joiner.on(" and ").join(deprecatedImports) + ".");
+                            DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("The support for implicit import of internal classes",
+                                "Please either stop using internal classes (recommended) or import them explicitly at the top of your build file.",
+                                StringUtils.capitalize(script.getDisplayName()) + " is using " + Joiner.on(" and ").join(deprecatedImports) + " from the private org.gradle.util package.");
                         }
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -295,10 +295,10 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
                     if (phase == Phases.CANONICALIZATION) {
                         Set<String> deprecatedImports = resolveVisitor.getDeprecatedImports();
                         if (!deprecatedImports.isEmpty()) {
-                            DeprecationLogger.nagUserWith(StringUtils.capitalize(script.getDisplayName()) + " is using " + Joiner.on(" and ").join(deprecatedImports)
-                                + " from the private org.gradle.util package without an explicit import.",
+                            DeprecationLogger.nagUserWith("The support for implicit import of internal classes is deprecated.",
                                 "The support for implicit import of internal classes is deprecated and will be removed in Gradle 5.0.",
-                                "Please either stop using these internal classes (recommended) or import them explicitly at the top of your build file.");
+                                "Please either stop using these internal classes (recommended) or import them explicitly at the top of your build file.",
+                                StringUtils.capitalize(script.getDisplayName()) + " is using " + Joiner.on(" and ").join(deprecatedImports) + ".");
                         }
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
@@ -24,7 +24,7 @@ import org.gradle.util.GradleVersion;
 
 public class UnsupportedJavaRuntimeException extends GradleException {
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
-    public static final String JAVA7_DEPRECATION_WARNING = "Support for running Gradle using Java 7 has been deprecated.";
+    public static final String JAVA7_DEPRECATION_WARNING = "Support for running Gradle using Java 7";
     private static final String JAVA7_DEPRECATION_WARNING_DOC = "Please see " + DOCUMENTATION_REGISTRY.getDocumentationFor("java_plugin", "sec:java_cross_compilation") + " for more details.";
 
     public UnsupportedJavaRuntimeException(String message) {

--- a/subprojects/core/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
@@ -33,7 +33,7 @@ public class UnsupportedJavaRuntimeException extends GradleException {
 
     public static void javaDeprecationWarning() {
         if (!JavaVersion.current().isJava8Compatible()) {
-            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(JAVA7_DEPRECATION_WARNING, JAVA7_DEPRECATION_WARNING_DOC);
+            DeprecationLogger.nagUserWithDeprecatedBuildInvocationFeature(JAVA7_DEPRECATION_WARNING, JAVA7_DEPRECATION_WARNING_DOC);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/jvm/UnsupportedJavaRuntimeException.java
@@ -24,7 +24,7 @@ import org.gradle.util.GradleVersion;
 
 public class UnsupportedJavaRuntimeException extends GradleException {
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
-    public static final String JAVA7_DEPRECATION_WARNING = "Support for running Gradle using Java 7 has been deprecated."; // and is scheduled to be removed in Gradle 5.0. ";
+    public static final String JAVA7_DEPRECATION_WARNING = "Support for running Gradle using Java 7 has been deprecated.";
     private static final String JAVA7_DEPRECATION_WARNING_DOC = "Please see " + DOCUMENTATION_REGISTRY.getDocumentationFor("java_plugin", "sec:java_cross_compilation") + " for more details.";
 
     public UnsupportedJavaRuntimeException(String message) {
@@ -33,7 +33,7 @@ public class UnsupportedJavaRuntimeException extends GradleException {
 
     public static void javaDeprecationWarning() {
         if (!JavaVersion.current().isJava8Compatible()) {
-            DeprecationLogger.nagUserWith(JAVA7_DEPRECATION_WARNING, JAVA7_DEPRECATION_WARNING_DOC);
+            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(JAVA7_DEPRECATION_WARNING, JAVA7_DEPRECATION_WARNING_DOC);
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -224,7 +224,7 @@ public class JavaCompilerArgumentsBuilder {
             String current = argIterator.next();
             if (current.equals("-sourcepath") || current.equals("--source-path")) {
                 if (!silently) {
-                    DeprecationLogger.nagUserOfDeprecated(
+                    DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(
                         "Specifying the source path in the CompilerOptions compilerArgs property",
                         "Instead, use the CompilerOptions sourcepath property directly");
                 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 
 public class AnnotationProcessorPathFactory {
+    public static final String COMPILE_CLASSPATH_DEPRECATION_SUMMARY = "Annotation processors were detected on the compile classpath.";
     public static final String COMPILE_CLASSPATH_DEPRECATION_MESSAGE = "The following annotation processors were detected on the compile classpath:";
     public static final String PROCESSOR_PATH_DEPRECATION_MESSAGE = "Specifying the processor path in the CompilerOptions compilerArgs property";
 
@@ -112,7 +113,7 @@ public class AnnotationProcessorPathFactory {
     }
 
     private static Set<File> extractProcessorPath(String processorpath) {
-        DeprecationLogger.nagUserOfDeprecated(
+        DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(
             PROCESSOR_PATH_DEPRECATION_MESSAGE,
             "Instead, use the CompilerOptions.annotationProcessorPath property directly");
         LinkedHashSet<File> files = new LinkedHashSet<File>();
@@ -145,13 +146,12 @@ public class AnnotationProcessorPathFactory {
                     }
                     Map<String, AnnotationProcessorDeclaration> processors = annotationProcessorDetector.detectProcessors(compileClasspath);
                     if (!processors.isEmpty()) {
-                        DeprecationLogger.nagUserWith(
-                            COMPILE_CLASSPATH_DEPRECATION_MESSAGE +
-                            " '" + Joiner.on("' and '").join(processors.keySet()) + "'. " +
+                        DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(
                             "Detecting annotation processors on the compile classpath is deprecated.",
                             "Gradle 5.0 will ignore annotation processors on the compile classpath.",
                             "Please add them to the annotation processor path instead. " +
-                            "If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them."
+                            "If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them.",
+                            COMPILE_CLASSPATH_DEPRECATION_MESSAGE + " '" + Joiner.on("' and '").join(processors.keySet()) + "'. "
                         );
                         return compileClasspath.getFiles();
                     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorPathFactory.java
@@ -147,7 +147,7 @@ public class AnnotationProcessorPathFactory {
                     Map<String, AnnotationProcessorDeclaration> processors = annotationProcessorDetector.detectProcessors(compileClasspath);
                     if (!processors.isEmpty()) {
                         DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(
-                            "Detecting annotation processors on the compile classpath is deprecated.",
+                            "Detecting annotation processors on the compile classpath",
                             "Gradle 5.0 will ignore annotation processors on the compile classpath.",
                             "Please add them to the annotation processor path instead. " +
                             "If you did not intend to use annotation processors, you can use the '-proc:none' compiler argument to ignore them.",

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -113,7 +113,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
             UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_7);
         } catch (IllegalArgumentException e) {
             // https://github.com/gradle/gradle/issues/3317
-            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(e.getMessage(), null);
+            LOGGER.warn(e.getMessage());
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -113,7 +113,7 @@ public class DefaultConnection implements ConnectionVersion4, InternalConnection
             UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_7);
         } catch (IllegalArgumentException e) {
             // https://github.com/gradle/gradle/issues/3317
-            DeprecationLogger.nagUserWith(e.getMessage(), null, null);
+            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(e.getMessage(), null);
         }
     }
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -127,6 +127,9 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         taskDoLastDeprecation.details.contextualAdvice == "Task ':t' should not have custom actions attached."
         taskDoLastDeprecation.details.type == 'USER_CODE_DIRECT'
         taskDoLastDeprecation.details.stackTrace.size > 0
+        taskDoLastDeprecation.details.stackTrace.each {
+            println "doLast{} " + it.toString();
+        }
         taskDoLastDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
         taskDoLastDeprecation.details.stackTrace[0].lineNumber == 13
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -40,9 +40,16 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
             apply from: 'script.gradle'
             apply plugin: SomePlugin
             
+            org.gradle.util.DeprecationLogger.nagUserWithDeprecatedInvocationFeature('Some invocation feature', "Don't do custom invocation.")
+            org.gradle.util.DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause('Some indirect deprecation', 'Some advice.')
+            
             task t(type:SomeTask) {
                 doLast {
-                    org.gradle.util.DeprecationLogger.nagUserOfDeprecated('Task t', 'Use task t2 instead.');
+                    org.gradle.util.DeprecationLogger.nagUserWith('Custom Task action will be deprecated.', 
+                        'Custom actions will not be supported in 2 weeks from now.',
+                        'Use task type X instead.', 
+                        "Task '\${getPath()}' should not have custom actions attached."
+                    );
                 }
             }
             
@@ -60,6 +67,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
                     org.gradle.util.DeprecationLogger.nagUserOfDeprecated('Typed task');
                 }
             }
+           
         """
         and:
         executer.noDeprecationChecks()
@@ -80,35 +88,57 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         pluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         pluginDeprecation.details.advice == null
         pluginDeprecation.details.contextualAdvice == null
+        pluginDeprecation.details.type == 'USER_CODE_DIRECT'
         pluginDeprecation.details.stackTrace.size > 0
         pluginDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
-        pluginDeprecation.details.stackTrace[0].lineNumber == 15
+        pluginDeprecation.details.stackTrace[0].lineNumber == 22
+
+        def invocationDeprecation = operations.only("Apply script build.gradle to root project 'root'").progress.findAll {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}[0]
+        invocationDeprecation.details.summary == 'Some invocation feature has been deprecated.'
+        invocationDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
+        invocationDeprecation.details.advice == "Don't do custom invocation."
+        invocationDeprecation.details.type == "INVOCATION"
+        invocationDeprecation.details.stackTrace.size > 0
+        invocationDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
+        invocationDeprecation.details.stackTrace[0].lineNumber == 5
+
+        def userIndirectCodeDeprecation = operations.only("Apply script build.gradle to root project 'root'").progress.findAll {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}[1]
+        userIndirectCodeDeprecation.details.summary == 'Some indirect deprecation has been deprecated.'
+        userIndirectCodeDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
+        userIndirectCodeDeprecation.details.advice == "Some advice."
+        userIndirectCodeDeprecation.details.type == 'USER_CODE_INDIRECT'
+        userIndirectCodeDeprecation.details.stackTrace.size > 0
+        userIndirectCodeDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
+        userIndirectCodeDeprecation.details.stackTrace[0].lineNumber == 6
 
         def scriptPluginDeprecation = operations.only("Apply script script.gradle to root project 'root'").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
         scriptPluginDeprecation.details.summary == 'Plugin script has been deprecated.'
         scriptPluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         scriptPluginDeprecation.details.advice == null
+        scriptPluginDeprecation.details.type == 'USER_CODE_DIRECT'
         scriptPluginDeprecation.details.stackTrace.size > 0
         scriptPluginDeprecation.details.stackTrace[0].fileName.endsWith('script.gradle')
         scriptPluginDeprecation.details.stackTrace[0].lineNumber == 2
 
         def taskDoLastDeprecation = operations.only("Execute doLast {} action for :t").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        taskDoLastDeprecation.details.summary == 'Task t has been deprecated.'
-        taskDoLastDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
-        taskDoLastDeprecation.details.advice == 'Use task t2 instead.'
-        taskDoLastDeprecation.details.contextualAdvice == null
+        taskDoLastDeprecation.details.summary == 'Custom Task action will be deprecated.'
+        taskDoLastDeprecation.details.removalDetails == 'Custom actions will not be supported in 2 weeks from now.'
+        taskDoLastDeprecation.details.advice == 'Use task type X instead.'
+        taskDoLastDeprecation.details.contextualAdvice == "Task ':t' should not have custom actions attached."
+        taskDoLastDeprecation.details.type == 'USER_CODE_DIRECT'
         taskDoLastDeprecation.details.stackTrace.size > 0
         taskDoLastDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
-        taskDoLastDeprecation.details.stackTrace[0].lineNumber == 7
+        taskDoLastDeprecation.details.stackTrace[0].lineNumber == 13
 
         def typedTaskDeprecation = operations.only("Execute someAction for :t").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
         typedTaskDeprecation.details.summary == 'Typed task has been deprecated.'
         typedTaskDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         typedTaskDeprecation.details.advice == null
         typedTaskDeprecation.details.contextualAdvice == null
+        typedTaskDeprecation.details.type == 'USER_CODE_DIRECT'
         typedTaskDeprecation.details.stackTrace.size > 0
         typedTaskDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
-        typedTaskDeprecation.details.stackTrace[0].lineNumber == 22
+        typedTaskDeprecation.details.stackTrace[0].lineNumber == 29
         typedTaskDeprecation.details.stackTrace[0].methodName == 'someAction'
 
         def typedTaskDeprecation2 = operations.only("Execute someAction for :t2").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
@@ -116,9 +146,10 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         typedTaskDeprecation2.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         typedTaskDeprecation2.details.advice == null
         typedTaskDeprecation2.details.contextualAdvice == null
+        typedTaskDeprecation2.details.type == 'USER_CODE_DIRECT'
         typedTaskDeprecation2.details.stackTrace.size > 0
         typedTaskDeprecation2.details.stackTrace[0].fileName.endsWith('build.gradle')
-        typedTaskDeprecation2.details.stackTrace[0].lineNumber == 22
+        typedTaskDeprecation2.details.stackTrace[0].lineNumber == 29
         typedTaskDeprecation2.details.stackTrace[0].methodName == 'someAction'
     }
 
@@ -138,6 +169,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         buildSrcDeprecations.details.removalDetails.contains('This is scheduled to be removed in Gradle 5.0.')
         buildSrcDeprecations.details.advice == null
         buildSrcDeprecations.details.contextualAdvice == null
+        buildSrcDeprecations.details.type == 'USER_CODE_DIRECT'
         buildSrcDeprecations.details.stackTrace.size > 0
         buildSrcDeprecations.details.stackTrace[0].fileName.endsWith("buildSrc${File.separator}build.gradle")
         buildSrcDeprecations.details.stackTrace[0].lineNumber == 2
@@ -174,6 +206,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         includedBuildScriptDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         includedBuildScriptDeprecations.details.advice == null
         includedBuildScriptDeprecations.details.contextualAdvice == null
+        includedBuildScriptDeprecations.details.type == 'USER_CODE_DIRECT'
         includedBuildScriptDeprecations.details.stackTrace.size > 0
         includedBuildScriptDeprecations.details.stackTrace[0].fileName.endsWith("included${File.separator}build.gradle")
         includedBuildScriptDeprecations.details.stackTrace[0].lineNumber == 2
@@ -183,6 +216,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         includedBuildTaskDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         includedBuildTaskDeprecations.details.advice == null
         includedBuildTaskDeprecations.details.contextualAdvice == null
+        includedBuildTaskDeprecations.details.type == 'USER_CODE_DIRECT'
         includedBuildTaskDeprecations.details.stackTrace.size > 0
         includedBuildTaskDeprecations.details.stackTrace[0].fileName.endsWith("included${File.separator}build.gradle")
         includedBuildTaskDeprecations.details.stackTrace[0].lineNumber == 6

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -48,7 +48,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
                     org.gradle.util.DeprecationLogger.nagUserWith('Custom Task action will be deprecated.', 
                         'Custom actions will not be supported in 2 weeks from now.',
                         'Use task type X instead.', 
-                        "Task '\${getPath()}' should not have custom actions attached."
+                        "Task ':t' should not have custom actions attached."
                     );
                 }
             }
@@ -127,11 +127,8 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         taskDoLastDeprecation.details.contextualAdvice == "Task ':t' should not have custom actions attached."
         taskDoLastDeprecation.details.type == 'USER_CODE_DIRECT'
         taskDoLastDeprecation.details.stackTrace.size > 0
-        taskDoLastDeprecation.details.stackTrace.each {
-            println "doLast{} " + it.toString();
-        }
         taskDoLastDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
-        taskDoLastDeprecation.details.stackTrace[0].lineNumber == 13
+        taskDoLastDeprecation.details.stackTrace[0].lineNumber == 10
 
         def typedTaskDeprecation = operations.only("Execute someAction for :t").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
         typedTaskDeprecation.details.summary == 'Typed task has been deprecated.'

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -40,7 +40,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
             apply from: 'script.gradle'
             apply plugin: SomePlugin
             
-            org.gradle.util.DeprecationLogger.nagUserWithDeprecatedInvocationFeature('Some invocation feature', "Don't do custom invocation.")
+            org.gradle.util.DeprecationLogger.nagUserWithDeprecatedBuildInvocationFeature('Some invocation feature', "Don't do custom invocation.")
             org.gradle.util.DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause('Some indirect deprecation', 'Some advice.')
             
             task t(type:SomeTask) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -67,50 +67,55 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         then:
         def initDeprecation = operations.only("Apply script init.gradle to build").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        initDeprecation.details.message == 'Init script has been deprecated.'
-        initDeprecation.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        initDeprecation.details.summary == 'Init script has been deprecated.'
+        initDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         initDeprecation.details.advice == null
+        initDeprecation.details.contextualAdvice == null
         initDeprecation.details.stackTrace.size > 0
         initDeprecation.details.stackTrace[0].fileName.endsWith('init.gradle')
         initDeprecation.details.stackTrace[0].lineNumber == 2
 
         def pluginDeprecation = operations.only("Apply plugin SomePlugin to root project 'root'").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        pluginDeprecation.details.message == 'Plugin has been deprecated.'
-        pluginDeprecation.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        pluginDeprecation.details.summary == 'Plugin has been deprecated.'
+        pluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         pluginDeprecation.details.advice == null
+        pluginDeprecation.details.contextualAdvice == null
         pluginDeprecation.details.stackTrace.size > 0
         pluginDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
         pluginDeprecation.details.stackTrace[0].lineNumber == 15
 
         def scriptPluginDeprecation = operations.only("Apply script script.gradle to root project 'root'").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        scriptPluginDeprecation.details.message == 'Plugin script has been deprecated.'
-        scriptPluginDeprecation.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        scriptPluginDeprecation.details.summary == 'Plugin script has been deprecated.'
+        scriptPluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         scriptPluginDeprecation.details.advice == null
         scriptPluginDeprecation.details.stackTrace.size > 0
         scriptPluginDeprecation.details.stackTrace[0].fileName.endsWith('script.gradle')
         scriptPluginDeprecation.details.stackTrace[0].lineNumber == 2
 
         def taskDoLastDeprecation = operations.only("Execute doLast {} action for :t").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        taskDoLastDeprecation.details.message == 'Task t has been deprecated.'
-        taskDoLastDeprecation.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        taskDoLastDeprecation.details.summary == 'Task t has been deprecated.'
+        taskDoLastDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         taskDoLastDeprecation.details.advice == 'Use task t2 instead.'
+        taskDoLastDeprecation.details.contextualAdvice == null
         taskDoLastDeprecation.details.stackTrace.size > 0
         taskDoLastDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
         taskDoLastDeprecation.details.stackTrace[0].lineNumber == 7
 
         def typedTaskDeprecation = operations.only("Execute someAction for :t").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        typedTaskDeprecation.details.message == 'Typed task has been deprecated.'
-        typedTaskDeprecation.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        typedTaskDeprecation.details.summary == 'Typed task has been deprecated.'
+        typedTaskDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         typedTaskDeprecation.details.advice == null
+        typedTaskDeprecation.details.contextualAdvice == null
         typedTaskDeprecation.details.stackTrace.size > 0
         typedTaskDeprecation.details.stackTrace[0].fileName.endsWith('build.gradle')
         typedTaskDeprecation.details.stackTrace[0].lineNumber == 22
         typedTaskDeprecation.details.stackTrace[0].methodName == 'someAction'
 
         def typedTaskDeprecation2 = operations.only("Execute someAction for :t2").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        typedTaskDeprecation2.details.message == 'Typed task has been deprecated.'
-        typedTaskDeprecation2.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        typedTaskDeprecation2.details.summary == 'Typed task has been deprecated.'
+        typedTaskDeprecation2.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         typedTaskDeprecation2.details.advice == null
+        typedTaskDeprecation2.details.contextualAdvice == null
         typedTaskDeprecation2.details.stackTrace.size > 0
         typedTaskDeprecation2.details.stackTrace[0].fileName.endsWith('build.gradle')
         typedTaskDeprecation2.details.stackTrace[0].lineNumber == 22
@@ -129,9 +134,10 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         then:
         def buildSrcDeprecations = operations.only("Apply script build.gradle to project ':buildSrc'").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        buildSrcDeprecations.details.message.contains('BuildSrc script has been deprecated.')
-        buildSrcDeprecations.details.details.contains('This is scheduled to be removed in Gradle 5.0.')
+        buildSrcDeprecations.details.summary.contains('BuildSrc script has been deprecated.')
+        buildSrcDeprecations.details.removalDetails.contains('This is scheduled to be removed in Gradle 5.0.')
         buildSrcDeprecations.details.advice == null
+        buildSrcDeprecations.details.contextualAdvice == null
         buildSrcDeprecations.details.stackTrace.size > 0
         buildSrcDeprecations.details.stackTrace[0].fileName.endsWith("buildSrc${File.separator}build.gradle")
         buildSrcDeprecations.details.stackTrace[0].lineNumber == 2
@@ -164,17 +170,19 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         then:
         def includedBuildScriptDeprecations = operations.only("Apply script build.gradle to project ':included'").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        includedBuildScriptDeprecations.details.message == 'Included build script has been deprecated.'
-        includedBuildScriptDeprecations.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        includedBuildScriptDeprecations.details.summary == 'Included build script has been deprecated.'
+        includedBuildScriptDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         includedBuildScriptDeprecations.details.advice == null
+        includedBuildScriptDeprecations.details.contextualAdvice == null
         includedBuildScriptDeprecations.details.stackTrace.size > 0
         includedBuildScriptDeprecations.details.stackTrace[0].fileName.endsWith("included${File.separator}build.gradle")
         includedBuildScriptDeprecations.details.stackTrace[0].lineNumber == 2
 
         def includedBuildTaskDeprecations = operations.only("Execute doLast {} action for :included:t").progress.find {it.hasDetailsOfType(DeprecatedUsageProgressDetails)}
-        includedBuildTaskDeprecations.details.message == 'Included build task has been deprecated.'
-        includedBuildTaskDeprecations.details.details == 'This is scheduled to be removed in Gradle 5.0.'
+        includedBuildTaskDeprecations.details.summary == 'Included build task has been deprecated.'
+        includedBuildTaskDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 5.0.'
         includedBuildTaskDeprecations.details.advice == null
+        includedBuildTaskDeprecations.details.contextualAdvice == null
         includedBuildTaskDeprecations.details.stackTrace.size > 0
         includedBuildTaskDeprecations.details.stackTrace[0].fileName.endsWith("included${File.separator}build.gradle")
         includedBuildTaskDeprecations.details.stackTrace[0].lineNumber == 6

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DefaultDeprecatedUsageProgressDetails.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DefaultDeprecatedUsageProgressDetails.java
@@ -41,12 +41,12 @@ public class DefaultDeprecatedUsageProgressDetails implements DeprecatedUsagePro
 
     @Override
     public String getContextualAdvice() {
-        return null;
+        return featureUsage.getContextualAdvice();
     }
 
     @Override
     public String getType() {
-        return null;
+        return featureUsage.getType().name();
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DefaultDeprecatedUsageProgressDetails.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DefaultDeprecatedUsageProgressDetails.java
@@ -27,16 +27,26 @@ public class DefaultDeprecatedUsageProgressDetails implements DeprecatedUsagePro
     }
 
     @Override
-    public String getMessage() {
-        return featureUsage.getMessage();
+    public String getSummary() {
+        return featureUsage.getSummary();
     }
 
-    public String getDetails() {
-        return featureUsage.getDetails();
+    public String getRemovalDetails() {
+        return featureUsage.getRemovalDetails();
     }
 
     public String getAdvice() {
         return featureUsage.getAdvice();
+    }
+
+    @Override
+    public String getContextualAdvice() {
+        return null;
+    }
+
+    @Override
+    public String getType() {
+        return null;
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedUsageProgressDetails.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedUsageProgressDetails.java
@@ -18,6 +18,7 @@ package org.gradle.internal.featurelifecycle;
 
 import org.gradle.internal.scan.UsedByScanPlugin;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -27,11 +28,19 @@ import java.util.List;
  */
 @UsedByScanPlugin
 public interface DeprecatedUsageProgressDetails {
-    String getMessage();
 
-    String getDetails();
+    String getSummary();
 
+    String getRemovalDetails();
+
+    @Nullable
     String getAdvice();
 
+    @Nullable
+    String getContextualAdvice();
+
+    String getType();
+
     List<StackTraceElement> getStackTrace();
+
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
@@ -40,24 +40,24 @@ public class FeatureUsage {
     public enum FeatureUsageType {
         /**
          * The feature usage in user code directly leads to a deprecation warning.
-         *  The stacktrace in that feature usage directly points to the user code
-         *  using the feature.
-         * */
+         * The stacktrace in that feature usage directly points to the user code
+         * using the feature.
+         */
         USER_CODE_DIRECT,
 
         /**
          * The feature usage in user code indirectly leads to a deprecation warning as
          * the usage was detect later in the build.  The stacktrace in that
          * feature usage does not directly point to the user code using the feature.
-         * */
+         */
         USER_CODE_INDIRECT,
 
         /**
          * A feature / functionality on how gradle is invoked is used.
          * This can be typically a no longer supported java version or the use of
          * a deprecated or incubating command line flag.
-         * */
-        INVOCATION
+         */
+        BUILD_INVOCATION
     }
 
     public FeatureUsage(String summary, String removalDetails, String advice, String contextualAdvice, FeatureUsageType usageType, Class<?> calledFrom) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
@@ -27,37 +27,49 @@ import java.util.List;
  * An immutable description of the usage of a deprecated feature.
  */
 public class FeatureUsage {
-    private final String message;
-    private final String details;
+    private final String summary;
+    private final String removalDetails;
     private final String advice;
+    private final FeatureUsageType usageType;
     private final Class<?> calledFrom;
     private final Exception traceException;
+    private final String contextualAdvice;
 
     private List<StackTraceElement> stack;
 
-    public FeatureUsage(String message, String details, String advice, Class<?> calledFrom) {
-        this.message = message;
-        this.details = details;
+    public enum FeatureUsageType {
+        USER_CODE_DIRECT,
+        USER_CODE_INDIRECT,
+        INVOCATION
+    }
+
+    public FeatureUsage(String summary, String removalDetails, String advice, String contextualAdvice, FeatureUsageType usageType, Class<?> calledFrom) {
+        this.summary = summary;
+        this.removalDetails = removalDetails;
         this.advice = advice;
+        this.contextualAdvice = contextualAdvice;
+        this.usageType = usageType;
         this.calledFrom = calledFrom;
         this.traceException = new Exception();
     }
 
     @VisibleForTesting
     FeatureUsage(FeatureUsage usage, Exception traceException) {
-        this.message = usage.message;
-        this.details = usage.details;
+        this.summary = usage.summary;
+        this.removalDetails = usage.removalDetails;
         this.advice = usage.advice;
+        this.contextualAdvice = usage.contextualAdvice;
+        this.usageType = usage.usageType;
         this.calledFrom = usage.calledFrom;
         this.traceException = Preconditions.checkNotNull(traceException);
     }
 
-    public String getMessage() {
-        return message;
+    public String getSummary() {
+        return summary;
     }
 
-    public String getDetails() {
-        return details;
+    public String getRemovalDetails() {
+        return removalDetails;
     }
 
     public String getAdvice() {
@@ -113,13 +125,17 @@ public class FeatureUsage {
     }
 
     public String formattedMessage() {
-        StringBuilder outputBuilder = new StringBuilder(message);
-        if (!StringUtils.isEmpty(details)) {
-            outputBuilder.append(" ").append(details);
+        StringBuilder outputBuilder = new StringBuilder(summary);
+        if (!StringUtils.isEmpty(removalDetails)) {
+            outputBuilder.append(" ").append(removalDetails);
+        }
+        if (!StringUtils.isEmpty(contextualAdvice)) {
+            outputBuilder.append(" ").append(contextualAdvice);
         }
         if (!StringUtils.isEmpty(advice)) {
             outputBuilder.append(" ").append(advice);
         }
         return outputBuilder.toString();
     }
+
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
@@ -38,8 +38,25 @@ public class FeatureUsage {
     private List<StackTraceElement> stack;
 
     public enum FeatureUsageType {
+        /**
+         * The feature usage in user code directly leads to a deprecation warning.
+         *  The stacktrace in that feature usage directly points to the user code
+         *  using the feature.
+         * */
         USER_CODE_DIRECT,
+
+        /**
+         * The feature usage in user code indirectly leads to a deprecation warning as
+         * the usage was detect later in the build.  The stacktrace in that
+         * feature usage does not directly point to the user code using the feature.
+         * */
         USER_CODE_INDIRECT,
+
+        /**
+         * A feature / functionality on how gradle is invoked is used.
+         * This can be typically a no longer supported java version or the use of
+         * a deprecated or incubating command line flag.
+         * */
         INVOCATION
     }
 
@@ -134,16 +151,16 @@ public class FeatureUsage {
 
     public String formattedMessage() {
         StringBuilder outputBuilder = new StringBuilder(summary);
+        append(outputBuilder, removalDetails);
+        append(outputBuilder, contextualAdvice);
+        append(outputBuilder, advice);
+        return outputBuilder.toString();
+    }
+
+    private void append(StringBuilder outputBuilder, String removalDetails) {
         if (!StringUtils.isEmpty(removalDetails)) {
             outputBuilder.append(" ").append(removalDetails);
         }
-        if (!StringUtils.isEmpty(contextualAdvice)) {
-            outputBuilder.append(" ").append(contextualAdvice);
-        }
-        if (!StringUtils.isEmpty(advice)) {
-            outputBuilder.append(" ").append(advice);
-        }
-        return outputBuilder.toString();
     }
 
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/FeatureUsage.java
@@ -30,7 +30,7 @@ public class FeatureUsage {
     private final String summary;
     private final String removalDetails;
     private final String advice;
-    private final FeatureUsageType usageType;
+    private final FeatureUsageType type;
     private final Class<?> calledFrom;
     private final Exception traceException;
     private final String contextualAdvice;
@@ -48,7 +48,7 @@ public class FeatureUsage {
         this.removalDetails = removalDetails;
         this.advice = advice;
         this.contextualAdvice = contextualAdvice;
-        this.usageType = usageType;
+        this.type = usageType;
         this.calledFrom = calledFrom;
         this.traceException = new Exception();
     }
@@ -59,7 +59,7 @@ public class FeatureUsage {
         this.removalDetails = usage.removalDetails;
         this.advice = usage.advice;
         this.contextualAdvice = usage.contextualAdvice;
-        this.usageType = usage.usageType;
+        this.type = usage.type;
         this.calledFrom = usage.calledFrom;
         this.traceException = Preconditions.checkNotNull(traceException);
     }
@@ -74,6 +74,14 @@ public class FeatureUsage {
 
     public String getAdvice() {
         return advice;
+    }
+
+    public String getContextualAdvice() {
+        return contextualAdvice;
+    }
+
+    public FeatureUsageType getType() {
+        return type;
     }
 
     public List<StackTraceElement> getStack() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingIncubatingFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingIncubatingFeatureHandler.java
@@ -30,8 +30,8 @@ public class LoggingIncubatingFeatureHandler implements FeatureHandler {
 
     @Override
     public void featureUsed(FeatureUsage usage) {
-        if (features.add(usage.getMessage())) {
-            LOGGER.warn(String.format(INCUBATION_MESSAGE, usage.getMessage()));
+        if (features.add(usage.getSummary())) {
+            LOGGER.warn(String.format(INCUBATION_MESSAGE, usage.getSummary()));
         }
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/util/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/DeprecationLogger.java
@@ -15,4 +15,5 @@
  */
 package org.gradle.util;
 
-public class DeprecationLogger extends SingleMessageLogger {}
+public class DeprecationLogger extends SingleMessageLogger {
+}

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -215,11 +215,11 @@ public class SingleMessageLogger {
     }
 
     public static void nagUserWithDeprecatedInvocationFeature(String summary, String advice) {
-        nagUserWith(summary, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.INVOCATION);
+        nagUserWithDeprecatedInvocationFeature(summary, thisWillBeRemovedMessage(), advice);
     }
 
     public static void nagUserWithDeprecatedInvocationFeature(String summary, String removalDetails, String advice) {
-        nagUserWith(summary, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.INVOCATION);
+        nagUserWith(String.format("%s has been deprecated.", summary), removalDetails, advice, null, FeatureUsage.FeatureUsageType.INVOCATION);
     }
 
     public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String advice) {

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -60,7 +60,11 @@ public class SingleMessageLogger {
 
     public static void nagUserOfReplacedPlugin(String pluginName, String replacement) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s plugin %s has been deprecated.", pluginName), getRemovalDetails(), String.format("Please use the %s plugin instead.", replacement));
+            nagUserWith(String.format("The %s plugin %s has been deprecated.", pluginName),
+                getRemovalDetails(),
+                String.format("Please use the %s plugin instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
@@ -69,69 +73,116 @@ public class SingleMessageLogger {
             nagUserWith(
                 String.format("The %s plugin has been deprecated.", pluginName),
                 getRemovalDetails(),
-                String.format("Consider using the %s plugin instead.", replacement));
+                String.format("Consider using the %s plugin instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfToolReplacedWithExternalOne(String toolName, String replacement) {
         if (isEnabled()) {
             nagUserWith(String.format(
-                    "The %s has been deprecated.", toolName), thisWillBeRemovedMessage(), String.format("Consider using %s instead.", replacement));
+                "The %s has been deprecated.", toolName),
+                thisWillBeRemovedMessage(),
+                String.format("Consider using %s instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfReplacedTask(String taskName, String replacement) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s task has been deprecated.", taskName), thisWillBeRemovedMessage(), String.format("Please use the %s task instead.", replacement));
+            nagUserWith(String.format("The %s task has been deprecated.", taskName),
+                thisWillBeRemovedMessage(), String.format("Please use the %s task instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfReplacedTaskType(String taskName, String replacement) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s task type has been deprecated.", taskName), thisWillBeRemovedMessage(), String.format("Please use the %s instead.", replacement));
+            nagUserWith(
+                String.format("The %s task type has been deprecated.", taskName),
+                thisWillBeRemovedMessage(), String.format("Please use the %s instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfReplacedMethod(String methodName, String replacement) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s method has been deprecated.", methodName), thisWillBeRemovedMessage(), String.format("Please use the %s method instead.", replacement));
+            nagUserWith(
+                String.format("The %s method has been deprecated.", methodName), thisWillBeRemovedMessage(),
+                String.format("Please use the %s method instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfReplacedProperty(String propertyName, String replacement) {
         if (isEnabled()) {
             nagUserWith(String.format(
-                    "The %s property has been deprecated.", propertyName), thisWillBeRemovedMessage(), String.format("Please use the %s property instead.", replacement));
+                "The %s property has been deprecated.", propertyName), thisWillBeRemovedMessage(), String.format("Please use the %s property instead.", replacement), null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDiscontinuedMethod(String methodName) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s method has been deprecated.", methodName), thisWillBeRemovedMessage(), null);
+            nagUserWith(String.format("The %s method has been deprecated.", methodName),
+                thisWillBeRemovedMessage(),
+                null,
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDiscontinuedMethod(String methodName, String advice) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s method has been deprecated.", methodName), thisWillBeRemovedMessage(), advice);
+            nagUserWith(String.format("The %s method has been deprecated.", methodName),
+                thisWillBeRemovedMessage(),
+                advice,
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
+        }
+    }
+
+    public static void nagUserOfDiscontinuedMethod(String methodName, String advice, String contextualAdvice) {
+        if (isEnabled()) {
+            nagUserWith(String.format("The %s method has been deprecated.", methodName),
+                thisWillBeRemovedMessage(),
+                advice,
+                contextualAdvice,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDiscontinuedProperty(String propertyName, String advice) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s property has been deprecated.", propertyName), thisWillBeRemovedMessage(), advice);
+            nagUserWith(String.format("The %s property has been deprecated.", propertyName),
+                thisWillBeRemovedMessage(),
+                advice,
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDiscontinuedApi(String api, String advice) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s has been deprecated.", api), thisWillBeRemovedMessage(), advice);
+            nagUserWith(String.format("The %s has been deprecated.", api),
+                thisWillBeRemovedMessage(),
+                advice,
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfReplacedNamedParameter(String parameterName, String replacement) {
         if (isEnabled()) {
-            nagUserWith(String.format("The %s named parameter has been deprecated.", parameterName), thisWillBeRemovedMessage(), String.format("Please use the %s named parameter instead.", replacement));
+            nagUserWith(String.format("The %s named parameter has been deprecated.", parameterName),
+                thisWillBeRemovedMessage(),
+                String.format("Please use the %s named parameter instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
@@ -139,9 +190,9 @@ public class SingleMessageLogger {
      * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
      */
     @VisibleForTesting
-    static void nagUserWith(String message) {
+    static void nagUserWith(String summary) {
         if (isEnabled()) {
-            nagUserWith(message, getRemovalDetails(), null);
+            nagUserWith(summary, null);
         }
     }
 
@@ -150,16 +201,54 @@ public class SingleMessageLogger {
      */
     public static void nagUserWith(String message, String advice) {
         if (isEnabled()) {
-            nagUserWith(message, thisWillBeRemovedMessage(), advice);
+            nagUserWith(message, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     /**
      * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
      */
-    public static void nagUserWith(String message, String details, String advice) {
+    public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary) {
         if (isEnabled()) {
-            nagUserWith(deprecatedFeatureHandler, new FeatureUsage(message, details, advice, SingleMessageLogger.class));
+            nagUserWithDeprecatedIndirectUserCodeCause(summary, null);
+        }
+    }
+
+    public static void nagUserWithDeprecatedInvocationFeature(String summary, String advice) {
+        nagUserWith(summary, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.INVOCATION);
+    }
+
+    public static void nagUserWithDeprecatedInvocationFeature(String summary, String removalDetails, String advice) {
+        nagUserWith(summary, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.INVOCATION);
+    }
+
+    public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String advice) {
+        if (isEnabled()) {
+            nagUserWithDeprecatedIndirectUserCodeCause(summary, advice, null);
+        }
+    }
+
+    public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String advice, String contextualAdvice) {
+        if (isEnabled()) {
+            nagUserWith(String.format("%s has been deprecated.", summary), thisWillBeRemovedMessage(), advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_INDIRECT);
+        }
+    }
+
+    public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String removalDetails, String advice, String contextualAdvice) {
+        if (isEnabled()) {
+            nagUserWith(summary, removalDetails, advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_INDIRECT);
+        }
+    }
+
+    public static void nagUserWith(String summary, String removalDetails, String advice, String contextualAdvice) {
+        if (isEnabled()) {
+            nagUserWith(deprecatedFeatureHandler, new FeatureUsage(summary, removalDetails, advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT, SingleMessageLogger.class));
+        }
+    }
+
+    public static void nagUserWith(String summary, String removalDetails, String advice, String contextualAdvice, FeatureUsage.FeatureUsageType usageType) {
+        if (isEnabled()) {
+            nagUserWith(deprecatedFeatureHandler, new FeatureUsage(summary, removalDetails, advice, contextualAdvice, usageType, SingleMessageLogger.class));
         }
     }
 
@@ -172,31 +261,35 @@ public class SingleMessageLogger {
      */
     public static void nagUserOfDeprecated(String thing) {
         if (isEnabled()) {
-            nagUserWith(String.format("%s has been deprecated.", thing), thisWillBeRemovedMessage(), null);
+            nagUserWith(String.format("%s has been deprecated.", thing),
+                thisWillBeRemovedMessage(),
+                null,
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDeprecated(String thing, String advice) {
         if (isEnabled()) {
-            nagUserWith(String.format("%s has been deprecated.", thing), thisWillBeRemovedMessage(), advice);
+            nagUserWith(String.format("%s has been deprecated.", thing), thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDeprecatedBehaviour(String behaviour) {
         if (isEnabled()) {
-            nagUserWith(behaviour, String.format("This behaviour has been deprecated and %s", getRemovalDetails()), null);
+            nagUserWith(behaviour, String.format("This behaviour has been deprecated and %s", getRemovalDetails()), null, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDeprecatedThing(String thing) {
         if (isEnabled()) {
-            nagUserWith(thing, String.format("This has been deprecated and %s", getRemovalDetails()), null);
+            nagUserWith(thing, String.format("This has been deprecated and %s", getRemovalDetails()), null, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
     public static void nagUserOfDeprecatedThing(String thing, String advice) {
         if (isEnabled()) {
-            nagUserWith(thing, String.format("This has been deprecated and %s", getRemovalDetails()), advice);
+            nagUserWith(thing, String.format("This has been deprecated and %s", getRemovalDetails()), advice, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 
@@ -228,6 +321,6 @@ public class SingleMessageLogger {
     }
 
     public static void incubatingFeatureUsed(String incubatingFeature) {
-        nagUserWith(incubatingFeatureHandler, new FeatureUsage(incubatingFeature, null, null, SingleMessageLogger.class));
+        nagUserWith(incubatingFeatureHandler, new FeatureUsage(incubatingFeature, null, null, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT, SingleMessageLogger.class));
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -195,12 +195,12 @@ public class SingleMessageLogger {
         }
     }
 
-    public static void nagUserWithDeprecatedInvocationFeature(String summary, String advice) {
-        nagUserWithDeprecatedInvocationFeature(summary, thisWillBeRemovedMessage(), advice);
+    public static void nagUserWithDeprecatedBuildInvocationFeature(String summary, String advice) {
+        nagUserWithDeprecatedBuildInvocationFeature(summary, thisWillBeRemovedMessage(), advice);
     }
 
-    public static void nagUserWithDeprecatedInvocationFeature(String summary, String removalDetails, String advice) {
-        nagUserWith(String.format("%s has been deprecated.", summary), removalDetails, advice, null, FeatureUsage.FeatureUsageType.INVOCATION);
+    public static void nagUserWithDeprecatedBuildInvocationFeature(String summary, String removalDetails, String advice) {
+        nagUserWith(String.format("%s has been deprecated.", summary), removalDetails, advice, null, FeatureUsage.FeatureUsageType.BUILD_INVOCATION);
     }
 
     public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String advice) {

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -217,7 +217,7 @@ public class SingleMessageLogger {
 
     public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String removalDetails, String advice, String contextualAdvice) {
         if (isEnabled()) {
-            nagUserWith(summary, removalDetails, advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_INDIRECT);
+            nagUserWith(String.format("%s has been deprecated.", summary), removalDetails, advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_INDIRECT);
         }
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -189,25 +189,6 @@ public class SingleMessageLogger {
     /**
      * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
      */
-    @VisibleForTesting
-    static void nagUserWith(String summary) {
-        if (isEnabled()) {
-            nagUserWith(summary, null);
-        }
-    }
-
-    /**
-     * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
-     */
-    public static void nagUserWith(String message, String advice) {
-        if (isEnabled()) {
-            nagUserWith(message, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
-        }
-    }
-
-    /**
-     * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
-     */
     public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary) {
         if (isEnabled()) {
             nagUserWithDeprecatedIndirectUserCodeCause(summary, null);
@@ -237,6 +218,25 @@ public class SingleMessageLogger {
     public static void nagUserWithDeprecatedIndirectUserCodeCause(String summary, String removalDetails, String advice, String contextualAdvice) {
         if (isEnabled()) {
             nagUserWith(summary, removalDetails, advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_INDIRECT);
+        }
+    }
+
+    /**
+     * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
+     */
+    @VisibleForTesting
+    static void nagUserWith(String summary) {
+        if (isEnabled()) {
+            nagUserWith(summary, null);
+        }
+    }
+
+    /**
+     * Try to avoid using this nagging method. The other methods use a consistent wording for when things will be removed.
+     */
+    public static void nagUserWith(String message, String advice) {
+        if (isEnabled()) {
+            nagUserWith(message, thisWillBeRemovedMessage(), advice, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
         }
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/FeatureUsageTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/FeatureUsageTest.groovy
@@ -31,14 +31,14 @@ class FeatureUsageTest extends Specification {
     def "stack is evaluated correctly for #callLocationClass.simpleName and #expectedMessage."() {
         expect:
         !usage.stack.empty
-        usage.message == expectedMessage
+        usage.summary == expectedSummary
 
         def stackTraceRoot = usage.stack[0]
         stackTraceRoot.className == callLocationClass.name
         stackTraceRoot.methodName == expectedMethod
 
         where:
-        callLocationClass           | expectedMessage | expectedMethod | usage
+        callLocationClass           | expectedSummary | expectedMethod | usage
         SimulatedJavaCallLocation   | DIRECT_CALL     | 'create'       | SimulatedJavaCallLocation.create()
         SimulatedJavaCallLocation   | INDIRECT_CALL   | 'indirectly'   | SimulatedJavaCallLocation.indirectly()
         SimulatedJavaCallLocation   | INDIRECT_CALL_2 | 'indirectly2'  | SimulatedJavaCallLocation.indirectly2()
@@ -49,12 +49,13 @@ class FeatureUsageTest extends Specification {
 
     def "formats messages"() {
         expect:
-        new FeatureUsage(message, warning, advice, getClass()).formattedMessage() == expected
+        new FeatureUsage(summary, removalDetails, advice, contextualAdvice, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT, getClass()).formattedMessage() == expected
 
         where:
-        expected                 | message   | warning   | advice
-        "message"                | "message" | null      | null
-        "message warning"        | "message" | "warning" | null
-        "message warning advice" | "message" | "warning" | "advice"
+        expected                         | summary   | removalDetails | advice   | contextualAdvice
+        "summary"                        | "summary" | null           | null     | null
+        "summary warning"                | "summary" | "warning"      | null     | null
+        "summary warning advice"         | "summary" | "warning"      | "advice" | null
+        "summary warning context advice" | "summary" | "warning"      | "advice" | "context"
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -277,7 +277,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, 'true')
 
         when:
-        handler.featureUsed(new FeatureUsage(new FeatureUsage('fake', null, null, FeatureUsageTest), mockTraceRootException(fakeStackTrace)))
+        handler.featureUsed(new FeatureUsage(new FeatureUsage('fake', null, null, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT, FeatureUsageTest), mockTraceRootException(fakeStackTrace)))
         def events = outputEventListener.events
 
         then:
@@ -303,7 +303,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         System.setProperty(deprecationTracePropertyName, '' + deprecationTraceProperty)
 
         when:
-        handler.featureUsed(new FeatureUsage('fake', null, null, FeatureUsageTest))
+        handler.featureUsed(new FeatureUsage('fake', null, null, null, null, FeatureUsageTest))
         def events = outputEventListener.events
 
         then:
@@ -397,13 +397,13 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         1 * buildOperationListener.progress(_, _) >> { progressFired(it[1], 'feature2') }
     }
 
-    private void progressFired(OperationProgressEvent progressEvent, String message) {
+    private void progressFired(OperationProgressEvent progressEvent, String summary) {
         assert progressEvent.details instanceof DeprecatedUsageProgressDetails
-        progressEvent.details.message == message
+        progressEvent.details.summary == summary
         progressEvent.details.stackTrace.size() > 0
     }
 
-    private static FeatureUsage deprecatedFeatureUsage(String message, Class<?> calledFrom = LoggingDeprecatedFeatureHandlerTest) {
-        new FeatureUsage(message, null, null, calledFrom)
+    private static FeatureUsage deprecatedFeatureUsage(String summary, Class<?> calledFrom = LoggingDeprecatedFeatureHandlerTest) {
+        new FeatureUsage(summary, null, null, null, FeatureUsage.FeatureUsageType.USER_CODE_DIRECT, calledFrom)
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedDeprecationMessageLogger.java
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/SimulatedDeprecationMessageLogger.java
@@ -30,6 +30,6 @@ public class SimulatedDeprecationMessageLogger {
     }
 
     public static FeatureUsage nagUserWith(String message) {
-        return new FeatureUsage(message, null, null, SimulatedDeprecationMessageLogger.class);
+        return new FeatureUsage(message, null, null, null, FeatureUsage.FeatureUsageType.USER_CODE_INDIRECT, SimulatedDeprecationMessageLogger.class);
     }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -89,7 +89,7 @@ public class PublishingPlugin implements Plugin<Project> {
         if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_PUBLISHING)) {
             return DefaultPublishingExtension.class;
         } else {
-            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(
+            DeprecationLogger.nagUserWithDeprecatedBuildInvocationFeature(
                 "As part of making the publishing plugins stable, the 'deferred configurable' behavior of the 'publishing {}' block is now deprecated.",
                 "In Gradle 5.0 the 'enableFeaturePreview('STABLE_PUBLISHING')' flag will be removed and the new behavior will become the default.",
                     "Please add 'enableFeaturePreview('STABLE_PUBLISHING')' to your settings file and do a test run by publishing to a local repository. " +

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -89,7 +89,7 @@ public class PublishingPlugin implements Plugin<Project> {
         if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_PUBLISHING)) {
             return DefaultPublishingExtension.class;
         } else {
-            DeprecationLogger.nagUserWith(
+            DeprecationLogger.nagUserWithDeprecatedInvocationFeature(
                 "As part of making the publishing plugins stable, the 'deferred configurable' behavior of the 'publishing {}' block is now deprecated.",
                 "In Gradle 5.0 the 'enableFeaturePreview('STABLE_PUBLISHING')' flag will be removed and the new behavior will become the default.",
                     "Please add 'enableFeaturePreview('STABLE_PUBLISHING')' to your settings file and do a test run by publishing to a local repository. " +

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1118,7 +1118,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     private String getPrefixedProperty(String propertyName, String replacement) {
         String value = System.getProperty(propertyName);
         if (value != null) {
-            SingleMessageLogger.nagUserOfDeprecated("System property '" + propertyName + "'", replacement);
+            SingleMessageLogger.nagUserWithDeprecatedInvocationFeature("System property '" + propertyName + "'", replacement);
         }
         return value;
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1118,7 +1118,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     private String getPrefixedProperty(String propertyName, String replacement) {
         String value = System.getProperty(propertyName);
         if (value != null) {
-            SingleMessageLogger.nagUserWithDeprecatedInvocationFeature("System property '" + propertyName + "'", replacement);
+            SingleMessageLogger.nagUserWithDeprecatedBuildInvocationFeature("System property '" + propertyName + "'", replacement);
         }
         return value;
     }


### PR DESCRIPTION
Enriched in two ways:

1. Distinguish between deprecations that have no use site (e.g. CLI option deprecations), those with use sites but no useful stack trace, and those with a use site and a useful stacktrace.
2. Separate advice about a particular usage of a deprecation from the general, non usage specific, advice.

