### PR TITLE
Intern class names when reading back from the cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingFileHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingFileHasher.java
@@ -28,6 +28,7 @@ import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.HashCodeSerializer;
+import org.gradle.internal.serialize.InterningStringSerializer;
 
 import java.io.File;
 
@@ -141,24 +142,6 @@ public class CachingFileHasher implements FileHasher {
         @Override
         public int hashCode() {
             return Objects.hashCode(super.hashCode(), hashCodeSerializer);
-        }
-    }
-
-    private static final class InterningStringSerializer extends AbstractSerializer<String> {
-        private final StringInterner stringInterner;
-
-        private InterningStringSerializer(StringInterner stringInterner) {
-            this.stringInterner = stringInterner;
-        }
-
-        @Override
-        public String read(Decoder decoder) throws Exception {
-            return stringInterner.intern(decoder.readString());
-        }
-
-        @Override
-        public void write(Encoder encoder, String value) throws Exception {
-            encoder.writeString(value);
         }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental;
 
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.cache.TaskScopedCompileCaches;
@@ -44,11 +45,12 @@ public class IncrementalCompilerDecorator {
     private final Compiler<JavaCompileSpec> rebuildAllCompiler;
     private final IncrementalCompilationInitializer compilationInitializer;
     private final PreviousCompilationOutputAnalyzer previousCompilationOutputAnalyzer;
+    private StringInterner interner;
 
     public IncrementalCompilerDecorator(ClasspathSnapshotMaker classpathSnapshotMaker, TaskScopedCompileCaches compileCaches,
                                         IncrementalCompilationInitializer compilationInitializer, CleaningJavaCompiler cleaningCompiler,
                                         RecompilationSpecProvider staleClassDetecter,
-                                        CompilationSourceDirs sourceDirs, Compiler<JavaCompileSpec> rebuildAllCompiler, PreviousCompilationOutputAnalyzer previousCompilationOutputAnalyzer) {
+                                        CompilationSourceDirs sourceDirs, Compiler<JavaCompileSpec> rebuildAllCompiler, PreviousCompilationOutputAnalyzer previousCompilationOutputAnalyzer, StringInterner interner) {
         this.classpathSnapshotMaker = classpathSnapshotMaker;
         this.compileCaches = compileCaches;
         this.compilationInitializer = compilationInitializer;
@@ -57,11 +59,12 @@ public class IncrementalCompilerDecorator {
         this.sourceDirs = sourceDirs;
         this.rebuildAllCompiler = rebuildAllCompiler;
         this.previousCompilationOutputAnalyzer = previousCompilationOutputAnalyzer;
+        this.interner = interner;
     }
 
     public Compiler<JavaCompileSpec> prepareCompiler(IncrementalTaskInputs inputs) {
         Compiler<JavaCompileSpec> compiler = getCompiler(inputs, sourceDirs);
-        return new IncrementalResultStoringCompiler(compiler, classpathSnapshotMaker, compileCaches.getPreviousCompilationStore());
+        return new IncrementalResultStoringCompiler(compiler, classpathSnapshotMaker, compileCaches.getPreviousCompilationStore(), interner);
     }
 
     private Compiler<JavaCompileSpec> getCompiler(IncrementalTaskInputs inputs, CompilationSourceDirs sourceDirs) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerFactory.java
@@ -77,7 +77,7 @@ public class IncrementalCompilerFactory {
         RecompilationSpecProvider recompilationSpecProvider = new RecompilationSpecProvider(sourceToNameConverter);
         IncrementalCompilationInitializer compilationInitializer = new IncrementalCompilationInitializer(fileOperations, sources);
         PreviousCompilationOutputAnalyzer previousCompilationOutputAnalyzer = new PreviousCompilationOutputAnalyzer(fileHasher, streamHasher, analyzer, fileOperations);
-        IncrementalCompilerDecorator incrementalSupport = new IncrementalCompilerDecorator(classpathSnapshotMaker, compileCaches, compilationInitializer, cleaningJavaCompiler, recompilationSpecProvider, sourceDirs, rebuildAllCompiler, previousCompilationOutputAnalyzer);
+        IncrementalCompilerDecorator incrementalSupport = new IncrementalCompilerDecorator(classpathSnapshotMaker, compileCaches, compilationInitializer, cleaningJavaCompiler, recompilationSpecProvider, sourceDirs, rebuildAllCompiler, previousCompilationOutputAnalyzer, interner);
         return incrementalSupport.prepareCompiler(inputs);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/DefaultUserHomeScopedCompileCaches.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/DefaultUserHomeScopedCompileCaches.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.cache;
 
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.FileSystemSnapshotter;
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
 import org.gradle.api.internal.tasks.compile.incremental.classpath.DefaultClasspathEntrySnapshotCache;
@@ -37,13 +38,13 @@ public class DefaultUserHomeScopedCompileCaches implements UserHomeScopedCompile
     private final ClasspathEntrySnapshotCache classpathEntrySnapshotCache;
     private final PersistentCache cache;
 
-    public DefaultUserHomeScopedCompileCaches(FileSystemSnapshotter fileSystemSnapshotter, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
+    public DefaultUserHomeScopedCompileCaches(FileSystemSnapshotter fileSystemSnapshotter, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, StringInterner interner) {
         cache = cacheRepository
             .cache("javaCompile")
             .withDisplayName("Java compile cache")
             .withLockOptions(mode(FileLockManager.LockMode.None)) // Lock on demand
             .open();
-        PersistentIndexedCacheParameters<HashCode, ClasspathEntrySnapshotData> jarCacheParameters = new PersistentIndexedCacheParameters<HashCode, ClasspathEntrySnapshotData>("jarAnalysis", new HashCodeSerializer(), new ClasspathEntrySnapshotDataSerializer())
+        PersistentIndexedCacheParameters<HashCode, ClasspathEntrySnapshotData> jarCacheParameters = new PersistentIndexedCacheParameters<HashCode, ClasspathEntrySnapshotData>("jarAnalysis", new HashCodeSerializer(), new ClasspathEntrySnapshotDataSerializer(interner))
             .cacheDecorator(inMemoryCacheDecoratorFactory.decorator(20000, true));
         this.classpathEntrySnapshotCache = new DefaultClasspathEntrySnapshotCache(fileSystemSnapshotter, cache.createCache(jarCacheParameters));
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotDataSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotDataSerializer.java
@@ -17,18 +17,18 @@
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
 import com.google.common.base.Objects;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.HashCodeSerializer;
+import org.gradle.internal.serialize.InterningStringSerializer;
 import org.gradle.internal.serialize.MapSerializer;
 import org.gradle.internal.serialize.Serializer;
 
 import java.util.Map;
-
-import static org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER;
 
 public class ClasspathEntrySnapshotDataSerializer extends AbstractSerializer<ClasspathEntrySnapshotData> {
 
@@ -36,10 +36,10 @@ public class ClasspathEntrySnapshotDataSerializer extends AbstractSerializer<Cla
     private final Serializer<ClassSetAnalysisData> analysisSerializer;
     private final HashCodeSerializer hashCodeSerializer;
 
-    public ClasspathEntrySnapshotDataSerializer() {
+    public ClasspathEntrySnapshotDataSerializer(StringInterner interner) {
         hashCodeSerializer = new HashCodeSerializer();
-        mapSerializer = new MapSerializer<String, HashCode>(STRING_SERIALIZER, hashCodeSerializer);
-        analysisSerializer = new ClassSetAnalysisData.Serializer();
+        mapSerializer = new MapSerializer<String, HashCode>(new InterningStringSerializer(interner), hashCodeSerializer);
+        analysisSerializer = new ClassSetAnalysisData.Serializer(interner);
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -87,6 +88,12 @@ public class ClassSetAnalysisData {
     }
 
     public static class Serializer extends AbstractSerializer<ClassSetAnalysisData> {
+
+        private final StringInterner interner;
+
+        public Serializer(StringInterner interner) {
+            this.interner = interner;
+        }
 
         @Override
         public ClassSetAnalysisData read(Decoder decoder) throws Exception {
@@ -193,7 +200,7 @@ public class ClassSetAnalysisData {
             int id = decoder.readSmallInt();
             if (id == 0) {
                 id = decoder.readSmallInt();
-                String className = decoder.readString();
+                String className = interner.intern(decoder.readString());
                 classNameMap.put(id, className);
                 return className;
             }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.compile.incremental.deps
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.fastutil.ints.IntSet
 import it.unimi.dsi.fastutil.ints.IntSets
+import org.gradle.api.internal.cache.StringInterner
 import org.gradle.internal.serialize.InputStreamBackedDecoder
 import org.gradle.internal.serialize.OutputStreamBackedEncoder
 import spock.lang.Specification
@@ -29,7 +30,7 @@ import static org.gradle.api.internal.tasks.compile.incremental.deps.DependentsS
 
 class ClassSetAnalysisDataSerializerTest extends Specification {
 
-    @Subject serializer = new ClassSetAnalysisData.Serializer()
+    @Subject serializer = new ClassSetAnalysisData.Serializer(new StringInterner())
 
     def "serializes"() {
         def data = new ClassSetAnalysisData(["A", "B", "C", "D"] as Set,

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/InterningStringSerializer.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/InterningStringSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize;
+
+import org.gradle.api.internal.cache.StringInterner;
+
+public class InterningStringSerializer extends AbstractSerializer<String> {
+    private final StringInterner stringInterner;
+
+    public InterningStringSerializer(StringInterner stringInterner) {
+        this.stringInterner = stringInterner;
+    }
+
+    @Override
+    public String read(Decoder decoder) throws Exception {
+        return stringInterner.intern(decoder.readString());
+    }
+
+    @Override
+    public void write(Encoder encoder, String value) throws Exception {
+        encoder.writeString(value);
+    }
+}
+

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/CompileServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/CompileServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.FileSystemSnapshotter;
 import org.gradle.api.internal.changedetection.state.InMemoryCacheDecoratorFactory;
 import org.gradle.api.internal.changedetection.state.WellKnownFileLocations;
@@ -49,14 +50,14 @@ public class CompileServices extends AbstractPluginServiceRegistry {
             initializer.initializeJdkTools();
         }
 
-        DefaultGeneralCompileCaches createGeneralCompileCaches(CacheRepository cacheRepository, Gradle gradle, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, UserHomeScopedCompileCaches userHomeScopedCompileCaches, WellKnownFileLocations wellKnownFileLocations, FileSystemSnapshotter fileSystemSnapshotter) {
-            return new DefaultGeneralCompileCaches(fileSystemSnapshotter, userHomeScopedCompileCaches, cacheRepository, gradle, inMemoryCacheDecoratorFactory, wellKnownFileLocations);
+        DefaultGeneralCompileCaches createGeneralCompileCaches(CacheRepository cacheRepository, Gradle gradle, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, UserHomeScopedCompileCaches userHomeScopedCompileCaches, WellKnownFileLocations wellKnownFileLocations, FileSystemSnapshotter fileSystemSnapshotter, StringInterner interner) {
+            return new DefaultGeneralCompileCaches(fileSystemSnapshotter, userHomeScopedCompileCaches, cacheRepository, gradle, inMemoryCacheDecoratorFactory, wellKnownFileLocations, interner);
         }
     }
 
     private class UserHomeScopeServices {
-        DefaultUserHomeScopedCompileCaches createCompileCaches(CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, FileSystemSnapshotter fileSystemSnapshotter) {
-            return new DefaultUserHomeScopedCompileCaches(fileSystemSnapshotter, cacheRepository, inMemoryCacheDecoratorFactory);
+        DefaultUserHomeScopedCompileCaches createCompileCaches(CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, FileSystemSnapshotter fileSystemSnapshotter, StringInterner interner) {
+            return new DefaultUserHomeScopedCompileCaches(fileSystemSnapshotter, cacheRepository, inMemoryCacheDecoratorFactory, interner);
         }
     }
 }


### PR DESCRIPTION
We intern class names when we analyze classes, but until
now we did not intern them when reading back from the on-disk
cache. This meant that builds with pre-existing caches would
have much higher memory footprint, just like builds that exceed
the in-memory size limit. With this change all builds now have
the same low footprint.