### PR TITLE
Clean up distributions at most every 24 hours

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DirectoryCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DirectoryCleanupAction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.gradle.api.Describable;
+import org.gradle.cache.CleanupProgressMonitor;
+
+public interface DirectoryCleanupAction extends Describable {
+    boolean execute(CleanupProgressMonitor progressMonitor);
+}

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
@@ -21,8 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.Action;
-import org.gradle.api.Describable;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
@@ -40,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache.FILE_HASHES_CACHE_KEY;
 
-public class VersionSpecificCacheCleanupAction implements Action<CleanupProgressMonitor>, Describable {
+public class VersionSpecificCacheCleanupAction implements DirectoryCleanupAction {
 
     @VisibleForTesting static final String MARKER_FILE_PATH = FILE_HASHES_CACHE_KEY + "/" + FILE_HASHES_CACHE_KEY + ".lock";
     private static final Logger LOGGER = Logging.getLogger(VersionSpecificCacheCleanupAction.class);
@@ -68,12 +66,14 @@ public class VersionSpecificCacheCleanupAction implements Action<CleanupProgress
         return "Deleting unused version-specific caches in " + versionSpecificCacheDirectoryScanner.getBaseDir();
     }
 
-    public void execute(@Nonnull CleanupProgressMonitor progressMonitor) {
+    public boolean execute(@Nonnull CleanupProgressMonitor progressMonitor) {
         if (requiresCleanup()) {
             Timer timer = Time.startTimer();
             performCleanup(progressMonitor);
             LOGGER.debug("Processed version-specific caches at {} for cleanup in {}", versionSpecificCacheDirectoryScanner.getBaseDir(), timer.getElapsed());
+            return true;
         }
+        return false;
     }
 
     private boolean requiresCleanup() {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -27,8 +27,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.Action;
-import org.gradle.api.Describable;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.CleanupProgressMonitor;
@@ -54,7 +52,7 @@ import java.util.zip.ZipFile;
 import static org.apache.commons.io.filefilter.FileFilterUtils.directoryFileFilter;
 import static org.gradle.util.CollectionUtils.single;
 
-public class WrapperDistributionCleanupAction implements Action<CleanupProgressMonitor>, Describable {
+public class WrapperDistributionCleanupAction implements DirectoryCleanupAction {
 
     @VisibleForTesting static final String WRAPPER_DISTRIBUTION_FILE_PATH = "wrapper/dists";
     private static final Logger LOGGER = Logging.getLogger(WrapperDistributionCleanupAction.class);
@@ -89,7 +87,7 @@ public class WrapperDistributionCleanupAction implements Action<CleanupProgressM
         return "Deleting unused Gradle distributions in " + distsDir;
     }
 
-    public void execute(@Nonnull CleanupProgressMonitor progressMonitor) {
+    public boolean execute(@Nonnull CleanupProgressMonitor progressMonitor) {
         long maximumTimestamp = Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1));
         Set<GradleVersion> usedVersions = this.usedGradleVersions.getUsedGradleVersions();
         Multimap<GradleVersion, File> checksumDirsByVersion = determineChecksumDirsByVersion();
@@ -100,6 +98,7 @@ public class WrapperDistributionCleanupAction implements Action<CleanupProgressM
                 progressMonitor.incrementSkipped(checksumDirsByVersion.get(version).size());
             }
         }
+        return true;
     }
 
     private void deleteDistributions(Collection<File> dirs, long maximumTimestamp, CleanupProgressMonitor progressMonitor) {

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -62,6 +62,21 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         currentDist.assertExists()
     }
 
+    def "skips cleanup of version-specific caches and distributions if gc.properties has recently been changed"() {
+        given:
+        def oldVersion = GradleVersion.version("2.3.4")
+        def oldCacheDir = createVersionSpecificCacheDir(oldVersion, NOT_USED_WITHIN_30_DAYS)
+        def oldDist = createDistributionChecksumDir(oldVersion).parentFile
+
+        when:
+        getGcFile(currentCacheDir).touch()
+        cleanupService.stop()
+
+        then:
+        oldCacheDir.assertExists()
+        oldDist.assertExists()
+    }
+
     @Override
     TestFile getGradleUserHomeDir() {
         return userHomeDir

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -50,9 +50,10 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
         def newerCacheDir = createVersionSpecificCacheDir(currentVersion.getNextMajor(), NOT_USED_WITHIN_30_DAYS)
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         4 * progressMonitor.incrementSkipped()
         2 * progressMonitor.incrementDeleted()
         ancientVersionWithoutMarkerFile.assertExists()
@@ -69,9 +70,10 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
         def dirWithUnparsableVersion = createCacheSubDir("42 foo")
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         1 * progressMonitor.incrementSkipped()
         0 * progressMonitor.incrementDeleted()
         sharedCacheDir.assertExists()
@@ -80,9 +82,10 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
 
     def "creates gc.properties file when it is missing"() {
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         getGcFile(currentCacheDir).assertExists()
     }
 
@@ -93,9 +96,10 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
         def originalLastModified = gcFile.lastModified()
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        !cleanedUp
         0 * progressMonitor._
         oldCacheDir.assertExists()
         gcFile.lastModified() == originalLastModified
@@ -109,67 +113,72 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
         gcFile.lastModified = originalLastModified
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         1 * progressMonitor.incrementSkipped()
         1 * progressMonitor.incrementDeleted()
         oldCacheDir.assertDoesNotExist()
         gcFile.lastModified() > originalLastModified
     }
 
-    def "cleans up caches of snapshot versions not used within 7 days if there's a cache for a later release version with same base version"() {
+    def "deletes caches of snapshot versions not used within 7 days if there's a cache for a later release version with same base version"() {
         given:
         def snapshot = createVersionSpecificCacheDir(GradleVersion.version("4.8-20180417000132+0000"), NOT_USED_WITHIN_7_DAYS)
         def release = createVersionSpecificCacheDir(GradleVersion.version("4.8"), NOT_USED_WITHIN_7_DAYS)
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         2 * progressMonitor.incrementSkipped()
         1 * progressMonitor.incrementDeleted()
         snapshot.assertDoesNotExist()
         release.assertExists()
     }
 
-    def "cleans up caches of snapshot versions not used within 7 days if there's a cache for a later snapshot version with same base version"() {
+    def "deletes caches of snapshot versions not used within 7 days if there's a cache for a later snapshot version with same base version"() {
         given:
         def snapshot = createVersionSpecificCacheDir(GradleVersion.version("4.8-20180417000132+0000"), NOT_USED_WITHIN_7_DAYS)
         def latestSnapshot = createVersionSpecificCacheDir(GradleVersion.version("4.8-20180507235951+0000"), NOT_USED_WITHIN_7_DAYS)
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         2 * progressMonitor.incrementSkipped()
         1 * progressMonitor.incrementDeleted()
         snapshot.assertDoesNotExist()
         latestSnapshot.assertExists()
     }
 
-    def "does not cleans up caches of snapshot versions not used within 7 days if there's no cache for a later version with same base version"() {
+    def "does not delete caches of snapshot versions not used within 7 days if there's no cache for a later version with same base version"() {
         given:
         def snapshot = createVersionSpecificCacheDir(GradleVersion.version("4.8-20180417000132+0000"), NOT_USED_WITHIN_7_DAYS)
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         2 * progressMonitor.incrementSkipped()
         0 * progressMonitor.incrementDeleted()
         snapshot.assertExists()
     }
 
-    def "does not cleans up caches of recently used snapshot versions"() {
+    def "does not delete caches of recently used snapshot versions"() {
         given:
         def snapshot = createVersionSpecificCacheDir(GradleVersion.version("4.8-20180417000132+0000"), USED_TODAY)
         def latestSnapshot = createVersionSpecificCacheDir(GradleVersion.version("4.8-20180507235951+0000"), NOT_USED_WITHIN_7_DAYS)
 
         when:
-        cleanupAction.execute(progressMonitor)
+        def cleanedUp = cleanupAction.execute(progressMonitor)
 
         then:
+        cleanedUp
         3 * progressMonitor.incrementSkipped()
         0 * progressMonitor.incrementDeleted()
         snapshot.assertExists()


### PR DESCRIPTION
Since the distribution cleanup was made independent of the
version-specific cache cleanup in #5981, it was run every time the
daemon was stopped. Now, instead of introducing yet another
`gc.properties` file, it is only executed if version-specific cache
cleanup was executed but regardless whether the latter actually deleted
something.

Fixes #6083.