### PR TITLE
Monitor execution timeout in build

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -32,9 +32,6 @@ import org.gradle.build.GradleDistributionWithSamples
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.CommandLineArgumentProvider
 import java.util.concurrent.Callable
-import java.util.concurrent.TimeUnit
-import java.util.Timer
-import kotlin.concurrent.timerTask
 
 
 /**
@@ -65,37 +62,6 @@ open class DistributionTest : Test() {
         jvmArgumentProviders.add(BinaryDistributionsEnvironmentProvider(binaryDistributions))
         jvmArgumentProviders.add(libsRepository)
         systemProperty("java9Home", project.findProperty("java9Home") ?: System.getProperty("java9Home"))
-    }
-
-    override fun executeTests() {
-        val timer = setTimeoutMonitor()
-        super.executeTests()
-        timer?.cancel()
-    }
-
-    private
-    fun setTimeoutMonitor(): Timer? {
-        return if (System.getenv().contains("CI")) {
-            Timer(true).also {
-                it.schedule(timerTask {
-                    project.javaexec {
-                        classpath = super<Test>.getClasspath()
-                        main = "org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitor"
-                    }
-                }, determineTimeoutMillis())
-            }
-        } else {
-            null
-        }
-    }
-
-    private
-    fun determineTimeoutMillis(): Long {
-        return if ("embeded" == System.getProperty("org.gradle.integtest.executer")) {
-            TimeUnit.MINUTES.toMillis(30)
-        } else {
-            TimeUnit.HOURS.toMillis(2)
-        }
     }
 }
 

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -55,7 +55,7 @@ open class IntegrationTest : DistributionTest() {
 
     private
     fun determineTimeoutMillis(): Long {
-        return if ("embeded" == System.getProperty("org.gradle.integtest.executer")) {
+        return if ("embedded" == getSystemProperties().get("org.gradle.integtest.executer")) {
             TimeUnit.MINUTES.toMillis(1)
         } else {
             TimeUnit.HOURS.toMillis(2)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -56,7 +56,7 @@ open class IntegrationTest : DistributionTest() {
     private
     fun determineTimeoutMillis(): Long {
         return if ("embeded" == System.getProperty("org.gradle.integtest.executer")) {
-            TimeUnit.MINUTES.toMillis(30)
+            TimeUnit.MINUTES.toMillis(1)
         } else {
             TimeUnit.HOURS.toMillis(2)
         }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -56,7 +56,7 @@ open class IntegrationTest : DistributionTest() {
     private
     fun determineTimeoutMillis(): Long {
         return if ("embedded" == getSystemProperties().get("org.gradle.integtest.executer")) {
-            TimeUnit.MINUTES.toMillis(1)
+            TimeUnit.MINUTES.toMillis(30)
         } else {
             TimeUnit.HOURS.toMillis(2)
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
@@ -16,14 +16,9 @@
 
 package org.gradle.integtests.fixtures.timeout
 
-import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
-import org.apache.commons.io.IOUtils
 import org.gradle.api.Action
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.InProcessGradleExecuter
-import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
-import org.gradle.internal.os.OperatingSystem
 import org.spockframework.runtime.SpockAssertionError
 import org.spockframework.runtime.SpockTimeoutError
 import org.spockframework.runtime.extension.IMethodInvocation
@@ -31,18 +26,9 @@ import org.spockframework.runtime.extension.MethodInvocation
 import org.spockframework.runtime.extension.builtin.TimeoutInterceptor
 import org.spockframework.runtime.model.MethodInfo
 
-import java.nio.file.Path
-import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 class IntegrationTestTimeoutInterceptor extends TimeoutInterceptor {
-    private static final Pattern UNIX_JAVA_COMMAND_PATTERN = ~/(?i)([^\s]+\/bin\/java)/
-    private static final Pattern WINDOWS_JAVA_COMMAND_PATTERN = ~/(?i)^"(.*[\/\\]bin[\/\\]java\.exe)"/
-    private static final Pattern WINDOWS_PID_PATTERN = ~/([0-9]+)\s*$/
-    private static final Pattern UNIX_PID_PATTERN = ~/([0-9]+)/
-
     IntegrationTestTimeoutInterceptor(IntegrationTestTimeout timeout) {
         super(new TimeoutAdapter(timeout))
     }
@@ -83,111 +69,13 @@ class IntegrationTestTimeoutInterceptor extends TimeoutInterceptor {
             if (instance instanceof AbstractIntegrationSpec && isInProcessExecuter(instance)) {
                 return getAllStackTracesInCurrentJVM()
             } else {
-                return getAllStackTracesByJstack()
+                return JavaProcessStackTracesMonitor.getAllStackTracesByJstack()
             }
         } catch (Throwable e) {
             def stream = new ByteArrayOutputStream()
             e.printStackTrace(new PrintStream(stream))
             return "Error in attempt to fetch  stacktraces: ${stream.toString()}"
         }
-    }
-
-    @EqualsAndHashCode
-    @ToString
-    static class JavaProcessInfo {
-        String pid
-        String javaCommand
-
-        String getJstackCommand() {
-            assert javaCommand.endsWith("java") || javaCommand.endsWith("java.exe"): "Unknown java command： $javaCommand"
-
-            Path javaPath = Paths.get(javaCommand)
-            String jstackExe = OperatingSystem.current().getExecutableName('jstack')
-            if (javaPath.parent.fileName.toString() == 'bin' && javaPath.parent.parent.fileName.toString() == 'jre') {
-                return javaPath.resolve("../../../bin/$jstackExe").normalize().toString()
-            } else {
-                return javaPath.resolve("../../bin/$jstackExe").normalize().toString()
-            }
-        }
-
-        String jstack() {
-            Map result = runProcess([jstackCommand, pid])
-            return "Run ${jstackCommand} ${pid} return ${result.code}:\n${result.stdout}\n---------\n${result.stderr}\n"
-        }
-    }
-
-    static class StdoutAndPatterns {
-        String stdout
-        Pattern pidPattern
-        Pattern javaCommandPattern
-
-        StdoutAndPatterns(String stdout) {
-            this.stdout = stdout
-            if (OperatingSystem.current().isWindows()) {
-                pidPattern = WINDOWS_PID_PATTERN
-                javaCommandPattern = WINDOWS_JAVA_COMMAND_PATTERN
-            } else {
-                pidPattern = UNIX_PID_PATTERN
-                javaCommandPattern = UNIX_JAVA_COMMAND_PATTERN
-            }
-        }
-
-        List<JavaProcessInfo> getSuspiciousDaemons() {
-            stdout.readLines().findAll(this.&isSuspiciousDaemon).collect(this.&extractProcessInfo)
-        }
-
-        private JavaProcessInfo extractProcessInfo(String line) {
-            Matcher javaCommandMatcher = javaCommandPattern.matcher(line)
-            Matcher pidMatcher = pidPattern.matcher(line)
-
-            javaCommandMatcher.find()
-            pidMatcher.find()
-            return new JavaProcessInfo(pid: pidMatcher.group(1), javaCommand: javaCommandMatcher.group(1))
-        }
-
-        private boolean isSuspiciousDaemon(String line) {
-            return !isTeamCityAgent(line) && javaCommandPattern.matcher(line).find() && pidPattern.matcher(line).find()
-        }
-
-        private boolean isTeamCityAgent(String line) {
-            return line.contains('jetbrains.buildServer.agent.AgentMain')
-        }
-    }
-
-    private static StdoutAndPatterns ps() {
-        List<String> command = OperatingSystem.current().isWindows() ? ["wmic", "process", "get", "processid,commandline"] : ["ps", "x"]
-        Map result = runProcess(command)
-
-        if (result.code == 0) {
-            println("Command $command stdout: ${result.stdout}")
-            println("Command $command stderr: ${result.stderr}")
-            return new StdoutAndPatterns(result.stdout)
-        } else {
-            def logFile = IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir.file("error-${System.currentTimeMillis()}.log")
-            logFile << "code:\n"
-            logFile << result.code
-            logFile << "stdout:\n"
-            logFile << result.stdout
-            logFile << "stderr:\n"
-            logFile << result.stderr
-
-            throw new RuntimeException("Error when fetching processes, see log file ${logFile.absolutePath}")
-        }
-    }
-
-    private static Map runProcess(List<String> command) {
-        // Don't use Groovy's Process.consumeProcessOutput
-        // https://issues.apache.org/jira/browse/GROOVY-7414
-        Process process = new ProcessBuilder(command).start()
-
-        String stdout = IOUtils.toString(process.getInputStream())
-        String stderr = IOUtils.toString(process.getErrorStream())
-        int code = process.waitFor()
-        return [code: code, stdout: stdout, stderr: stderr]
-    }
-
-    static String getAllStackTracesByJstack() {
-        return ps().getSuspiciousDaemons().collect { it.jstack() }.join("\n")
     }
 
     static String getAllStackTracesInCurrentJVM() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.timeout
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.apache.commons.io.IOUtils
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.internal.os.OperatingSystem
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+class JavaProcessStackTracesMonitor {
+    private static final Pattern UNIX_JAVA_COMMAND_PATTERN = ~/(?i)([^\s]+\/bin\/java)/
+    private static final Pattern WINDOWS_JAVA_COMMAND_PATTERN = ~/(?i)^"(.*[\/\\]bin[\/\\]java\.exe)"/
+    private static final Pattern WINDOWS_PID_PATTERN = ~/([0-9]+)\s*$/
+    private static final Pattern UNIX_PID_PATTERN = ~/([0-9]+)/
+
+    static void main(String[] args) {
+        System.out.println(getAllStackTracesByJstack())
+    }
+
+    @EqualsAndHashCode
+    @ToString
+    static class JavaProcessInfo {
+        String pid
+        String javaCommand
+
+        String getJstackCommand() {
+            assert javaCommand.endsWith("java") || javaCommand.endsWith("java.exe"): "Unknown java command： $javaCommand"
+
+            Path javaPath = Paths.get(javaCommand)
+            String jstackExe = OperatingSystem.current().getExecutableName('jstack')
+            if (javaPath.parent.fileName.toString() == 'bin' && javaPath.parent.parent.fileName.toString() == 'jre') {
+                return javaPath.resolve("../../../bin/$jstackExe").normalize().toString()
+            } else {
+                return javaPath.resolve("../../bin/$jstackExe").normalize().toString()
+            }
+        }
+
+        String jstack() {
+            Map result = runProcess([jstackCommand, pid])
+            return "Run ${jstackCommand} ${pid} return ${result.code}:\n${result.stdout}\n---------\n${result.stderr}\n"
+        }
+    }
+
+    static class StdoutAndPatterns {
+        String stdout
+        Pattern pidPattern
+        Pattern javaCommandPattern
+
+        StdoutAndPatterns(String stdout) {
+            this.stdout = stdout
+            if (OperatingSystem.current().isWindows()) {
+                pidPattern = WINDOWS_PID_PATTERN
+                javaCommandPattern = WINDOWS_JAVA_COMMAND_PATTERN
+            } else {
+                pidPattern = UNIX_PID_PATTERN
+                javaCommandPattern = UNIX_JAVA_COMMAND_PATTERN
+            }
+        }
+
+        List<JavaProcessInfo> getSuspiciousDaemons() {
+            stdout.readLines().findAll(this.&isSuspiciousDaemon).collect(this.&extractProcessInfo)
+        }
+
+        private JavaProcessInfo extractProcessInfo(String line) {
+            Matcher javaCommandMatcher = javaCommandPattern.matcher(line)
+            Matcher pidMatcher = pidPattern.matcher(line)
+
+            javaCommandMatcher.find()
+            pidMatcher.find()
+            return new JavaProcessInfo(pid: pidMatcher.group(1), javaCommand: javaCommandMatcher.group(1))
+        }
+
+        private boolean isSuspiciousDaemon(String line) {
+            return !isTeamCityAgent(line) && javaCommandPattern.matcher(line).find() && pidPattern.matcher(line).find()
+        }
+
+        private boolean isTeamCityAgent(String line) {
+            return line.contains('jetbrains.buildServer.agent.AgentMain')
+        }
+    }
+
+    private static StdoutAndPatterns ps() {
+        List<String> command = OperatingSystem.current().isWindows() ? ["wmic", "process", "get", "processid,commandline"] : ["ps", "x"]
+        Map result = runProcess(command)
+
+        if (result.code == 0) {
+            println("Command $command stdout: ${result.stdout}")
+            println("Command $command stderr: ${result.stderr}")
+            return new StdoutAndPatterns(result.stdout)
+        } else {
+            def logFile = IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir.file("error-${System.currentTimeMillis()}.log")
+            logFile << "code:\n"
+            logFile << result.code
+            logFile << "stdout:\n"
+            logFile << result.stdout
+            logFile << "stderr:\n"
+            logFile << result.stderr
+
+            throw new RuntimeException("Error when fetching processes, see log file ${logFile.absolutePath}")
+        }
+    }
+
+    private static Map runProcess(List<String> command) {
+        // Don't use Groovy's Process.consumeProcessOutput
+        // https://issues.apache.org/jira/browse/GROOVY-7414
+        Process process = new ProcessBuilder(command).start()
+
+        String stdout = IOUtils.toString(process.getInputStream())
+        String stderr = IOUtils.toString(process.getErrorStream())
+        int code = process.waitFor()
+        return [code: code, stdout: stdout, stderr: stderr]
+    }
+
+    static String getAllStackTracesByJstack() {
+        return ps().getSuspiciousDaemons().collect { it.jstack() }.join("\n")
+    }
+}

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitorSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitorSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
-class IntegrationTestTimeoutInterceptorSpec extends Specification {
+class JavaProcessStackTracesMonitorSpec extends Specification {
 
     @Requires(TestPrecondition.NOT_WINDOWS)
     def 'can extract process info from unix ps()'() {
@@ -40,14 +40,14 @@ class IntegrationTestTimeoutInterceptorSpec extends Specification {
 32167 ?        Ssl    8:50 /opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx2500m -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/home/tcagent1/agent/temp/buildTmp -Duser.country=US -Duser.language=en -Duser.variant -cp /home/tcagent1/.gradle/wrapper/dists/gradle-4.9-20180607113442+0000-bin/6o1ijseqszb59y1oe4hyx3o6o/gradle-4.9-20180607113442+0000/lib/gradle-launcher-4.9.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 4.9-20180607113442+0000
 '''
         when:
-        def suspiciousDaemons = new IntegrationTestTimeoutInterceptor.StdoutAndPatterns(output).getSuspiciousDaemons()
+        def suspiciousDaemons = new JavaProcessStackTracesMonitor.StdoutAndPatterns(output).getSuspiciousDaemons()
 
         then:
         suspiciousDaemons == [
-            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '2477', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
-            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '15818', javaCommand: '/opt/jdk/oracle-jdk-8/bin/java'),
-            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '24438', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
-            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '32167', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
+            new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '2477', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
+            new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '15818', javaCommand: '/opt/jdk/oracle-jdk-8/bin/java'),
+            new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '24438', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
+            new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '32167', javaCommand: '/opt/files/jdk-linux/jdk-8u161-linux-x64.tar.gz/bin/java'),
         ]
     }
 
@@ -73,12 +73,12 @@ cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcage
 "C:\\Program Files\\Java\\jdk1.8/bin/java.exe" -Xmx128m -Dfile.encoding=UTF-8 -XX:MaxPermSize=512m "-Djava.io.tmpdir=C:\\tcagent1\\temp\\buildTmp" "-Dorg.gradle.appname=gradlew" -classpath "C:\\tcagent1\\work\\668602365d1521fc\\\\gradle\\wrapper\\gradle-wrapper.jar" org.gradle.wrapper.GradleWrapperMain --init-script C:\\tcagent1\\plugins\\gradle-runner\\scripts\\init.gradle -PmaxParallelForks=4 -s --daemon --continue -I C:\\tcagent1\\work\\668602365d1521fc/gradle/init-scripts/build-scan.init.gradle.kts "-Djava7Home=C:\\Program Files\\Java\\jdk1.7" "-Djava9Home=C:\\Program Files\\Java\\jdk1.9" -Dorg.gradle.internal.tasks.createops --build-cache -Dgradle.cache.remote.url="https://e.grdev.net/cache/" -Dgradle.cache.remote.username="gradle" -Dgradle.cache.remote.password="Pw2^8w2PHN6JUCOTo7R3" "-PtestJavaHome=C:\\Program Files\\Java\\jdk1.8" -Dscan.tag.FunctionalTest -Dscan.value.coverageOs=windows -Dscan.value.coverageJvmVendor=oracle -Dscan.value.coverageJvmVersion=java8 -PteamCityUsername=TeamcityRestBot -PteamCityPassword=DxQyNUvR2Yx6P5z6 -PteamCityBuildId=13871238 -Dscan.tag.Check -Dscan.tag.BranchBuildAccept -Dorg.gradle.daemon=false clean buildCacheHttp:platformTest 3908    
 '''
         when:
-        def suspiciousDaemons = new IntegrationTestTimeoutInterceptor.StdoutAndPatterns(output).getSuspiciousDaemons()
+        def suspiciousDaemons = new JavaProcessStackTracesMonitor.StdoutAndPatterns(output).getSuspiciousDaemons()
 
         then:
         suspiciousDaemons == [
-            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '1368', javaCommand: "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"),
-            new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '3908', javaCommand: "C:\\Program Files\\Java\\jdk1.8/bin/java.exe")
+            new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '1368', javaCommand: "C:\\Program Files\\Java\\jdk1.8\\bin\\java.exe"),
+            new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '3908', javaCommand: "C:\\Program Files\\Java\\jdk1.8/bin/java.exe")
         ]
     }
 
@@ -86,7 +86,7 @@ cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcage
     @Requires(TestPrecondition.NOT_WINDOWS)
     def 'can locate jstack on Unix'() {
         expect:
-        new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
+        new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
 
         where:
         javaCommand                                                | jstackCommand
@@ -99,7 +99,7 @@ cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcage
     @Requires(TestPrecondition.WINDOWS)
     def 'can locate jstack on Windows'() {
         expect:
-        new IntegrationTestTimeoutInterceptor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
+        new JavaProcessStackTracesMonitor.JavaProcessInfo(pid: '0', javaCommand: javaCommand).jstackCommand == jstackCommand
 
         where:
         javaCommand                                           | jstackCommand
@@ -115,13 +115,13 @@ cmd /c C:\\tcagent1\\work\\668602365d1521fc\\gradlew.bat --init-script C:\\tcage
 
     def 'can print all threads of all running JVM by jstack'() {
         when:
-        String stacktraces = IntegrationTestTimeoutInterceptor.getAllStackTracesByJstack()
+        String stacktraces = JavaProcessStackTracesMonitor.getAllStackTracesByJstack()
 
         then:
         stacktraces.contains("Full thread dump")
         stacktraces.contains("${getClass().getName()}.\$spock_feature")
 //        - org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethod0(java.lang.Class, java.lang.Object, java.lang.String) @bci=6, line=189 (Interpreted frame)
-//        - org.gradle.integtests.fixtures.timeout.IntegrationTestTimeoutInterceptorSpec.$spock_feature_1_4() @bci=98, line=105 (Interpreted frame)
+//        - org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitorSpec.$spock_feature_1_4() @bci=98, line=105 (Interpreted frame)
 //        - sun.reflect.NativeMethodAccessorImpl.invoke0(java.lang.reflect.Method, java.lang.Object, java.lang.Object[]) @bci=0 (Interpreted frame)
     }
 }


### PR DESCRIPTION
### Context

We have been bitten by execution timeout for a long time. To diagnose the cause, in this PR we set a hourly timer when integration tests start, then print all java processes' stack traces on the machine if it timeouts. The default timeout for embedded executer is 1 hour, and 3 hours for all other integration tests.

Most of the work was finished in https://github.com/gradle/gradle/pull/5806 , now we're just reusing the code to invoke `jstack` on all running JVMs of current build agent.