### PR TITLE
Describe JavaExec argument parsing in JavaDocs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -283,8 +283,19 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     }
 
     /**
-     * Command line arguments passed to the main class.
-     * @param args the command line arguments as a single string. Will be parsed to argument list.
+     * Parses an argument list from {@code args} and passes it to {@link #setArgs(List)}.
+     *
+     * <p>
+     * The parser supports both single quote ({@code '}) and double quote ({@code "}) as quote delimiters.
+     * For example, to pass the argument {@code foo bar}, use {@code "foo bar"}.
+     * </p>
+     * <p>
+     * Note: the parser does <strong>not</strong> support using backslash to escape quotes. If this is needed,
+     * use the other quote delimiter around it.
+     * For example, to pass the argument {@code 'singly quoted'}, use {@code "'singly quoted'"}.
+     * </p>
+     *
+     * @param args Args for the main class. Will be parsed into an argument list.
      * @return this
      * @since 4.9
      */


### PR DESCRIPTION
### Context
See #6056

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
