### PR TITLE
Upgrade Kotlin DSL {0.18.4 => 0.19.0}

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,7 @@ import org.gradle.gradlebuild.ProjectGroups.pluginProjects
 import org.gradle.gradlebuild.ProjectGroups.publishedProjects
 
 buildscript {
-    project.apply {
-        from("$rootDir/gradle/shared-with-buildSrc/mirrors.gradle.kts")
-    }
+    project.apply(from = "$rootDir/gradle/shared-with-buildSrc/mirrors.gradle.kts")
 }
 
 plugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,7 @@ allprojects {
         maven(url = "https://repo.gradle.org/gradle/libs")
         maven(url = "https://repo.gradle.org/gradle/libs-milestones")
         maven(url = "https://repo.gradle.org/gradle/libs-snapshots")
+        maven(url = "https://dl.bintray.com/kotlin/kotlin-dev")
     }
 
     // patchExternalModules lives in the root project - we need to activate normalization there, too.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -278,7 +278,7 @@ tasks.register<PatchExternalModules>("patchExternalModules") {
 
 evaluationDependsOn(":distributions")
 
-val gradle_installPath: Any? by project
+val gradle_installPath: Any? = findProperty("gradle_installPath")
 
 tasks.register<Install>("install") {
     description = "Installs the minimal distribution into directory $gradle_installPath"
@@ -309,4 +309,5 @@ fun Project.buildCacheConfiguration() =
     (gradle as GradleInternal).settings.buildCache
 
 fun Configuration.usage(named: String) =
-    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(named))
+    //TODO:kotlin-dsl - revert to reified syntax after nightly upgrade
+    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, named))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,8 @@ buildscript {
 
 plugins {
     `kotlin-dsl`
-    id("org.gradle.kotlin.ktlint-convention") version "0.1.8" apply false
+    //TODO:kotlin-dsl - uncomment after nightly upgrade
+    //id("org.gradle.kotlin.ktlint-convention") version "0.1.10" apply false
 }
 
 subprojects {
@@ -188,10 +189,10 @@ fun Project.applyGroovyProjectConventions() {
 }
 
 fun Project.applyKotlinProjectConventions() {
-    apply {
-        plugin("kotlin")
-        plugin("org.gradle.kotlin.ktlint-convention")
-    }
+    apply(plugin = "kotlin")
+
+    //TODO:kotlin-dsl - uncomment after nightly upgrade
+    //apply(plugin = "org.gradle.kotlin.ktlint-convention")
 
     tasks.withType<KotlinCompile>().configureEach {
         kotlinOptions {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,9 +24,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext.plus
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_DEFAULT_URL
 
 buildscript {
-    project.apply {
-        from("$rootDir/../gradle/shared-with-buildSrc/mirrors.gradle.kts")
-    }
+    project.apply(from = "$rootDir/../gradle/shared-with-buildSrc/mirrors.gradle.kts")
 }
 
 plugins {
@@ -37,7 +35,7 @@ plugins {
 
 subprojects {
 
-    apply { plugin("java-library") }
+    apply(plugin = "java-library")
 
     if (file("src/main/groovy").isDirectory || file("src/test/groovy").isDirectory) {
 
@@ -49,10 +47,8 @@ subprojects {
         applyKotlinProjectConventions()
     }
 
-    apply {
-        plugin("idea")
-        plugin("eclipse")
-    }
+    apply(plugin = "idea")
+    apply(plugin = "eclipse")
 
     configure<IdeaModel> {
         module.name = "buildSrc-${this@subprojects.name}"
@@ -95,7 +91,7 @@ dependencies {
 // TODO Avoid duplication of what defines a CI Server with BuildEnvironment
 val isCiServer: Boolean by extra { "CI" in System.getenv() }
 if (!isCiServer || System.getProperty("enableCodeQuality")?.toLowerCase() == "true") {
-    apply { from("../gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts") }
+    apply(from = "../gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")
 }
 
 if (isCiServer) {
@@ -149,7 +145,7 @@ val checkSameDaemonArgs = tasks.register("checkSameDaemonArgs") {
 tasks.named("build").configure { dependsOn(checkSameDaemonArgs) }
 
 fun Project.applyGroovyProjectConventions() {
-    apply { plugin("groovy") }
+    apply(plugin = "groovy")
 
     dependencies {
         compile(localGroovy())

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -14,9 +14,25 @@
  * limitations under the License.
  */
 
-apply {
-    from("../gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
+fun RepositoryHandler.kotlinDev() =
+    maven(url = "https://dl.bintray.com/kotlin/kotlin-dev")
+
+pluginManagement {
+    repositories {
+        kotlinDev()
+        gradlePluginPortal()
+    }
 }
+
+gradle.rootProject {
+    allprojects {
+        repositories {
+            kotlinDev()
+        }
+    }
+}
+
+apply(from = "../gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
 
 val upperCaseLetters = "\\p{Upper}".toRegex()
 

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/DependencyVulnerabilitiesPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/DependencyVulnerabilitiesPlugin.kt
@@ -28,9 +28,7 @@ open class DependencyVulnerabilitiesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
         configure(projectsIncludedInDistribution()) {
-            apply {
-                plugin("org.owasp.dependencycheck")
-            }
+            apply(plugin = "org.owasp.dependencycheck")
 
             configure<DependencyCheckExtension> {
                 failBuildOnCVSS = 8F // 10 is the maximum

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
@@ -6,7 +6,7 @@ import org.gradle.internal.os.OperatingSystem
 
 object BuildEnvironment {
     val isCiServer = "CI" in System.getenv()
-    val gradleKotlinDslVersion = "0.18.4"
+    val gradleKotlinDslVersion = "0.19.0"
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()
     val isWindows = OperatingSystem.current().isWindows

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -65,9 +65,7 @@ open class IdePlugin : Plugin<Project> {
 
     private
     fun Project.configureEclipseForAllProjects() = allprojects {
-        apply {
-            plugin("eclipse")
-        }
+        apply(plugin = "eclipse")
 
         plugins.withType<JavaPlugin> {
             eclipse {
@@ -94,9 +92,7 @@ open class IdePlugin : Plugin<Project> {
 
     private
     fun Project.configureIdeaForAllProjects() = allprojects {
-        apply {
-            plugin("idea")
-        }
+        apply(plugin = "idea")
         idea {
             module {
                 configureLanguageLevel(this)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -49,7 +49,7 @@ open class TestFixturesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 
-        apply { plugin("java") }
+        apply(plugin = "java")
 
         //TODO:kotlin-dsl - revert to reified syntax after nightly upgrade
         extensions.create("testFixtures", TestFixturesExtension::class.java)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -51,7 +51,8 @@ open class TestFixturesPlugin : Plugin<Project> {
 
         apply { plugin("java") }
 
-        extensions.create<TestFixturesExtension>("testFixtures")
+        //TODO:kotlin-dsl - revert to reified syntax after nightly upgrade
+        extensions.create("testFixtures", TestFixturesExtension::class.java)
 
         if (file("src/testFixtures").isDirectory) {
             configureAsProducer()

--- a/buildSrc/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensionsTest.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensionsTest.kt
@@ -32,7 +32,7 @@ class TaskContainerExtensionsTest {
     fun `can configure by name and type using getByName`() {
 
         val task = mock<Upload>()
-        val tasks = mock<TaskContainer>() {
+        val tasks = mock<TaskContainer>(name = "tasks") {
             on { getByName("uploadArchives") } doReturn task
         }
 

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJar.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJar.kt
@@ -103,7 +103,7 @@ open class ShadedJar : DefaultTask() {
     private
     inline fun <reified T> readJson(file: File) =
         file.bufferedReader().use { reader ->
-            Gson().fromJson<T>(reader, object : TypeToken<T>() {}.type)
+            Gson().fromJson<T>(reader, object : TypeToken<T>() {}.type)!!
         }
 }
 

--- a/buildSrc/subprojects/performance/performance.gradle.kts
+++ b/buildSrc/subprojects/performance/performance.gradle.kts
@@ -1,4 +1,4 @@
-apply { plugin("org.gradle.kotlin.kotlin-dsl") }
+apply(plugin = "org.gradle.kotlin.kotlin-dsl")
 
 dependencies {
     api(project(":integrationTesting"))

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -4,10 +4,8 @@ plugins {
     `java-gradle-plugin`
 }
 
-apply {
-    plugin("org.gradle.kotlin.kotlin-dsl")
-    plugin<PrecompiledScriptPlugins>()
-}
+apply(plugin = "org.gradle.kotlin.kotlin-dsl")
+apply<PrecompiledScriptPlugins>()
 
 dependencies {
     implementation(project(":binaryCompatibility"))

--- a/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/strict-compile.gradle.kts
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/strict-compile.gradle.kts
@@ -17,7 +17,8 @@ package gradlebuild
 
 import org.gradle.plugins.strictcompile.StrictCompileExtension
 
-val strictCompile = extensions.create<StrictCompileExtension>("strictCompile")
+//TODO:kotlin-dsl - revert to reified syntax after nightly upgrade
+val strictCompile = extensions.create("strictCompile", StrictCompileExtension::class.java)
 
 afterEvaluate {
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -59,7 +59,7 @@ enum class ModuleType(val source: JavaVersion, val target: JavaVersion, val requ
 
 class UnitTestAndCompilePlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
-        apply { plugin("groovy") }
+        apply(plugin = "groovy")
 
         val extension = extensions.create<UnitTestAndCompileExtension>("gradlebuildJava", this)
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -36,7 +36,9 @@ class BuildTypesPlugin : Plugin<Project> {
             if (!isTaskHelpInvocation(invokedTaskNames, index)) {
                 buildType.active = true
                 buildType.onProjectProperties = { properties: ProjectProperties ->
-                    properties.forEach(project::setOrCreateProperty)
+                    properties.forEach { (name, value) ->
+                        project.setOrCreateProperty(name, value)
+                    }
                 }
                 afterEvaluate {
                     invokedTaskNames.removeAt(index)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -83,9 +83,7 @@ const val performanceExperimentCategory = "org.gradle.performance.categories.Per
 class PerformanceTestPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-        apply {
-            plugin("java")
-        }
+        apply(plugin = "java")
 
         val performanceTestSourceSet = createPerformanceTestSourceSet()
         addConfigurationAndDependencies()

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
@@ -79,11 +79,11 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = "sub"
-        val taskContainer = mock<TaskContainer> {
+        val taskContainer = mock<TaskContainer>(name = "tasks") {
             on { findByPath("sub:BT0") } doReturn mock<Task>()
             on { findByPath("sub:my:BT1") } doReturn mock<Task>()
         }
-        val project = mock<Project> {
+        val project = mock<Project>(name = "project") {
             on { findProject(subproject) } doReturn mock<Project>()
             on { tasks } doReturn taskContainer
         }
@@ -107,10 +107,10 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = "sub"
-        val taskContainer = mock<TaskContainer> {
+        val taskContainer = mock<TaskContainer>(name = "tasks") {
             on { findByPath("sub:my:BT1") } doReturn mock<Task>()
         }
-        val project = mock<Project> {
+        val project = mock<Project>(name = "project") {
             on { findProject(subproject) } doReturn mock<Project>()
             on { tasks } doReturn taskContainer
         }

--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -4,10 +4,8 @@ plugins {
     `java-gradle-plugin`
 }
 
-apply {
-    plugin("org.gradle.kotlin.kotlin-dsl")
-    plugin<PrecompiledScriptPlugins>()
-}
+apply(plugin = "org.gradle.kotlin.kotlin-dsl")
+apply<PrecompiledScriptPlugins>()
 
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.7")

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-projects.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-projects.gradle.kts
@@ -15,27 +15,25 @@
  */
 package gradlebuild
 
-apply {
-    plugin("gradlebuild.unittest-and-compile")
-    plugin("gradlebuild.test-fixtures")
-    plugin("gradlebuild.distribution-testing")
-    plugin("gradlebuild.int-test-image")
+apply(plugin = "gradlebuild.unittest-and-compile")
+apply(plugin = "gradlebuild.test-fixtures")
+apply(plugin = "gradlebuild.distribution-testing")
+apply(plugin = "gradlebuild.int-test-image")
 
-    if (file("src/integTest").isDirectory) {
-        plugin("gradlebuild.integration-tests")
-    }
+if (file("src/integTest").isDirectory) {
+    apply(plugin = "gradlebuild.integration-tests")
+}
 
-    if (file("src/crossVersionTest").isDirectory) {
-        plugin("gradlebuild.cross-version-tests")
-    }
+if (file("src/crossVersionTest").isDirectory) {
+    apply(plugin = "gradlebuild.cross-version-tests")
+}
 
-    if (file("src/performanceTest").isDirectory) {
-        plugin("gradlebuild.performance-test")
-    }
+if (file("src/performanceTest").isDirectory) {
+    apply(plugin = "gradlebuild.performance-test")
+}
 
-    if (file("src/jmh").isDirectory) {
-        plugin("gradlebuild.jmh")
-    }
+if (file("src/jmh").isDirectory) {
+    apply(plugin = "gradlebuild.jmh")
 }
 
 tasks.named("check").configure {

--- a/buildSrc/subprojects/uber-plugins/uber-plugins.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/uber-plugins.gradle.kts
@@ -4,10 +4,8 @@ plugins {
     `java-gradle-plugin`
 }
 
-apply {
-    plugin("org.gradle.kotlin.kotlin-dsl")
-    plugin<PrecompiledScriptPlugins>()
-}
+apply(plugin = "org.gradle.kotlin.kotlin-dsl")
+apply<PrecompiledScriptPlugins>()
 
 dependencies {
     implementation(project(":binaryCompatibility"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-apply {
-    from("gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
-}
+apply(from = "gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
 
 enableFeaturePreview("IMPROVED_POM_SUPPORT")
 

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        194
+        195
     }
 
     def "no duplicate entries"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -69,7 +69,6 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             }
         """
         when:
-        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         skippedTasks.empty
@@ -79,7 +78,6 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("buildSrc/.gradle").deleteDir()
         cleanBuildDir()
 
-        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         skippedTasks.contains ":customTask"
@@ -99,7 +97,6 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             }
         """
         when:
-        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         skippedTasks.empty
@@ -109,7 +106,6 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         taskSourceFile.text = customKotlinTask(" modified")
 
         cleanBuildDir()
-        executer.expectDeprecationWarning()
         withBuildCache().run "customTask"
         then:
         nonSkippedTasks.contains ":customTask"

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -36,7 +36,24 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
 
     def setup() {
         settingsFile << "rootProject.buildFileName = '$defaultBuildFileName'"
-        file("buildSrc/settings.gradle") << localCacheConfiguration()
+
+        // TODO:kotlin-dsl
+        // In order to facilitate the upgrade to the latest version of the
+        // Kotlin DSL, which ships with Kotlin 1.2.60-eap-44,
+        // the presence of settings.gradle.kts causes
+        // the kotlin-dev repository to be added to settings.buildscript.repositories,
+        // settings.pluginManagement.repositories and to every project.repositories
+        // and project.buildscript.repositories.
+        // This behaviour is temporary and will be removed once the Kotlin DSL
+        // upgrades to the next GA release of Kotlin.
+        file("buildSrc/settings.gradle.kts") << """
+            buildCache {
+                local(DirectoryBuildCache::class.java) {
+                    directory = "${cacheDir.absoluteFile.toURI()}"
+                    isPush = true
+                }
+            }
+        """
     }
 
     @IgnoreIf({GradleContextualExecuter.parallel})

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -91,6 +91,16 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
     }
 
     private void setupTaskWithNestedAction(String actionType, String actionInvocation) {
+        // TODO:kotlin-dsl
+        // In order to facilitate the upgrade to the latest version of the
+        // Kotlin DSL, which ships with Kotlin 1.2.60-eap-44,
+        // the presence of settings.gradle.kts causes
+        // the kotlin-dev repository to be added to settings.buildscript.repositories,
+        // settings.pluginManagement.repositories and to every project.repositories
+        // and project.buildscript.repositories.
+        // This behaviour is temporary and will be removed once the Kotlin DSL
+        // upgrades to the next GA release of Kotlin.
+        file('buildSrc/settings.gradle.kts') << ""
         file('buildSrc/build.gradle.kts') << """
             plugins {
                 `kotlin-dsl`

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -41,7 +41,6 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
         buildFile.makeOlder()
 
         when:
-        executer.expectDeprecationWarning()
         run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
@@ -52,7 +51,6 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
                 action = Action { writeText("changed") }
             }                      
         """
-        executer.expectDeprecationWarning()
         run 'myTask', '--info'
         then:
         executedAndNotSkipped(':myTask')
@@ -71,7 +69,6 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
         buildFile.makeOlder()
 
         when:
-        executer.expectDeprecationWarning()
         run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
@@ -82,7 +79,6 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
                 action = { it.writeText("changed") }
             }
         """
-        executer.expectDeprecationWarning()
         run 'myTask', '--info'
         then:
         executedAndNotSkipped(':myTask')

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
-import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
 class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTest {
@@ -43,6 +42,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         testProject                              | _
         LARGE_MONOLITHIC_JAVA_PROJECT            | _
         LARGE_JAVA_MULTI_PROJECT                 | _
-        LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL      | _
+        // TODO:kotlin-dsl - uncomment after we have a new nightly
+        //LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL      | _
     }
 }

--- a/subprojects/performance/src/templates/kts-empty/build.gradle.kts
+++ b/subprojects/performance/src/templates/kts-empty/build.gradle.kts
@@ -39,7 +39,7 @@ buildscript {
     }
 }
 <% if (binding.hasVariable("buildScanPluginVersion")) { %>
-apply { plugin("com.gradle.build-scan") }
+apply(plugin = "com.gradle.build-scan")
 // TODO: fix buildScan configuration
 // buildScan { licenseAgreementUrl = 'https://gradle.com/terms-of-service'; licenseAgree = 'yes' }
 <% }%>

--- a/subprojects/performance/src/templates/kts-project-with-source/build.gradle.kts
+++ b/subprojects/performance/src/templates/kts-project-with-source/build.gradle.kts
@@ -21,8 +21,8 @@ import org.gradle.plugins.ide.idea.IdeaPlugin
 import java.io.File
 
 apply<IdeaPlugin>()
-apply { plugin("java") }
-apply { plugin("eclipse") }
+apply(plugin = "java")
+apply(plugin = "eclipse")
 
 repositories {
     mavenCentral()

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -27,7 +27,7 @@ tasks.register("gradleBuildBaseline", RemoteProject) {
     remoteUri = rootDir.absolutePath
     // Remember to update accordingly when rebasing/squashing
     // Do not use the "Rebase and merge" nor "Squash and merge" Github buttons when merging a PR that change the baseline
-    ref = 'b2da504225add9aa044feb1bb305c21b82272fd9'
+    ref = 'da8eebf7674d7ba95c2c0a7b46db78d9695aac5b'
 }
 
 // === Java ===

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-dsl-multi-project-with-buildSrc/settings.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-dsl-multi-project-with-buildSrc/settings.gradle
@@ -1,2 +1,0 @@
-
-include 'bluewhale', 'krill'

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-dsl-multi-project-with-buildSrc/settings.gradle.kts
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-dsl-multi-project-with-buildSrc/settings.gradle.kts
@@ -1,0 +1,2 @@
+
+include("bluewhale", "krill")

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -70,7 +70,7 @@ testFixtures {
     from(":ide")
 }
 
-apply { from("buildship.gradle") }
+apply(from = "buildship.gradle")
 
 tasks.named("sourceJar").configureAs<Jar> {
     configurations.compile.allDependencies.withType<ProjectDependency>().forEach {


### PR DESCRIPTION
This requires temporarily adding the `kotlin-dev` repository to the build due to the Kotlin 1.2.60-eap-44 dependency