### PR TITLE
Provide more details on cache cleanup

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -29,10 +29,13 @@ There are a number of limitations to be aware of. These will be improved in late
 
 Caching has always been one of the strong suits of Gradle. Over time, more and more persistent caches have been added to improve performance and support new features, requiring more and more disk space on build servers and developer workstations. Gradle now addresses one of the most highly voted issues on GitHub and introduces the following cleanup strategies:
 
-- Version-specific cache directories in `GRADLE_USER_HOME/caches/<gradle-version>/` are checked periodically (at most every 24 hours) for whether they are still in use. If not, directories for release versions are deleted after 30 days of inactivity, snapshot versions after 7 days of inactivity. Moreover, the corresponding Gradle distributions in `GRADLE_USER_HOME/wrapper/dists/` are deleted as well, if present.
-- Similarly, after building a project, version-specific cache directories in `PROJECT_DIR/.gradle/<gradle-version>/` are checked periodically (at most every 24 hours) for whether they are still in use. They are deleted if they haven't been used for 7 days.
+- Version-specific cache directories in `GRADLE_USER_HOME/caches/<gradle-version>/` are checked periodically (at most every 24 hours) for whether they are still in use. If not, directories for release versions are deleted after 30 days of inactivity, snapshot versions after 7 days of inactivity.
+- Gradle distributions in `GRADLE_USER_HOME/wrapper/dists/` are checked periodically (at most every 24 hours) for whether they are still in use, i.e. whether there's a corresponding version-specific cache directory. Unused distributions are deleted.
+- After building a project, version-specific cache directories in `PROJECT_DIR/.gradle/<gradle-version>/` are checked periodically (at most every 24 hours) for whether they are still in use. They are deleted if they haven't been used for 7 days.
 - Shared versioned cache directories in `GRADLE_USER_HOME/caches/` (e.g. `jars-*`) are checked periodically (at most every 24 hours) for whether they are still in use. If there's no Gradle version that still uses them, they are deleted.
 - Files in shared caches used by the current Gradle version in `GRADLE_USER_HOME/caches/` (e.g. `jars-3` or `modules-2`) are checked periodically (at most every 24 hours) for when they were last accessed. Depending on whether the file can be recreated locally or would have to be downloaded from a remote repository again, it will be deleted after 7 or 30 days of not being accessed, respectively.
+
+Cache cleanup for `GRADLE_USER_HOME` is performed in the background when the Gradle daemon is stopped or shuts down. If using `--no-daemon`, it runs in the foreground after the build session with a visual progress indicator.
 
 ### Authorization for Maven repositories with custom HTTP headers
 

--- a/subprojects/docs/src/docs/userguide/dependency_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/dependency_cache.adoc
@@ -49,4 +49,8 @@ The Gradle dependency cache uses file-based locking to ensure that it can safely
 [[sub:cache_cleanup]]
 === Cache Cleanup
 
-Gradle keeps track of which artifacts in the dependency cache are accessed. Using this information, the cache is periodically (at most every 24 hours) scanned for artifacts that have not been used for more than 30 days. Obsolete artifacts are then deleted to ensure the cache does not grow indefinitely.
+Gradle keeps track of which files in its caches are accessed. Using this information, caches are periodically (at most every 24 hours) scanned for files that have not been used for more than a certain amount of days. Depending on whether a file can be recreated locally or would have to be downloaded from a remote repository again, it will be deleted after 7 or 30 days of not being accessed, respectively.
+
+Moreover, shared versioned cache directories (e.g. `jars-*`) are checked periodically (at most every 24 hours) for whether they are still in use. If there's no Gradle version that still uses them, they are deleted.
+
+Dependency cache cleanup is performed in the background when the Gradle daemon is stopped or shuts down. If using `--no-daemon`, it runs in the foreground after the build session with a visual progress indicator.


### PR DESCRIPTION
This PR adds the following:

- Add dependency-cache relevant information to User Guide
- Update release notes to mention distribution cleanup as a separate item
- Add a paragraph explaining when the cleanup is performed

The release notes still provide a few more details on some of the cleanup strategies because those are not concerned with Dependency Caches and thus are not a good fit for the corresponding user guide chapter.

Resolves #6063.