### PR TITLE
Improve error messages on failure to realize a task

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -310,6 +310,62 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         result.assertNotOutput("task2")
     }
 
+    def "reports failure in task constructor when task realized"() {
+        settingsFile << """
+            include "child"
+        """
+        file("child/build.gradle") << """
+            class Broken extends DefaultTask {
+                Broken() {
+                    throw new RuntimeException("broken task")
+                }
+            }
+            tasks.register("broken", Broken)
+        """
+
+        expect:
+        fails("broken")
+        failure.assertHasDescription("A problem occurred configuring project ':child'.")
+        failure.assertHasCause("Could not create task ':child:broken'.")
+        failure.assertHasCause("Could not create task of type 'Broken'.")
+        failure.assertHasCause("broken task")
+    }
+
+    def "reports failure in task configuration block when task created"() {
+        settingsFile << """
+            include "child"
+        """
+        file("child/build.gradle") << """
+            tasks.register("broken") {
+                throw new RuntimeException("broken task")
+            }
+        """
+
+        expect:
+        fails("broken")
+        failure.assertHasDescription("A problem occurred configuring project ':child'.")
+        failure.assertHasCause("Could not create task ':child:broken'.")
+        failure.assertHasCause("broken task")
+    }
+
+    def "reports failure in configure block when task created"() {
+        settingsFile << """
+            include "child"
+        """
+        file("child/build.gradle") << """
+            tasks.configureEach {
+                throw new RuntimeException("broken task")
+            }
+            tasks.register("broken")
+        """
+
+        expect:
+        fails("broken")
+        failure.assertHasDescription("A problem occurred configuring project ':child'.")
+        failure.assertHasCause("Could not create task ':child:broken'.")
+        failure.assertHasCause("broken task")
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/5148")
     def "can get a task by name with a filtered collection"() {
         buildFile << '''

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -684,7 +684,9 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
-        failure.assertHasCause("Could not create task 'myTask' (CustomTask)")
+        failure.assertHasCause("Could not create task ':myTask'.")
+        failure.assertHasCause("Could not create task of type 'CustomTask'.")
+        failure.assertHasCause("Unable to determine CustomTask_Decorated argument #2: missing parameter value of type int, or no service of type int")
     }
 
     def "fails to create custom task if all constructor arguments missing"() {
@@ -696,7 +698,9 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
-        failure.assertHasCause("Could not create task 'myTask' (CustomTask)")
+        failure.assertHasCause("Could not create task ':myTask'.")
+        failure.assertHasCause("Could not create task of type 'CustomTask'.")
+        failure.assertHasCause("Unable to determine CustomTask_Decorated argument #1: missing parameter value of type class java.lang.String, or no service of type class java.lang.String")
     }
 
     @Unroll
@@ -709,7 +713,8 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
-        failure.assertHasCause("Could not create task 'myTask' (CustomTask)")
+        failure.assertHasCause("Could not create task ':myTask'.")
+        failure.assertHasCause("Could not create task of type 'CustomTask'.")
 
         where:
         description | constructorArgs | argumentNumber | outputType
@@ -727,7 +732,7 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
-        failure.assertHasCause("Could not create task 'myTask' (CustomTask)")
+        failure.assertHasCause("Could not create task ':myTask'.")
 
         where:
         position | script

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -148,7 +148,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private AbstractTask(TaskInfo taskInfo) {
         if (taskInfo == null) {
-            throw new TaskInstantiationException(String.format("Task of type '%s' has been instantiated directly which is not supported. Tasks can only be created using the DSL.", getClass().getName()));
+            throw new TaskInstantiationException(String.format("Task of type '%s' has been instantiated directly which is not supported. Tasks can only be created using the Gradle API or DSL.", getClass().getName()));
         }
 
         this.identity = taskInfo.identity;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -22,6 +22,7 @@ import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonNullApi;
@@ -40,6 +41,7 @@ import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.Cast;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.Transformers;
+import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -127,34 +129,38 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
             @Override
             public Task call(BuildOperationContext context) {
-                Object[] constructorArgs = getConstructorArgs(actualArgs);
-                TaskInternal task = createTask(identity, constructorArgs);
-                statistics.eagerTask(type);
+                try {
+                    Object[] constructorArgs = getConstructorArgs(actualArgs);
+                    TaskInternal task = createTask(identity, constructorArgs);
+                    statistics.eagerTask(type);
 
-                Object dependsOnTasks = actualArgs.get(Task.TASK_DEPENDS_ON);
-                if (dependsOnTasks != null) {
-                    task.dependsOn(dependsOnTasks);
-                }
-                Object description = actualArgs.get(Task.TASK_DESCRIPTION);
-                if (description != null) {
-                    task.setDescription(description.toString());
-                }
-                Object group = actualArgs.get(Task.TASK_GROUP);
-                if (group != null) {
-                    task.setGroup(group.toString());
-                }
-                Object action = actualArgs.get(Task.TASK_ACTION);
-                if (action instanceof Action) {
-                    Action<? super Task> taskAction = Cast.uncheckedCast(action);
-                    task.doFirst(taskAction);
-                } else if (action != null) {
-                    Closure closure = (Closure) action;
-                    task.doFirst(closure);
-                }
+                    Object dependsOnTasks = actualArgs.get(Task.TASK_DEPENDS_ON);
+                    if (dependsOnTasks != null) {
+                        task.dependsOn(dependsOnTasks);
+                    }
+                    Object description = actualArgs.get(Task.TASK_DESCRIPTION);
+                    if (description != null) {
+                        task.setDescription(description.toString());
+                    }
+                    Object group = actualArgs.get(Task.TASK_GROUP);
+                    if (group != null) {
+                        task.setGroup(group.toString());
+                    }
+                    Object action = actualArgs.get(Task.TASK_ACTION);
+                    if (action instanceof Action) {
+                        Action<? super Task> taskAction = Cast.uncheckedCast(action);
+                        task.doFirst(taskAction);
+                    } else if (action != null) {
+                        Closure closure = (Closure) action;
+                        task.doFirst(closure);
+                    }
 
-                addTask(task, replace);
-                context.setResult(REALIZE_RESULT);
-                return task;
+                    addTask(task, replace);
+                    context.setResult(REALIZE_RESULT);
+                    return task;
+                } catch (Throwable t) {
+                    throw taskCreationException(name, t);
+                }
             }
         });
     }
@@ -232,7 +238,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     private <T extends Task> T duplicateTask(String task) {
-        throw new InvalidUserDataException(String.format("Cannot add task '%s' as a task with that name already exists.", task));
+        throw new DuplicateTaskException(String.format("Cannot add task '%s' as a task with that name already exists.", task));
     }
 
     public <U extends Task> U maybeCreate(String name, Class<U> type) throws InvalidUserDataException {
@@ -258,11 +264,15 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return buildOperationExecutor.call(new CallableBuildOperation<T>() {
             @Override
             public T call(BuildOperationContext context) {
-                T task = createTask(identity, constructorArgs);
-                statistics.eagerTask(type);
-                addTask(task, false);
-                context.setResult(REALIZE_RESULT);
-                return task;
+                try {
+                    T task = createTask(identity, constructorArgs);
+                    statistics.eagerTask(type);
+                    addTask(task, false);
+                    context.setResult(REALIZE_RESULT);
+                    return task;
+                } catch (Throwable t) {
+                    throw taskCreationException(name, t);
+                }
             }
 
             @Override
@@ -372,10 +382,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         return buildOperationExecutor.call(new CallableBuildOperation<T>() {
             @Override
             public T call(BuildOperationContext context) {
-                T task = taskFactory.create(identity);
-                addTask(task, true);
-                context.setResult(REALIZE_RESULT);
-                return task;
+                try {
+                    T task = taskFactory.create(identity);
+                    addTask(task, true);
+                    context.setResult(REALIZE_RESULT);
+                    return task;
+                } catch (Throwable t) {
+                    throw taskCreationException(name, t);
+                }
             }
 
             @Override
@@ -570,7 +584,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     public class TaskCreatingProvider<I extends Task> extends DefaultTaskProvider<I> {
         private Object[] constructorArgs;
         private I task;
-        private Throwable cause;
+        private RuntimeException failure;
         private ImmutableActionSet<I> onCreate;
 
         public TaskCreatingProvider(TaskIdentity<I> identity, @Nullable Action<? super I> configureAction, Object... constructorArgs) {
@@ -596,8 +610,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public I getOrNull() {
-            if (cause != null) {
-                throw createIllegalStateException();
+            if (failure != null) {
+                throw failure;
             }
             if (task == null) {
                 task = getType().cast(findByNameWithoutRules(getName()));
@@ -618,9 +632,9 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                                 add(task, onCreate);
                                 // TODO removing this stuff from the store should be handled through some sort of decoration
                                 context.setResult(REALIZE_RESULT);
-                            } catch (RuntimeException ex) {
-                                cause = ex;
-                                throw createIllegalStateException();
+                            } catch (Throwable ex) {
+                                failure = taskCreationException(getName(), ex);
+                                throw failure;
                             } finally {
                                 // Discard state that is no longer required
                                 constructorArgs = null;
@@ -637,10 +651,13 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             }
             return task;
         }
+    }
 
-        private IllegalStateException createIllegalStateException() {
-            return new IllegalStateException(String.format("Could not create task '%s' (%s)", getName(), getType().getSimpleName()), cause);
+    private RuntimeException taskCreationException(String name, Throwable cause) {
+        if (cause instanceof DuplicateTaskException) {
+            return (RuntimeException) cause;
         }
+        return new TaskCreationException(String.format("Could not create task '%s'.", project.identityPath(name)), cause);
     }
 
     private static BuildOperationDescriptor.Builder realizeDescriptor(TaskIdentity<?> identity, boolean replacement, boolean eager) {
@@ -690,6 +707,19 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     };
     private static final RealizeTaskBuildOperationType.Result REALIZE_RESULT = new RealizeTaskBuildOperationType.Result() {
     };
+
+    @Contextual
+    private static class TaskCreationException extends GradleException {
+        TaskCreationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private static class DuplicateTaskException extends InvalidUserDataException {
+        public DuplicateTaskException(String message) {
+            super(message);
+        }
+    }
 
     private static final class RealizeDetails implements RealizeTaskBuildOperationType.Details {
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/TaskInstantiationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/TaskInstantiationException.java
@@ -16,10 +16,12 @@
 package org.gradle.api.tasks;
 
 import org.gradle.api.GradleException;
+import org.gradle.internal.exceptions.Contextual;
 
 /**
  * A {@code TaskInstantiationException} is thrown when a task cannot be instantiated for some reason.
  */
+@Contextual
 public class TaskInstantiationException extends GradleException {
     public TaskInstantiationException(String message) {
         this(message, null);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks
 
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Rule
 import org.gradle.api.Task
@@ -43,6 +44,9 @@ class DefaultTaskContainerTest extends Specification {
     private taskFactory = Mock(ITaskFactory)
     def modelRegistry = Mock(ModelRegistry)
     private project = Mock(ProjectInternal, name: "<project>") {
+        identityPath(_) >> { String name ->
+            Path.path(":project").child(name)
+        }
         getGradle() >> Mock(GradleInternal) {
             getIdentityPath() >> Path.path(":")
         }
@@ -209,6 +213,71 @@ class DefaultTaskContainerTest extends Specification {
         then:
         added == task
         1 * action.execute(task)
+    }
+
+    void "create by map wraps task creation failure"() {
+        given:
+        def failure = new RuntimeException()
+
+        taskFactory.create(_ as TaskIdentity) >> { throw failure }
+
+        when:
+        container.create(name: "task")
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "Could not create task ':project:task'."
+        e.cause == failure
+    }
+
+    void "create wraps task creation failure"() {
+        given:
+        def failure = new RuntimeException()
+
+        taskFactory.create(_ as TaskIdentity) >> { throw failure }
+
+        when:
+        container.create("task")
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "Could not create task ':project:task'."
+        e.cause == failure
+    }
+
+    void "create with action wraps task creation failure"() {
+        given:
+        def failure = new RuntimeException()
+        def action = Mock(Action)
+
+        taskFactory.create(_ as TaskIdentity) >> { throw failure }
+
+        when:
+        container.create("task", action)
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "Could not create task ':project:task'."
+        e.cause == failure
+    }
+
+    void "create wraps task configuration failure"() {
+        given:
+        def failure = new RuntimeException()
+        def action = Mock(Action)
+        def task = task("task")
+
+        taskFactory.create(_ as TaskIdentity) >> task
+        action.execute(task) >> { throw failure }
+
+        when:
+        container.all(action)
+        container.create("task", action)
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "Could not create task ':project:task'."
+        e.cause == failure
     }
 
     void "replaces task by name"() {
@@ -785,8 +854,8 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing creation rule"
 
         and:
@@ -808,9 +877,8 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing creation rule"
+        def ex2 = thrown(GradleException)
+        ex2.is(ex)
         0 * _
     }
 
@@ -827,8 +895,8 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing creation rule"
 
         and:
@@ -843,37 +911,18 @@ class DefaultTaskContainerTest extends Specification {
 
         when:
         creationProvider.get() == task
+
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing creation rule"
+        def ex2 = thrown(GradleException)
+        ex2.is(ex)
 
         when:
         provider.get()
 
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing creation rule"
+        def ex3 = thrown(GradleException)
+        ex3.is(ex)
         0 * _
-    }
-
-    void "fails task creation when task instantiation is unsuccessful"() {
-        def action = Mock(Action)
-
-        when:
-        container.create("task", DefaultTask, action)
-
-        then:
-        def ex = thrown(RuntimeException)
-        ex.message == "Failing constructor"
-
-        and:
-        container.findByName("task") == null
-
-        and:
-        1 * taskFactory.create(_ as TaskIdentity) >> { throw new RuntimeException("Failing constructor") }
-        0 * action.execute(_)
     }
 
     void "fails later creation upon realizing through register provider when task instantiation is unsuccessful"() {
@@ -889,8 +938,8 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing constructor"
 
         and:
@@ -904,18 +953,17 @@ class DefaultTaskContainerTest extends Specification {
 
         when:
         container.findByName("task")
+
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing constructor"
+        def ex2 = thrown(GradleException)
+        ex2.is(ex)
 
         when:
         provider.getOrNull()
 
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing constructor"
+        def ex3 = thrown(GradleException)
+        ex3.is(ex)
         0 * _
     }
 
@@ -931,54 +979,28 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing constructor"
+
         and:
         provider.isPresent()
         creationProvider.isPresent()
 
         when:
         container.findByName("task")
+
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing constructor"
+        def ex2 = thrown(GradleException)
+        ex2.is(ex)
 
         when:
         provider.getOrNull()
+
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing constructor"
+        def ex3 = thrown(GradleException)
+        ex3.is(ex)
         0 * _
-    }
-
-    void "fails task creation when task configuration via withType is unsuccessful"() {
-        def action = Mock(Action)
-        def task = task("task")
-
-        given:
-        container.withType(DefaultTask, action)
-
-        when:
-        container.create("task", DefaultTask)
-
-        then:
-        def ex = thrown(RuntimeException)
-        ex.message == "Failing withType configuration rule"
-
-        and:
-        container.findByName("task") != null
-        container.findByName("task") == task
-
-        and:
-        container.withType(DefaultTask).named("task").isPresent()
-        container.withType(DefaultTask).named("task").get() == task
-
-        and:
-        1 * taskFactory.create(_ as TaskIdentity) >> task
-        1 * action.execute(_) >> { throw new RuntimeException("Failing withType configuration rule") }
     }
 
     void "fails later creation when task configuration via withType is unsuccessful"() {
@@ -993,8 +1015,8 @@ class DefaultTaskContainerTest extends Specification {
         container.register("task", DefaultTask)
 
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing withType configuration rule"
 
         and:
@@ -1021,8 +1043,9 @@ class DefaultTaskContainerTest extends Specification {
         container.create("task", DefaultTask)
 
         then:
-        def ex = thrown(RuntimeException)
-        ex.message == "Failing configureEach configuration rule"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
+        ex.cause.message == "Failing configureEach configuration rule"
 
         and:
         container.findByName("task") != null
@@ -1049,8 +1072,8 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing configureEach configuration rule"
 
         and:
@@ -1072,9 +1095,8 @@ class DefaultTaskContainerTest extends Specification {
         provider.get()
 
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing configureEach configuration rule"
+        def ex2 = thrown(GradleException)
+        ex2.is(ex)
         0 * _
     }
 
@@ -1092,8 +1114,8 @@ class DefaultTaskContainerTest extends Specification {
         when:
         provider.get()
         then:
-        def ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
+        def ex = thrown(GradleException)
+        ex.message == "Could not create task ':project:task'."
         ex.cause.message == "Failing configureEach configuration rule"
         and:
         provider.isPresent()
@@ -1103,16 +1125,15 @@ class DefaultTaskContainerTest extends Specification {
         when:
         creationProvider.get()
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing configureEach configuration rule"
+        def ex2 = thrown(GradleException)
+        ex2.is(ex)
 
         when:
         provider.get()
         then:
-        ex = thrown(IllegalStateException)
-        ex.message == "Could not create task 'task' (DefaultTask)"
-        ex.cause.message == "Failing configureEach configuration rule"
+        def ex3 = thrown(GradleException)
+        ex3.is(ex)
+
         0 * _
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -209,6 +209,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails()
         failure.assertHasLineNumber(3)
         failure.assertHasDescription("A problem occurred evaluating project ':child'.")
+        failure.assertHasCause("Could not create task ':child:broken'.")
         failure.assertHasCause("broken task")
     }
 
@@ -342,7 +343,9 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
+        failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
+        failure.assertHasCause("Unable to determine CustomTask_Decorated argument #2: missing parameter value of type int, or no service of type int")
 
         where:
         description   | script
@@ -360,7 +363,9 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
+        failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
+        failure.assertHasCause("Unable to determine CustomTask_Decorated argument #1: missing parameter value of type class java.lang.String, or no service of type class java.lang.String")
 
         where:
         description   | script
@@ -379,6 +384,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
+        failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("constructorArgs must be a List or Object[]")
 
         where:
@@ -399,6 +405,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
+        failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
 
         where:
@@ -417,6 +424,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         fails 'myTask'
 
         then:
+        failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Received null for CustomTask constructor argument #$position")
 
         where:


### PR DESCRIPTION
### Context

This change ensures that all failures in task construction and in configuration actions executed during realization of a task are reported consistently regardless of whether the task is eagerly created or lazily registered.

The error message includes details about which task could not be created and the project the task belongs to, and also consistently makes the failure visible in the console as a cause.

The change also ensures that this work is all performed within the realization build operation associated with task. Previously some configuration actions were executed outside this build operation.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
