### PR TITLE
Avoid calling File.listRoots()

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 
 public class FileOrUriNotationConverter implements NotationConverter<Object, Object> {
 
-    private static final Pattern URI_SCHEME = Pattern.compile("[a-zA-Z][a-zA-Z0-9+-\\.]*:.+");
+    private static final Pattern URI_SCHEME = Pattern.compile("([a-zA-Z][a-zA-Z0-9+-\\.]*:).+");
     private static final Pattern ENCODED_URI = Pattern.compile("%([0-9a-fA-F]{2})");
     private final FileSystem fileSystem;
 
@@ -98,18 +98,12 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
                 result.converted(new File(uriDecode(notationString.substring(5))));
                 return;
             }
-            if (URI_SCHEME.matcher(notationString).matches()) {
-                for (File file : File.listRoots()) {
-                    String rootPath = file.getAbsolutePath();
-                    String normalisedStr = notationString;
-                    if (!fileSystem.isCaseSensitive()) {
-                        rootPath = rootPath.toLowerCase();
-                        normalisedStr = normalisedStr.toLowerCase();
-                    }
-                    if (normalisedStr.startsWith(rootPath) || normalisedStr.startsWith(rootPath.replace(File.separatorChar, '/'))) {
-                        result.converted(new File(notationString));
-                        return;
-                    }
+            Matcher schemeMatcher = URI_SCHEME.matcher(notationString);
+            if (schemeMatcher.matches()) {
+                String scheme = schemeMatcher.group(1);
+                if (new File(scheme).isDirectory()) {
+                    result.converted(new File(notationString));
+                    return;
                 }
                 try {
                     result.converted(new URI(notationString));

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -128,10 +128,10 @@ class BaseDirFileResolverSpec extends Specification {
 
     def "normalizes file system roots"() {
         expect:
-        normalize(root) == root
+        normalize(root) == new File(root)
 
         where:
-        root << getFsRoots()
+        root << getFsRoots().collect { it.absolutePath }
     }
 
     @Requires(TestPrecondition.WINDOWS)


### PR DESCRIPTION
This is now incredibly expensive on Windows 10,
taking up to several seconds per call.

Instead we simply check whether the scheme is an
existing folder, e.g. `C:`