### PR TITLE
 Respect default excludes for snapshotting

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/mirror/MirrorUpdatingDirectoryWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/mirror/MirrorUpdatingDirectoryWalkerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state.mirror
 
+import org.apache.tools.ant.DirectoryScanner
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.util.PatternSet
@@ -121,6 +122,27 @@ class MirrorUpdatingDirectoryWalkerTest extends Specification {
             'root/a/c', 'root/a/c/c.txt',
             'root/a.txt'
         ] as Set
+    }
+
+    def "default excludes are correctly parsed"() {
+        def defaultExcludes = new MirrorUpdatingDirectoryWalker.DefaultExcludes(DirectoryScanner.getDefaultExcludes())
+
+        expect:
+        DirectoryScanner.getDefaultExcludes().toList() == ['**/%*%', '**/.git/**', '**/SCCS', '**/.bzr', '**/.hg/**', '**/.bzrignore', '**/.git', '**/SCCS/**', '**/.hg', '**/.#*', '**/vssver.scc', '**/.bzr/**', '**/._*', '**/#*#', '**/*~', '**/CVS', '**/.hgtags', '**/.svn/**', '**/.hgignore', '**/.svn', '**/.gitignore', '**/.gitmodules', '**/.hgsubstate', '**/.gitattributes', '**/CVS/**', '**/.hgsub', '**/.DS_Store', '**/.cvsignore']
+
+        ['%some%', 'SCCS', '.bzr', '.bzrignore', '.git', '.hg', '.#anything', '.#', 'vssver.scc', '._something', '#anyt#', '##', 'temporary~', '~'].each {
+            assert defaultExcludes.excludeFile(it)
+        }
+
+        ['.git', '.hg', 'CVS'].each {
+            assert defaultExcludes.excludeDir(it)
+        }
+
+        !defaultExcludes.excludeDir('#some#')
+        !defaultExcludes.excludeDir('.cvsignore')
+
+        !defaultExcludes.excludeFile('.svnsomething')
+        !defaultExcludes.excludeFile('#some')
     }
 
     private static PhysicalSnapshot walkDir(File dir, PatternSet patterns, MirrorUpdatingDirectoryWalker walker) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -291,7 +291,12 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         inputDir.file('.gitignore').text = "some ignored file"
-        run 'myTask'
+        inputDir.file('#ignored#').text = "some ignored file"
+        inputDir.file('.git/any-name.txt').text = "some ignored file"
+        inputDir.file('._ignored').text = "some ignored file"
+        inputDir.file('some-file.txt~').text = "some ignored file"
+
+        run 'myTask', "--info"
         then:
         skipped(':myTask')
     }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -270,9 +270,10 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped ":customTask"
     }
 
-    def "changing default excludes leaves task up-to-date"() {
+    def "changes to inputs that are excluded by default leave task up-to-date"() {
         def inputDir = file("inputDir").createDir()
         inputDir.file('inputFile.txt').text = "input file"
+        inputDir.createDir('something')
 
         buildFile << """
             task myTask {
@@ -293,6 +294,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
         inputDir.file('.gitignore').text = "some ignored file"
         inputDir.file('#ignored#').text = "some ignored file"
         inputDir.file('.git/any-name.txt').text = "some ignored file"
+        inputDir.file('something/.git/deeper/dir/structure/any-name.txt').text = "some ignored file"
         inputDir.file('._ignored').text = "some ignored file"
         inputDir.file('some-file.txt~').text = "some ignored file"
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -269,4 +269,30 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
         then:
         executedAndNotSkipped ":customTask"
     }
+
+    def "changing default excludes leaves task up-to-date"() {
+        def inputDir = file("inputDir").createDir()
+        inputDir.file('inputFile.txt').text = "input file"
+
+        buildFile << """
+            task myTask {
+                inputs.dir('inputDir')
+                outputs.file('build/output.txt')
+                doLast {
+                    file('build/output.txt').text = "Hello world"
+                }
+            }
+        """
+
+        when:
+        run 'myTask'
+        then:
+        executedAndNotSkipped(':myTask')
+
+        when:
+        inputDir.file('.gitignore').text = "some ignored file"
+        run 'myTask'
+        then:
+        skipped(':myTask')
+    }
 }


### PR DESCRIPTION
We dropped respecting the default excludes for snapshotting when we converted to hierarchical snapshots.