### PR TITLE
Report progress for cache cleanup

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.cache.internal
 
 import org.gradle.api.Action
 import org.gradle.cache.CacheRepository
+import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.GlobalScopeServices
@@ -49,6 +50,11 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
 
     def DefaultServiceRegistry services = (DefaultServiceRegistry) ServiceRegistryBuilder.builder()
             .parent(NativeServicesTestFixture.getInstance())
+            .provider(new Object() {
+                OutputEventListener createOutputEventListener() {
+                    return OutputEventListener.NO_OP
+                }
+            })
             .provider(new GlobalScopeServices(false))
             .build()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.cache.internal
 
 import org.gradle.api.Action
 import org.gradle.cache.CacheRepository
-import org.gradle.internal.logging.events.OutputEventListener
+import org.gradle.internal.logging.services.LoggingServiceRegistry
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.GlobalScopeServices
@@ -50,11 +50,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
 
     def DefaultServiceRegistry services = (DefaultServiceRegistry) ServiceRegistryBuilder.builder()
             .parent(NativeServicesTestFixture.getInstance())
-            .provider(new Object() {
-                OutputEventListener createOutputEventListener() {
-                    return OutputEventListener.NO_OP
-                }
-            })
+            .provider(LoggingServiceRegistry.NO_OP)
             .provider(new GlobalScopeServices(false))
             .build()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.GradleVersion
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.NOT_USED_WITHIN_30_DAYS
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.USED_TODAY
 
-class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements GradleUserHomeCleanupFixture {
 
     def "cleans up unused version-specific cache directories and corresponding distributions"() {
         given:

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/layout/ProjectCacheDirIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/layout/ProjectCacheDirIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.initialization.layout
 
 import org.gradle.cache.internal.VersionSpecificCacheCleanupFixture
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 
@@ -26,8 +25,6 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.USED_TODAY
 
 class ProjectCacheDirIntegrationTest extends AbstractIntegrationSpec implements VersionSpecificCacheCleanupFixture {
-
-    def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
     def "cleans up unused version-specific cache directories from project directory"() {
         given:
@@ -39,9 +36,6 @@ class ProjectCacheDirIntegrationTest extends AbstractIntegrationSpec implements 
         succeeds("tasks")
 
         then:
-        buildOperations.hasOperation("Delete unused version-specific caches in ${cachesDir}")
-
-        and:
         oldButRecentlyUsedCacheDir.assertExists()
         oldCacheDir.assertDoesNotExist()
         currentCacheDir.assertExists()

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -56,6 +56,11 @@ import spock.lang.Specification
 abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
     @Shared DefaultServiceRegistry services = (DefaultServiceRegistry) ServiceRegistryBuilder.builder()
         .parent(NativeServicesTestFixture.getInstance())
+        .provider(new Object() {
+            OutputEventListener createOutputEventListener() {
+                return OutputEventListener.NO_OP
+            }
+        })
         .provider(new GlobalScopeServices(false))
         .build()
     final MessagingServer server = services.get(MessagingServer.class)

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -56,11 +56,7 @@ import spock.lang.Specification
 abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
     @Shared DefaultServiceRegistry services = (DefaultServiceRegistry) ServiceRegistryBuilder.builder()
         .parent(NativeServicesTestFixture.getInstance())
-        .provider(new Object() {
-            OutputEventListener createOutputEventListener() {
-                return OutputEventListener.NO_OP
-            }
-        })
+        .provider(LoggingServiceRegistry.NO_OP)
         .provider(new GlobalScopeServices(false))
         .build()
     final MessagingServer server = services.get(MessagingServer.class)

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -16,9 +16,13 @@
 
 package org.gradle.cache.internal;
 
+import org.gradle.api.Action;
+import org.gradle.api.Describable;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.logging.progress.ProgressLogger;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 
 import java.io.File;
 
@@ -30,18 +34,33 @@ public class GradleUserHomeCleanupService implements Stoppable {
     private final GradleUserHomeDirProvider userHomeDirProvider;
     private final CacheScopeMapping cacheScopeMapping;
     private final UsedGradleVersions usedGradleVersions;
+    private final ProgressLoggerFactory progressLoggerFactory;
 
-    public GradleUserHomeCleanupService(GradleUserHomeDirProvider userHomeDirProvider, CacheScopeMapping cacheScopeMapping, UsedGradleVersions usedGradleVersions) {
+    public GradleUserHomeCleanupService(GradleUserHomeDirProvider userHomeDirProvider, CacheScopeMapping cacheScopeMapping, UsedGradleVersions usedGradleVersions, ProgressLoggerFactory progressLoggerFactory) {
         this.userHomeDirProvider = userHomeDirProvider;
         this.cacheScopeMapping = cacheScopeMapping;
         this.usedGradleVersions = usedGradleVersions;
+        this.progressLoggerFactory = progressLoggerFactory;
     }
 
     @Override
     public void stop() {
         File cacheBaseDir = cacheScopeMapping.getRootDirectory(null);
-        new VersionSpecificCacheCleanupAction(cacheBaseDir, MAX_UNUSED_DAYS_FOR_RELEASES, MAX_UNUSED_DAYS_FOR_SNAPSHOTS).execute(CleanupProgressMonitor.NO_OP);
+        execute(new VersionSpecificCacheCleanupAction(cacheBaseDir, MAX_UNUSED_DAYS_FOR_RELEASES, MAX_UNUSED_DAYS_FOR_SNAPSHOTS));
         File gradleUserHomeDirectory = userHomeDirProvider.getGradleUserHomeDirectory();
-        new WrapperDistributionCleanupAction(gradleUserHomeDirectory, usedGradleVersions).execute();
+        execute(new WrapperDistributionCleanupAction(gradleUserHomeDirectory, usedGradleVersions));
+    }
+
+    private <T extends Action<CleanupProgressMonitor> & Describable> void execute(T action) {
+        ProgressLogger progressLogger = startNewOperation(action.getClass(), action.getDisplayName());
+        try {
+            action.execute(new DefaultCleanupProgressMonitor(progressLogger));
+        } finally {
+            progressLogger.completed();
+        }
+    }
+
+    private ProgressLogger startNewOperation(Class<?> loggerClass, String description) {
+        return progressLoggerFactory.newOperation(loggerClass).start(description, description);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -16,6 +16,7 @@
 
 package org.gradle.cache.internal;
 
+import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.concurrent.Stoppable;
 
@@ -39,7 +40,7 @@ public class GradleUserHomeCleanupService implements Stoppable {
     @Override
     public void stop() {
         File cacheBaseDir = cacheScopeMapping.getRootDirectory(null);
-        new VersionSpecificCacheCleanupAction(cacheBaseDir, MAX_UNUSED_DAYS_FOR_RELEASES, MAX_UNUSED_DAYS_FOR_SNAPSHOTS).execute();
+        new VersionSpecificCacheCleanupAction(cacheBaseDir, MAX_UNUSED_DAYS_FOR_RELEASES, MAX_UNUSED_DAYS_FOR_SNAPSHOTS).execute(CleanupProgressMonitor.NO_OP);
         File gradleUserHomeDirectory = userHomeDirProvider.getGradleUserHomeDirectory();
         new WrapperDistributionCleanupAction(gradleUserHomeDirectory, usedGradleVersions).execute();
     }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupServices.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupServices.java
@@ -17,15 +17,16 @@
 package org.gradle.cache.internal;
 
 import org.gradle.initialization.GradleUserHomeDirProvider;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.service.ServiceRegistration;
 
 public class GradleUserHomeCleanupServices {
 
-    public void configure(ServiceRegistration registration, GradleUserHomeDirProvider gradleUserHomeDirProvider, CacheScopeMapping cacheScopeMapping) {
+    public void configure(ServiceRegistration registration, GradleUserHomeDirProvider gradleUserHomeDirProvider, CacheScopeMapping cacheScopeMapping, ProgressLoggerFactory progressLoggerFactory) {
         UsedGradleVersions usedGradleVersions = new UsedGradleVersionsFromGradleUserHomeCaches(cacheScopeMapping);
         registration.add(UsedGradleVersions.class, usedGradleVersions);
         // register eagerly so stop() is triggered when services are being stopped
-        registration.add(GradleUserHomeCleanupService.class, new GradleUserHomeCleanupService(gradleUserHomeDirProvider, cacheScopeMapping, usedGradleVersions));
+        registration.add(GradleUserHomeCleanupService.class, new GradleUserHomeCleanupService(gradleUserHomeDirProvider, cacheScopeMapping, usedGradleVersions, progressLoggerFactory));
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
@@ -21,6 +21,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.apache.commons.io.FileUtils;
+import org.gradle.api.Action;
+import org.gradle.api.Describable;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
@@ -30,6 +32,7 @@ import org.gradle.internal.time.Timer;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.GradleVersion;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.util.SortedSet;
@@ -37,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache.FILE_HASHES_CACHE_KEY;
 
-public class VersionSpecificCacheCleanupAction {
+public class VersionSpecificCacheCleanupAction implements Action<CleanupProgressMonitor>, Describable {
 
     @VisibleForTesting static final String MARKER_FILE_PATH = FILE_HASHES_CACHE_KEY + "/" + FILE_HASHES_CACHE_KEY + ".lock";
     private static final Logger LOGGER = Logging.getLogger(VersionSpecificCacheCleanupAction.class);
@@ -59,11 +62,17 @@ public class VersionSpecificCacheCleanupAction {
         this.maxUnusedDaysForSnapshots = maxUnusedDaysForSnapshots;
     }
 
-    public void execute(CleanupProgressMonitor progressMonitor) {
+    @Override
+    @Nonnull
+    public String getDisplayName() {
+        return "Deleting unused version-specific caches in " + versionSpecificCacheDirectoryScanner.getBaseDir();
+    }
+
+    public void execute(@Nonnull CleanupProgressMonitor progressMonitor) {
         if (requiresCleanup()) {
             Timer timer = Time.startTimer();
             performCleanup(progressMonitor);
-            LOGGER.debug("Processed version-specific caches for cleanup in {}", timer.getElapsed());
+            LOGGER.debug("Processed version-specific caches at {} for cleanup in {}", versionSpecificCacheDirectoryScanner.getBaseDir(), timer.getElapsed());
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheDirectoryScanner.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheDirectoryScanner.java
@@ -38,6 +38,10 @@ public class VersionSpecificCacheDirectoryScanner {
         this.baseDir = baseDir;
     }
 
+    public File getBaseDir() {
+        return baseDir;
+    }
+
     public File getDirectory(GradleVersion gradleVersion) {
         return new File(baseDir, gradleVersion.getVersion());
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization.layout;
 
+import org.gradle.cache.internal.DefaultCleanupProgressMonitor;
 import org.gradle.cache.internal.VersionSpecificCacheCleanupAction;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.logging.progress.ProgressLogger;
@@ -44,7 +45,7 @@ public class ProjectCacheDir implements Stoppable {
         String description = "Deleting unused version-specific caches in " + dir;
         ProgressLogger progressLogger = progressLoggerFactory.newOperation(ProjectCacheDir.class).start(description, description);
         try {
-            new VersionSpecificCacheCleanupAction(dir, MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS).execute();
+            new VersionSpecificCacheCleanupAction(dir, MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS).execute(new DefaultCleanupProgressMonitor(progressLogger));
         } finally {
             progressLogger.completed();
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
@@ -42,10 +42,11 @@ public class ProjectCacheDir implements Stoppable {
 
     @Override
     public void stop() {
-        String description = "Deleting unused version-specific caches in " + dir;
+        VersionSpecificCacheCleanupAction cleanupAction = new VersionSpecificCacheCleanupAction(dir, MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS);
+        String description = cleanupAction.getDisplayName();
         ProgressLogger progressLogger = progressLoggerFactory.newOperation(ProjectCacheDir.class).start(description, description);
         try {
-            new VersionSpecificCacheCleanupAction(dir, MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS).execute(new DefaultCleanupProgressMonitor(progressLogger));
+            cleanupAction.execute(new DefaultCleanupProgressMonitor(progressLogger));
         } finally {
             progressLogger.completed();
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -72,6 +72,7 @@ import org.gradle.internal.hash.DefaultFileHasher;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationListenerManager;
@@ -136,10 +137,10 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new BuildOperationCrossProjectConfigurator(buildOperationExecutor);
     }
 
-    ProjectCacheDir createCacheLayout(StartParameter startParameter, BuildLayoutFactory buildLayoutFactory, BuildOperationExecutor buildOperationExecutor) {
+    ProjectCacheDir createCacheLayout(StartParameter startParameter, BuildLayoutFactory buildLayoutFactory, ProgressLoggerFactory progressLoggerFactory) {
         BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
         File cacheDir = startParameter.getProjectCacheDir() != null ? startParameter.getProjectCacheDir() : new File(buildLayout.getRootDirectory(), ".gradle");
-        return new ProjectCacheDir(cacheDir, buildOperationExecutor);
+        return new ProjectCacheDir(cacheDir, progressLoggerFactory);
     }
 
     BuildScopeFileTimeStampInspector createFileTimeStampInspector(ProjectCacheDir projectCacheDir, CacheScopeMapping cacheScopeMapping, ListenerManager listenerManager) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -198,8 +198,8 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultPluginModuleRegistry(moduleRegistry);
     }
 
-    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory) {
-        return new DefaultCacheFactory(fileLockManager, executorFactory);
+    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+        return new DefaultCacheFactory(fileLockManager, executorFactory, progressLoggerFactory);
     }
 
     ClassLoaderRegistry createClassLoaderRegistry(ClassPathRegistry classPathRegistry, LegacyTypesSupport legacyTypesSupport) {

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryCacheFactory.java
@@ -21,6 +21,7 @@ import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.CacheValidator;
 import org.gradle.cache.CleanupAction;
+import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
 import org.gradle.cache.PersistentIndexedCache;
@@ -71,7 +72,7 @@ public class InMemoryCacheFactory implements CacheFactory {
         public void close() {
             if (cleanup!=null) {
                 synchronized (this) {
-                    cleanup.clean(this);
+                    cleanup.clean(this, CleanupProgressMonitor.NO_OP);
                 }
             }
             closed = true;

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryCacheFactory.java
@@ -30,7 +30,6 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.Pair;
 import org.gradle.internal.serialize.Serializer;
-import org.gradle.internal.time.Time;
 import org.gradle.util.GFileUtils;
 
 import javax.annotation.Nullable;
@@ -38,7 +37,6 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public class InMemoryCacheFactory implements CacheFactory {
     final Map<Pair<File, String>, PersistentIndexedCache<?, ?>> caches = Maps.newLinkedHashMap();
@@ -73,7 +71,7 @@ public class InMemoryCacheFactory implements CacheFactory {
         public void close() {
             if (cleanup!=null) {
                 synchronized (this) {
-                    cleanup.clean(this, Time.startCountdownTimer(1, TimeUnit.MINUTES));
+                    cleanup.clean(this);
                 }
             }
             closed = true;

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
@@ -38,7 +38,7 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
     }
 
     @Override
-    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory) {
+    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
         return new InMemoryCacheFactory();
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.cache.internal
 
 import org.gradle.initialization.GradleUserHomeDirProvider
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
@@ -40,8 +41,9 @@ class GradleUserHomeCleanupServiceTest extends Specification implements VersionS
     def usedGradleVersions = Stub(UsedGradleVersions) {
         getUsedGradleVersions() >> ([] as SortedSet)
     }
+    def progressLoggerFactory = Stub(ProgressLoggerFactory)
 
-    @Subject def cleanupService = new GradleUserHomeCleanupService(userHomeDirProvider, cacheScopeMapping, usedGradleVersions)
+    @Subject def cleanupService = new GradleUserHomeCleanupService(userHomeDirProvider, cacheScopeMapping, usedGradleVersions, progressLoggerFactory)
 
     def "cleans up unused version-specific cache directories and deletes distributions for unused versions"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Subject
 
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.NOT_USED_WITHIN_30_DAYS
 
-class GradleUserHomeCleanupServiceTest extends Specification implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+class GradleUserHomeCleanupServiceTest extends Specification implements GradleUserHomeCleanupFixture {
 
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.NOT_USED_WITHIN_7_DAYS
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.USED_TODAY
 
-class VersionSpecificCacheCleanupActionTest extends Specification implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+class VersionSpecificCacheCleanupActionTest extends Specification implements GradleUserHomeCleanupFixture {
 
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.internal.time.CountdownTimer
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
@@ -158,25 +157,6 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Ver
         then:
         snapshot.assertExists()
         latestSnapshot.assertExists()
-    }
-
-    def "aborts cleanup when timeout has expired"() {
-        given:
-        def oldestCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.2.3"), NOT_USED_WITHIN_30_DAYS)
-        def oldCacheDir = createVersionSpecificCacheDir(GradleVersion.version("2.3.4"), NOT_USED_WITHIN_30_DAYS)
-        def timer = Mock(CountdownTimer)
-
-        when:
-        cleanupAction.performCleanup(timer)
-
-        then:
-        1 * timer.hasExpired() >> false
-        1 * timer.hasExpired() >> true
-
-        and:
-        getGcFile(currentCacheDir).assertDoesNotExist()
-        oldestCacheDir.assertDoesNotExist()
-        oldCacheDir.assertExists()
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheDirectoryScannerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheDirectoryScannerTest.groovy
@@ -56,4 +56,9 @@ class VersionSpecificCacheDirectoryScannerTest extends Specification {
         expect:
         versionSpecificCacheDirectoryService.getDirectory(GradleVersion.version("1.2.3")) == cacheBaseDir.file("1.2.3")
     }
+
+    def "returns base directory"() {
+        expect:
+        versionSpecificCacheDirectoryService.getBaseDir() == cacheBaseDir
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
@@ -25,7 +25,7 @@ import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
 
-class WrapperDistributionCleanupActionTest extends Specification implements VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture {
+class WrapperDistributionCleanupActionTest extends Specification implements GradleUserHomeCleanupFixture {
 
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/ProjectCacheDirTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/ProjectCacheDirTest.groovy
@@ -55,6 +55,7 @@ class ProjectCacheDirTest extends Specification implements VersionSpecificCacheC
         then:
         1 * progressLoggerFactory.newOperation(ProjectCacheDir.class) >> progressLogger
         1 * progressLogger.start(_, _) >> progressLogger
+        6 * progressLogger.progress(_)
         1 * progressLogger.completed()
         ancientVersionWithoutMarkerFile.assertExists()
         oldestCacheDir.assertDoesNotExist()

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -52,6 +52,7 @@ import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.remote.MessagingServer
 import org.gradle.internal.resource.local.FileAccessTimeJournal
 import org.gradle.internal.service.ServiceRegistry
@@ -80,6 +81,9 @@ class GradleUserHomeScopeServicesTest extends WorkspaceTest {
                             return new File("")
                         }
                     }
+                }
+                ProgressLoggerFactory createProgressLoggerFactory() {
+                    return new NoOpProgressLoggerFactory();
                 }
             })
             .provider(new GradleUserHomeScopeServices(parent))

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 
 import static org.gradle.cache.internal.WrapperDistributionCleanupAction.WRAPPER_DISTRIBUTION_FILE_PATH
 
-trait VersionSpecificCacheAndWrapperDistributionCleanupServiceFixture implements VersionSpecificCacheCleanupFixture {
+trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture {
 
     private static final BiAction<GradleVersion, File> DEFAULT_JAR_WRITER = { version, jarFile ->
         jarFile << JarUtils.jarWithContents((GradleVersion.RESOURCE_NAME.substring(1)): "${GradleVersion.VERSION_NUMBER_PROPERTY}: ${version.version}")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DownloadableGradleDistribution.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DownloadableGradleDistribution.groovy
@@ -26,6 +26,7 @@ import org.gradle.cache.internal.DefaultFileLockManager
 import org.gradle.cache.internal.DefaultProcessMetaDataProvider
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
 import org.gradle.internal.concurrent.DefaultExecutorFactory
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.gradle.util.GradleVersion
@@ -42,7 +43,7 @@ abstract class DownloadableGradleDistribution extends DefaultGradleDistribution 
                         new DefaultProcessMetaDataProvider(
                                 NativeServicesTestFixture.getInstance().get(org.gradle.internal.nativeintegration.ProcessEnvironment)),
                         20 * 60 * 1000 // allow up to 20 minutes to download a distribution
-                        , new NoOpFileLockContentionHandler()), new DefaultExecutorFactory())
+                        , new NoOpFileLockContentionHandler()), new DefaultExecutorFactory(), new NoOpProgressLoggerFactory())
     }
 
     protected TestFile versionDir

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -30,7 +30,7 @@ import org.gradle.cache.internal.CacheRepositoryServices;
 import org.gradle.internal.Factory;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
-import org.gradle.internal.logging.events.OutputEventListener;
+import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -169,7 +169,7 @@ public class ZincScalaCompilerFactory {
         private ZincCompilerServices(File gradleUserHome) {
             super(NativeServices.getInstance());
 
-            add(OutputEventListener.class, OutputEventListener.NO_OP);
+            addProvider(LoggingServiceRegistry.NO_OP);
             addProvider(new GlobalScopeServices(true));
             addProvider(new CacheRepositoryServices(gradleUserHome, null));
         }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -30,6 +30,7 @@ import org.gradle.cache.internal.CacheRepositoryServices;
 import org.gradle.internal.Factory;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -168,6 +169,7 @@ public class ZincScalaCompilerFactory {
         private ZincCompilerServices(File gradleUserHome) {
             super(NativeServices.getInstance());
 
+            add(OutputEventListener.class, OutputEventListener.NO_OP);
             addProvider(new GlobalScopeServices(true));
             addProvider(new CacheRepositoryServices(gradleUserHome, null));
         }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OutputEventListener.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/events/OutputEventListener.java
@@ -21,4 +21,10 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 @UsedByScanPlugin
 public interface OutputEventListener {
     void onOutput(OutputEvent event);
+
+    OutputEventListener NO_OP = new OutputEventListener() {
+        @Override
+        public void onOutput(OutputEvent event) {
+        }
+    };
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
@@ -48,6 +48,13 @@ import org.gradle.internal.time.Time;
  * </ol>
  */
 public abstract class LoggingServiceRegistry extends DefaultServiceRegistry {
+
+    public static final Object NO_OP = new Object() {
+        OutputEventListener createOutputEventListener() {
+            return OutputEventListener.NO_OP;
+        }
+    };
+
     private TextStreamOutputEventListener stdoutListener;
 
     protected final OutputEventRenderer renderer = makeOutputEventRenderer();

--- a/subprojects/persistent-cache/persistent-cache.gradle
+++ b/subprojects/persistent-cache/persistent-cache.gradle
@@ -26,6 +26,7 @@ dependencies {
     api project(":messaging")
     api project(":native")
     api project(":resources")
+    api project(":logging")
     api libraries.jcip.coordinates
 
     implementation libraries.commons_collections.coordinates

--- a/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -196,6 +196,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
             import org.gradle.cache.FileLockManager
             import org.gradle.cache.internal.filelock.LockOptionsBuilder
             import org.gradle.cache.internal.CacheRepositoryServices;
+            import org.gradle.internal.logging.events.OutputEventListener;
             import org.gradle.internal.nativeintegration.services.NativeServices;
             import org.gradle.internal.service.DefaultServiceRegistry;
             import org.gradle.internal.service.scopes.GlobalScopeServices;
@@ -239,6 +240,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
                 private ZincCompilerServices(File gradleUserHome) {
                     super(NativeServices.getInstance());
         
+                    add(OutputEventListener.class, OutputEventListener.NO_OP);
                     addProvider(new GlobalScopeServices(true));
                     addProvider(new CacheRepositoryServices(gradleUserHome, null));
                 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupAction.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupAction.java
@@ -16,8 +16,6 @@
 
 package org.gradle.cache;
 
-import org.gradle.internal.time.CountdownTimer;
-
 /**
  * An action that cleans up a {@link CleanableStore}.
  *
@@ -26,11 +24,11 @@ import org.gradle.internal.time.CountdownTimer;
  */
 public interface CleanupAction {
 
-    void clean(CleanableStore cleanableStore, CountdownTimer timer);
+    void clean(CleanableStore cleanableStore);
 
     CleanupAction NO_OP = new CleanupAction() {
         @Override
-        public void clean(CleanableStore cleanableStore, CountdownTimer timer) {
+        public void clean(CleanableStore cleanableStore) {
             // no-op
         }
     };

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupProgressMonitor.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupProgressMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,19 @@
 
 package org.gradle.cache;
 
-/**
- * An action that cleans up a {@link CleanableStore}.
- *
- * @see org.gradle.cache.internal.CompositeCleanupAction
- * @see CacheBuilder#withCleanup(CleanupAction)
- */
-public interface CleanupAction {
+public interface CleanupProgressMonitor {
 
-    void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor);
+    void incrementDeleted();
 
-    CleanupAction NO_OP = new CleanupAction() {
+    void incrementSkipped();
+
+    CleanupProgressMonitor NO_OP = new CleanupProgressMonitor() {
         @Override
-        public void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor) {
-            // no-op
+        public void incrementDeleted() {
+        }
+
+        @Override
+        public void incrementSkipped() {
         }
     };
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupProgressMonitor.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupProgressMonitor.java
@@ -22,6 +22,8 @@ public interface CleanupProgressMonitor {
 
     void incrementSkipped();
 
+    void incrementSkipped(long amount);
+
     CleanupProgressMonitor NO_OP = new CleanupProgressMonitor() {
         @Override
         public void incrementDeleted() {
@@ -29,6 +31,10 @@ public interface CleanupProgressMonitor {
 
         @Override
         public void incrementSkipped() {
+        }
+
+        @Override
+        public void incrementSkipped(long amount) {
         }
     };
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -19,6 +19,7 @@ package org.gradle.cache.internal;
 import org.apache.commons.io.FileUtils;
 import org.gradle.cache.CleanableStore;
 import org.gradle.cache.CleanupAction;
+import org.gradle.cache.CleanupProgressMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,14 +36,17 @@ public abstract class AbstractCacheCleanup implements CleanupAction {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore) {
+    public void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor) {
         int filesDeleted = 0;
         for (File file : findEligibleFiles(cleanableStore)) {
             if (shouldDelete(file)) {
+                progressMonitor.incrementDeleted();
                 if (FileUtils.deleteQuietly(file)) {
                     handleDeletion(file);
                     filesDeleted += 1 + deleteEmptyParentDirectories(cleanableStore.getBaseDir(), file.getParentFile());
                 }
+            } else {
+                progressMonitor.incrementSkipped();
             }
         }
         LOGGER.debug("{} cleanup deleted {} files/directories.", cleanableStore.getDisplayName(), filesDeleted);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -19,7 +19,6 @@ package org.gradle.cache.internal;
 import org.apache.commons.io.FileUtils;
 import org.gradle.cache.CleanableStore;
 import org.gradle.cache.CleanupAction;
-import org.gradle.internal.time.CountdownTimer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,13 +35,9 @@ public abstract class AbstractCacheCleanup implements CleanupAction {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore, CountdownTimer timer) {
+    public void clean(CleanableStore cleanableStore) {
         int filesDeleted = 0;
         for (File file : findEligibleFiles(cleanableStore)) {
-            if (timer.hasExpired()) {
-                LOGGER.debug("{} cleanup was aborted because timeout has expired", cleanableStore.getDisplayName());
-                break;
-            }
             if (shouldDelete(file)) {
                 if (FileUtils.deleteQuietly(file)) {
                     handleDeletion(file);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
@@ -18,6 +18,7 @@ package org.gradle.cache.internal;
 
 import org.gradle.cache.CleanableStore;
 import org.gradle.cache.CleanupAction;
+import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -44,11 +45,11 @@ public class CleanupActionFactory {
         }
 
         @Override
-        public void clean(final CleanableStore persistentCache) {
+        public void clean(final CleanableStore persistentCache, final CleanupProgressMonitor progressMonitor) {
             buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
                 public void run(BuildOperationContext context) {
-                    delegate.clean(persistentCache);
+                    delegate.clean(persistentCache, progressMonitor);
                 }
 
                 @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CleanupActionFactory.java
@@ -22,7 +22,6 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.time.CountdownTimer;
 
 public class CleanupActionFactory {
     private final BuildOperationExecutor buildOperationExecutor;
@@ -45,11 +44,11 @@ public class CleanupActionFactory {
         }
 
         @Override
-        public void clean(final CleanableStore persistentCache, final CountdownTimer timer) {
+        public void clean(final CleanableStore persistentCache) {
             buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
                 public void run(BuildOperationContext context) {
-                    delegate.clean(persistentCache, timer);
+                    delegate.clean(persistentCache);
                 }
 
                 @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CompositeCleanupAction.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CompositeCleanupAction.java
@@ -19,6 +19,7 @@ package org.gradle.cache.internal;
 import com.google.common.collect.ImmutableList;
 import org.gradle.cache.CleanableStore;
 import org.gradle.cache.CleanupAction;
+import org.gradle.cache.CleanupProgressMonitor;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -39,9 +40,9 @@ public class CompositeCleanupAction implements CleanupAction {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore) {
+    public void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor) {
         for (CleanupAction action : cleanups) {
-            action.clean(cleanableStore);
+            action.clean(cleanableStore, progressMonitor);
         }
     }
 
@@ -78,8 +79,8 @@ public class CompositeCleanupAction implements CleanupAction {
         }
 
         @Override
-        public void clean(CleanableStore cleanableStore) {
-            action.clean(new CleanableSubDir(cleanableStore, baseDir));
+        public void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor) {
+            action.clean(new CleanableSubDir(cleanableStore, baseDir), progressMonitor);
         }
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CompositeCleanupAction.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CompositeCleanupAction.java
@@ -19,7 +19,6 @@ package org.gradle.cache.internal;
 import com.google.common.collect.ImmutableList;
 import org.gradle.cache.CleanableStore;
 import org.gradle.cache.CleanupAction;
-import org.gradle.internal.time.CountdownTimer;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -40,12 +39,9 @@ public class CompositeCleanupAction implements CleanupAction {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore, CountdownTimer timer) {
+    public void clean(CleanableStore cleanableStore) {
         for (CleanupAction action : cleanups) {
-            if (timer.hasExpired()) {
-                break;
-            }
-            action.clean(cleanableStore, timer);
+            action.clean(cleanableStore);
         }
     }
 
@@ -82,8 +78,8 @@ public class CompositeCleanupAction implements CleanupAction {
         }
 
         @Override
-        public void clean(CleanableStore cleanableStore, CountdownTimer timer) {
-            action.clean(new CleanableSubDir(cleanableStore, baseDir), timer);
+        public void clean(CleanableStore cleanableStore) {
+            action.clean(new CleanableSubDir(cleanableStore, baseDir));
         }
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -29,6 +29,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.serialize.Serializer;
 
 import javax.annotation.Nullable;
@@ -46,11 +47,13 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
     private final Map<File, DirCacheReference> dirCaches = new HashMap<File, DirCacheReference>();
     private final FileLockManager lockManager;
     private final ExecutorFactory executorFactory;
+    private final ProgressLoggerFactory progressLoggerFactory;
     private final Lock lock = new ReentrantLock();
 
-    public DefaultCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory) {
+    public DefaultCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
         this.lockManager = fileLockManager;
         this.executorFactory = executorFactory;
+        this.progressLoggerFactory = progressLoggerFactory;
     }
 
     void onOpen(Object cache) {
@@ -85,9 +88,9 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         if (dirCacheReference == null) {
             ReferencablePersistentCache cache;
             if (!properties.isEmpty() || validator != null || initializer != null) {
-                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, validator, properties, lockTarget, lockOptions, initializer, cleanup, lockManager, executorFactory);
+                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, validator, properties, lockTarget, lockOptions, initializer, cleanup, lockManager, executorFactory, progressLoggerFactory);
             } else {
-                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cleanup, lockManager, executorFactory);
+                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cleanup, lockManager, executorFactory, progressLoggerFactory);
             }
             cache.open();
             dirCacheReference = new DirCacheReference(cache, properties, lockTarget, lockOptions);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCleanupProgressMonitor.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCleanupProgressMonitor.java
@@ -38,7 +38,12 @@ public class DefaultCleanupProgressMonitor implements CleanupProgressMonitor {
 
     @Override
     public void incrementSkipped() {
-        skipped++;
+        incrementSkipped(1);
+    }
+
+    @Override
+    public void incrementSkipped(long amount) {
+        skipped += amount;
         updateProgress();
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCleanupProgressMonitor.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCleanupProgressMonitor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.gradle.cache.CleanupProgressMonitor;
+import org.gradle.internal.logging.progress.ProgressLogger;
+
+public class DefaultCleanupProgressMonitor implements CleanupProgressMonitor {
+
+    private final ProgressLogger progressLogger;
+
+    private long deleted;
+    private long skipped;
+
+    public DefaultCleanupProgressMonitor(ProgressLogger progressLogger) {
+        this.progressLogger = progressLogger;
+    }
+
+    @Override
+    public void incrementDeleted() {
+        deleted++;
+        updateProgress();
+    }
+
+    @Override
+    public void incrementSkipped() {
+        skipped++;
+        updateProgress();
+    }
+
+    private void updateProgress() {
+        progressLogger.progress(progressLogger.getDescription() + ": "
+            + mandatoryNumber(deleted, " entry", " entries") + " deleted"
+            + optionalNumber(", ", skipped, " skipped"));
+    }
+
+    private String mandatoryNumber(long value, String singular, String plural) {
+        return value == 1 ? value + singular : value + plural;
+    }
+
+    private String optionalNumber(String separator, long value, String description) {
+        return value == 0 ? "" : separator + value + description;
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -25,6 +25,7 @@ import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
 import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.GUtil;
 import org.slf4j.Logger;
@@ -43,8 +44,8 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
     private final CacheValidator validator;
     private boolean didRebuild;
 
-    public DefaultPersistentDirectoryCache(File dir, String displayName, CacheValidator validator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CleanupAction cleanupAction, FileLockManager lockManager, ExecutorFactory executorFactory) {
-        super(dir, displayName, lockTarget, lockOptions, cleanupAction, lockManager, executorFactory);
+    public DefaultPersistentDirectoryCache(File dir, String displayName, CacheValidator validator, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CleanupAction cleanupAction, FileLockManager lockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+        super(dir, displayName, lockTarget, lockOptions, cleanupAction, lockManager, executorFactory, progressLoggerFactory);
         this.validator = validator;
         this.initAction = initAction;
         this.properties.putAll(properties);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -208,7 +208,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
                 ProgressLogger progressLogger = progressLoggerFactory.newOperation(CacheCleanupAction.class).start(description, description);
                 Timer timer = Time.startTimer();
                 try {
-                    cleanupAction.clean(DefaultPersistentDirectoryStore.this);
+                    cleanupAction.clean(DefaultPersistentDirectoryStore.this, new DefaultCleanupProgressMonitor(progressLogger));
                     GFileUtils.touch(gcFile);
                 } finally {
                     LOGGER.info("{} cleaned up in {}.", DefaultPersistentDirectoryStore.this, timer.getElapsed());

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanup.java
@@ -17,6 +17,7 @@
 package org.gradle.cache.internal;
 
 import org.gradle.cache.CleanableStore;
+import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.resource.local.FileAccessTimeJournal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,9 +45,9 @@ public class LeastRecentlyUsedCacheCleanup extends AbstractCacheCleanup {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore) {
+    public void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor) {
         LOGGER.info("{} removing files not accessed on or after {}.", cleanableStore.getDisplayName(), new Date(minimumTimestamp));
-        super.clean(cleanableStore);
+        super.clean(cleanableStore, progressMonitor);
     }
 
     @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanup.java
@@ -18,7 +18,6 @@ package org.gradle.cache.internal;
 
 import org.gradle.cache.CleanableStore;
 import org.gradle.internal.resource.local.FileAccessTimeJournal;
-import org.gradle.internal.time.CountdownTimer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,9 +44,9 @@ public class LeastRecentlyUsedCacheCleanup extends AbstractCacheCleanup {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore, CountdownTimer timer) {
+    public void clean(CleanableStore cleanableStore) {
         LOGGER.info("{} removing files not accessed on or after {}.", cleanableStore.getDisplayName(), new Date(minimumTimestamp));
-        super.clean(cleanableStore, timer);
+        super.clean(cleanableStore);
     }
 
     @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/UnusedVersionsCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/UnusedVersionsCacheCleanup.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.gradle.cache.CleanableStore;
+import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,9 +69,9 @@ public class UnusedVersionsCacheCleanup extends AbstractCacheCleanup {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore) {
+    public void clean(CleanableStore cleanableStore, CleanupProgressMonitor progressMonitor) {
         determineUsedVersions();
-        super.clean(cleanableStore);
+        super.clean(cleanableStore, progressMonitor);
     }
 
     private void determineUsedVersions() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/UnusedVersionsCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/UnusedVersionsCacheCleanup.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.gradle.cache.CleanableStore;
-import org.gradle.internal.time.CountdownTimer;
 import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,9 +68,9 @@ public class UnusedVersionsCacheCleanup extends AbstractCacheCleanup {
     }
 
     @Override
-    public void clean(CleanableStore cleanableStore, CountdownTimer timer) {
+    public void clean(CleanableStore cleanableStore) {
         determineUsedVersions();
-        super.clean(cleanableStore, timer);
+        super.clean(cleanableStore);
     }
 
     private void determineUsedVersions() {

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.cache.internal
 
 import org.gradle.api.specs.Spec
 import org.gradle.cache.CleanableStore
-import org.gradle.internal.time.CountdownTimer
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -31,7 +30,6 @@ class AbstractCacheCleanupTest extends Specification {
         getReservedCacheFiles() >> []
     }
     def deletedFiles = [];
-    def timer = Mock(CountdownTimer)
 
     def "deletes non-reserved matching files"() {
         def cacheEntries = [
@@ -42,11 +40,10 @@ class AbstractCacheCleanupTest extends Specification {
 
         when:
         cleanupAction(finder(cacheEntries), { it != cacheEntries[2] })
-            .clean(cleanableStore, timer)
+            .clean(cleanableStore)
 
         then:
         1 * cleanableStore.getReservedCacheFiles() >> [cacheEntries[0]]
-        2 * timer.hasExpired()
         cacheEntries[0].assertExists()
         cacheEntries[1].assertDoesNotExist()
         cacheEntries[2].assertExists()
@@ -60,27 +57,12 @@ class AbstractCacheCleanupTest extends Specification {
 
         when:
         cleanupAction(finder([cacheEntry.parentFile]), { true })
-            .clean(cleanableStore, timer)
+            .clean(cleanableStore)
 
         then:
-        1 * timer.hasExpired()
         cacheEntry.assertDoesNotExist()
         cacheEntry.parentFile.assertDoesNotExist()
         deletedFiles == [cacheEntry.parentFile]
-    }
-
-    def "aborts cleanup when timer has expired"() {
-        given:
-        def cacheEntry = cacheDir.createFile("somefile")
-
-        when:
-        cleanupAction(finder([cacheEntry]), { true })
-            .clean(cleanableStore, timer)
-
-        then:
-        1 * timer.hasExpired() >> true
-        cacheEntry.assertExists()
-        deletedFiles == []
     }
 
     def "deletes empty parent directories"() {
@@ -91,10 +73,9 @@ class AbstractCacheCleanupTest extends Specification {
 
         when:
         cleanupAction(finder([file]), { true })
-            .clean(cleanableStore, timer)
+            .clean(cleanableStore)
 
         then:
-        1 * timer.hasExpired()
         file.assertDoesNotExist()
         parent.assertDoesNotExist()
         grandparent.assertDoesNotExist()
@@ -111,10 +92,9 @@ class AbstractCacheCleanupTest extends Specification {
 
         when:
         cleanupAction(finder([file]), { true })
-            .clean(cleanableStore, timer)
+            .clean(cleanableStore)
 
         then:
-        1 * timer.hasExpired()
         file.assertDoesNotExist()
         parent.assertDoesNotExist()
         grandparent.assertExists()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/CompositeCleanupActionTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/CompositeCleanupActionTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.cache.internal
 
 import org.gradle.cache.CleanableStore
 import org.gradle.cache.CleanupAction
+import org.gradle.cache.CleanupProgressMonitor
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -29,6 +30,7 @@ class CompositeCleanupActionTest extends Specification {
         getBaseDir() >> temporaryFolder.getTestDirectory()
         getDisplayName() >> "My Cache"
     }
+    def progressMonitor = Stub(CleanupProgressMonitor)
 
     def "calls configured cleanup actions for correct dirs"() {
         given:
@@ -41,13 +43,13 @@ class CompositeCleanupActionTest extends Specification {
             .add(firstCleanupAction)
             .add(subDir, secondCleanupAction)
             .build()
-            .clean(cleanableStore)
+            .clean(cleanableStore, progressMonitor)
 
         then:
-        1 * firstCleanupAction.clean(_) >> { CleanableStore store ->
+        1 * firstCleanupAction.clean(_, progressMonitor) >> { store, m ->
             assert store.getBaseDir() == temporaryFolder.getTestDirectory()
         }
-        1 * secondCleanupAction.clean(_) >> { CleanableStore store ->
+        1 * secondCleanupAction.clean(_, progressMonitor) >> { store, m ->
             assert store.getBaseDir() == subDir
         }
     }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheFactoryTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheFactoryTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheValidator
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
 import org.gradle.internal.concurrent.ExecutorFactory
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -34,7 +35,8 @@ class DefaultCacheFactoryTest extends Specification {
     final Action<?> opened = Mock()
     final Action<?> closed = Mock()
     final ProcessMetaDataProvider metaDataProvider = Mock()
-    private final DefaultCacheFactory factory = new DefaultCacheFactory(new DefaultFileLockManager(metaDataProvider, new NoOpFileLockContentionHandler()), Mock(ExecutorFactory)) {
+    def progressLoggerFactory = new NoOpProgressLoggerFactory()
+    private final DefaultCacheFactory factory = new DefaultCacheFactory(new DefaultFileLockManager(metaDataProvider, new NoOpFileLockContentionHandler()), Mock(ExecutorFactory), progressLoggerFactory) {
         @Override
         void onOpen(Object cache) {
             opened.execute(cache)

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCleanupProgressMonitorTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCleanupProgressMonitorTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.internal.logging.progress.ProgressLogger
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DefaultCleanupProgressMonitorTest extends Specification {
+
+    def progressLogger = Mock(ProgressLogger) {
+        getDescription() >> "Progress"
+    }
+
+    @Subject def progressMonitor = new DefaultCleanupProgressMonitor(progressLogger)
+
+    def "reports deleted and skipped"() {
+        when:
+        progressMonitor.incrementDeleted()
+
+        then:
+        1 * progressLogger.progress("Progress: 1 entry deleted")
+
+        when:
+        progressMonitor.incrementSkipped()
+
+        then:
+        1 * progressLogger.progress("Progress: 1 entry deleted, 1 skipped")
+
+        when:
+        progressMonitor.incrementDeleted()
+
+        then:
+        1 * progressLogger.progress("Progress: 2 entries deleted, 1 skipped")
+    }
+
+    def "always reports deleted, even if all entries are skipped"() {
+        when:
+        progressMonitor.incrementSkipped()
+
+        then:
+        1 * progressLogger.progress("Progress: 0 entries deleted, 1 skipped")
+    }
+}

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
 import org.gradle.internal.concurrent.ExecutorFactory
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GUtil
@@ -42,6 +43,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     }
     def initializationAction = Mock(Action)
     def cleanupAction = Stub(CleanupAction)
+    def progressLoggerFactory = Stub(ProgressLoggerFactory)
 
     def properties = ['prop': 'value', 'prop2': 'other-value']
 
@@ -53,7 +55,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         emptyDir.assertDoesNotExist()
 
         when:
-        def cache = new DefaultPersistentDirectoryCache(emptyDir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(emptyDir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
         try {
             cache.open()
         } finally {
@@ -69,7 +71,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def initializesCacheWhenPropertiesFileDoesNotExist() {
         given:
         def dir = temporaryFolder.getTestDirectory().file("dir").createDir()
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -87,7 +89,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def rebuildsCacheWhenPropertiesHaveChanged() {
         given:
         def dir = createCacheDir(prop: "other-value")
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -106,7 +108,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         given:
         def dir = createCacheDir()
         def properties = properties + [newProp: 'newValue']
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -125,7 +127,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         given:
         def dir = createCacheDir()
         def invalidator = Mock(CacheValidator)
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", invalidator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", invalidator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -149,7 +151,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         Action<PersistentCache> failingAction = Stub(Action) {
             execute(_ as PersistentCache) >> { throw failure }
         }
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), failingAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), failingAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -163,7 +165,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         e.cause.is(failure)
 
         when:
-        cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
         try {
             cache.open()
         } finally {
@@ -179,7 +181,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def doesNotInitializeCacheWhenCacheDirExistsAndIsNotInvalid() {
         given:
         def dir = createCacheDir()
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory))
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -200,7 +202,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def initialized = false
         def init = { initialized = true } as Action
         def cache = new DefaultPersistentDirectoryCache(dir, "test", null, [:], CacheBuilder.LockTarget.DefaultTarget,
-            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory))
+            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         unlockUncleanly(dir.file("cache.properties"))
@@ -220,7 +222,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def init = { initialized = true } as Action
         def properties = [foo: 'bar']
         def cache = new DefaultPersistentDirectoryCache(dir, "test", null, properties, CacheBuilder.LockTarget.DefaultTarget,
-            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory))
+            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         dir.file("cache.properties").delete()
@@ -240,7 +242,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def init = { initialized = true } as Action
         def properties = [:]
         def cache = new DefaultPersistentDirectoryCache(dir, "test", null, properties, CacheBuilder.LockTarget.DefaultTarget,
-            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory))
+            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         dir.file("cache.properties").delete()
@@ -269,7 +271,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         properties.putAll(this.properties)
         properties.putAll(extraProps)
 
-        DefaultPersistentDirectoryCache cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), null, null, lockManager, Mock(ExecutorFactory))
+        DefaultPersistentDirectoryCache cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", validator, properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), null, null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         try {
             cache.open()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.cache.internal
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
 import org.gradle.internal.nativeintegration.ProcessEnvironment
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
 import org.gradle.internal.serialize.NullSafeStringSerializer
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -39,7 +40,7 @@ class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
 
     @Issue("GRADLE-3206")
     def "can create new caches and access them in parallel"() {
-        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, executorFactory)
+        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, executorFactory, new NoOpProgressLoggerFactory())
         store.open()
 
         when:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -148,7 +148,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
         then:
         gcFile.lastModified() > modificationTimeBefore
-        1 * cleanupAction.clean(store, _)
+        1 * cleanupAction.clean(store)
         0 * _
     }
 
@@ -167,7 +167,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
         store.close()
 
         then:
-        1 * cleanupAction.clean(store, _) >> {
+        1 * cleanupAction.clean(store) >> {
             throw new RuntimeException("Boom")
         }
         noExceptionThrown()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.cache.CleanupAction
 import org.gradle.cache.FileLock
 import org.gradle.cache.FileLockManager
 import org.gradle.internal.concurrent.ExecutorFactory
+import org.gradle.internal.logging.progress.ProgressLogger
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -42,9 +44,16 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     def cleanupAction = Mock(CleanupAction)
     def lockManager = Mock(FileLockManager)
     def lock = Mock(FileLock)
+    def progressLoggerFactory = Stub(ProgressLoggerFactory) {
+        newOperation(_) >> {
+            def progressLogger = Stub(ProgressLogger)
+            progressLogger.start(_, _) >> progressLogger
+            return progressLogger
+        }
+    }
 
     @Subject @AutoCleanup
-    def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), cleanupAction, lockManager, Mock(ExecutorFactory))
+    def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
     def "has useful toString() implementation"() {
         expect:
@@ -74,7 +83,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     def "open locks cache directory with requested mode"() {
-        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(Shared), null, lockManager, Mock(ExecutorFactory))
+        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(Shared), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         store.open()
@@ -92,7 +101,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     def "locks requested target"() {
-        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", target, mode(Shared), null, lockManager, Mock(ExecutorFactory))
+        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", target, mode(Shared), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         store.open()
@@ -116,7 +125,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     def "open does not lock cache directory when None mode requested"() {
-        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, Mock(ExecutorFactory))
+        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         store.open()
@@ -148,7 +157,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
         then:
         gcFile.lastModified() > modificationTimeBefore
-        1 * cleanupAction.clean(store)
+        1 * cleanupAction.clean(store, _)
         0 * _
     }
 
@@ -167,7 +176,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
         store.close()
 
         then:
-        1 * cleanupAction.clean(store) >> {
+        1 * cleanupAction.clean(store, _) >> {
             throw new RuntimeException("Boom")
         }
         noExceptionThrown()
@@ -175,7 +184,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
     def "does not use gc.properties when no cleanup action is defined"() {
         given:
-        store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, Mock(ExecutorFactory))
+        store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(None), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         store.open()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.cache.internal
 
 import org.gradle.cache.CleanableStore
+import org.gradle.cache.CleanupProgressMonitor
 import org.gradle.internal.resource.local.ModificationTimeFileAccessTimeJournal
 import org.gradle.internal.time.CountdownTimer
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -34,6 +35,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
     }
     def timer = Stub(CountdownTimer)
     def fileAccessTimeJournal = Spy(ModificationTimeFileAccessTimeJournal)
+    def progressMonitor = Stub(CleanupProgressMonitor)
     @Subject def cleanupAction = new LeastRecentlyUsedCacheCleanup(
         new SingleDepthFilesFinder(1), fileAccessTimeJournal, 1)
 
@@ -49,7 +51,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
         ]
 
         when:
-        cleanupAction.clean(cleanableStore)
+        cleanupAction.clean(cleanableStore, progressMonitor)
 
         then:
         cacheEntries[0].assertExists()
@@ -69,7 +71,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
         ]
 
         when:
-        cleanupAction.clean(cleanableStore)
+        cleanupAction.clean(cleanableStore, progressMonitor)
 
         then:
         cacheEntries[0].assertExists()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
@@ -49,7 +49,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
         ]
 
         when:
-        cleanupAction.clean(cleanableStore, timer)
+        cleanupAction.clean(cleanableStore)
 
         then:
         cacheEntries[0].assertExists()
@@ -69,7 +69,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
         ]
 
         when:
-        cleanupAction.clean(cleanableStore, timer)
+        cleanupAction.clean(cleanableStore)
 
         then:
         cacheEntries[0].assertExists()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/UnusedVersionsCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/UnusedVersionsCacheCleanupTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.cache.internal
 
 import org.gradle.cache.CleanableStore
-import org.gradle.internal.time.CountdownTimer
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -53,7 +52,7 @@ class UnusedVersionsCacheCleanupTest extends Specification {
 
         when:
         UnusedVersionsCacheCleanup.create(CACHE_NAME, cacheVersionMapping, usedGradleVersions)
-            .clean(cleanableStore, Stub(CountdownTimer))
+            .clean(cleanableStore)
 
         then:
         usedGradleVersions.getUsedGradleVersions() >> (gradleVersions.collect { GradleVersion.version(it) } as SortedSet)


### PR DESCRIPTION
This PR makes cache cleanup non-incremental so when it is due a full cleanup is performed. Most cleanup operations are triggered on daemon shutdown. However, when the daemon is disabled, they are run after the build is finished. Previously, it looked like Gradle was unresponsive, especially for large caches. Now, progress is reported using the `ProgressLogger` API with status updates for each deleted/skipped cache entry. There's currently no percentage reported because in some cases we currently don't know the number of cache entries a priori (that could be changed, though). Another potential addition would be to count the number of deleted files and append it to the status.

Here's a screenshot of what it looks like:
<img width="1171" alt="screen shot 2018-07-19 at 15 37 37" src="https://user-images.githubusercontent.com/214207/42945857-c36b3030-8b69-11e8-96e9-3509e2e18208.png">

Resolves #6024.