### PR TITLE
Make URI scheme matching faster

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/AbstractFileResolver.java
@@ -46,7 +46,7 @@ public abstract class AbstractFileResolver implements FileResolver {
 
     protected AbstractFileResolver(FileSystem fileSystem, Factory<PatternSet> patternSetFactory) {
         this.fileSystem = fileSystem;
-        this.fileNotationParser = FileOrUriNotationConverter.parser(fileSystem);
+        this.fileNotationParser = FileOrUriNotationConverter.parser();
         this.patternSetFactory = patternSetFactory;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
@@ -167,6 +167,6 @@ The following types/formats are supported:
     }
 
     def parse(def value) {
-        return FileOrUriNotationConverter.parser(TestFiles.fileSystem()).parseNotation(value)
+        return FileOrUriNotationConverter.parser().parseNotation(value)
     }
 }


### PR DESCRIPTION
Put the Windows special case behind an if-condition
and optimize for the well-known http and https schemes
instead of matching a regex for them.