### PR TITLE
Reinstate requirement for removal details in deprecation notices

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -656,14 +656,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     @Deprecated
     @Override
     public boolean add(Task o) {
-        DeprecationLogger.nagUserOfReplacedMethodWithoutRemoval("add()", "create() or register()");
+        DeprecationLogger.nagUserOfReplacedMethodWithoutCustomRemoval("add()", "create() or register()", "This method will cause an error in Gradle 6.0.");
         return addInternal(o);
     }
 
     @Deprecated
     @Override
     public boolean addAll(Collection<? extends Task> c) {
-        DeprecationLogger.nagUserOfReplacedMethodWithoutRemoval("addAll()", "create() or register()");
+        DeprecationLogger.nagUserOfReplacedMethodWithoutCustomRemoval("addAll()", "create() or register()", "This method will cause an error in Gradle 6.0.");
         return addAllInternal(c);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -656,14 +656,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     @Deprecated
     @Override
     public boolean add(Task o) {
-        DeprecationLogger.nagUserOfReplacedMethodWithoutCustomRemoval("add()", "create() or register()", "This method will cause an error in Gradle 6.0.");
+        DeprecationLogger.nagUserOfReplacedMethodWithCustomRemoval("add()", "create() or register()", "This method will cause an error in Gradle 6.0.");
         return addInternal(o);
     }
 
     @Deprecated
     @Override
     public boolean addAll(Collection<? extends Task> c) {
-        DeprecationLogger.nagUserOfReplacedMethodWithoutCustomRemoval("addAll()", "create() or register()", "This method will cause an error in Gradle 6.0.");
+        DeprecationLogger.nagUserOfReplacedMethodWithCustomRemoval("addAll()", "create() or register()", "This method will cause an error in Gradle 6.0.");
         return addAllInternal(c);
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -508,7 +508,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("help")
 
         then:
-        outputContains("The add() method has been deprecated. Please use the create() or register() method instead.")
+        outputContains("The add() method has been deprecated. This method will cause an error in Gradle 6.0. Please use the create() or register() method instead.")
     }
 
     def "cannot add a pre-created task provider to the task container"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedFeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedFeatureUsage.java
@@ -32,14 +32,14 @@ public class DeprecatedFeatureUsage extends FeatureUsage {
 
     public DeprecatedFeatureUsage(
         String summary,
-        @Nullable String removalDetails,
+        String removalDetails,
         @Nullable String advice,
         @Nullable String contextualAdvice,
         Type type,
         Class<?> calledFrom
     ) {
         super(summary, calledFrom);
-        this.removalDetails = removalDetails;
+        this.removalDetails = Preconditions.checkNotNull(removalDetails);
         this.advice = advice;
         this.contextualAdvice = contextualAdvice;
         this.type = Preconditions.checkNotNull(type);

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedUsageProgressDetails.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedUsageProgressDetails.java
@@ -37,7 +37,6 @@ public interface DeprecatedUsageProgressDetails {
     /**
      * See {@link DeprecatedFeatureUsage#getRemovalDetails()}
      */
-    @Nullable
     String getRemovalDetails();
 
     /**

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -121,10 +121,10 @@ public class SingleMessageLogger {
         }
     }
 
-    public static void nagUserOfReplacedMethodWithoutRemoval(String methodName, String replacement) {
+    public static void nagUserOfReplacedMethodWithoutCustomRemoval(String methodName, String replacement, String removalDetails) {
         if (isEnabled()) {
             nagUserWith(
-                String.format("The %s method has been deprecated.", methodName), null,
+                String.format("The %s method has been deprecated.", methodName), removalDetails,
                 String.format("Please use the %s method instead.", replacement),
                 null,
                 DeprecatedFeatureUsage.Type.USER_CODE_DIRECT);

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -121,10 +121,11 @@ public class SingleMessageLogger {
         }
     }
 
-    public static void nagUserOfReplacedMethodWithoutCustomRemoval(String methodName, String replacement, String removalDetails) {
+    public static void nagUserOfReplacedMethodWithCustomRemoval(String methodName, String replacement, String removalDetails) {
         if (isEnabled()) {
             nagUserWith(
-                String.format("The %s method has been deprecated.", methodName), removalDetails,
+                String.format("The %s method has been deprecated.", methodName),
+                removalDetails,
                 String.format("Please use the %s method instead.", replacement),
                 null,
                 DeprecatedFeatureUsage.Type.USER_CODE_DIRECT);


### PR DESCRIPTION
If something is deprecated, it must be removed at some point (otherwise there is no point). Removing doesn't have to mean “physically” removing the _thing_. In the case in question, we will be removing the functionality but keeping the method (because its part of an interface we have to fulfill).