### PR TITLE
Intern Strings when read from the backing store of the file hasher

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
@@ -54,6 +54,13 @@ public class CrossBuildFileHashCache implements Closeable, TaskHistoryStore {
     }
 
     @Override
+    public <K, V> PersistentIndexedCache<K, V> createCache(String cacheName, Serializer<K> keySerializer, Serializer<V> valueSerializer, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
+        PersistentIndexedCacheParameters<K, V> parameters = new PersistentIndexedCacheParameters<K, V>(cacheName, keySerializer, valueSerializer)
+                .cacheDecorator(inMemoryCacheDecoratorFactory.decorator(maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses));
+        return cache.createCache(parameters);
+    }
+
+    @Override
     public void close() throws IOException {
         cache.close();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultTaskHistoryStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultTaskHistoryStore.java
@@ -50,4 +50,11 @@ public class DefaultTaskHistoryStore implements TaskHistoryStore, Closeable {
                 .cacheDecorator(inMemoryCacheDecoratorFactory.decorator(maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses));
         return cache.createCache(parameters);
     }
+
+    @Override
+    public <K, V> PersistentIndexedCache<K, V> createCache(String cacheName, Serializer<K> keySerializer, Serializer<V> valueSerializer, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
+        PersistentIndexedCacheParameters<K, V> parameters = new PersistentIndexedCacheParameters<K, V>(cacheName, keySerializer, valueSerializer)
+            .cacheDecorator(inMemoryCacheDecoratorFactory.decorator(maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses));
+        return cache.createCache(parameters);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskHistoryStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/TaskHistoryStore.java
@@ -29,4 +29,6 @@ public interface TaskHistoryStore {
      * @param cacheInMemoryForShortLivedProcesses When true, entries are cached in memory. When false, entries are cached in memory only when it possible that another build will be run in this process.
      */
     <K, V> PersistentIndexedCache<K, V> createCache(String name, Class<K> keyType, Serializer<V> valueSerializer, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses);
+
+    <K, V> PersistentIndexedCache<K, V> createCache(String cacheName, Serializer<K> keySerializer, Serializer<V> valueSerializer, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses);
 }


### PR DESCRIPTION
We were interning the strings when putting them into the in-memory cache,
but when that cache got full it would start discarding entries and later
loading them from the backing store. The load operation would return a
non-interned String, resulting in much higher memory pressure. This is
now fixed by using an interning serializer.