### PR TITLE
Change release-note.gradle mavenCentral() to mirror

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import java.util.Properties
 import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
+import org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_DEFAULT_URL
 
 buildscript {
     project.apply {
@@ -74,12 +75,13 @@ subprojects {
         }
     }
 }
+var pluginPortalUrl = (project.rootProject.extensions.extraProperties.get("repositoryMirrors") as Map<String, String>).get("gradleplugins")
 
 allprojects {
     repositories {
         maven(url = "https://repo.gradle.org/gradle/libs-releases")
         maven(url = "https://repo.gradle.org/gradle/libs-snapshots")
-        gradlePluginPortal()
+        maven(url = pluginPortalUrl ?: PLUGIN_PORTAL_DEFAULT_URL)
     }
 }
 

--- a/buildSrc/subprojects/docs/docs.gradle.kts
+++ b/buildSrc/subprojects/docs/docs.gradle.kts
@@ -4,4 +4,7 @@ dependencies {
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
     implementation("org.pegdown:pegdown:1.6.0")
+    implementation("com.uwyn:jhighlight:1.0") {
+        exclude(module = "servlet-api")
+    }
 }

--- a/gradle/shared-with-buildSrc/mirrors.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.gradle.kts
@@ -15,18 +15,21 @@
  */
 
 
-val gradleMirrorUrl = findMirrorUrls()["gradle"]
+val repositoryMirrors = findMirrorUrls()
+
+rootProject.extensions["ext"].withGroovyBuilder {
+    setProperty("repositoryMirrors", repositoryMirrors)
+}
+
+val gradleMirrorUrl = repositoryMirrors["gradle"]
 if (gradleMirrorUrl != null) {
-    project.buildscript {
-        repositories {
+    project.allprojects {
+        buildscript.repositories {
             maven {
                 name = "gradle-mirror"
                 url = uri(gradleMirrorUrl)
             }
         }
-    }
-
-    project.allprojects {
         repositories {
             maven {
                 name = "gradle-mirror"

--- a/gradle/shared-with-buildSrc/mirrors.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.gradle.kts
@@ -16,10 +16,7 @@
 
 
 val repositoryMirrors = findMirrorUrls()
-
-rootProject.extensions["ext"].withGroovyBuilder {
-    setProperty("repositoryMirrors", repositoryMirrors)
-}
+rootProject.extensions.extraProperties.set("repositoryMirrors", repositoryMirrors)
 
 val gradleMirrorUrl = repositoryMirrors["gradle"]
 if (gradleMirrorUrl != null) {

--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -1,20 +1,3 @@
-buildscript {
-
-    def mavenCentralUrl = project.rootProject.ext.repositoryMirrors?.get("mavencentral")
-
-    repositories {
-        maven {
-            url mavenCentralUrl ?: ArtifactRepositoryContainer.MAVEN_CENTRAL_URL
-        }
-    }
-
-    dependencies {
-        classpath('com.uwyn:jhighlight:1.0') {
-            exclude module: "servlet-api"
-        }
-    }
-}
-
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.TextNode
 import org.jsoup.select.Elements

--- a/subprojects/docs/src/transforms/release-notes.gradle
+++ b/subprojects/docs/src/transforms/release-notes.gradle
@@ -1,7 +1,13 @@
 buildscript {
+
+    def mavenCentralUrl = project.rootProject.ext.repositoryMirrors?.get("mavencentral")
+
     repositories {
-        mavenCentral()
+        maven {
+            url mavenCentralUrl ?: ArtifactRepositoryContainer.MAVEN_CENTRAL_URL
+        }
     }
+
     dependencies {
         classpath('com.uwyn:jhighlight:1.0') {
             exclude module: "servlet-api"


### PR DESCRIPTION
### Context

Previously there's a `mavenCentral` in release-note.gradle's buildscript
block. This PR replaces that `mavenCentral` with our own repo mirror.
