### PR TITLE
Let the `kotlin-dsl` plugin handle the Kotlin DSL dependencies

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -1,5 +1,6 @@
+apply(plugin = "org.gradle.kotlin.kotlin-dsl")
+
 dependencies {
-    api("org.gradle:gradle-kotlin-dsl:0.18.4")
     testImplementation("junit:junit:4.12")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
 }

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream.kt
@@ -82,7 +82,7 @@ fun <reified T : Any> TaskContainer.getByName(name: String, configure: T.() -> U
 @Suppress("extension_shadowed_by_member")
 inline
 fun <reified T : Task> TaskContainer.register(name: String, noinline configurationAction: T.() -> Unit) =
-    register(name, T::class.java) { configurationAction(it) }
+    register(name, T::class.java) { configurationAction() }
 
 
 inline fun <reified T : Task> TaskContainer.withType(): TaskCollection<T> =
@@ -92,7 +92,7 @@ inline fun <reified T : Task> TaskContainer.withType(): TaskCollection<T> =
 inline fun <reified T : Any> TaskProvider<out Task>.configureAs(noinline configurationAction: T.() -> Unit) =
     configure {
         configurationAction(
-            it as? T
+            this as? T
                 ?: throw IllegalArgumentException(
-                    "Task of type '${it.javaClass.name}' cannot be cast to '${T::class.qualifiedName}'."))
+                    "Task of type '${javaClass.name}' cannot be cast to '${T::class.qualifiedName}'."))
     }


### PR DESCRIPTION
The previous setup was adding multiple gradle-kotlin-dsl jars to the
classpath causing the Kotlin compiler with the new type inference
engine enabled to fail on some of the overloads.

- [x] [Feedback build](https://builds.gradle.org/viewLog.html?buildId=14405302&buildTypeId=Gradle_Check_Stage_BranchBuildAccept_Trigger)