### PR TITLE
Let task logger be replaceable temporarily

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -122,6 +122,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private final TaskStateInternal state;
 
+    private Logger logger = BUILD_LOGGER;
+
     private final TaskMutator taskMutator;
     private ObservableList observableActionList;
     private boolean impliesSubProjects;
@@ -481,7 +483,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Override
     public Logger getLogger() {
-        return BUILD_LOGGER;
+        return logger;
     }
 
     @Override
@@ -490,6 +492,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
             loggingManager = new LoggingManagerInternalCompatibilityBridge(services.getFactory(org.gradle.internal.logging.LoggingManagerInternal.class).create());
         }
         return loggingManager;
+    }
+
+    @Override
+    public void replaceLogger(Logger logger) {
+        this.logger = logger;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.tasks.ContextAwareTaskAction;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.execution.TaskValidator;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.internal.Factory;
@@ -104,4 +105,14 @@ public interface TaskInternal extends Task, Configurable<Task> {
 
     @Internal
     TaskIdentity<?> getTaskIdentity();
+
+    /**
+     * Replace this task's logger.
+     *
+     * Callers of {@link #getLogger()} will get the replacement logger after this method invocation.
+     *
+     * @param logger the replacement logger
+     */
+    @Deprecated
+    void replaceLogger(Logger logger);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.internal.tasks.ContextAwareTaskAction
+import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.AbstractTaskTest
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.TaskExecutionException
@@ -546,6 +547,18 @@ class DefaultTaskTest extends AbstractTaskTest {
 
         then:
         task.actions[0].displayName == "Execute unnamed action"
+    }
+
+    def "can replace task logger"() {
+        expect:
+        task.logger == AbstractTask.BUILD_LOGGER
+
+        when:
+        def logger = Mock(Logger)
+        task.replaceLogger(logger)
+
+        then:
+        task.logger == logger
     }
 }
 


### PR DESCRIPTION
For the sake of rewording/silencing a harsh kotlin compiler warning triggered by the `SamConversionForKotlinFunction` feature.

This is a temporary measure and will be removed once https://youtrack.jetbrains.com/issue/KT-24770 is resolved.

Hence the method being `@Deprecated` already.

See https://github.com/gradle/kotlin-dsl/issues/971