### PR TITLE
Disable adding tasks/providers directly to TaskContainer

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -655,7 +655,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public boolean add(Task o) {
-        throw new UnsupportedOperationException("Adding tasks directly to the task container is not supported.  Use the create() method instead.");
+        // Only fail if the task is not already in the container.  This is a workaround to a problem in kotlin 1.2.41 where
+        // tasks.add(tasks.create()) is being used.  This problem is fixed in 1.2.60, which will be used in gradle/kotlin-dsl 0.19.x.
+        // We can remove this conditional and always throw an exception once gradle/gradle uses the 0.19.x version of kotlin-dsl.
+        if (addInternal(o)) {
+            throw new UnsupportedOperationException("Adding tasks directly to the task container is not supported.  Use the create() method instead.");
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -354,7 +354,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                 DefaultTaskProvider<T> provider = Cast.uncheckedCast(getInstantiator()
                     .newInstance(TaskCreatingProvider.class, DefaultTaskContainer.this, identity, configurationAction, constructorArgs)
                 );
-                DefaultTaskContainer.super.addLater(provider);
+                addLaterInternal(provider);
                 context.setResult(REGISTER_RESULT);
                 return provider;
             }
@@ -655,19 +655,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
     @Override
     public boolean add(Task o) {
-        // Only fail if the task is not already in the container.  This is a workaround to a problem in kotlin 1.2.41 where
-        // tasks.add(tasks.create()) is being used.  This problem is fixed in 1.2.60, which will be used in gradle/kotlin-dsl 0.19.x.
-        // We can remove this conditional and always throw an exception once gradle/gradle uses the 0.19.x version of kotlin-dsl.
-        if (addInternal(o)) {
-            throw new UnsupportedOperationException("Adding tasks directly to the task container is not supported.  Use the create() method instead.");
-        } else {
-            return false;
-        }
+        DeprecationLogger.nagUserOfReplacedMethod("add()", "create() or register()");
+        return addInternal(o);
     }
 
     @Override
     public boolean addAll(Collection<? extends Task> c) {
-        throw new UnsupportedOperationException("Adding tasks directly to the task container is not supported.  Use the create() method instead.");
+        DeprecationLogger.nagUserOfReplacedMethod("addAll()", "create() or register()");
+        return addAllInternal(c);
     }
 
     @Override
@@ -683,6 +678,10 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     @Override
     public boolean addAllInternal(Collection<? extends Task> task) {
         return super.addAll(task);
+    }
+
+    private void addLaterInternal(Provider<? extends Task> provider) {
+        super.addLater(provider);
     }
 
     private static final RegisterTaskBuildOperationType.Result REGISTER_RESULT = new RegisterTaskBuildOperationType.Result() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.initialization.ProjectAccessListener;
@@ -56,6 +57,7 @@ import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -226,7 +228,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             duplicateTask(name);
         }
 
-        add(task);
+        addInternal(task);
     }
 
     private <T extends Task> T duplicateTask(String task) {
@@ -352,7 +354,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                 DefaultTaskProvider<T> provider = Cast.uncheckedCast(getInstantiator()
                     .newInstance(TaskCreatingProvider.class, DefaultTaskContainer.this, identity, configurationAction, constructorArgs)
                 );
-                addLater(provider);
+                DefaultTaskContainer.super.addLater(provider);
                 context.setResult(REGISTER_RESULT);
                 return provider;
             }
@@ -649,6 +651,31 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     private static BuildOperationDescriptor.Builder registerDescriptor(TaskIdentity<?> identity) {
         return BuildOperationDescriptor.displayName("Register task " + identity.identityPath)
             .details(new RegisterDetails(identity));
+    }
+
+    @Override
+    public boolean add(Task o) {
+        throw new UnsupportedOperationException("Adding tasks directly to the task container is not supported.  Use the create() method instead.");
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Task> c) {
+        throw new UnsupportedOperationException("Adding tasks directly to the task container is not supported.  Use the create() method instead.");
+    }
+
+    @Override
+    public void addLater(Provider<? extends Task> provider) {
+        throw new UnsupportedOperationException("Adding a task provider directly to the task container is not supported.  Use the register() method instead.");
+    }
+
+    @Override
+    public boolean addInternal(Task task) {
+        return super.add(task);
+    }
+
+    @Override
+    public boolean addAllInternal(Collection<? extends Task> task) {
+        return super.addAll(task);
     }
 
     private static final RegisterTaskBuildOperationType.Result REGISTER_RESULT = new RegisterTaskBuildOperationType.Result() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -653,15 +653,17 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             .details(new RegisterDetails(identity));
     }
 
+    @Deprecated
     @Override
     public boolean add(Task o) {
-        DeprecationLogger.nagUserOfReplacedMethod("add()", "create() or register()");
+        DeprecationLogger.nagUserOfReplacedMethodWithoutRemoval("add()", "create() or register()");
         return addInternal(o);
     }
 
+    @Deprecated
     @Override
     public boolean addAll(Collection<? extends Task> c) {
-        DeprecationLogger.nagUserOfReplacedMethod("addAll()", "create() or register()");
+        DeprecationLogger.nagUserOfReplacedMethodWithoutRemoval("addAll()", "create() or register()");
         return addAllInternal(c);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainerFactory.java
@@ -109,7 +109,7 @@ public class DefaultTaskContainerFactory implements Factory<TaskContainerInterna
                     @Override
                     public void execute(MutableModelNode modelNode, Task task) {
                         TaskContainerInternal taskContainer = modelNode.getParent().getPrivateData(TaskContainerInternal.MODEL_TYPE);
-                        taskContainer.add(task);
+                        taskContainer.addInternal(task);
                     }
                 }));
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskContainerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskContainerInternal.java
@@ -23,6 +23,8 @@ import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.model.internal.core.ModelPath;
 import org.gradle.model.internal.type.ModelType;
 
+import java.util.Collection;
+
 public interface TaskContainerInternal extends TaskContainer, TaskResolver, PolymorphicDomainObjectContainerInternal<Task> {
 
     // The path to the project's task container in the model registry
@@ -51,4 +53,14 @@ public interface TaskContainerInternal extends TaskContainer, TaskResolver, Poly
      * Ensures that all configuration has been applied to the given task, and the task is ready to be added to the task graph.
      */
     void prepareForExecution(Task task);
+
+    /**
+     * Adds a previously constructed task into the container.  For internal use with software model bridging.
+     */
+    boolean addInternal(Task task);
+
+    /**
+     * Adds a previously constructed task into the container.  For internal use with software model bridging.
+     */
+    boolean addAllInternal(Collection<? extends Task> task);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.ITaskFactory
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.operations.TestBuildOperationExecutor
@@ -1416,6 +1417,35 @@ class DefaultTaskContainerTest extends Specification {
 
         then:
         container.findByName("task") == null
+    }
+
+    def "cannot add a task directly to the task container"() {
+        when:
+        container.add(task("foo"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "cannot add a collection of tasks directly to the task container"() {
+        when:
+        container.addAll([task("foo"), task("bar")])
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "cannot add a provider directly to the task container"() {
+        given:
+        def provider = Mock(Provider) {
+            _ * get() >> task("foo")
+        }
+
+        when:
+        container.addLater(provider)
+
+        then:
+        thrown(UnsupportedOperationException)
     }
 
     private ProjectInternal expectTaskLookupInOtherProject(final String projectPath, final String taskName, def task) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -1419,22 +1419,6 @@ class DefaultTaskContainerTest extends Specification {
         container.findByName("task") == null
     }
 
-    def "cannot add a task directly to the task container"() {
-        when:
-        container.add(task("foo"))
-
-        then:
-        thrown(UnsupportedOperationException)
-    }
-
-    def "cannot add a collection of tasks directly to the task container"() {
-        when:
-        container.addAll([task("foo"), task("bar")])
-
-        then:
-        thrown(UnsupportedOperationException)
-    }
-
     def "cannot add a provider directly to the task container"() {
         given:
         def provider = Mock(Provider) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -83,6 +83,10 @@ Instances of this class are intended to be created only by the `base` plugin and
 
 Instances of this class are intended to be created only by the `project-reports` plugin and should not be created directly. Creating instances using the constructor of `ProjectReportsPluginConvention` will become an error in Gradle 5.0. The class itself is not deprecated and it is still be possible to use the instances created by the `project-reports` plugin.
 
+### Adding tasks via TaskContainer.add() and TaskContainer.addAll() 
+
+These methods have been deprecated and the `create()` or `register()` methods should be used instead.
+
 ## Potential breaking changes
 
 ### Kotlin DSL breakages

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -52,6 +52,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             }
         """
         when:
+        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         skippedTasks.empty
@@ -61,6 +62,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("buildSrc/.gradle").deleteDir()
         cleanBuildDir()
 
+        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         skippedTasks.contains ":customTask"
@@ -80,6 +82,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             }
         """
         when:
+        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         skippedTasks.empty
@@ -89,6 +92,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         taskSourceFile.text = customKotlinTask(" modified")
 
         cleanBuildDir()
+        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         nonSkippedTasks.contains ":customTask"

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -41,6 +41,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
         buildFile.makeOlder()
 
         when:
+        executer.expectDeprecationWarning()
         run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
@@ -51,6 +52,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
                 action = Action { writeText("changed") }
             }                      
         """
+        executer.expectDeprecationWarning()
         run 'myTask', '--info'
         then:
         executedAndNotSkipped(':myTask')
@@ -69,6 +71,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
         buildFile.makeOlder()
 
         when:
+        executer.expectDeprecationWarning()
         run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
@@ -79,6 +82,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
                 action = { it.writeText("changed") }
             }
         """
+        executer.expectDeprecationWarning()
         run 'myTask', '--info'
         then:
         executedAndNotSkipped(':myTask')

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -478,4 +478,34 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.output.contains("got it 15")
     }
+
+    def "cannot add a pre-created task to the task container"() {
+        given:
+        buildFile << """
+            Task foo = tasks.create("foo")
+            
+            tasks.add(foo)
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("Adding tasks directly to the task container is not supported.")
+    }
+
+    def "cannot add a pre-created task provider to the task container"() {
+        given:
+        buildFile << """
+            Task foo = tasks.create("foo")
+            
+            tasks.addLater(provider { foo })
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("Adding a task provider directly to the task container is not supported.")
+    }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -508,7 +508,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("help")
 
         then:
-        outputContains("The add() method has been deprecated.")
+        outputContains("The add() method has been deprecated. Please use the create() or register() method instead.")
     }
 
     def "cannot add a pre-created task provider to the task container"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -479,7 +479,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         result.output.contains("got it 15")
     }
 
-    def "cannot add a pre-created task to the task container"() {
+    def "renders deprecation warning when adding a pre-created task to the task container"() {
         given:
         buildFile << """
             Task foo = tasks.create("foo")
@@ -504,10 +504,11 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        fails("help")
+        executer.expectDeprecationWarning()
+        succeeds("help")
 
         then:
-        failure.assertHasCause("Adding tasks directly to the task container is not supported.")
+        outputContains("The add() method has been deprecated.")
     }
 
     def "cannot add a pre-created task provider to the task container"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -484,7 +484,23 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             Task foo = tasks.create("foo")
             
-            tasks.add(foo)
+            tasks.add(new Bar("bar", foo))
+            
+            class Bar implements Task {
+                String name
+                
+                @Delegate
+                Task delegate
+                
+                Bar(String name, Task delegate) {
+                    this.name = name
+                    this.delegate = delegate
+                }
+                
+                String getName() {
+                    return name
+                }
+            }
         """
 
         when:

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -119,6 +119,16 @@ public class SingleMessageLogger {
         }
     }
 
+    public static void nagUserOfReplacedMethodWithoutRemoval(String methodName, String replacement) {
+        if (isEnabled()) {
+            nagUserWith(
+                String.format("The %s method has been deprecated.", methodName), null,
+                String.format("Please use the %s method instead.", replacement),
+                null,
+                FeatureUsage.FeatureUsageType.USER_CODE_DIRECT);
+        }
+    }
+
     public static void nagUserOfReplacedProperty(String propertyName, String replacement) {
         if (isEnabled()) {
             nagUserWith(String.format(

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/plugins/BinaryBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/plugins/BinaryBasePlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
+import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.model.Each;
@@ -68,13 +69,14 @@ public class BinaryBasePlugin implements Plugin<Project> {
         @Mutate
         void copyBinaryTasksToTaskContainer(TaskContainer tasks, BinaryContainer binaries) {
             for (BinarySpecInternal binary : binaries.withType(BinarySpecInternal.class)) {
+                TaskContainerInternal tasksInternal = (TaskContainerInternal) tasks;
                 if (binary.isLegacyBinary()) {
                     continue;
                 }
-                tasks.addAll(binary.getTasks());
+                tasksInternal.addAllInternal(binary.getTasks());
                 Task buildTask = binary.getBuildTask();
                 if (buildTask != null) {
-                    tasks.add(buildTask);
+                    tasksInternal.addInternal(buildTask);
                 }
             }
         }

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
@@ -20,10 +20,8 @@ import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
-import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.plugins.PluginDescriptor
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.logging.events.LogEvent
 import org.gradle.internal.logging.events.OutputEvent
@@ -175,31 +173,6 @@ class JavaGradlePluginPluginTest extends AbstractProjectBuilderSpec {
         }
     }
 
-    def "apply configures filesMatching actions on jar spec"() {
-        setup:
-        project.pluginManager.apply(JavaPlugin)
-        def Jar mockJarTask = mockJar(project)
-
-        when:
-        project.pluginManager.apply(JavaGradlePluginPlugin)
-
-        then:
-        1 * mockJarTask.filesMatching(JavaGradlePluginPlugin.PLUGIN_DESCRIPTOR_PATTERN, { it instanceof JavaGradlePluginPlugin.PluginDescriptorCollectorAction })
-        1 * mockJarTask.filesMatching(JavaGradlePluginPlugin.CLASSES_PATTERN, { it instanceof JavaGradlePluginPlugin.ClassManifestCollectorAction })
-    }
-
-    def "apply configures doLast action on jar"() {
-        setup:
-        project.pluginManager.apply(JavaPlugin)
-        def Jar mockJarTask = mockJar(project)
-
-        when:
-        project.pluginManager.apply(JavaGradlePluginPlugin)
-
-        then:
-        1 * mockJarTask.appendParallelSafeAction({ it instanceof JavaGradlePluginPlugin.PluginValidationAction })
-    }
-
     def "creates tasks with group and description"() {
         when:
         project.pluginManager.apply(JavaGradlePluginPlugin)
@@ -216,16 +189,6 @@ class JavaGradlePluginPluginTest extends AbstractProjectBuilderSpec {
         def validateTaskProperties = project.tasks.getByName(JavaGradlePluginPlugin.VALIDATE_TASK_PROPERTIES_TASK_NAME)
         validateTaskProperties.group == JavaGradlePluginPlugin.PLUGIN_DEVELOPMENT_GROUP
         validateTaskProperties.description == JavaGradlePluginPlugin.VALIDATE_TASK_PROPERTIES_TASK_DESCRIPTION
-    }
-
-    def Jar mockJar(project) {
-        def Jar mockJar = Mock(Jar) {
-            _ * getName() >> { JavaGradlePluginPlugin.JAR_TASK }
-            _ * getConventionMapping() >> { Stub(ConventionMapping) }
-        }
-        project.tasks.remove(project.tasks.getByName(JavaGradlePluginPlugin.JAR_TASK))
-        project.tasks.addInternal(mockJar)
-        return mockJar
     }
 
     static class ResettableOutputEventListener implements OutputEventListener {

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
@@ -224,7 +224,7 @@ class JavaGradlePluginPluginTest extends AbstractProjectBuilderSpec {
             _ * getConventionMapping() >> { Stub(ConventionMapping) }
         }
         project.tasks.remove(project.tasks.getByName(JavaGradlePluginPlugin.JAR_TASK))
-        project.tasks.add(mockJar)
+        project.tasks.addInternal(mockJar)
         return mockJar
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
+import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.base.plugins.ComponentModelBasePlugin;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -93,7 +94,7 @@ public class TestingModelBasePlugin implements Plugin<Project> {
             for (BinarySpec binary : binaries) {
                 Task checkTask = binary.getCheckTask();
                 if (checkTask != null) {
-                    tasks.add(checkTask);
+                    ((TaskContainerInternal)tasks).addInternal(checkTask);
                 }
             }
         }


### PR DESCRIPTION
We want user code to use the `create()` and `register()` factory methods when adding tasks.  This disables the `add()`, `addAll()` and `addLater()` methods to prevent tasks being added that have been created outside of the factory methods.