### PR TITLE
Make task output parsing robust against sub progress loggers

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -33,8 +33,7 @@ public class GroupedOutputFixture {
      */
     private final static String TASK_HEADER = "> Task (:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n?";
 
-    private final static String EMBEDDED_BUILD_START = "> :\\w* > :\\w+";
-    private final static String COMPILING_INTO_CACHE = "> :\\w* > Compiling[^\\n]+cache";
+    private final static String EMBEDDED_BUILD_START = "> :\\w* > [:\\w]+";
     private final static String BUILD_STATUS_FOOTER = "BUILD SUCCESSFUL";
     private final static String BUILD_FAILED_FOOTER = "BUILD FAILED";
     private final static String ACTIONABLE_TASKS = "[0-9]+ actionable tasks?:";
@@ -42,7 +41,7 @@ public class GroupedOutputFixture {
     /**
      * Various patterns to detect the end of the task output
      */
-    private final static String END_OF_TASK_OUTPUT = TASK_HEADER + "|" + BUILD_STATUS_FOOTER + "|" + BUILD_FAILED_FOOTER + "|" + EMBEDDED_BUILD_START + "|" + COMPILING_INTO_CACHE + "|" + ACTIONABLE_TASKS + "|\\z";
+    private final static String END_OF_TASK_OUTPUT = TASK_HEADER + "|" + BUILD_STATUS_FOOTER + "|" + BUILD_FAILED_FOOTER + "|" + EMBEDDED_BUILD_START + "|" + ACTIONABLE_TASKS + "|\\z";
 
     /**
      * Pattern to extract task output.

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -383,6 +383,20 @@ Hello, World!
         groupedOutput.task(':helloWorld').output == 'Hello, World!'
     }
 
+    def "accepts start of sub progress logger as end of group"() {
+        def consoleOutput = """
+> Task :helloWorld
+Hello, World!
+
+> :otherBuild > Doing some work"""
+
+        when:
+        GroupedOutputFixture groupedOutput = new GroupedOutputFixture(consoleOutput)
+
+        then:
+        groupedOutput.task(':helloWorld').output == 'Hello, World!'
+    }
+
     def "does not fail with with stack overflow error"() {
         def consoleOutput = """
  [1m> Task :xx:


### PR DESCRIPTION
Prior to this commit only logged status messages from subtasks and
"Compiling ... into cache" actions from embedded builds were recognized
as valid ends of task outputs. Now any action from an embedded build,
including "Deleting from versions-specific caches in ..." is handled.

Fixes gradle/gradle-private#1401.